### PR TITLE
refactor: split Runtime (launcher host) from Platform (Core server)

### DIFF
--- a/.github/workflows/toolchain-build.yml
+++ b/.github/workflows/toolchain-build.yml
@@ -90,6 +90,23 @@ jobs:
             echo "Version ${{ steps.version.outputs.version }} will be built"
           fi
 
+      # Qt's PCH compilation in qtdeclarative-arm-build exhausts the runner
+      # disk (~14 GB usable of 22 GB) once the image layers contain the ARM
+      # GCC toolchain, four Qt source trees, and the host + ARM builds. Freeing
+      # the pre-installed Android SDK / .NET / Haskell / tool-cache recovers
+      # ~30 GB and is cheap (~3 min).
+      - name: Free disk space
+        if: steps.check.outputs.exists != 'true'
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
+          docker-images: true
+
       - name: Set up Docker Buildx
         if: steps.check.outputs.exists != 'true'
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4

--- a/cmake/ZaparooRust.cmake
+++ b/cmake/ZaparooRust.cmake
@@ -51,7 +51,7 @@ corrosion_set_env_vars(zaparoo_launcher_rs
     "QMAKE=${_rs_qmake}"
 )
 if(_rs_qt6_core_type STREQUAL "STATIC_LIBRARY")
-    corrosion_set_env_vars(zaparoo_launcher_rs "ZAPAROO_MISTER=1")
+    corrosion_set_env_vars(zaparoo_launcher_rs "ZAPAROO_RUNTIME=mister")
 endif()
 if(ZAPAROO_DEV)
     corrosion_set_env_vars(zaparoo_launcher_rs "ZAPAROO_DEV_BUILD=1")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,7 +28,9 @@ src/app/main.cpp
     │           systems_catalog.rs — derives categories + systems from server data
     │           config.rs          — TOML config (launcher.toml)
     │           logger.rs          — tracing-subscriber: stderr + JSONL file sinks
-    │           platform_paths.rs  — log/config paths per platform
+    │           runtime.rs         — Runtime enum: what device the launcher runs on
+    │           platform.rs        — Platform enum: what Zaparoo Core is running on
+    │           platform_paths.rs  — log/config paths routed through runtime
     │           media_types.rs     — file-extension → media-type lookup
     │
     └── src/ui/app/  [Zaparoo.App QML module]
@@ -71,6 +73,39 @@ No `qrc:/` strings anywhere else.
 - **Dynamic Qt on desktop, static Qt on MiSTer.** `BUILD_SHARED_LIBS=ON`
   is the default (LGPL compliance for distribution). The ARM32 Docker
   build passes `-DBUILD_SHARED_LIBS=OFF` via the Qt CMake toolchain.
+
+## Runtime vs Platform
+
+Two orthogonal facts the launcher reasons about. Keep them separate —
+gating the wrong one reintroduces bugs the split was designed to prevent.
+
+| Concept | Source of truth | Question answered |
+|---|---|---|
+| **Runtime** | `zaparoo_core::runtime::current()` (filesystem-cached) | What device is the **launcher binary** running on? |
+| **Platform** | `zaparoo_core::platform::subscribe()` (from `version` RPC) | What OS/device is **Zaparoo Core** running on? |
+
+`Runtime == Mister` does **not** imply `Platform == Mister`. The launcher
+can run on a desktop while talking to Core on a MiSTer on the network,
+or vice-versa.
+
+### When to use which
+
+- **Runtime gate** — "this code path behaves differently depending on
+  the launcher's host device." Read `runtime::current()`. Prefer runtime
+  gating for behaviour.
+- **Build-time cfg `#[cfg(zaparoo_runtime = "mister")]`** — reserve for
+  code that genuinely should not compile into desktop binaries (system
+  calls, MiSTer-only dependencies). Currently only `mister_runtime.rs`
+  uses this. Set by `ZAPAROO_RUNTIME=mister` in `cmake/ZaparooRust.cmake`
+  for static-Qt (ARM32) builds.
+- **Platform gate** — "this feature depends on what Core supports."
+  Subscribe to `platform::subscribe()`; treat `None` as "unknown — don't
+  enable platform-specific features until the first `version` RPC
+  completes." Never gate on `Platform` from C++/QML directly; route the
+  decision through Rust and expose a QML property.
+
+**Never gate runtime behaviour on `Platform`, never gate Core
+assumptions on `Runtime`.** They are independent.
 
 ## LGPL compliance
 

--- a/rust/launcher/build.rs
+++ b/rust/launcher/build.rs
@@ -33,13 +33,19 @@ fn main() {
         })
         .build();
 
-    println!("cargo:rerun-if-env-changed=ZAPAROO_MISTER");
+    println!("cargo:rerun-if-env-changed=ZAPAROO_RUNTIME");
     println!("cargo:rerun-if-env-changed=ZAPAROO_DEV_BUILD");
 
-    println!("cargo:rustc-check-cfg=cfg(mister)");
+    println!("cargo:rustc-check-cfg=cfg(zaparoo_runtime, values(\"mister\"))");
     println!("cargo:rustc-check-cfg=cfg(dev_build)");
-    if std::env::var("ZAPAROO_MISTER").is_ok() {
-        println!("cargo:rustc-cfg=mister");
+    if let Ok(rt) = std::env::var("ZAPAROO_RUNTIME") {
+        if rt == "mister" {
+            println!("cargo:rustc-cfg=zaparoo_runtime=\"mister\"");
+        } else {
+            println!(
+                "cargo:warning=ignoring unknown ZAPAROO_RUNTIME value: {rt:?} (expected \"mister\")"
+            );
+        }
     }
     if std::env::var("ZAPAROO_DEV_BUILD").is_ok() {
         println!("cargo:rustc-cfg=dev_build");

--- a/rust/launcher/build.rs
+++ b/rust/launcher/build.rs
@@ -39,7 +39,7 @@ fn main() {
     println!("cargo:rustc-check-cfg=cfg(zaparoo_runtime, values(\"mister\"))");
     println!("cargo:rustc-check-cfg=cfg(dev_build)");
     if let Ok(rt) = std::env::var("ZAPAROO_RUNTIME") {
-        if rt == "mister" {
+        if rt.trim().eq_ignore_ascii_case("mister") {
             println!("cargo:rustc-cfg=zaparoo_runtime=\"mister\"");
         } else {
             println!(

--- a/rust/launcher/src/lib.rs
+++ b/rust/launcher/src/lib.rs
@@ -34,8 +34,8 @@ pub unsafe extern "C" fn zaparoo_log_qt(level: u8, msg_ptr: *const u8, msg_len: 
 use std::ffi::c_int;
 use std::sync::Arc;
 use zaparoo_core::{
-    client::Client, config::load_config, logger::install, platform_paths::config_file_path,
-    systems_catalog,
+    client::Client, config::load_config, logger::install, platform,
+    platform_paths::config_file_path, systems_catalog,
 };
 
 /// Called by the C++ main before `QGuiApplication` is constructed.
@@ -67,6 +67,7 @@ pub extern "C" fn zaparoo_rust_init() -> c_int {
     mister_runtime::apply_pre_qt_setup(&config);
 
     let client = Client::new(config.core_endpoint.clone(), &runtime);
+    platform::spawn_fetcher(client.clone(), &runtime);
     let catalog_tx = systems_catalog::spawn(client.clone(), &runtime);
 
     // init_globals stores Arcs — runtime keeps running after this fn returns.

--- a/rust/launcher/src/mister_runtime.rs
+++ b/rust/launcher/src/mister_runtime.rs
@@ -8,7 +8,7 @@ use zaparoo_core::config::Config;
 /// `vmode -r W H rgb32`. Must be called before `QGuiApplication`. No-op on
 /// non-MiSTer builds.
 pub fn apply_pre_qt_setup(config: &Config) {
-    #[cfg(mister)]
+    #[cfg(zaparoo_runtime = "mister")]
     {
         use tracing::warn;
         std::env::set_var("QT_QPA_PLATFORM", "linuxfb");
@@ -36,13 +36,13 @@ pub fn apply_pre_qt_setup(config: &Config) {
             Ok(_) => {}
         }
     }
-    #[cfg(not(mister))]
+    #[cfg(not(zaparoo_runtime = "mister"))]
     let _ = config;
 }
 
 /// Fire-and-forget `zaparoo.sh -service start`. No-op on non-MiSTer builds.
 pub fn ensure_core_service_running() {
-    #[cfg(mister)]
+    #[cfg(zaparoo_runtime = "mister")]
     {
         use tracing::warn;
         if let Err(e) = std::process::Command::new("/media/fat/Scripts/zaparoo.sh")

--- a/rust/zaparoo-core/src/client.rs
+++ b/rust/zaparoo-core/src/client.rs
@@ -8,7 +8,7 @@
 
 use crate::media_types::{
     MediaBrowseParams, MediaBrowseResult, MediaSearchParams, MediaSearchResult, RunParams,
-    RunResult, SystemsParams, SystemsResult,
+    RunResult, SystemsParams, SystemsResult, VersionResult,
 };
 use futures_util::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
@@ -231,6 +231,15 @@ impl Client {
             text: String,
         }
         let val = self.call("run", &P { text: params.text }).await?;
+        serde_json::from_value(val).map_err(|e| ClientError {
+            message: e.to_string(),
+        })
+    }
+
+    pub async fn version(&self) -> Result<VersionResult, ClientError> {
+        #[derive(Serialize)]
+        struct P {}
+        let val = self.call("version", &P {}).await?;
         serde_json::from_value(val).map_err(|e| ClientError {
             message: e.to_string(),
         })

--- a/rust/zaparoo-core/src/lib.rs
+++ b/rust/zaparoo-core/src/lib.rs
@@ -6,5 +6,7 @@ pub mod client;
 pub mod config;
 pub mod logger;
 pub mod media_types;
+pub mod platform;
 pub mod platform_paths;
+pub mod runtime;
 pub mod systems_catalog;

--- a/rust/zaparoo-core/src/media_types.rs
+++ b/rust/zaparoo-core/src/media_types.rs
@@ -86,6 +86,14 @@ pub struct SystemsResult {
     pub systems: Vec<SystemInfo>,
 }
 
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct VersionResult {
+    #[serde(default)]
+    pub version: String,
+    #[serde(default)]
+    pub platform: String,
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(

--- a/rust/zaparoo-core/src/media_types.rs
+++ b/rust/zaparoo-core/src/media_types.rs
@@ -103,7 +103,7 @@ mod tests {
         reason = "tests should fail-fast on unexpected errors"
     )]
 
-    use super::{BrowseEntry, MediaSearchResult, SystemsResult};
+    use super::{BrowseEntry, MediaSearchResult, SystemsResult, VersionResult};
 
     #[test]
     fn is_folder_accepts_both_spellings() {
@@ -174,5 +174,20 @@ mod tests {
         let json = r#"{"results":[]}"#;
         let result: MediaSearchResult = serde_json::from_str(json).expect("parse");
         assert!(!result.has_next_page);
+    }
+
+    #[test]
+    fn version_result_parses_populated_payload() {
+        let json = r#"{"version":"1.2.3","platform":"mister"}"#;
+        let result: VersionResult = serde_json::from_str(json).expect("parse");
+        assert_eq!(result.version, "1.2.3");
+        assert_eq!(result.platform, "mister");
+    }
+
+    #[test]
+    fn version_result_missing_fields_default_to_empty() {
+        let result: VersionResult = serde_json::from_str("{}").expect("parse");
+        assert_eq!(result.version, "");
+        assert_eq!(result.platform, "");
     }
 }

--- a/rust/zaparoo-core/src/platform.rs
+++ b/rust/zaparoo-core/src/platform.rs
@@ -11,7 +11,7 @@
 use crate::client::Client;
 use crate::media_types::VersionResult;
 use std::sync::{Arc, OnceLock};
-use tokio::sync::watch;
+use tokio::sync::{broadcast, watch};
 use tracing::{info, warn};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -97,7 +97,10 @@ pub fn spawn_fetcher(client: Arc<Client>, runtime: &Arc<tokio::runtime::Runtime>
                     Err(e) => warn!("version RPC failed: {}", e.message),
                 },
                 Ok(false) => {}
-                Err(_) => break,
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    warn!("connected channel lagged by {n}, continuing");
+                }
+                Err(broadcast::error::RecvError::Closed) => break,
             }
         }
     });

--- a/rust/zaparoo-core/src/platform.rs
+++ b/rust/zaparoo-core/src/platform.rs
@@ -1,0 +1,171 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+//
+// Platform: what is the connected Zaparoo Core server running on?
+//
+// Populated by the `version` RPC after each successful connect. Independent
+// of `runtime` (which describes the launcher binary's host).
+// See docs/architecture.md for the gating rules.
+
+use crate::client::Client;
+use crate::media_types::VersionResult;
+use std::sync::{Arc, OnceLock};
+use tokio::sync::watch;
+use tracing::{info, warn};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Platform {
+    Mister,
+    BatoceraLinux,
+    SteamOs,
+    Windows,
+    Mac,
+    Linux,
+    Unknown(String),
+}
+
+impl Platform {
+    pub fn from_api_string(raw: &str) -> Self {
+        match raw.trim().to_lowercase().as_str() {
+            "mister" => Self::Mister,
+            "batocera" | "batocera-linux" | "batoceralinux" => Self::BatoceraLinux,
+            "steamos" => Self::SteamOs,
+            "windows" | "win" | "win32" => Self::Windows,
+            "mac" | "macos" | "darwin" | "osx" => Self::Mac,
+            "linux" => Self::Linux,
+            "" => Self::Unknown(String::new()),
+            _ => Self::Unknown(raw.to_string()),
+        }
+    }
+}
+
+impl std::fmt::Display for Platform {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Mister => f.write_str("mister"),
+            Self::BatoceraLinux => f.write_str("batocera-linux"),
+            Self::SteamOs => f.write_str("steamos"),
+            Self::Windows => f.write_str("windows"),
+            Self::Mac => f.write_str("mac"),
+            Self::Linux => f.write_str("linux"),
+            Self::Unknown(s) if s.is_empty() => f.write_str("unknown"),
+            Self::Unknown(s) => write!(f, "unknown({s})"),
+        }
+    }
+}
+
+fn channel() -> &'static watch::Sender<Option<Platform>> {
+    static CHANNEL: OnceLock<watch::Sender<Option<Platform>>> = OnceLock::new();
+    CHANNEL.get_or_init(|| watch::channel(None).0)
+}
+
+/// Subscribe to platform updates. The initial value is `None` until the first
+/// `version` RPC after a successful connect completes.
+pub fn subscribe() -> watch::Receiver<Option<Platform>> {
+    channel().subscribe()
+}
+
+/// Snapshot of the last-known platform, or `None` before the first RPC.
+pub fn current() -> Option<Platform> {
+    channel().borrow().clone()
+}
+
+/// Internal: set the platform. Keeps writes funnelled through one place.
+fn publish(p: Platform) {
+    channel().send_replace(Some(p));
+}
+
+/// Spawns a task on `runtime` that issues a `version` RPC each time the
+/// client reports a successful connect, parses the response, and publishes
+/// the result to [`subscribe`] listeners.
+///
+/// Failure of the RPC is logged at `warn` and the platform is left at its
+/// prior value (or `None`). `systems` and other catalog fetches continue
+/// regardless.
+pub fn spawn_fetcher(client: Arc<Client>, runtime: &Arc<tokio::runtime::Runtime>) {
+    let mut connected_rx = client.connected.subscribe();
+    runtime.spawn(async move {
+        loop {
+            match connected_rx.recv().await {
+                Ok(true) => match client.version().await {
+                    Ok(VersionResult { version, platform }) => {
+                        let parsed = Platform::from_api_string(&platform);
+                        info!("core version: {version} platform: {parsed}");
+                        publish(parsed);
+                    }
+                    Err(e) => warn!("version RPC failed: {}", e.message),
+                },
+                Ok(false) => {}
+                Err(_) => break,
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(
+        clippy::expect_used,
+        clippy::unwrap_used,
+        clippy::panic,
+        reason = "tests should fail-fast on unexpected errors"
+    )]
+
+    use super::Platform;
+
+    #[test]
+    fn from_api_string_known_values() {
+        assert_eq!(Platform::from_api_string("mister"), Platform::Mister);
+        assert_eq!(Platform::from_api_string("MiSTer"), Platform::Mister);
+        assert_eq!(Platform::from_api_string("linux"), Platform::Linux);
+        assert_eq!(Platform::from_api_string("Linux"), Platform::Linux);
+        assert_eq!(Platform::from_api_string("windows"), Platform::Windows);
+        assert_eq!(Platform::from_api_string("win32"), Platform::Windows);
+        assert_eq!(Platform::from_api_string("mac"), Platform::Mac);
+        assert_eq!(Platform::from_api_string("darwin"), Platform::Mac);
+        assert_eq!(Platform::from_api_string("osx"), Platform::Mac);
+        assert_eq!(Platform::from_api_string("steamos"), Platform::SteamOs);
+        assert_eq!(
+            Platform::from_api_string("batocera"),
+            Platform::BatoceraLinux,
+        );
+        assert_eq!(
+            Platform::from_api_string("batocera-linux"),
+            Platform::BatoceraLinux,
+        );
+    }
+
+    #[test]
+    fn from_api_string_trims_and_lowercases() {
+        assert_eq!(Platform::from_api_string("  LINUX  "), Platform::Linux);
+    }
+
+    #[test]
+    fn from_api_string_unknown_preserves_original_casing() {
+        let p = Platform::from_api_string("Playdate");
+        match p {
+            Platform::Unknown(s) => assert_eq!(s, "Playdate"),
+            other => panic!("expected Unknown(...), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn from_api_string_empty_becomes_unknown_empty() {
+        assert_eq!(
+            Platform::from_api_string(""),
+            Platform::Unknown(String::new()),
+        );
+    }
+
+    #[test]
+    fn display_formats_known_and_unknown() {
+        assert_eq!(Platform::Mister.to_string(), "mister");
+        assert_eq!(Platform::BatoceraLinux.to_string(), "batocera-linux");
+        assert_eq!(Platform::Unknown(String::new()).to_string(), "unknown");
+        assert_eq!(
+            Platform::Unknown("custom".into()).to_string(),
+            "unknown(custom)",
+        );
+    }
+}

--- a/rust/zaparoo-core/src/platform_paths.rs
+++ b/rust/zaparoo-core/src/platform_paths.rs
@@ -2,14 +2,11 @@
 // Copyright (c) 2026 The Zaparoo Project Contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
+use crate::runtime;
 use std::path::PathBuf;
 
-pub fn is_mister() -> bool {
-    std::path::Path::new("/media/fat").exists()
-}
-
 pub fn config_file_path() -> PathBuf {
-    if is_mister() {
+    if runtime::current().is_mister() {
         PathBuf::from("/media/fat/zaparoo/launcher.toml")
     } else {
         dirs_next::config_dir()
@@ -20,7 +17,7 @@ pub fn config_file_path() -> PathBuf {
 }
 
 pub fn log_file_path() -> PathBuf {
-    if is_mister() {
+    if runtime::current().is_mister() {
         PathBuf::from("/tmp/zaparoo/launcher.log")
     } else {
         dirs_next::data_local_dir()
@@ -40,7 +37,8 @@ mod tests {
         reason = "tests should fail-fast on unexpected errors"
     )]
 
-    use super::{config_file_path, is_mister, log_file_path};
+    use super::{config_file_path, log_file_path};
+    use crate::runtime;
 
     #[test]
     fn paths_end_with_expected_filenames() {
@@ -58,10 +56,10 @@ mod tests {
     }
 
     #[test]
-    fn mister_detection_matches_configured_paths() {
-        // When /media/fat is absent, paths route through dirs_next (per-user dirs)
+    fn runtime_matches_configured_paths() {
+        // When runtime is Desktop, paths route through dirs_next (per-user dirs)
         // rather than the fixed MiSTer locations. Asserts the branches stay in sync.
-        if is_mister() {
+        if runtime::current().is_mister() {
             assert_eq!(
                 config_file_path().to_str(),
                 Some("/media/fat/zaparoo/launcher.toml")

--- a/rust/zaparoo-core/src/runtime.rs
+++ b/rust/zaparoo-core/src/runtime.rs
@@ -1,0 +1,73 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+//
+// Runtime: what device is the launcher binary running on?
+//
+// Independent of `platform` (which describes the Zaparoo Core server).
+// See docs/architecture.md for the gating rules.
+
+use std::sync::OnceLock;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Runtime {
+    Mister,
+    Desktop,
+}
+
+impl Runtime {
+    pub fn is_mister(self) -> bool {
+        matches!(self, Self::Mister)
+    }
+
+    pub fn is_desktop(self) -> bool {
+        matches!(self, Self::Desktop)
+    }
+}
+
+impl std::fmt::Display for Runtime {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Mister => "mister",
+            Self::Desktop => "desktop",
+        })
+    }
+}
+
+pub fn current() -> Runtime {
+    static CACHED: OnceLock<Runtime> = OnceLock::new();
+    *CACHED.get_or_init(detect)
+}
+
+fn detect() -> Runtime {
+    if std::path::Path::new("/media/fat").exists() {
+        Runtime::Mister
+    } else {
+        Runtime::Desktop
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{current, Runtime};
+
+    #[test]
+    fn current_is_stable_across_calls() {
+        let a = current();
+        let b = current();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn helpers_are_mutually_exclusive() {
+        for r in [Runtime::Mister, Runtime::Desktop] {
+            assert_ne!(r.is_mister(), r.is_desktop());
+        }
+    }
+
+    #[test]
+    fn display_matches_expected_tokens() {
+        assert_eq!(Runtime::Mister.to_string(), "mister");
+        assert_eq!(Runtime::Desktop.to_string(), "desktop");
+    }
+}

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -204,8 +204,8 @@ ApplicationWindow {
         Text {
             anchors.centerIn: gamesCarousel
             // qmllint disable compiler
-            visible: root.gamesRef.errorMessage !== ""
-            text: root.gamesRef.errorMessage
+            visible: (root.gamesRef.errorMessage ?? "") !== ""
+            text: root.gamesRef.errorMessage ?? ""
             // qmllint enable compiler
             font.family: Theme.fontRetro
             font.pixelSize: Sizing.fontSize(3)


### PR DESCRIPTION
## Summary

- **Splits the conflated \"MiSTer detection\" into two independent signals:** `Runtime` (what device the launcher runs on) and `Platform` (what device Zaparoo Core is running on). The two are orthogonal — the launcher on a desktop can talk to Core on a MiSTer, or vice versa. Full rationale + gating rules now in `docs/architecture.md`.
- **Adds the `version` RPC and wires Platform into the WebSocket connect path** via a `tokio::sync::watch` channel; `None` until the first successful call.
- **Renames the build-time gate** `ZAPAROO_MISTER=1` / `#[cfg(mister)]` → `ZAPAROO_RUNTIME=mister` / `#[cfg(zaparoo_runtime = \"mister\")]`. Value-based cfg leaves room for future runtimes without a second flag.
- **CI fix:** adds `jlumbroso/free-disk-space` (SHA-pinned) before the ARM32 toolchain build — Qt's qtdeclarative PCH compile was hitting \"No space left on device\" on `ubuntu-latest`. Gated so it only runs when the toolchain tag doesn't already exist.
- **Small Main.qml fix:** nullish-coalesce `errorMessage` to silence a QString/undefined warning on first paint.

## Why now

Foundational — future features (e.g. \"only show X when Core is MiSTer\", \"only attempt Y when the launcher runs on desktop\") need a standard, non-confused mechanism. Doing the split first prevents adding feature code to the wrong dimension.

## Files touched

| File | Role |
|---|---|
| `rust/zaparoo-core/src/runtime.rs` | **new** — Runtime enum, OnceLock-cached filesystem detection |
| `rust/zaparoo-core/src/platform.rs` | **new** — Platform enum + `subscribe()` watch channel + `spawn_fetcher` |
| `rust/zaparoo-core/src/client.rs`, `media_types.rs` | `version()` RPC + `VersionResult` |
| `rust/zaparoo-core/src/platform_paths.rs` | drops `is_mister()`; routes through `runtime::current()` |
| `rust/launcher/src/lib.rs` | spawns the platform fetcher alongside the systems task |
| `rust/launcher/build.rs`, `src/mister_runtime.rs`, `cmake/ZaparooRust.cmake` | rename env var + cfg |
| `docs/architecture.md` | new *Runtime vs Platform* section + gating rules; module graph refreshed |
| `src/ui/app/Main.qml` | `errorMessage ?? \"\"` to fix QString/undefined warning |
| `.github/workflows/toolchain-build.yml` | `jlumbroso/free-disk-space@v1.3.1` before ARM32 buildx |

## Test plan

- [x] `just lint` — clang-tidy, clippy, cargo-deny, qmllint all clean
- [x] `just test` — 31 Rust unit tests pass; QML tests pass
- [x] `just build && ./build/bin/launcher` — desktop boot clean, Runtime logs as `Desktop`
- [x] `just arm32 && just deploy-mister` — on-device boot clean, Runtime logs as `Mister`, `vmode` + `zaparoo.sh` still fire
- [x] FPS counter stays green at 720p (no visual regression)
- [ ] Next `toolchain-build.yml` run finishes ARM32 Qt build without \"No space left on device\"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime and platform detection and a background fetcher to learn core version/platform
  * Exposed core version retrieval to client APIs

* **Bug Fixes**
  * Prevented null/undefined error message rendering in the games screen

* **Documentation**
  * Clarified Runtime vs Platform behavior in architecture docs

* **Chores**
  * Reduced CI runner disk usage and renamed build configuration variable for runtime selection
<!-- end of auto-generated comment: release notes by coderabbit.ai -->