### PR TITLE
docs: audit AGENTS.md and fix Dockerfile.toolchain heredoc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,148 +6,65 @@ rendering) and desktop Linux (x86_64, windowed). The hard rendering
 constraint shapes every visual decision. See @docs/architecture.md for the
 module graph and @docs/building.md for the full build matrix.
 
-## Hard Constraints
+## Constraints
 
-**Software rendering only.** MiSTer has no GPU. Never use: shaders,
-`LinearGradient`, `RadialGradient`, `DropShadow`, `Glow`, `OpacityMask`,
-`MultiEffect`, `Qt5Compat.GraphicalEffects`. Stick to `Rectangle`, `Image`,
-`Text`, `Repeater`, `NumberAnimation`, `ColorAnimation`. The "Basic"
-`QQuickStyle` is mandatory for the same reason.
+### NEVER
 
-**Resolution-agnostic layout.** The UI runs from 240p (CRT) to 1080p. Use
-`Sizing.pctH()`, `Sizing.pctW()`, `Sizing.fontSize()` for all dimensions.
-Scale element counts with resolution (e.g. `Sizing.visibleCovers`). Never
-hardcode pixel values.
+- Use shaders, `LinearGradient`, `RadialGradient`, `DropShadow`, `Glow`,
+  `OpacityMask`, `MultiEffect`, `Qt5Compat.GraphicalEffects`, or any other
+  GPU-dependent QML type. MiSTer renders in software on a framebuffer.
+  Stick to `Rectangle`, `Image`, `Text`, `Repeater`, `NumberAnimation`,
+  `ColorAnimation`. "Basic" `QQuickStyle` is mandatory.
+- Hardcode pixel values. The UI runs 240p (CRT) → 1080p; use
+  `Sizing.pctH()`, `Sizing.pctW()`, `Sizing.fontSize()`, and
+  `Sizing.visibleCovers` for every dimension and element count.
+- Add Qt5 compatibility code or `#if QT_VERSION` guards. Qt 6.7+ only.
+- Change `BUILD_SHARED_LIBS` — `ON` on desktop is required for LGPL
+  compliance; `OFF` on ARM32/MiSTer is set by the Docker toolchain.
+- Hold in-memory-only application state. MiSTer's launcher script kills
+  and relaunches the binary freely; every piece of user-visible state
+  (selected game, carousel position, menu state, settings) must be
+  serializable to disk and restored before the first frame paints.
+- Leave a lint warning or failing test unresolved.
+- `cd rust/` or invoke raw cmake/cargo. Drive every workflow from the
+  repo root via `just`.
 
-**Qt 6.7+ only.** No Qt5 compatibility code. No `#if QT_VERSION` guards.
+### ASK
 
-**Dynamic Qt on desktop; static on MiSTer.** `BUILD_SHARED_LIBS ON` is the
-default and required for LGPL compliance on desktop. The ARM32 Docker build
-uses static Qt — do not change this.
+- Before adding or changing a `Client` method in
+  `rust/zaparoo-core/src/client.rs` — cross-check
+  https://zaparoo.org/docs/core/api/ first. Method names, param shapes,
+  and return types must match upstream.
 
-**Watch the FPS counter.** `src/ui/components/FpsCounter.qml` shows a live
-FPS readout (green ≥55, yellow ≥30, red <30). When changing visuals, verify
-it stays green at 720p+ and doesn't fall red at 240p.
+### ALWAYS
 
-**State is always serializable; the app is effectively stateless across runs.**
-MiSTer launcher scripts kill and relaunch the binary freely. Design all
-application state (selected game, carousel position, menu state, settings) so
-it can be persisted to disk at any time and fully restored on the next launch.
-On startup, load persisted state before the first frame paints — the relaunch
-must feel instant to the user. Never hold in-memory-only state that would be
-lost on kill.
+- After editing any C++, Rust, or QML file: run `just lint` (zero
+  warnings is the bar) and `just test` if the change can affect runtime
+  behaviour.
+- Watch `src/ui/components/FpsCounter.qml` when changing visuals —
+  it must stay green (≥55) at 720p+ and not fall red (<30) at 240p.
 
 ## Commands
 
-Common workflows are wrapped in `justfile` recipes — run `just --list` for the
-full menu. Prefer `just X` over raw cmake/cargo invocations.
+Run `just --list` for the full menu. The `justfile` is the source of
+truth — `.cargo/config.toml` and `CMakePresets.json` are tuned to it.
 
-```bash
-# Build and run (desktop)
-just build        # cmake configure + build
-just run          # build + launch desktop binary
+    just build | run                   desktop cmake + run
+    just test | test-qml | test-rust   ctest + cargo nextest
+    just lint | lint-cpp | lint-rust   clang-format/tidy + qmllint +
+                                       rustfmt + clippy + cargo-deny
+    just fmt                           pre-commit + cargo fmt
+    just arm32 | deploy-mister         cross-build + SCP to MiSTer
 
-# Tests
-just test         # ctest + cargo nextest
-just test-qml     # QML smoke tests only
-just test-rust    # Rust unit tests only
+## Deploy to MiSTer
 
-# Linters (clang-format + clang-tidy + qmllint + rustfmt + clippy + cargo-deny)
-just lint
-just lint-cpp     # C++/QML only
-just lint-rust    # Rust only
-
-# Auto-format (pre-commit for C++/QML, cargo fmt for Rust)
-just fmt
-
-# ARM32 cross-build and deploy
-just arm32
-just deploy-mister
-```
-
-The raw commands still work; `just` just wraps them. Equivalents:
-
-```bash
-cmake -S . -B build && cmake --build build         # just build
-ctest --test-dir build --output-on-failure         # just test-qml
-cmake --build build --target lint                  # just lint-cpp
-cd rust && cargo clippy --workspace --all-targets -- -D warnings  # part of just lint-rust
-```
-
-# Deploy to MiSTer
-
-```bash
-./scripts/deploy-mister.sh
-```
-
-Builds the ARM32 binary, backs up the existing binary on the device to
-`launcher.bak`, SCPs the new binary over, kills any running `launcher` and
-`MiSTer_Zaparoo` processes, then restarts `MiSTer_Zaparoo`. Reads `MISTER_IP`
-from a `.env` file in the project root — create it with
-`echo 'MISTER_IP=<ip>' > .env` if it doesn't exist yet. When the user asks
-to deploy, run this script.
-
-`/media/fat/MiSTer_Zaparoo` is the pre-existing Zaparoo integration binary
-that ships with MiSTer; it is responsible for launching our `launcher` binary.
-Restarting it picks up the newly deployed binary automatically.
-
-The launcher binary is self-contained: it sets `QT_QPA_PLATFORM=linuxfb` and
-`QT_QUICK_BACKEND=software`, runs `vmode -r W H rgb32` (width/height from
-config), and starts the Zaparoo Core service automatically. Resolution and
-endpoint can be overridden in `/media/fat/zaparoo/launcher.toml`
-(TOML format; create the file manually — see `docs/building.md` for an
-example).
-
-For ARM32 / MiSTer builds and deploy bundle, see @docs/building.md.
-
-## IMPORTANT: Repo Policy
-
-After editing any C++, Rust, or QML file, ALWAYS run:
-1. `just lint` — zero warnings is the bar (covers clang-tidy, qmllint,
-   rustfmt, clippy, and cargo-deny).
-2. `just test` — if the change can affect runtime behaviour.
-
-Never leave a lint warning or failing test unresolved.
-
-## QML Gotchas
-
-These pitfalls come up repeatedly; qmllint only catches them after you've
-written the code:
-
-- **Typed properties, not `var`.** Use `list<string>`, `list<url>`, `int`,
-  `real` — `var` produces `QVariant` warnings and blocks AOT compilation.
-- **`Repeater` delegates need `pragma ComponentBehavior: Bound`** at the top
-  of the file. Add `required property int index` to the delegate, plus
-  `required property string modelData` when the model is a list.
-- **Nested delegate children** that reference the delegate's properties must
-  qualify: give the delegate an `id` and use `id.modelData`, not bare
-  `modelData`.
-- **Singleton QML types** need both `pragma Singleton` in the `.qml` file
-  and `set_source_files_properties(Foo.qml PROPERTIES QT_QML_SINGLETON_TYPE TRUE)`
-  in CMake, or qmllint will warn "not declared as singleton in qmldir".
-- **Function type annotations required.** Add `: ParamType` parameters and
-  `: ReturnType` return types to all functions in singleton `.qml` files.
-- **`NumberAnimation on propName`** conflicts with `property T propName: value`.
-  Drop the `: value` initialiser — the animation takes over immediately.
-
-## cxx-qt Bridge Gotchas
-
-When writing Rust QML models via cxx-qt 0.7:
-
-- **`cxx = "1"` must be a direct dependency.** The `#[cxx_qt::bridge]` macro
-  expands to `#[cxx::bridge]`. Rust resolves proc-macro attributes in the
-  calling crate's scope, so `cxx` must appear in that crate's `[dependencies]`
-  — being a transitive dep through `cxx-qt` is not sufficient.
-- **`#[qproperty(T, snake_case_name)]` auto-converts to camelCase** on the Qt
-  and QML side. `#[qproperty(bool, has_next_page)]` → accessible as
-  `hasNextPage` in QML.
-- **User-defined `#[qinvokable]` methods are exposed with their Rust name**
-  (snake_case). QML calls them as `model.set_system(id)` etc. Add
-  `#[cxx_name = "..."]` only when you need camelCase (e.g. to match a Qt
-  base-class virtual like `rowCount`, `roleNames`, `beginResetModel`).
-- **cxx-qt plugin class name** for a `Zaparoo.Browse` module is
-  `Zaparoo_Browse_plugin` (not `Zaparoo_BrowsePlugin`). Use
-  `Q_IMPORT_QML_PLUGIN(Zaparoo_Browse_plugin)` in the C++ entry point.
+`./scripts/deploy-mister.sh` — reads `MISTER_IP` from a `.env` in the
+project root (create with `echo 'MISTER_IP=<ip>' > .env`). Non-obvious
+context: `/media/fat/MiSTer_Zaparoo` is a pre-existing integration binary
+shipped with MiSTer that is responsible for launching our `launcher`; the
+deploy script restarts it, which picks up the newly-SCP'd binary
+automatically. User-editable resolution and endpoint overrides live at
+`/media/fat/zaparoo/launcher.toml` (example in @docs/building.md).
 
 ## Module Map
 
@@ -157,46 +74,29 @@ When writing Rust QML models via cxx-qt 0.7:
 | `src/ui/components/` | `Zaparoo.Ui` | `Carousel`, `CoverDelegate`, `TextTileDelegate`, `FpsCounter` |
 | `src/ui/app/` | `Zaparoo.App` | `Main.qml` + embedded fonts and images |
 | `rust/launcher/src/models/` | `Zaparoo.Browse` | `CategoriesModel`, `SystemsModel`, `GamesModel`, `BrowseModel` (dormant) — Rust QML singletons via cxx-qt |
-| `rust/zaparoo-core/` | — | `client`, `config`, `logger`, `systems_catalog`, `media_types`, `platform_paths` (Rust, no Qt dependency) |
+| `rust/zaparoo-core/` | — | `client`, `config`, `logger`, `systems_catalog`, `media_types`, `platform_paths` (no Qt dependency) |
 
 Import QML modules as `import Zaparoo.Theme`, `import Zaparoo.Ui`, etc.
 Resources are embedded at `qrc:/qt/qml/Zaparoo/App/resources/...`.
-`compile_commands.json` is always generated in `build/`; no extra CMake flag needed.
+`compile_commands.json` is generated in `build/` unconditionally.
 
 ## Logging
 
-Use `tracing::info!`, `tracing::debug!`, `tracing::warn!`, `tracing::error!`
-in Rust code:
+Use `tracing::{info,debug,warn,error}!` in Rust. Two sinks write
+simultaneously: stderr (RFC-3339 human-readable) and JSONL file at
+`platform_paths::log_file_path()` — `/tmp/zaparoo/launcher.log` on MiSTer,
+`~/.local/share/zaparoo/logs/launcher.log` on desktop. Qt messages route
+through `zaparoo_log_qt` (`rust/launcher/src/lib.rs`) with `target="qt"`,
+so Qt warnings land in the same file.
 
-```rust
-tracing::info!("catalog loaded: {} systems", count);
-tracing::debug!(target: "qt", "message from Qt layer");
-tracing::warn!("vmode exited with {:?}", code);
-```
-
-The logger writes two sinks simultaneously:
-- **stderr**: human-readable RFC-3339 timestamp + level + message
-- **file**: JSONL at `platform_paths::log_file_path()`. MiSTer:
-  `/tmp/zaparoo/launcher.log`. Desktop:
-  `~/.local/share/zaparoo/logs/launcher.log`.
-
-Qt messages are forwarded through the same tracing registry via the
-`zaparoo_log_qt` extern in `rust/launcher/src/lib.rs`, so Qt warnings
-appear in `launcher.log` with `target="qt"`.
-
-Debug-level output is filtered out by default. Enable it two ways:
-- **Config**: set `[logging] debug = true` in `launcher.toml`.
-- **Env var**: `ZAPAROO_DEBUG=1 ./launcher` (takes effect before config loads).
-
-## Zaparoo Core API
-
-Full API reference: https://zaparoo.org/docs/core/api/
-
-Before adding or modifying any `Client` method in `rust/zaparoo-core/src/client.rs`,
-check the upstream docs to verify method names, param shapes, and return types.
+Debug level is filtered out by default. Enable with `[logging] debug =
+true` in `launcher.toml`, or `ZAPAROO_DEBUG=1` env var (takes effect
+before config loads, useful for debugging startup).
 
 ## Further Reading
 
-- @docs/architecture.md — module graph, data-flow plan, LGPL notes
-- @docs/building.md — full build matrix (ARM32 toolchain, deploy bundle, sanitizers)
+- @docs/architecture.md — module graph, data-flow, LGPL notes
+- @docs/building.md — full build matrix, ARM32 toolchain, sanitizers, deploy bundle
+- @docs/qml-gotchas.md — QML pitfalls qmllint only catches post-hoc (read when writing QML)
+- @docs/cxx-qt-bridge.md — cxx-qt 0.7 bridge gotchas (read when editing Rust QML models)
 - `src/LICENSES/` — Qt LGPL notices

--- a/Dockerfile.toolchain
+++ b/Dockerfile.toolchain
@@ -123,8 +123,10 @@ RUN mkdir qtwebsockets-host-build && cd qtwebsockets-host-build && \
     && cmake --build . --parallel $(nproc) \
     && cmake --install .
 
-# Stage 2: CMake toolchain file for ARM32 cross-compilation
-RUN cat > /build/arm32-toolchain.cmake << 'EOF'
+# Stage 2: CMake toolchain file for ARM32 cross-compilation.
+# Single-quoted heredoc tag so ${CMAKE_SYSROOT} reaches the file literally
+# rather than being expanded by the Dockerfile frontend.
+COPY <<'EOF' /build/arm32-toolchain.cmake
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR arm)
 
@@ -142,7 +144,7 @@ set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
 
-# MiSTer FPGA: Cyclone V SoC — Cortex-A9, NEON, hard-float ABI
+# MiSTer FPGA: Cyclone V SoC, Cortex-A9, NEON, hard-float ABI.
 set(CMAKE_C_FLAGS_INIT   "-mcpu=cortex-a9 -mfloat-abi=hard -mtune=cortex-a9 -mfpu=neon")
 set(CMAKE_CXX_FLAGS_INIT "-mcpu=cortex-a9 -mfloat-abi=hard -mtune=cortex-a9 -mfpu=neon")
 EOF

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Zaparoo Launcher
 
-A Qt/QML game launcher frontend for [Zaparoo Core](https://zaparoo.org), designed to run on MiSTer FPGA (Linux framebuffer, no GPU) and desktop systems. Built with Qt 6.7+, software rendering, and a retro carousel UI that scales from 240p CRT to 1080p.
+A game launcher frontend for [Zaparoo Core](https://zaparoo.org).
 
 ## Building
 
@@ -32,18 +32,15 @@ This repository contains Zaparoo trademarks which are explicitly licensed to the
 
 Copyright 2026 The Zaparoo Project Contributors.
 Source available under the [PolyForm Noncommercial License 1.0.0](COPYING).
-Non-commercial use only.
-
-For commercial licensing, contact
-[legal@zaparoo.org](mailto:legal@zaparoo.org) to discuss terms.
+Non-commercial use only. For commercial licensing, contact [legal@zaparoo.org](mailto:legal@zaparoo.org) to discuss terms.
 
 Third-party components:
 
-- **Qt framework** — LGPLv3. Dynamically linked on desktop builds; statically
+- **Qt framework**: LGPLv3. Dynamically linked on desktop builds; statically
   linked on MiSTer ARM32. Object files for re-linking against a modified Qt
   are available on request at
   [legal@zaparoo.org](mailto:legal@zaparoo.org).
   See [`src/LICENSES/`](src/LICENSES/).
-- **Press Start 2P** font — SIL Open Font License 1.1, © 2012 The Press Start 2P
+- **Press Start 2P** font: SIL Open Font License 1.1, © 2012 The Press Start 2P
   Project Authors. See [`src/LICENSES/OFL.txt`](src/LICENSES/OFL.txt) and
   [`src/LICENSES/PressStart2P-ATTRIBUTION.txt`](src/LICENSES/PressStart2P-ATTRIBUTION.txt).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,8 +74,8 @@ No `qrc:/` strings anywhere else.
 
 ## LGPL compliance
 
-Qt is used under LGPLv3. The desktop binary links Qt dynamically — end
-users may replace the bundled Qt libraries. The MiSTer ARM32 binary is
+Qt is used under LGPLv3. The desktop binary links Qt dynamically, so end
+users can replace the bundled Qt libraries. The MiSTer ARM32 binary is
 statically linked; object files are available on request per LGPL §4(d)(1).
 License texts live in `src/LICENSES/`.
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -8,7 +8,7 @@
 - CMake 3.22+
 - C++17 compiler (GCC 10+, Clang 12+, MSVC 2019+)
 - Rust stable toolchain (`rustup install stable`)
-- Ninja (required — pinned by `CMakePresets.json`)
+- Ninja (required; pinned by `CMakePresets.json`)
 - mold (used as linker on x86_64 Linux; pinned by `rust/.cargo/config.toml`)
 
 On Fedora/RHEL: `sudo dnf install qt6-qtdeclarative-devel qt6-qtquickcontrols2-devel cmake ninja-build mold`
@@ -19,7 +19,7 @@ Install Rust via rustup: `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup
 ### MiSTer ARM32 cross-build
 
 - Docker (any recent version)
-- x86_64 host (no emulation needed — pure cross-compilation)
+- x86_64 host (no emulation needed, pure cross-compilation)
 - ~8 GB disk space for the toolchain image
 
 The toolchain Docker image ships a cross-compiler-aware `rust/.cargo/config.toml`
@@ -110,7 +110,7 @@ The binary is self-contained on MiSTer: it sets `QT_QPA_PLATFORM=linuxfb` and
 `QT_QUICK_BACKEND=software`, runs `vmode -r W H rgb32` (width/height from
 config, defaulting to 1920×1080), and starts
 `/media/fat/Scripts/zaparoo.sh -service start` automatically. Just run the
-binary — no wrapper script required.
+binary; no wrapper script required.
 
 User-editable config lives at `/media/fat/zaparoo/launcher.toml`. Example:
 
@@ -150,7 +150,7 @@ cmake --build build --target lint
 ```
 
 This runs clang-format (check only), clang-tidy, and qmllint in one shot.
-`compile_commands.json` is always generated in `build/` — no extra cmake flag needed.
+`compile_commands.json` is always generated in `build/`, so no extra cmake flag is needed.
 
 ### Individual lint targets
 

--- a/docs/cxx-qt-bridge.md
+++ b/docs/cxx-qt-bridge.md
@@ -1,0 +1,22 @@
+# cxx-qt Bridge Gotchas
+
+Read this when writing Rust QML models via cxx-qt 0.7 in
+`rust/launcher/src/models/`.
+
+- **`cxx = "1"` must be a direct dependency.** The `#[cxx_qt::bridge]` macro
+  expands to `#[cxx::bridge]`. Rust resolves proc-macro attributes in the
+  calling crate's scope, so `cxx` must appear in that crate's `[dependencies]`.
+  A transitive dep through `cxx-qt` is not sufficient.
+
+- **`#[qproperty(T, snake_case_name)]` auto-converts to camelCase** on the Qt
+  and QML side. `#[qproperty(bool, has_next_page)]` → accessible as
+  `hasNextPage` in QML.
+
+- **User-defined `#[qinvokable]` methods are exposed with their Rust name**
+  (snake_case). QML calls them as `model.set_system(id)` etc. Add
+  `#[cxx_name = "..."]` only when you need camelCase (e.g. to match a Qt
+  base-class virtual like `rowCount`, `roleNames`, `beginResetModel`).
+
+- **cxx-qt plugin class name** for a `Zaparoo.Browse` module is
+  `Zaparoo_Browse_plugin` (not `Zaparoo_BrowsePlugin`). Use
+  `Q_IMPORT_QML_PLUGIN(Zaparoo_Browse_plugin)` in the C++ entry point.

--- a/docs/qml-gotchas.md
+++ b/docs/qml-gotchas.md
@@ -1,0 +1,25 @@
+# QML Gotchas
+
+Read this when writing or reviewing QML. These are pitfalls `qmllint` only
+catches *after* the code is written, so it's cheaper to avoid them up front.
+
+- **Typed properties, not `var`.** Use `list<string>`, `list<url>`, `int`,
+  `real`. `var` produces `QVariant` warnings and blocks AOT compilation.
+
+- **`Repeater` delegates need `pragma ComponentBehavior: Bound`** at the top
+  of the file. Add `required property int index` to the delegate, plus
+  `required property string modelData` when the model is a list.
+
+- **Nested delegate children** that reference the delegate's properties must
+  qualify: give the delegate an `id` and use `id.modelData`, not bare
+  `modelData`.
+
+- **Singleton QML types** need both `pragma Singleton` in the `.qml` file
+  and `set_source_files_properties(Foo.qml PROPERTIES QT_QML_SINGLETON_TYPE TRUE)`
+  in CMake, or qmllint will warn "not declared as singleton in qmldir".
+
+- **Function type annotations required.** Add `: ParamType` parameters and
+  `: ReturnType` return types to all functions in singleton `.qml` files.
+
+- **`NumberAnimation on propName`** conflicts with `property T propName: value`.
+  Drop the `: value` initialiser; the animation takes over immediately.


### PR DESCRIPTION
## Summary

- **AGENTS.md audit**: rewrite (203 → 102 lines) around NEVER/ASK/ALWAYS tiers and progressive disclosure. Extracted QML and cxx-qt pitfalls into `docs/qml-gotchas.md` and `docs/cxx-qt-bridge.md`, imported via `@docs/...` so they only load when relevant. Dropped raw cmake/cargo equivalents in favour of `just` recipes. Every judgment rule from the old file landed either in the new tiered block or in one of the two extracted docs — nothing silently dropped.
- **README + docs tidy**: simplified intro, joined the commercial-licensing line into the non-commercial line, replaced em dashes in the third-party section, and ran the humanizer pass across `docs/architecture.md` and `docs/building.md` (9 prose em dashes swapped for commas/semicolons/periods; tree-diagram separators inside code blocks preserved).
- **Dockerfile.toolchain fix**: buildx rejected the shell heredoc (`RUN cat > file << 'EOF'`) with a parse error on the first `set()` line on main (run 24869891636). Switched to the Dockerfile-native `COPY <<'EOF' /path` form — keeps `\${CMAKE_SYSROOT}` literal for CMake to expand at configure time. The `ensure-toolchain` job is gated to `push` + `refs/heads/main`, which is why PR CI never exercised this path — the break only surfaced post-merge.

## Test plan

- [ ] `ensure-toolchain` job succeeds on the post-merge push to main (the case PR CI can't exercise).
- [ ] `wc -l AGENTS.md` ≤ 135.
- [ ] `ls -la CLAUDE.md` still symlinks to AGENTS.md.
- [ ] `just lint` passes locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized agent guidelines for clearer constraint and workflow definitions.
  * Added new development guides for QML patterns and cxx-qt bridge best practices.
  * Improved clarity and consistency across project documentation with minor wording refinements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->