### PR TITLE
feat(ui): persist per-screen navigation state across relaunches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,12 @@ env:
   # Qt 6.7.2 (built from source in its own toolchain image); this env is
   # only for desktop CI via aqtinstall.
   QT_VERSION: "6.10.3"
+  # CI doesn't reuse incremental metadata across runs — it only bloats the
+  # cached `target/` and slows the Swatinem post-cache upload.
+  CARGO_INCREMENTAL: 0
+  # Strip debug info from test binaries to keep `target/` small for caching.
+  CARGO_PROFILE_TEST_DEBUG: 0
+  CARGO_TERM_COLOR: always
 
 jobs:
   rust-lint:
@@ -98,47 +104,10 @@ jobs:
         run: cargo nextest run --workspace
 
   desktop-build:
-    name: Desktop build + ctest
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Install system deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            cmake ninja-build mold \
-            libgl1-mesa-dev libxkbcommon-dev libxcb-xkb-dev \
-            libvulkan-dev
-      - name: Install Qt ${{ env.QT_VERSION }}
-        uses: jurplel/install-qt-action@48d3ad6db93f3627c8ee7a0454bc6f3744f7e730 # v4
-        with:
-          version: ${{ env.QT_VERSION }}
-          modules: qtshadertools
-          cache: true
-      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
-        with:
-          toolchain: stable
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          workspaces: rust
-          env-vars: "CARGO CC CFLAGS CXX CMAKE RUST QT"
-      - name: Configure
-        run: cmake --preset desktop-debug
-      - name: Build
-        run: cmake --build --preset desktop-debug
-      - name: Test
-        run: ctest --preset desktop-debug
-      - name: Upload launcher binary
-        if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: launcher-debug-${{ github.run_id }}
-          path: build/bin/launcher
-          if-no-files-found: warn
-          retention-days: 7
-
-  cpp-lint:
-    name: C++ / QML lint
+    # Folds the old `cpp-lint` job in: clang-tidy needs compile_commands.json
+    # and the autogen/moc outputs that the desktop build already produces, so
+    # running lint as the final step of the same job avoids building twice.
+    name: Desktop build + ctest + lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -162,12 +131,22 @@ jobs:
         with:
           workspaces: rust
           env-vars: "CARGO CC CFLAGS CXX CMAKE RUST QT"
-      - name: Configure (required for compile_commands.json)
+      - name: Configure
         run: cmake --preset desktop-debug
-      - name: Build (autogen + moc outputs needed by clang-tidy)
+      - name: Build
         run: cmake --build --preset desktop-debug
+      - name: Test
+        run: ctest --preset desktop-debug
       - name: Lint (clang-format + clang-tidy + qmllint)
         run: cmake --build build --target lint
+      - name: Upload launcher binary
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: launcher-debug-${{ github.run_id }}
+          path: build/bin/launcher
+          if-no-files-found: warn
+          retention-days: 7
 
   ensure-toolchain:
     name: Ensure ARM32 toolchain image

--- a/cmake/SyncCxxqtQmlModules.cmake
+++ b/cmake/SyncCxxqtQmlModules.cmake
@@ -1,0 +1,171 @@
+# Zaparoo Launcher
+# Copyright (c) 2026 The Zaparoo Project Contributors.
+# SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+#
+# Sync cxx-qt-generated QML module directories (qmldir + plugin.qmltypes)
+# from cargo's OUT_DIR into the central CMAKE_BINARY_DIR/qml tree, so Qt
+# tooling (qmllint in particular) can resolve types declared by Rust-side
+# QML plugins. cxx-qt writes these files under
+# <cargo_out>/qt-build-utils/qml_modules/<Module/Path>/ but qmllint only
+# searches the Qt qml output root; copying makes them siblings of the
+# C++-generated App/Theme/Ui modules.
+#
+# Also patches plugin.qmltypes to work around three cxx-qt 0.7 gaps that
+# make qmllint noisy against Rust-backed singletons. Remove the patch
+# block when we upgrade to cxx-qt 0.8, which adds first-class
+# qmllint/qmlls support:
+#
+#   1. `isSingleton: true` / `isCreatable: false` for types declared
+#      `QML_SINGLETON`. The macro lands in the C++ header but
+#      qmltyperegistrar does not forward it to .qmltypes, so without the
+#      patch qmllint treats every `Browse.QAppState.property` access as
+#      a static meta-object lookup and reports [missing-property].
+#
+#   2. `::std::int32_t` → `int`. cxx-qt-gen emits the C++ typedef
+#      verbatim (upstream issue cxx-qt#60). Qt's qmllint has no mapping
+#      from `::std::int32_t` to its built-in `int` type, so every
+#      int-valued property or method return trips [unresolved-type].
+#
+#   3. `prototype: "::rust::cxxqt1::CxxQtType<T>"` /
+#      `"::rust::cxxqt1::CxxQtThreading<T>"` → `"QObject"`. The cxx-qt
+#      bridge templates inherit from QObject at the C++ level, but
+#      qmllint sees them as unresolved types and therefore refuses to
+#      use a singleton as a `Connections.target:` (expects QObject).
+#
+#   4. `isFinal: true` on every Property of a singleton Component. QML
+#      singletons can't be subclassed, so the QQmlCompiler "Member X
+#      can be shadowed" warning is a false positive — qmllint only
+#      suppresses it when the member is marked final. Methods are left
+#      untouched: the qmltypes schema has no isFinal slot for Method
+#      (qmllint itself rejects it with "Expected only name, lineNumber,
+#      ..."), so method-shadowing warnings linger until we upgrade to
+#      cxx-qt 0.8.
+#
+# Run via:
+#   cmake -DCARGO_DIR=... -DDEST_QML_DIR=... -P SyncCxxqtQmlModules.cmake
+
+cmake_minimum_required(VERSION 3.22)
+
+if(NOT DEFINED CARGO_DIR)
+    message(FATAL_ERROR "SyncCxxqtQmlModules: CARGO_DIR is required")
+endif()
+if(NOT DEFINED DEST_QML_DIR)
+    message(FATAL_ERROR "SyncCxxqtQmlModules: DEST_QML_DIR is required")
+endif()
+
+file(GLOB_RECURSE _all_qmldirs "${CARGO_DIR}/*qmldir")
+
+set(_qmldirs "")
+foreach(_candidate IN LISTS _all_qmldirs)
+    if(_candidate MATCHES "/qt-build-utils/qml_modules/.+/qmldir$")
+        list(APPEND _qmldirs "${_candidate}")
+    endif()
+endforeach()
+
+foreach(_qmldir IN LISTS _qmldirs)
+    string(REGEX REPLACE
+        ".*/qt-build-utils/qml_modules/(.+)/qmldir$"
+        "\\1"
+        _module_path
+        "${_qmldir}"
+    )
+    get_filename_component(_src_dir "${_qmldir}" DIRECTORY)
+    set(_dst_dir "${DEST_QML_DIR}/${_module_path}")
+    file(MAKE_DIRECTORY "${_dst_dir}")
+    file(GLOB _contents "${_src_dir}/*")
+    foreach(_src_file IN LISTS _contents)
+        get_filename_component(_name "${_src_file}" NAME)
+        execute_process(
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                "${_src_file}" "${_dst_dir}/${_name}"
+        )
+    endforeach()
+endforeach()
+
+# ── Patch plugin.qmltypes for cxx-qt singletons ──────────────────────────────
+# Collect the set of QML element names declared as singletons by scanning
+# every cxx-qt-generated header for a QML_SINGLETON macro paired with a
+# Q_CLASSINFO("QML.Element", "<Name>") line. Then rewrite each synced
+# plugin.qmltypes so qmllint sees those Components as singletons.
+
+set(_singleton_names "")
+file(GLOB_RECURSE _all_cxxqt_headers "${CARGO_DIR}/*.cxxqt.h")
+foreach(_hdr IN LISTS _all_cxxqt_headers)
+    file(READ "${_hdr}" _hdr_content)
+    if(NOT _hdr_content MATCHES "QML_SINGLETON")
+        continue()
+    endif()
+    string(REGEX MATCHALL
+        "Q_CLASSINFO\\(\"QML.Element\", \"[A-Za-z_][A-Za-z0-9_]*\"\\)[ \t\r\n]*QML_SINGLETON"
+        _matches "${_hdr_content}")
+    foreach(_m IN LISTS _matches)
+        if(_m MATCHES "\"QML.Element\", \"([A-Za-z_][A-Za-z0-9_]*)\"")
+            list(APPEND _singleton_names "${CMAKE_MATCH_1}")
+        endif()
+    endforeach()
+endforeach()
+list(REMOVE_DUPLICATES _singleton_names)
+
+file(GLOB_RECURSE _synced_qmltypes "${DEST_QML_DIR}/*/plugin.qmltypes")
+foreach(_qt_file IN LISTS _synced_qmltypes)
+    file(READ "${_qt_file}" _qt_content)
+    set(_original "${_qt_content}")
+
+    # (1) Inject isSingleton / isCreatable for each QML_SINGLETON class.
+    # Idempotent — rerunning the sync target leaves the file unchanged
+    # once all three patches have already been applied.
+    foreach(_name IN LISTS _singleton_names)
+        string(REGEX MATCH
+            "name: \"${_name}\"\n[ \t]+accessSemantics: \"reference\"\n[ \t]+isSingleton: true"
+            _already "${_qt_content}")
+        if(_already)
+            continue()
+        endif()
+        string(REGEX REPLACE
+            "(name: \"${_name}\"\n)([ \t]+)(accessSemantics: \"reference\")"
+            "\\1\\2\\3\n\\2isSingleton: true\n\\2isCreatable: false"
+            _qt_content "${_qt_content}")
+    endforeach()
+
+    # (2) ::std::int32_t → int. qmltyperegistrar emits the C++ typedef
+    # spelled exactly like this; Qt's qmllint only knows the short form.
+    string(REPLACE "::std::int32_t" "int" _qt_content "${_qt_content}")
+
+    # (3) cxx-qt bridge template → QObject. The templated C++ ancestor
+    # is a QObject mixin, but qmllint can't see through unresolved
+    # template instantiations; collapsing to the concrete base unlocks
+    # Connections.target:, signal bindings, etc.
+    string(REGEX REPLACE
+        "prototype: \"::rust::cxxqt1::CxxQt(Type|Threading)<[^\"]+>\""
+        "prototype: \"QObject\""
+        _qt_content "${_qt_content}")
+
+    # (4) isFinal: true on every Property / multi-line Method.
+    # Only run when *every* Component in the file is a known singleton —
+    # non-singleton types can legitimately be subclassed, and marking
+    # their members final would be incorrect. Today all cxx-qt-backed
+    # types we register are singletons; the guard keeps this honest if
+    # that ever changes.
+    string(REGEX MATCHALL
+        "    Component \\{\n[ \t]+file: \"[^\"]+\"\n[ \t]+lineNumber: [0-9]+\n[ \t]+name: \"[^\"]+\""
+        _component_headers "${_qt_content}")
+    set(_non_singleton_components "")
+    foreach(_hdr IN LISTS _component_headers)
+        if(_hdr MATCHES "name: \"([^\"]+)\"")
+            list(FIND _singleton_names "${CMAKE_MATCH_1}" _sidx)
+            if(_sidx EQUAL -1)
+                list(APPEND _non_singleton_components "${CMAKE_MATCH_1}")
+            endif()
+        endif()
+    endforeach()
+    if(NOT _non_singleton_components)
+        string(REGEX REPLACE
+            "(Property \\{\n)([ \t]+)(name:)"
+            "\\1\\2isFinal: true\n\\2\\3"
+            _qt_content "${_qt_content}")
+    endif()
+
+    if(NOT _qt_content STREQUAL _original)
+        file(WRITE "${_qt_file}" "${_qt_content}")
+    endif()
+endforeach()

--- a/cmake/ZaparooLint.cmake
+++ b/cmake/ZaparooLint.cmake
@@ -94,4 +94,22 @@ add_dependencies(lint format-check tidy)
 
 if(TARGET all_qmllint)
     add_dependencies(lint all_qmllint)
+    # qmllint must see cxx-qt-generated qmldir + plugin.qmltypes under the
+    # Qt QML output root; otherwise Rust-backed singletons resolve as
+    # [unresolved-type]. The aggregate all_qmllint target lists per-module
+    # qmllint targets as siblings — ninja treats the dep list as unordered
+    # and will race qmllint against the sync unless each per-module target
+    # depends on the sync individually.
+    if(TARGET zaparoo_cxxqt_qml_sync)
+        add_dependencies(all_qmllint zaparoo_cxxqt_qml_sync)
+        foreach(_qmllint_target IN ITEMS
+                zaparoo_ui_app_qmllint
+                zaparoo_ui_components_qmllint
+                zaparoo_ui_theme_qmllint
+                tst_ui_qmllint)
+            if(TARGET ${_qmllint_target})
+                add_dependencies(${_qmllint_target} zaparoo_cxxqt_qml_sync)
+            endif()
+        endforeach()
+    endif()
 endif()

--- a/cmake/ZaparooRust.cmake
+++ b/cmake/ZaparooRust.cmake
@@ -107,6 +107,17 @@ target_link_libraries(launcher
         Qt6::QuickControls2
 )
 
+# Dummy CMake target satisfying qmlimportscanner's lookup for the cxx-qt
+# plugin. build/qml/Zaparoo/Browse/qmldir declares `optional plugin
+# Zaparoo_Browse`, and qt_import_qml_plugins() warns when that name has
+# no matching CMake target. The real plugin code is baked into
+# zaparoo_launcher_rs (already linked above); the INTERFACE target here
+# is a no-op link-wise but silences the "plugin will not be linked"
+# warning. Defined at global scope so tests/ui sees it too.
+if(NOT TARGET Zaparoo_Browse)
+    add_library(Zaparoo_Browse INTERFACE)
+endif()
+
 # Critical: documented Qt static-plugin machinery. Runs qmlimportscanner,
 # traverses the QML module dependency graph, and emits correct
 # Q_IMPORT_QML_PLUGIN calls + --whole-archive link lines for every Qt
@@ -140,4 +151,20 @@ endif()
 
 set_target_properties(launcher PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
+
+# ── cxx-qt QML module sync for tooling ───────────────────────────────────────
+# cxx-qt writes qmldir + plugin.qmltypes under cargo's OUT_DIR, which qmllint
+# does not search. Copy them into ${QT_QML_OUTPUT_DIRECTORY}/<module>/ so
+# qmllint's -I path resolves types (Browse.QAppState, Browse.GamesModel, …)
+# exposed by the Rust staticlib. The cmake script globs at build time because
+# Corrosion's hash-segmented path is not known at configure time.
+add_custom_target(zaparoo_cxxqt_qml_sync
+    COMMAND ${CMAKE_COMMAND}
+        -DCARGO_DIR=${CMAKE_BINARY_DIR}/cargo
+        -DDEST_QML_DIR=${CMAKE_BINARY_DIR}/qml
+        -P ${CMAKE_SOURCE_DIR}/cmake/SyncCxxqtQmlModules.cmake
+    DEPENDS cargo-build_zaparoo_launcher_rs
+    COMMENT "Syncing cxx-qt QML module manifests into ${CMAKE_BINARY_DIR}/qml"
+    VERBATIM
 )

--- a/rust/launcher/build.rs
+++ b/rust/launcher/build.rs
@@ -27,6 +27,9 @@ fn main() {
                 "src/models/systems.rs",
                 "src/models/games.rs",
                 "src/models/browse.rs",
+                "src/models/app_state.rs",
+                "src/models/hub_state.rs",
+                "src/models/games_state.rs",
             ],
             qml_files: &[],
             ..Default::default()

--- a/rust/launcher/src/lib.rs
+++ b/rust/launcher/src/lib.rs
@@ -32,9 +32,9 @@ pub unsafe extern "C" fn zaparoo_log_qt(level: u8, msg_ptr: *const u8, msg_len: 
 }
 
 use std::ffi::c_int;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use zaparoo_core::{
-    client::Client, config::load_config, logger::install, platform,
+    client::Client, config::load_config, logger::install, persist, platform,
     platform_paths::config_file_path, systems_catalog,
 };
 
@@ -70,8 +70,12 @@ pub extern "C" fn zaparoo_rust_init() -> c_int {
     platform::spawn_fetcher(client.clone(), &runtime);
     let catalog_tx = systems_catalog::spawn(client.clone(), &runtime);
 
+    // Load persisted UI state up front so per-screen singletons can seed
+    // their properties from a consistent snapshot during Initialize.
+    let persist_state = Arc::new(Mutex::new(persist::load()));
+
     // init_globals stores Arcs — runtime keeps running after this fn returns.
-    models::init_globals(runtime, client, catalog_tx);
+    models::init_globals(runtime, client, catalog_tx, persist_state);
 
     0
 }

--- a/rust/launcher/src/models/app_state.rs
+++ b/rust/launcher/src/models/app_state.rs
@@ -1,0 +1,76 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+//
+// `Browse.AppState` — top-level singleton for launch-resume routing.
+// Holds only the currently-active screen; every per-screen detail
+// lives in its own singleton (`Browse.HubState`, `Browse.GamesState`)
+// so a screen can evolve its schema without touching the others.
+
+use cxx_qt::{CxxQtType, Initialize};
+use cxx_qt_lib::QString;
+use std::pin::Pin;
+use zaparoo_core::persist;
+
+#[derive(Default)]
+pub struct AppStateRust {
+    active_screen: QString,
+}
+
+#[cxx_qt::bridge]
+pub mod ffi {
+    unsafe extern "C++" {
+        include!("model_includes.h");
+
+        type QString = cxx_qt_lib::QString;
+    }
+
+    unsafe extern "RustQt" {
+        #[qobject]
+        #[qml_element]
+        #[qml_singleton]
+        #[qproperty(QString, active_screen, READ, WRITE = set_active_screen, NOTIFY)]
+        type AppState = super::AppStateRust;
+
+        #[qinvokable]
+        fn set_active_screen(self: Pin<&mut AppState>, value: QString);
+    }
+
+    impl cxx_qt::Initialize for AppState {}
+}
+
+impl Initialize for ffi::AppState {
+    fn initialize(mut self: Pin<&mut Self>) {
+        let shared = crate::models::persist_state();
+        let snapshot = {
+            let guard = shared.lock().expect("persist mutex poisoned");
+            guard.active_screen.clone()
+        };
+        self.as_mut().rust_mut().active_screen = QString::from(snapshot.as_str());
+        // No *_changed emits here: QML bindings haven't attached yet
+        // during Initialize, and Main.qml reads the property directly
+        // in Component.onCompleted.
+    }
+}
+
+impl ffi::AppState {
+    fn set_active_screen(mut self: Pin<&mut Self>, value: QString) {
+        if self.active_screen == value {
+            return;
+        }
+        let value_str = value.to_string();
+        self.as_mut().rust_mut().active_screen = value;
+        self.as_mut().active_screen_changed();
+        persist_active_screen(value_str);
+    }
+}
+
+fn persist_active_screen(value: String) {
+    let shared = crate::models::persist_state();
+    let snapshot = {
+        let mut guard = shared.lock().expect("persist mutex poisoned");
+        guard.active_screen = value;
+        guard.clone()
+    };
+    persist::save(&snapshot);
+}

--- a/rust/launcher/src/models/categories.rs
+++ b/rust/launcher/src/models/categories.rs
@@ -40,6 +40,9 @@ pub mod ffi {
         #[qinvokable]
         fn category_at(self: &CategoriesModel, index: i32) -> QString;
 
+        #[qinvokable]
+        fn index_for_category(self: &CategoriesModel, name: &QString) -> i32;
+
         #[inherit]
         #[cxx_name = "beginResetModel"]
         fn begin_reset_model(self: Pin<&mut CategoriesModel>);
@@ -127,5 +130,16 @@ impl ffi::CategoriesModel {
             return QString::default();
         }
         QString::from(self.categories[index as usize].as_str())
+    }
+
+    fn index_for_category(&self, name: &QString) -> i32 {
+        let needle = name.to_string();
+        if needle.is_empty() {
+            return -1;
+        }
+        self.categories
+            .iter()
+            .position(|c| c == &needle)
+            .map_or(-1, |i| i as i32)
     }
 }

--- a/rust/launcher/src/models/games.rs
+++ b/rust/launcher/src/models/games.rs
@@ -77,6 +77,12 @@ pub mod ffi {
         fn name_at(self: &GamesModel, index: i32) -> QString;
 
         #[qinvokable]
+        fn path_at(self: &GamesModel, index: i32) -> QString;
+
+        #[qinvokable]
+        fn index_for_game_path(self: &GamesModel, path: &QString) -> i32;
+
+        #[qinvokable]
         fn set_selected_index(self: Pin<&mut GamesModel>, index: i32);
 
         #[inherit]
@@ -209,6 +215,24 @@ impl ffi::GamesModel {
             return QString::default();
         }
         QString::from(self.items[index as usize].name.as_str())
+    }
+
+    fn path_at(&self, index: i32) -> QString {
+        if index < 0 || index >= self.count {
+            return QString::default();
+        }
+        QString::from(self.items[index as usize].path.as_str())
+    }
+
+    fn index_for_game_path(&self, path: &QString) -> i32 {
+        let needle = path.to_string();
+        if needle.is_empty() {
+            return -1;
+        }
+        self.items
+            .iter()
+            .position(|item| item.path == needle)
+            .map_or(-1, |i| i as i32)
     }
 
     fn set_selected_index(mut self: Pin<&mut Self>, index: i32) {

--- a/rust/launcher/src/models/games_state.rs
+++ b/rust/launcher/src/models/games_state.rs
@@ -1,0 +1,89 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+//
+// `Browse.GamesState` — persisted state owned by the games screen.
+// Records the system currently scoped to the games grid and the
+// highlighted game path. Schema version is checked independently
+// from other screens on load (see `zaparoo_core::persist`).
+
+use cxx_qt::{CxxQtType, Initialize};
+use cxx_qt_lib::QString;
+use std::pin::Pin;
+use zaparoo_core::persist::{self, GamesState};
+
+#[derive(Default)]
+pub struct GamesStateRust {
+    system_id: QString,
+    game_path: QString,
+}
+
+#[cxx_qt::bridge]
+pub mod ffi {
+    unsafe extern "C++" {
+        include!("model_includes.h");
+
+        type QString = cxx_qt_lib::QString;
+    }
+
+    unsafe extern "RustQt" {
+        #[qobject]
+        #[qml_element]
+        #[qml_singleton]
+        #[qproperty(QString, system_id, READ, WRITE = set_system_id, NOTIFY)]
+        #[qproperty(QString, game_path, READ, WRITE = set_game_path, NOTIFY)]
+        type GamesState = super::GamesStateRust;
+
+        #[qinvokable]
+        fn set_system_id(self: Pin<&mut GamesState>, value: QString);
+
+        #[qinvokable]
+        fn set_game_path(self: Pin<&mut GamesState>, value: QString);
+    }
+
+    impl cxx_qt::Initialize for GamesState {}
+}
+
+impl Initialize for ffi::GamesState {
+    fn initialize(mut self: Pin<&mut Self>) {
+        let shared = crate::models::persist_state();
+        let snapshot: GamesState = {
+            let guard = shared.lock().expect("persist mutex poisoned");
+            guard.games.clone()
+        };
+        self.as_mut().rust_mut().system_id = QString::from(snapshot.system_id.as_str());
+        self.as_mut().rust_mut().game_path = QString::from(snapshot.game_path.as_str());
+    }
+}
+
+impl ffi::GamesState {
+    fn set_system_id(mut self: Pin<&mut Self>, value: QString) {
+        if self.system_id == value {
+            return;
+        }
+        let value_str = value.to_string();
+        self.as_mut().rust_mut().system_id = value;
+        self.as_mut().system_id_changed();
+        persist_games(|g| g.system_id = value_str);
+    }
+
+    fn set_game_path(mut self: Pin<&mut Self>, value: QString) {
+        if self.game_path == value {
+            return;
+        }
+        let value_str = value.to_string();
+        self.as_mut().rust_mut().game_path = value;
+        self.as_mut().game_path_changed();
+        persist_games(|g| g.game_path = value_str);
+    }
+}
+
+fn persist_games<F: FnOnce(&mut GamesState)>(mutator: F) {
+    let shared = crate::models::persist_state();
+    let snapshot = {
+        let mut guard = shared.lock().expect("persist mutex poisoned");
+        mutator(&mut guard.games);
+        guard.clone()
+    };
+    persist::save(&snapshot);
+}

--- a/rust/launcher/src/models/hub_state.rs
+++ b/rust/launcher/src/models/hub_state.rs
@@ -1,0 +1,105 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+//
+// `Browse.HubState` — persisted state owned by the hub screen.
+// `focus`, `category`, and the highlighted `system_id` at the moment
+// the user last left the hub. Schema version is checked independently
+// from other screens on load (see `zaparoo_core::persist`).
+
+use cxx_qt::{CxxQtType, Initialize};
+use cxx_qt_lib::QString;
+use std::pin::Pin;
+use zaparoo_core::persist::{self, HubState};
+
+#[derive(Default)]
+pub struct HubStateRust {
+    focus: QString,
+    category: QString,
+    system_id: QString,
+}
+
+#[cxx_qt::bridge]
+pub mod ffi {
+    unsafe extern "C++" {
+        include!("model_includes.h");
+
+        type QString = cxx_qt_lib::QString;
+    }
+
+    unsafe extern "RustQt" {
+        #[qobject]
+        #[qml_element]
+        #[qml_singleton]
+        #[qproperty(QString, focus, READ, WRITE = set_focus, NOTIFY)]
+        #[qproperty(QString, category, READ, WRITE = set_category, NOTIFY)]
+        #[qproperty(QString, system_id, READ, WRITE = set_system_id, NOTIFY)]
+        type HubState = super::HubStateRust;
+
+        #[qinvokable]
+        fn set_focus(self: Pin<&mut HubState>, value: QString);
+
+        #[qinvokable]
+        fn set_category(self: Pin<&mut HubState>, value: QString);
+
+        #[qinvokable]
+        fn set_system_id(self: Pin<&mut HubState>, value: QString);
+    }
+
+    impl cxx_qt::Initialize for HubState {}
+}
+
+impl Initialize for ffi::HubState {
+    fn initialize(mut self: Pin<&mut Self>) {
+        let shared = crate::models::persist_state();
+        let snapshot: HubState = {
+            let guard = shared.lock().expect("persist mutex poisoned");
+            guard.hub.clone()
+        };
+        self.as_mut().rust_mut().focus = QString::from(snapshot.focus.as_str());
+        self.as_mut().rust_mut().category = QString::from(snapshot.category.as_str());
+        self.as_mut().rust_mut().system_id = QString::from(snapshot.system_id.as_str());
+    }
+}
+
+impl ffi::HubState {
+    fn set_focus(mut self: Pin<&mut Self>, value: QString) {
+        if self.focus == value {
+            return;
+        }
+        let value_str = value.to_string();
+        self.as_mut().rust_mut().focus = value;
+        self.as_mut().focus_changed();
+        persist_hub(|h| h.focus = value_str);
+    }
+
+    fn set_category(mut self: Pin<&mut Self>, value: QString) {
+        if self.category == value {
+            return;
+        }
+        let value_str = value.to_string();
+        self.as_mut().rust_mut().category = value;
+        self.as_mut().category_changed();
+        persist_hub(|h| h.category = value_str);
+    }
+
+    fn set_system_id(mut self: Pin<&mut Self>, value: QString) {
+        if self.system_id == value {
+            return;
+        }
+        let value_str = value.to_string();
+        self.as_mut().rust_mut().system_id = value;
+        self.as_mut().system_id_changed();
+        persist_hub(|h| h.system_id = value_str);
+    }
+}
+
+fn persist_hub<F: FnOnce(&mut HubState)>(mutator: F) {
+    let shared = crate::models::persist_state();
+    let snapshot = {
+        let mut guard = shared.lock().expect("persist mutex poisoned");
+        mutator(&mut guard.hub);
+        guard.clone()
+    };
+    persist::save(&snapshot);
+}

--- a/rust/launcher/src/models/mod.rs
+++ b/rust/launcher/src/models/mod.rs
@@ -16,24 +16,29 @@
     reason = "process-local init invariants: any violation is a wiring bug and must be fatal"
 )]
 
+pub mod app_state;
 pub mod browse;
 pub mod categories;
 pub mod games;
+pub mod games_state;
+pub mod hub_state;
 pub mod systems;
 
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 use tokio::runtime::Runtime;
 use tokio::sync::watch;
-use zaparoo_core::{client::Client, systems_catalog::CatalogData};
+use zaparoo_core::{client::Client, persist::PersistedState, systems_catalog::CatalogData};
 
 static RUNTIME: OnceLock<Arc<Runtime>> = OnceLock::new();
 static CLIENT: OnceLock<Arc<Client>> = OnceLock::new();
 static CATALOG_TX: OnceLock<watch::Sender<Option<CatalogData>>> = OnceLock::new();
+static PERSIST_STATE: OnceLock<Arc<Mutex<PersistedState>>> = OnceLock::new();
 
 pub fn init_globals(
     runtime: Arc<Runtime>,
     client: Arc<Client>,
     catalog_tx: watch::Sender<Option<CatalogData>>,
+    persist_state: Arc<Mutex<PersistedState>>,
 ) {
     RUNTIME
         .set(runtime)
@@ -44,6 +49,9 @@ pub fn init_globals(
     CATALOG_TX
         .set(catalog_tx)
         .unwrap_or_else(|_| panic!("CATALOG_TX already initialized"));
+    PERSIST_STATE
+        .set(persist_state)
+        .unwrap_or_else(|_| panic!("PERSIST_STATE already initialized"));
 }
 
 pub fn global_runtime() -> Arc<Runtime> {
@@ -59,4 +67,11 @@ pub fn subscribe_catalog() -> watch::Receiver<Option<CatalogData>> {
         .get()
         .expect("CATALOG_TX not initialized")
         .subscribe()
+}
+
+pub fn persist_state() -> Arc<Mutex<PersistedState>> {
+    PERSIST_STATE
+        .get()
+        .expect("PERSIST_STATE not initialized")
+        .clone()
 }

--- a/rust/launcher/src/models/systems.rs
+++ b/rust/launcher/src/models/systems.rs
@@ -75,6 +75,9 @@ pub mod ffi {
         #[qinvokable]
         fn system_name_at(self: &SystemsModel, index: i32) -> QString;
 
+        #[qinvokable]
+        fn index_for_system_id(self: &SystemsModel, id: &QString) -> i32;
+
         #[inherit]
         #[cxx_name = "beginResetModel"]
         fn begin_reset_model(self: Pin<&mut SystemsModel>);
@@ -214,5 +217,16 @@ impl ffi::SystemsModel {
             return QString::default();
         }
         QString::from(self.systems[index as usize].name.as_str())
+    }
+
+    fn index_for_system_id(&self, id: &QString) -> i32 {
+        let needle = id.to_string();
+        if needle.is_empty() {
+            return -1;
+        }
+        self.systems
+            .iter()
+            .position(|s| s.id == needle)
+            .map_or(-1, |i| i as i32)
     }
 }

--- a/rust/zaparoo-core/src/lib.rs
+++ b/rust/zaparoo-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod client;
 pub mod config;
 pub mod logger;
 pub mod media_types;
+pub mod persist;
 pub mod platform;
 pub mod platform_paths;
 pub mod runtime;

--- a/rust/zaparoo-core/src/persist.rs
+++ b/rust/zaparoo-core/src/persist.rs
@@ -1,0 +1,336 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+//
+// Persistent UI state. MiSTer's parent process kills the launcher binary
+// without notice; every user-visible navigation choice must round-trip
+// through disk so the next boot resumes where the user was.
+//
+// Layout: a single TOML with one section per screen. Each section owns
+// its own `schema_version` so a screen can evolve its schema (rename
+// fields, change types) without forcing other screens to reset. On
+// load, any section whose `schema_version` doesn't match the current
+// owner's constant is replaced with `Default` — other sections
+// survive.
+//
+// Written synchronously on every mutation (write-through). Parent can
+// SIGKILL between any two lines, so the loss window must be zero. File
+// is tiny (<300 bytes) and lives on tmpfs on MiSTer; sync cost on the
+// Qt thread is microseconds.
+
+use crate::platform_paths::state_file_path;
+use serde::{Deserialize, Serialize};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use tracing::warn;
+
+pub const HUB_SCHEMA: u32 = 1;
+pub const GAMES_SCHEMA: u32 = 1;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct PersistedState {
+    pub active_screen: String,
+    pub hub: HubState,
+    pub games: GamesState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct HubState {
+    pub schema_version: u32,
+    pub focus: String,
+    pub category: String,
+    pub system_id: String,
+}
+
+impl Default for HubState {
+    fn default() -> Self {
+        Self {
+            schema_version: HUB_SCHEMA,
+            focus: String::new(),
+            category: String::new(),
+            system_id: String::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct GamesState {
+    pub schema_version: u32,
+    pub system_id: String,
+    pub game_path: String,
+}
+
+impl Default for GamesState {
+    fn default() -> Self {
+        Self {
+            schema_version: GAMES_SCHEMA,
+            system_id: String::new(),
+            game_path: String::new(),
+        }
+    }
+}
+
+pub fn load() -> PersistedState {
+    load_from(&state_file_path())
+}
+
+pub fn save(state: &PersistedState) {
+    save_to(&state_file_path(), state);
+}
+
+fn load_from(path: &Path) -> PersistedState {
+    let Ok(src) = std::fs::read_to_string(path) else {
+        return PersistedState::default();
+    };
+    let mut state: PersistedState = match toml::from_str(&src) {
+        Ok(s) => s,
+        Err(e) => {
+            warn!("persist state parse error in {}: {e}", path.display());
+            return PersistedState::default();
+        }
+    };
+    if state.hub.schema_version != HUB_SCHEMA {
+        warn!(
+            "persist: hub section version {} != expected {}; resetting section",
+            state.hub.schema_version, HUB_SCHEMA
+        );
+        state.hub = HubState::default();
+    }
+    if state.games.schema_version != GAMES_SCHEMA {
+        warn!(
+            "persist: games section version {} != expected {}; resetting section",
+            state.games.schema_version, GAMES_SCHEMA
+        );
+        state.games = GamesState::default();
+    }
+    state
+}
+
+fn save_to(path: &Path, state: &PersistedState) {
+    let serialized = match toml::to_string(state) {
+        Ok(s) => s,
+        Err(e) => {
+            warn!("persist state serialisation failed: {e}");
+            return;
+        }
+    };
+    if let Some(parent) = path.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            warn!("could not create {}: {e}", parent.display());
+            return;
+        }
+    }
+    // Atomic replace: write to a unique sibling temp file, then rename. A
+    // crash mid-write leaves the temp behind but never a torn state.toml.
+    let tmp = tmp_sibling(path);
+    match std::fs::File::create(&tmp).and_then(|mut f| {
+        f.write_all(serialized.as_bytes())?;
+        f.sync_all()?;
+        Ok(())
+    }) {
+        Ok(()) => {}
+        Err(e) => {
+            warn!("persist state write to {} failed: {e}", tmp.display());
+            let _ = std::fs::remove_file(&tmp);
+            return;
+        }
+    }
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        warn!(
+            "persist state rename {} → {} failed: {e}",
+            tmp.display(),
+            path.display()
+        );
+        let _ = std::fs::remove_file(&tmp);
+    }
+}
+
+fn tmp_sibling(path: &Path) -> PathBuf {
+    // Per-process-and-thread suffix keeps concurrent writers from
+    // clobbering each other's temp file and then racing on rename. The
+    // final rename is still atomic; only the last one wins, which is the
+    // desired semantics.
+    let pid = std::process::id();
+    let tid = format!("{:?}", std::thread::current().id());
+    let tid_clean: String = tid.chars().filter(char::is_ascii_alphanumeric).collect();
+    let suffix = format!(".tmp.{pid}.{tid_clean}");
+    let mut buf = path.as_os_str().to_owned();
+    buf.push(&suffix);
+    PathBuf::from(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(
+        clippy::expect_used,
+        clippy::unwrap_used,
+        clippy::panic,
+        reason = "tests should fail-fast on unexpected errors"
+    )]
+
+    use super::{
+        load_from, save_to, GamesState, HubState, PersistedState, GAMES_SCHEMA, HUB_SCHEMA,
+    };
+    use std::thread;
+
+    #[test]
+    fn load_returns_default_on_missing_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("missing.toml");
+        let state = load_from(&path);
+        assert_eq!(state, PersistedState::default());
+        assert_eq!(state.hub.schema_version, HUB_SCHEMA);
+        assert_eq!(state.games.schema_version, GAMES_SCHEMA);
+    }
+
+    #[test]
+    fn save_then_load_round_trips_all_sections() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("state.toml");
+        let original = PersistedState {
+            active_screen: "games".into(),
+            hub: HubState {
+                schema_version: HUB_SCHEMA,
+                focus: "systems".into(),
+                category: "Consoles".into(),
+                system_id: "nes".into(),
+            },
+            games: GamesState {
+                schema_version: GAMES_SCHEMA,
+                system_id: "nes".into(),
+                game_path: "/roms/smb.nes".into(),
+            },
+        };
+        save_to(&path, &original);
+        let loaded = load_from(&path);
+        assert_eq!(loaded, original);
+    }
+
+    #[test]
+    fn load_from_malformed_toml_returns_default() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("state.toml");
+        std::fs::write(&path, "this is = not [ valid toml").expect("write");
+        let state = load_from(&path);
+        assert_eq!(state, PersistedState::default());
+    }
+
+    #[test]
+    fn section_with_unknown_schema_version_resets_only_that_section() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("state.toml");
+        // Hub with a stale version; games at current. Hub must reset,
+        // games must be preserved intact.
+        let on_disk = format!(
+            r#"active_screen = "games"
+
+[hub]
+schema_version = 999
+focus = "systems"
+category = "ancient"
+system_id = "ancient_sys"
+
+[games]
+schema_version = {GAMES_SCHEMA}
+system_id = "nes"
+game_path = "/roms/smb.nes"
+"#
+        );
+        std::fs::write(&path, on_disk).expect("write");
+        let state = load_from(&path);
+        assert_eq!(state.active_screen, "games");
+        assert_eq!(state.hub, HubState::default(), "hub should reset");
+        assert_eq!(state.games.schema_version, GAMES_SCHEMA);
+        assert_eq!(state.games.system_id, "nes");
+        assert_eq!(state.games.game_path, "/roms/smb.nes");
+    }
+
+    #[test]
+    fn save_creates_parent_directories() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let nested = dir.path().join("deeper").join("sub").join("state.toml");
+        save_to(&nested, &PersistedState::default());
+        assert!(nested.exists(), "state file was not created at {nested:?}");
+    }
+
+    #[test]
+    fn save_is_atomic_under_concurrent_writes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("state.toml");
+        let handles: Vec<_> = (0..8)
+            .map(|i| {
+                let path = path.clone();
+                thread::spawn(move || {
+                    for j in 0..20 {
+                        let state = PersistedState {
+                            active_screen: format!("screen-{i}"),
+                            hub: HubState {
+                                schema_version: HUB_SCHEMA,
+                                focus: format!("focus-{j}"),
+                                category: format!("cat-{i}-{j}"),
+                                system_id: format!("sys-{i}-{j}"),
+                            },
+                            games: GamesState {
+                                schema_version: GAMES_SCHEMA,
+                                system_id: format!("sys-{i}-{j}"),
+                                game_path: format!("/roms/{i}/{j}.rom"),
+                            },
+                        };
+                        save_to(&path, &state);
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().expect("thread join");
+        }
+        let final_state = load_from(&path);
+        assert!(final_state.active_screen.starts_with("screen-"));
+        assert!(final_state.hub.focus.starts_with("focus-"));
+        assert_eq!(final_state.hub.schema_version, HUB_SCHEMA);
+        assert_eq!(final_state.games.schema_version, GAMES_SCHEMA);
+    }
+
+    #[test]
+    fn empty_sections_deserialise_via_default() {
+        // A file with only `active_screen` — both sections should
+        // populate from `Default`, which sets the current schema_version.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("state.toml");
+        std::fs::write(&path, "active_screen = \"hub\"\n").expect("write");
+        let state = load_from(&path);
+        assert_eq!(state.active_screen, "hub");
+        assert_eq!(state.hub, HubState::default());
+        assert_eq!(state.games, GamesState::default());
+    }
+
+    #[test]
+    fn unknown_field_in_section_is_ignored() {
+        // Forward-compat: adding a new field in a future version then
+        // downgrading should not wipe state. Serde default drops
+        // unknown fields silently.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("state.toml");
+        let on_disk = format!(
+            r#"[hub]
+schema_version = {HUB_SCHEMA}
+focus = "categories"
+category = "Arcade"
+system_id = "nes"
+future_field = "ignored"
+
+[games]
+schema_version = {GAMES_SCHEMA}
+system_id = "nes"
+game_path = "/x.rom"
+"#
+        );
+        std::fs::write(&path, on_disk).expect("write");
+        let state = load_from(&path);
+        assert_eq!(state.hub.category, "Arcade");
+        assert_eq!(state.games.game_path, "/x.rom");
+    }
+}

--- a/rust/zaparoo-core/src/platform_paths.rs
+++ b/rust/zaparoo-core/src/platform_paths.rs
@@ -28,6 +28,24 @@ pub fn log_file_path() -> PathBuf {
     }
 }
 
+pub fn state_file_path() -> PathBuf {
+    // ZAPAROO_STATE_FILE lets tests (and ad-hoc runs) redirect state
+    // persistence away from the real user path. Checked first so the
+    // override applies on every platform.
+    if let Ok(custom) = std::env::var("ZAPAROO_STATE_FILE") {
+        if !custom.is_empty() {
+            return PathBuf::from(custom);
+        }
+    }
+    if runtime::current().is_mister() {
+        PathBuf::from("/tmp/zaparoo/state.toml")
+    } else {
+        let mut path = config_file_path();
+        path.set_file_name("state.toml");
+        path
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(
@@ -37,7 +55,7 @@ mod tests {
         reason = "tests should fail-fast on unexpected errors"
     )]
 
-    use super::{config_file_path, log_file_path};
+    use super::{config_file_path, log_file_path, state_file_path};
     use crate::runtime;
 
     #[test]
@@ -53,6 +71,12 @@ mod tests {
             log.file_name().and_then(|n| n.to_str()),
             Some("launcher.log")
         );
+
+        let state = state_file_path();
+        assert_eq!(
+            state.file_name().and_then(|n| n.to_str()),
+            Some("state.toml")
+        );
     }
 
     #[test]
@@ -65,6 +89,7 @@ mod tests {
                 Some("/media/fat/zaparoo/launcher.toml")
             );
             assert_eq!(log_file_path().to_str(), Some("/tmp/zaparoo/launcher.log"));
+            assert_eq!(state_file_path().to_str(), Some("/tmp/zaparoo/state.toml"));
         } else {
             let cfg = config_file_path();
             assert!(
@@ -76,6 +101,25 @@ mod tests {
                 log.ends_with("zaparoo/logs/launcher.log"),
                 "log path did not end with zaparoo/logs/launcher.log: {log:?}"
             );
+            let state = state_file_path();
+            assert!(
+                state.ends_with("zaparoo/state.toml"),
+                "state path did not end with zaparoo/state.toml: {state:?}"
+            );
         }
+    }
+
+    #[test]
+    fn state_file_sits_next_to_config_file_on_desktop() {
+        if runtime::current().is_mister() {
+            return;
+        }
+        let cfg = config_file_path();
+        let state = state_file_path();
+        assert_eq!(
+            cfg.parent(),
+            state.parent(),
+            "state.toml must be a sibling of launcher.toml: cfg={cfg:?} state={state:?}"
+        );
     }
 }

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -9,6 +9,13 @@ import Zaparoo.Ui
 import Zaparoo.Theme
 import Zaparoo.Browse as Browse
 
+// cxx-qt 0.7 doesn't emit FINAL markers in plugin.qmltypes, so qmllint
+// flags every call on a Zaparoo.Browse singleton as "can be shadowed".
+// Nearly every statement in this file touches one, so silence the whole
+// category here rather than sprinkling block pragmas. Remove after the
+// cxx-qt 0.8 upgrade (which fixes the qmltypes emission).
+// qmllint disable compiler
+
 ApplicationWindow {
     id: root
 
@@ -47,6 +54,12 @@ ApplicationWindow {
         const savedFocus = Browse.HubState.focus
         if (savedFocus === root.focusCategories || savedFocus === root.focusSystems)
             root.hubFocus = savedFocus
+        // If Core responded before Main.qml finished loading, CategoriesModel
+        // has already emitted modelReset and the Connections below missed it.
+        // Kick the restore chain manually; the set_category cascade re-fires
+        // SystemsModel.modelReset (now wired) which cascades into GamesModel.
+        if (Browse.CategoriesModel.count > 0)
+            root.restoreFromCategoriesReset()
     }
 
     // Screen state.
@@ -63,31 +76,27 @@ ApplicationWindow {
         }
     }
 
-    // Reset carousel indices when models deliver new data, then restore the
-    // last-saved identifier if it's still present. A miss (system removed, ROM
-    // deleted) silently falls back to index 0. Each handler also cascades to
-    // the next model so the full hub→systems→games chain restores in order.
-    //
-    // Each handler body sits inside a qmllint `disable compiler` block.
-    // cxx-qt 0.7 can't mark #[qinvokable] methods final in plugin.qmltypes,
-    // so every call below trips "can be shadowed" even though these
-    // singletons are non-subclassable. Drop the pragmas after the cxx-qt
-    // 0.8 upgrade, which adds proper qmllint/qmlls support.
+    // Seed carousel indices from persisted state when models deliver new data.
+    // A miss (system removed, ROM deleted) falls back to index 0 and leaves
+    // the saved identifier untouched on disk — so the user's intent survives
+    // a transient catalog gap. State writes only happen in handleKey (user
+    // navigation); these programmatic seeds are inert with respect to state.
+    function restoreFromCategoriesReset(): void {
+        const savedCategory = Browse.HubState.category
+        const idx = savedCategory === "" ? -1 : Browse.CategoriesModel.index_for_category(savedCategory)
+        categoriesCarousel.currentIndex = idx >= 0 ? idx : 0
+        if (savedCategory !== "")
+            Browse.SystemsModel.set_category(savedCategory)
+    }
+
     Connections {
         target: Browse.CategoriesModel
-        // qmllint disable compiler
         function onModelReset(): void {
-            const savedCategory = Browse.HubState.category
-            const idx = savedCategory === "" ? -1 : Browse.CategoriesModel.index_for_category(savedCategory)
-            categoriesCarousel.currentIndex = idx >= 0 ? idx : 0
-            if (savedCategory !== "")
-                Browse.SystemsModel.set_category(savedCategory)
+            root.restoreFromCategoriesReset()
         }
-        // qmllint enable compiler
     }
     Connections {
         target: Browse.SystemsModel
-        // qmllint disable compiler
         // On a games-screen restore, the saved system lives in GamesState —
         // the hub's own system_id may be stale or unset. Fall back to
         // HubState otherwise (resume into hub, or first launch).
@@ -100,17 +109,14 @@ ApplicationWindow {
             if (idx >= 0)
                 Browse.GamesModel.set_system(savedSystem)
         }
-        // qmllint enable compiler
     }
     Connections {
         target: Browse.GamesModel
-        // qmllint disable compiler
         function onModelReset(): void {
             const savedPath = Browse.GamesState.game_path
             const idx = savedPath === "" ? -1 : Browse.GamesModel.index_for_game_path(savedPath)
             gamesCarousel.currentIndex = idx >= 0 ? idx : 0
         }
-        // qmllint enable compiler
     }
 
     // ── Background ────────────────────────────────────────────────────────────
@@ -155,12 +161,6 @@ ApplicationWindow {
             delegate: TextTileDelegate {}
             placeholderCover: ""
 
-            // qmllint disable compiler
-            onCurrentIndexChanged: {
-                Browse.HubState.category = Browse.CategoriesModel.category_at(currentIndex)
-            }
-            // qmllint enable compiler
-
             Behavior on y {
                 NumberAnimation {
                     duration: 250
@@ -184,24 +184,16 @@ ApplicationWindow {
             model: Browse.SystemsModel
             delegate: TextTileDelegate {}
             placeholderCover: ""
-
-            // qmllint disable compiler
-            onCurrentIndexChanged: {
-                Browse.HubState.system_id = Browse.SystemsModel.system_id_at(currentIndex)
-            }
-            // qmllint enable compiler
         }
 
         Text {
             anchors.horizontalCenter: parent.horizontalCenter
             y: systemsCarousel.y + systemsCarousel.height + Sizing.pctH(1)
             visible: root.hubFocus === root.focusSystems
-            // qmllint disable compiler
             text: {
                 Browse.SystemsModel.count
                 return Browse.SystemsModel.system_name_at(systemsCarousel.currentIndex)
             }
-            // qmllint enable compiler
             font.family: Theme.fontRetro
             font.pixelSize: Sizing.fontSize(4)
             color: Theme.textPrimary
@@ -224,19 +216,10 @@ ApplicationWindow {
             y: Sizing.pctH(12)
             width: parent.width
             height: Sizing.pctH(55)
-            // qmllint disable compiler
             opacity: Browse.GamesModel.loading ? 0.5 : 1.0
             model: root.activeScreen === root.screenGames ? Browse.GamesModel : null
-            // qmllint enable compiler
             delegate: CoverDelegate {}
             placeholderCover: "qrc:/qt/qml/Zaparoo/App/resources/images/placeholder/cover_generic.png"
-
-            // qmllint disable compiler
-            onCurrentIndexChanged: {
-                Browse.GamesModel.set_selected_index(currentIndex)
-                Browse.GamesState.game_path = Browse.GamesModel.path_at(currentIndex)
-            }
-            // qmllint enable compiler
 
             Behavior on opacity {
                 NumberAnimation {
@@ -262,12 +245,10 @@ ApplicationWindow {
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.top: gamesCarousel.bottom
             anchors.topMargin: Sizing.pctH(1)
-            // qmllint disable compiler
             text: {
                 Browse.GamesModel.count
                 return Browse.GamesModel.name_at(gamesCarousel.currentIndex)
             }
-            // qmllint enable compiler
             font.family: Theme.fontRetro
             font.pixelSize: Sizing.fontSize(4)
             color: Theme.textPrimary
@@ -321,37 +302,50 @@ ApplicationWindow {
         Keys.onPressed: event => root.handleKey(event.key)
     }
 
-    // qmllint disable compiler
-    function navigateCarousel(carousel, delta) {
-        if (carousel.itemCount > 0)
-            carousel.currentIndex = (carousel.currentIndex + delta + carousel.itemCount) % carousel.itemCount
+    // Returns true if the carousel actually moved. Callers use this to gate
+    // persistence writes — navigating an empty carousel must not overwrite
+    // saved state with "" (the `_at(-1)` or `_at(0)` fallback on an empty
+    // model).
+    function navigateCarousel(carousel, delta): bool {
+        if (carousel.itemCount <= 0)
+            return false
+        carousel.currentIndex = (carousel.currentIndex + delta + carousel.itemCount) % carousel.itemCount
+        return true
     }
 
     // Navigation key router. Called by the focus Item's Keys.onPressed and
-    // directly from tests (offscreen key routing is unreliable). Kept as a
-    // pure function of root state + the three carousel ids.
+    // directly from tests (offscreen key routing is unreliable). Every
+    // user-initiated selection change writes through to the persisted state
+    // singletons *here* — the carousels themselves don't persist on index
+    // change, so programmatic seeds during restore leave disk state intact.
     function handleKey(key) {
         if (root.activeScreen === root.screenGames) {
             if (key === Qt.Key_Left) {
-                navigateCarousel(gamesCarousel, -1)
+                if (navigateCarousel(gamesCarousel, -1))
+                    Browse.GamesState.game_path = Browse.GamesModel.path_at(gamesCarousel.currentIndex)
             } else if (key === Qt.Key_Right) {
-                navigateCarousel(gamesCarousel, 1)
+                if (navigateCarousel(gamesCarousel, 1))
+                    Browse.GamesState.game_path = Browse.GamesModel.path_at(gamesCarousel.currentIndex)
             } else if (key === Qt.Key_Return || key === Qt.Key_Enter) {
-                Browse.GamesModel.launch_at(gamesCarousel.currentIndex)
+                if (gamesCarousel.itemCount > 0)
+                    Browse.GamesModel.launch_at(gamesCarousel.currentIndex)
             } else if (key === Qt.Key_Escape || key === Qt.Key_Backspace) {
                 root.activeScreen = root.screenHub
                 Browse.AppState.active_screen = root.screenHub
             }
         } else if (root.hubFocus === root.focusSystems) {
             if (key === Qt.Key_Left) {
-                navigateCarousel(systemsCarousel, -1)
+                if (navigateCarousel(systemsCarousel, -1))
+                    Browse.HubState.system_id = Browse.SystemsModel.system_id_at(systemsCarousel.currentIndex)
             } else if (key === Qt.Key_Right) {
-                navigateCarousel(systemsCarousel, 1)
+                if (navigateCarousel(systemsCarousel, 1))
+                    Browse.HubState.system_id = Browse.SystemsModel.system_id_at(systemsCarousel.currentIndex)
             } else if (key === Qt.Key_Return || key === Qt.Key_Enter) {
-                const chosen = Browse.SystemsModel.system_id_at(systemsCarousel.currentIndex)
-                Browse.GamesModel.set_system(chosen)
-                Browse.GamesState.system_id = chosen
-                gamesCarousel.currentIndex = 0
+                if (systemsCarousel.itemCount > 0) {
+                    const chosen = Browse.SystemsModel.system_id_at(systemsCarousel.currentIndex)
+                    Browse.GamesModel.set_system(chosen)
+                    Browse.GamesState.system_id = chosen
+                }
                 root.activeScreen = root.screenGames
                 Browse.AppState.active_screen = root.screenGames
             } else if (key === Qt.Key_Escape || key === Qt.Key_Backspace) {
@@ -360,12 +354,14 @@ ApplicationWindow {
             }
         } else {
             if (key === Qt.Key_Left) {
-                navigateCarousel(categoriesCarousel, -1)
+                if (navigateCarousel(categoriesCarousel, -1))
+                    Browse.HubState.category = Browse.CategoriesModel.category_at(categoriesCarousel.currentIndex)
             } else if (key === Qt.Key_Right) {
-                navigateCarousel(categoriesCarousel, 1)
+                if (navigateCarousel(categoriesCarousel, 1))
+                    Browse.HubState.category = Browse.CategoriesModel.category_at(categoriesCarousel.currentIndex)
             } else if (key === Qt.Key_Return || key === Qt.Key_Enter) {
-                systemsCarousel.currentIndex = 0
-                Browse.SystemsModel.set_category(Browse.CategoriesModel.category_at(categoriesCarousel.currentIndex))
+                if (categoriesCarousel.itemCount > 0)
+                    Browse.SystemsModel.set_category(Browse.CategoriesModel.category_at(categoriesCarousel.currentIndex))
                 root.hubFocus = root.focusSystems
                 Browse.HubState.focus = root.focusSystems
             } else if (key === Qt.Key_Escape || key === Qt.Key_Backspace) {
@@ -373,5 +369,4 @@ ApplicationWindow {
             }
         }
     }
-    // qmllint enable compiler
 }

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -337,8 +337,16 @@ ApplicationWindow {
                 if (navigateCarousel(gamesCarousel, 1))
                     Browse.GamesState.game_path = Browse.GamesModel.path_at(gamesCarousel.currentIndex)
             } else if (key === Qt.Key_Return || key === Qt.Key_Enter) {
-                if (gamesCarousel.itemCount > 0)
+                if (gamesCarousel.itemCount > 0) {
+                    // Persist before handing control away. Left/Right already
+                    // writes game_path on every move, but the user may press
+                    // Enter on the first highlighted game without navigating,
+                    // leaving game_path stale from a prior system. Writing
+                    // here makes the commit explicit so a kill during launch
+                    // resumes on the correct game.
+                    Browse.GamesState.game_path = Browse.GamesModel.path_at(gamesCarousel.currentIndex)
                     Browse.GamesModel.launch_at(gamesCarousel.currentIndex)
+                }
             } else if (key === Qt.Key_Escape || key === Qt.Key_Backspace) {
                 root.activeScreen = root.screenHub
                 Browse.AppState.active_screen = root.screenHub

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -12,13 +12,6 @@ import Zaparoo.Browse as Browse
 ApplicationWindow {
     id: root
 
-    // Typed local references to singletons — required for property access in tooling.
-    // qmllint disable compiler
-    readonly property Browse.CategoriesModel categoriesRef: Browse.CategoriesModel
-    readonly property Browse.SystemsModel systemsRef: Browse.SystemsModel
-    readonly property Browse.GamesModel gamesRef: Browse.GamesModel
-    // qmllint enable compiler
-
     // Screen/focus state constants — use these instead of bare string literals.
     readonly property string screenHub: "hub"
     readonly property string screenGames: "games"
@@ -44,6 +37,16 @@ ApplicationWindow {
     Component.onCompleted: {
         Sizing.screenWidth = width
         Sizing.screenHeight = height
+        // Restore screen/focus synchronously before first paint. The parent
+        // process on MiSTer kills the launcher without notice, so we resume
+        // exactly where we left off. Selection restore happens asynchronously
+        // in the modelReset handlers below as catalog data arrives.
+        const savedScreen = Browse.AppState.active_screen
+        if (savedScreen === root.screenGames || savedScreen === root.screenHub)
+            root.activeScreen = savedScreen
+        const savedFocus = Browse.HubState.focus
+        if (savedFocus === root.focusCategories || savedFocus === root.focusSystems)
+            root.hubFocus = savedFocus
     }
 
     // Screen state.
@@ -60,27 +63,55 @@ ApplicationWindow {
         }
     }
 
-    // Reset carousel indices when models deliver new data.
+    // Reset carousel indices when models deliver new data, then restore the
+    // last-saved identifier if it's still present. A miss (system removed, ROM
+    // deleted) silently falls back to index 0. Each handler also cascades to
+    // the next model so the full hub→systems→games chain restores in order.
+    //
+    // Each handler body sits inside a qmllint `disable compiler` block.
+    // cxx-qt 0.7 can't mark #[qinvokable] methods final in plugin.qmltypes,
+    // so every call below trips "can be shadowed" even though these
+    // singletons are non-subclassable. Drop the pragmas after the cxx-qt
+    // 0.8 upgrade, which adds proper qmllint/qmlls support.
     Connections {
-        target: root.categoriesRef
+        target: Browse.CategoriesModel
+        // qmllint disable compiler
         function onModelReset(): void {
-            categoriesCarousel.currentIndex = 0
+            const savedCategory = Browse.HubState.category
+            const idx = savedCategory === "" ? -1 : Browse.CategoriesModel.index_for_category(savedCategory)
+            categoriesCarousel.currentIndex = idx >= 0 ? idx : 0
+            if (savedCategory !== "")
+                Browse.SystemsModel.set_category(savedCategory)
         }
+        // qmllint enable compiler
     }
     Connections {
-        target: root.systemsRef
+        target: Browse.SystemsModel
+        // qmllint disable compiler
+        // On a games-screen restore, the saved system lives in GamesState —
+        // the hub's own system_id may be stale or unset. Fall back to
+        // HubState otherwise (resume into hub, or first launch).
         function onModelReset(): void {
-            systemsCarousel.currentIndex = 0
+            const savedSystem = root.activeScreen === root.screenGames
+                ? Browse.GamesState.system_id
+                : Browse.HubState.system_id
+            const idx = savedSystem === "" ? -1 : Browse.SystemsModel.index_for_system_id(savedSystem)
+            systemsCarousel.currentIndex = idx >= 0 ? idx : 0
+            if (idx >= 0)
+                Browse.GamesModel.set_system(savedSystem)
         }
+        // qmllint enable compiler
     }
-    // qmllint disable compiler
     Connections {
-        target: root.gamesRef
+        target: Browse.GamesModel
+        // qmllint disable compiler
         function onModelReset(): void {
-            gamesCarousel.currentIndex = 0
+            const savedPath = Browse.GamesState.game_path
+            const idx = savedPath === "" ? -1 : Browse.GamesModel.index_for_game_path(savedPath)
+            gamesCarousel.currentIndex = idx >= 0 ? idx : 0
         }
+        // qmllint enable compiler
     }
-    // qmllint enable compiler
 
     // ── Background ────────────────────────────────────────────────────────────
 
@@ -120,9 +151,15 @@ ApplicationWindow {
             coverHeight: Sizing.pctH(20)
             coverSpacing: Sizing.pctH(23)
 
-            model: root.categoriesRef
+            model: Browse.CategoriesModel
             delegate: TextTileDelegate {}
             placeholderCover: ""
+
+            // qmllint disable compiler
+            onCurrentIndexChanged: {
+                Browse.HubState.category = Browse.CategoriesModel.category_at(currentIndex)
+            }
+            // qmllint enable compiler
 
             Behavior on y {
                 NumberAnimation {
@@ -144,9 +181,15 @@ ApplicationWindow {
             coverHeight: Sizing.pctH(20)
             coverSpacing: Sizing.pctH(23)
 
-            model: root.systemsRef
+            model: Browse.SystemsModel
             delegate: TextTileDelegate {}
             placeholderCover: ""
+
+            // qmllint disable compiler
+            onCurrentIndexChanged: {
+                Browse.HubState.system_id = Browse.SystemsModel.system_id_at(currentIndex)
+            }
+            // qmllint enable compiler
         }
 
         Text {
@@ -155,8 +198,8 @@ ApplicationWindow {
             visible: root.hubFocus === root.focusSystems
             // qmllint disable compiler
             text: {
-                root.systemsRef.count
-                return root.systemsRef.system_name_at(systemsCarousel.currentIndex)
+                Browse.SystemsModel.count
+                return Browse.SystemsModel.system_name_at(systemsCarousel.currentIndex)
             }
             // qmllint enable compiler
             font.family: Theme.fontRetro
@@ -182,17 +225,18 @@ ApplicationWindow {
             width: parent.width
             height: Sizing.pctH(55)
             // qmllint disable compiler
-            opacity: root.gamesRef.loading ? 0.5 : 1.0
-            model: root.activeScreen === root.screenGames ? root.gamesRef : null
+            opacity: Browse.GamesModel.loading ? 0.5 : 1.0
+            model: root.activeScreen === root.screenGames ? Browse.GamesModel : null
             // qmllint enable compiler
             delegate: CoverDelegate {}
             placeholderCover: "qrc:/qt/qml/Zaparoo/App/resources/images/placeholder/cover_generic.png"
 
+            // qmllint disable compiler
             onCurrentIndexChanged: {
-                // qmllint disable compiler
-                root.gamesRef.set_selected_index(currentIndex)
-                // qmllint enable compiler
+                Browse.GamesModel.set_selected_index(currentIndex)
+                Browse.GamesState.game_path = Browse.GamesModel.path_at(currentIndex)
             }
+            // qmllint enable compiler
 
             Behavior on opacity {
                 NumberAnimation {
@@ -203,10 +247,8 @@ ApplicationWindow {
 
         Text {
             anchors.centerIn: gamesCarousel
-            // qmllint disable compiler
-            visible: (root.gamesRef.errorMessage ?? "") !== ""
-            text: root.gamesRef.errorMessage ?? ""
-            // qmllint enable compiler
+            visible: (Browse.GamesModel.error_message ?? "") !== ""
+            text: Browse.GamesModel.error_message ?? ""
             font.family: Theme.fontRetro
             font.pixelSize: Sizing.fontSize(3)
             color: Theme.textDim
@@ -222,8 +264,8 @@ ApplicationWindow {
             anchors.topMargin: Sizing.pctH(1)
             // qmllint disable compiler
             text: {
-                root.gamesRef.count
-                return root.gamesRef.name_at(gamesCarousel.currentIndex)
+                Browse.GamesModel.count
+                return Browse.GamesModel.name_at(gamesCarousel.currentIndex)
             }
             // qmllint enable compiler
             font.family: Theme.fontRetro
@@ -295,9 +337,10 @@ ApplicationWindow {
             } else if (key === Qt.Key_Right) {
                 navigateCarousel(gamesCarousel, 1)
             } else if (key === Qt.Key_Return || key === Qt.Key_Enter) {
-                root.gamesRef.launch_at(gamesCarousel.currentIndex)
+                Browse.GamesModel.launch_at(gamesCarousel.currentIndex)
             } else if (key === Qt.Key_Escape || key === Qt.Key_Backspace) {
                 root.activeScreen = root.screenHub
+                Browse.AppState.active_screen = root.screenHub
             }
         } else if (root.hubFocus === root.focusSystems) {
             if (key === Qt.Key_Left) {
@@ -305,11 +348,15 @@ ApplicationWindow {
             } else if (key === Qt.Key_Right) {
                 navigateCarousel(systemsCarousel, 1)
             } else if (key === Qt.Key_Return || key === Qt.Key_Enter) {
-                root.gamesRef.set_system(root.systemsRef.system_id_at(systemsCarousel.currentIndex))
+                const chosen = Browse.SystemsModel.system_id_at(systemsCarousel.currentIndex)
+                Browse.GamesModel.set_system(chosen)
+                Browse.GamesState.system_id = chosen
                 gamesCarousel.currentIndex = 0
                 root.activeScreen = root.screenGames
+                Browse.AppState.active_screen = root.screenGames
             } else if (key === Qt.Key_Escape || key === Qt.Key_Backspace) {
                 root.hubFocus = root.focusCategories
+                Browse.HubState.focus = root.focusCategories
             }
         } else {
             if (key === Qt.Key_Left) {
@@ -318,8 +365,9 @@ ApplicationWindow {
                 navigateCarousel(categoriesCarousel, 1)
             } else if (key === Qt.Key_Return || key === Qt.Key_Enter) {
                 systemsCarousel.currentIndex = 0
-                root.systemsRef.set_category(root.categoriesRef.category_at(categoriesCarousel.currentIndex))
+                Browse.SystemsModel.set_category(Browse.CategoriesModel.category_at(categoriesCarousel.currentIndex))
                 root.hubFocus = root.focusSystems
+                Browse.HubState.focus = root.focusSystems
             } else if (key === Qt.Key_Escape || key === Qt.Key_Backspace) {
                 Qt.quit()
             }

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -77,16 +77,22 @@ ApplicationWindow {
     }
 
     // Seed carousel indices from persisted state when models deliver new data.
-    // A miss (system removed, ROM deleted) falls back to index 0 and leaves
+    // A miss (category renamed, ROM deleted) falls back to index 0 and leaves
     // the saved identifier untouched on disk — so the user's intent survives
     // a transient catalog gap. State writes only happen in handleKey (user
     // navigation); these programmatic seeds are inert with respect to state.
+    //
+    // Always cascade into set_category (even on a miss or first-launch empty
+    // HubState.category): SystemsModel is the only way to drive the next
+    // onModelReset handler, and a games-screen restore depends on that chain
+    // firing so GamesModel.set_system runs.
     function restoreFromCategoriesReset(): void {
         const savedCategory = Browse.HubState.category
         const idx = savedCategory === "" ? -1 : Browse.CategoriesModel.index_for_category(savedCategory)
-        categoriesCarousel.currentIndex = idx >= 0 ? idx : 0
-        if (savedCategory !== "")
-            Browse.SystemsModel.set_category(savedCategory)
+        const chosenIndex = idx >= 0 ? idx : 0
+        const chosenCategory = idx >= 0 ? savedCategory : Browse.CategoriesModel.category_at(chosenIndex)
+        categoriesCarousel.currentIndex = chosenIndex
+        Browse.SystemsModel.set_category(chosenCategory)
     }
 
     Connections {
@@ -97,12 +103,16 @@ ApplicationWindow {
     }
     Connections {
         target: Browse.SystemsModel
-        // On a games-screen restore, the saved system lives in GamesState —
-        // the hub's own system_id may be stale or unset. Fall back to
-        // HubState otherwise (resume into hub, or first launch).
+        // On a games-screen restore, GamesState.system_id is authoritative;
+        // fall back to HubState.system_id only if it's empty (edge case: user
+        // pressed Enter on an empty systems carousel and we flipped the
+        // screen without ever committing a system). On a hub restore,
+        // HubState.system_id is authoritative — don't peek at GamesState, or
+        // we'd override the user's hub position with a stale games target
+        // from a prior escape-back-to-hub.
         function onModelReset(): void {
             const savedSystem = root.activeScreen === root.screenGames
-                ? Browse.GamesState.system_id
+                ? (Browse.GamesState.system_id !== "" ? Browse.GamesState.system_id : Browse.HubState.system_id)
                 : Browse.HubState.system_id
             const idx = savedSystem === "" ? -1 : Browse.SystemsModel.index_for_system_id(savedSystem)
             systemsCarousel.currentIndex = idx >= 0 ? idx : 0
@@ -344,6 +354,7 @@ ApplicationWindow {
                 if (systemsCarousel.itemCount > 0) {
                     const chosen = Browse.SystemsModel.system_id_at(systemsCarousel.currentIndex)
                     Browse.GamesModel.set_system(chosen)
+                    Browse.HubState.system_id = chosen
                     Browse.GamesState.system_id = chosen
                 }
                 root.activeScreen = root.screenGames
@@ -360,8 +371,11 @@ ApplicationWindow {
                 if (navigateCarousel(categoriesCarousel, 1))
                     Browse.HubState.category = Browse.CategoriesModel.category_at(categoriesCarousel.currentIndex)
             } else if (key === Qt.Key_Return || key === Qt.Key_Enter) {
-                if (categoriesCarousel.itemCount > 0)
-                    Browse.SystemsModel.set_category(Browse.CategoriesModel.category_at(categoriesCarousel.currentIndex))
+                if (categoriesCarousel.itemCount > 0) {
+                    const chosen = Browse.CategoriesModel.category_at(categoriesCarousel.currentIndex)
+                    Browse.SystemsModel.set_category(chosen)
+                    Browse.HubState.category = chosen
+                }
                 root.hubFocus = root.focusSystems
                 Browse.HubState.focus = root.focusSystems
             } else if (key === Qt.Key_Escape || key === Qt.Key_Backspace) {

--- a/tests/ui/CMakeLists.txt
+++ b/tests/ui/CMakeLists.txt
@@ -12,6 +12,7 @@ qt_add_qml_module(
         tst_smoke.qml
         tst_navigation.qml
         tst_sizing.qml
+        tst_persistence.qml
     IMPORTS
         Zaparoo.App
         Zaparoo.Browse

--- a/tests/ui/tst_main.cpp
+++ b/tests/ui/tst_main.cpp
@@ -2,6 +2,8 @@
 // Copyright (c) 2026 The Zaparoo Project Contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
+#include <QDir>
+#include <QFile>
 #include <QQuickStyle>
 #include <QtQml/qqmlextensionplugin.h>
 #include <QtQuickTest/quicktest.h>
@@ -25,6 +27,13 @@ class UiSetup : public QObject
     // NOLINTNEXTLINE(readability-convert-member-functions-to-static) — Qt slot, must be a member
     void applicationAvailable()
     {
+        // Redirect persistent UI state to a throwaway temp file so the
+        // Browse.AppState/HubState/GamesState setters don't clobber the
+        // real ~/.config/zaparoo/state.toml when tests drive navigation.
+        const QString tmpState = QDir::temp().filePath("zaparoo-test-state.toml");
+        QFile::remove(tmpState);
+        qputenv("ZAPAROO_STATE_FILE", tmpState.toUtf8());
+
         // Match the real launcher's style selection. Also forces the test
         // binary to reference QQuickStyle, which keeps libQt6QuickControls2
         // on the link line under GNU ld --as-needed (cxx-qt-lib's

--- a/tests/ui/tst_persistence.qml
+++ b/tests/ui/tst_persistence.qml
@@ -1,0 +1,91 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+import QtQuick
+import QtTest
+import Zaparoo.App
+import Zaparoo.Browse as Browse
+
+// Regression tests for the kill/relaunch persistence flow. The failure
+// these guard against: during restore the carousels seed their
+// currentIndex *programmatically*; prior revisions wrote that seeded
+// value back to disk via onCurrentIndexChanged, silently overwriting
+// the user's saved identifier with a fallback. These tests exercise
+// the key-handler guards that keep disk state intact when the model
+// is empty (the same code path that runs if keys arrive mid-restore).
+TestCase {
+    name: "UiPersistence"
+    when: windowShown
+
+    Main {
+        id: main
+        width: 1280
+        height: 720
+    }
+
+    function init(): void {
+        main.activeScreen = main.screenHub
+        main.hubFocus = main.focusCategories
+        tryCompare(main, "screenOffset", 0, 2000)
+    }
+
+    // Browse.* singletons are process-wide, so state writes leak across
+    // TestCases. Reset to defaults (empty strings) after every test so
+    // later suites — in particular tst_smoke's test_initial_state — see
+    // a clean Component.onCompleted path.
+    function cleanup(): void {
+        Browse.AppState.active_screen = ""
+        Browse.HubState.focus = ""
+        Browse.HubState.category = ""
+        Browse.HubState.system_id = ""
+        Browse.GamesState.system_id = ""
+        Browse.GamesState.game_path = ""
+    }
+
+    // CategoriesModel is empty in this test harness (no live Core).
+    // Left/Right must not call navigateCarousel → _at(0) → "" on an
+    // empty model, because that would wipe the saved category from
+    // persisted state.
+    function test_empty_categories_navigation_preserves_hub_state(): void {
+        Browse.HubState.category = "persistence-probe-category"
+        main.handleKey(Qt.Key_Left)
+        main.handleKey(Qt.Key_Right)
+        compare(Browse.HubState.category, "persistence-probe-category",
+                "navigating an empty categories carousel must not overwrite HubState.category")
+    }
+
+    function test_empty_systems_navigation_preserves_hub_state(): void {
+        Browse.HubState.system_id = "persistence-probe-system"
+        main.hubFocus = main.focusSystems
+        main.handleKey(Qt.Key_Left)
+        main.handleKey(Qt.Key_Right)
+        compare(Browse.HubState.system_id, "persistence-probe-system",
+                "navigating an empty systems carousel must not overwrite HubState.system_id")
+    }
+
+    function test_empty_games_navigation_preserves_games_state(): void {
+        Browse.GamesState.game_path = "persistence-probe-path"
+        main.activeScreen = main.screenGames
+        main.handleKey(Qt.Key_Left)
+        main.handleKey(Qt.Key_Right)
+        compare(Browse.GamesState.game_path, "persistence-probe-path",
+                "navigating an empty games carousel must not overwrite GamesState.game_path")
+    }
+
+    // Focus/screen flips are user-visible intent, not selection state.
+    // They should persist even when the underlying model is empty (so
+    // the launcher resumes on the right screen next boot).
+    function test_focus_flip_on_empty_categories_persists_hub_focus(): void {
+        main.handleKey(Qt.Key_Return)
+        compare(Browse.HubState.focus, main.focusSystems,
+                "Enter must flip hubFocus even on an empty carousel")
+    }
+
+    function test_screen_flip_on_empty_systems_persists_active_screen(): void {
+        main.hubFocus = main.focusSystems
+        main.handleKey(Qt.Key_Return)
+        compare(Browse.AppState.active_screen, main.screenGames,
+                "Enter must flip active_screen even on an empty carousel")
+    }
+}

--- a/tests/ui/tst_persistence.qml
+++ b/tests/ui/tst_persistence.qml
@@ -88,4 +88,24 @@ TestCase {
         compare(Browse.AppState.active_screen, main.screenGames,
                 "Enter must flip active_screen even on an empty carousel")
     }
+
+    // Enter commits the highlighted selection into HubState so first-launch
+    // users who never press Left/Right still get a restorable identifier on
+    // disk. The write is guarded by itemCount > 0 — on an empty carousel
+    // (this harness) the guard must skip the write, leaving prior state
+    // intact.
+    function test_enter_on_empty_categories_preserves_hub_state(): void {
+        Browse.HubState.category = "persistence-probe-category"
+        main.handleKey(Qt.Key_Return)
+        compare(Browse.HubState.category, "persistence-probe-category",
+                "Enter on an empty categories carousel must not overwrite HubState.category")
+    }
+
+    function test_enter_on_empty_systems_preserves_hub_state(): void {
+        Browse.HubState.system_id = "persistence-probe-system"
+        main.hubFocus = main.focusSystems
+        main.handleKey(Qt.Key_Return)
+        compare(Browse.HubState.system_id, "persistence-probe-system",
+                "Enter on an empty systems carousel must not overwrite HubState.system_id")
+    }
 }

--- a/tests/ui/tst_persistence.qml
+++ b/tests/ui/tst_persistence.qml
@@ -108,4 +108,12 @@ TestCase {
         compare(Browse.HubState.system_id, "persistence-probe-system",
                 "Enter on an empty systems carousel must not overwrite HubState.system_id")
     }
+
+    function test_enter_on_empty_games_preserves_games_state(): void {
+        Browse.GamesState.game_path = "persistence-probe-path"
+        main.activeScreen = main.screenGames
+        main.handleKey(Qt.Key_Return)
+        compare(Browse.GamesState.game_path, "persistence-probe-path",
+                "Enter on an empty games carousel must not overwrite GamesState.game_path")
+    }
 }


### PR DESCRIPTION
## Summary

- **Per-screen persistence.** MiSTer's launcher script kills and relaunches the binary freely, so user-visible navigation state has to survive restart. Each screen now owns its own TOML section and `schema_version`; a version mismatch resets only that section, leaving the others untouched. Adding a new screen means one struct + one const + one singleton — no other screen changes.
- **Rust:** new `zaparoo_core::persist` (atomic tmp+rename writes, unit tests for missing/malformed/stale-section inputs) and three cxx-qt singletons `Browse.{AppState,HubState,GamesState}` sharing an `Arc<Mutex<PersistedState>>`.
- **QML:** `Main.qml` seeds `activeScreen` / `hubFocus` / carousel indices from the appropriate section on model reset and writes through on key events. Systems carousel read is conditional on the active screen; writes always go to `HubState` (the systems list serves hub browsing).
- **Also bundled** (from commit c61e8d8): CI cleanup — folds `cpp-lint` into `desktop-build` and trims the Rust cache. Unrelated to persistence but shipped on the same branch.

## Test plan

- [x] `just lint` — zero warnings
- [x] `just test` — 42 Rust tests + 1 UI test pass (new tests cover: default on missing file, round-trip, malformed TOML warns + defaults, unknown schema_version resets only that section, concurrent writes atomic, unknown fields ignored)
- [x] Desktop smoke: valid state → no warning; `[games] schema_version = 999` → `WARN persist: games section version 999 != expected 1; resetting section`, hub preserved; malformed TOML → parse-error warn + default
- [ ] MiSTer on-device smoke via `/media/fat/MiSTer_Zaparoo` restart loop
- [ ] FPS counter stays green at 720p+

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent UI state expanded: AppState, HubState and GamesState singletons; restore active screen, hub focus/category, system ID and game path on startup; new model APIs for querying/restoring indices and game paths.

* **Bug Fixes / UX**
  * Avoids spurious persistence when carousels are empty; deterministic restore and safer navigation/selection behavior.

* **Tests**
  * Added UI persistence regression tests.

* **Build**
  * CI and lint pipeline streamlined; QML module sync/lint ordering improved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->