### PR TITLE
feat(ui): split Main.qml for visual editing + add Design Studio sidecar

### DIFF
--- a/design/README.md
+++ b/design/README.md
@@ -1,0 +1,103 @@
+# Zaparoo Launcher — Designer Guide
+
+This directory lets a UX designer open the launcher UI visually in
+**Qt Design Studio**. Nothing under `design/` is compiled into the
+launcher binary — it's a designer-only sidecar.
+
+## Setup (one-time)
+
+1. **Install Qt Design Studio.** Free, GPLv3. Fastest path: install
+   via the Qt online installer (<https://www.qt.io/download-qt-installer>)
+   and tick *Qt Design Studio*. Linux package managers sometimes ship
+   it as `qt-design-studio`.
+2. **Build the launcher once** from the repo root so the generated
+   QML modules exist:
+
+   ```
+   just build
+   ```
+
+   This populates `build/qml/Zaparoo/{App,Ui,Theme}/` with the real
+   QML files. Design Studio reads them directly from there. The
+   `Zaparoo.Browse` module — backed by Rust — is replaced by mocks
+   under `design/mocks/`.
+3. **Open the project** in Qt Design Studio:
+
+   ```
+   design/launcher.qmlproject
+   ```
+
+   The 2D view should render `MainPreview.qml` at 1280×720 with a
+   populated categories/systems carousel drawn from the mock
+   singletons. If carousels look empty, double-check step 2.
+
+## Editable vs. off-limits files
+
+| Path                            | Touch?                                                     |
+| ------------------------------- | ---------------------------------------------------------- |
+| `src/ui/theme/Theme.qml`        | Yes — colour & font constants.                             |
+| `src/ui/theme/Sizing.qml`       | Logic tweaks only; ask first.                              |
+| `src/ui/components/*.qml`       | Yes — delegates, carousel, FPS counter.                    |
+| `src/ui/app/MainLayout.qml`     | Yes — screen layout, backgrounds, anchors.                 |
+| `src/ui/app/Main.qml`           | **No.** Engineer-owned state machine. Flag changes.        |
+| `design/mocks/**`               | No. Design-time stubs; edit only if engineering asks.      |
+| `design/previews/MainPreview.qml` | Change preview canvas here; don't add real UI.           |
+
+## Hard constraints — software rendering only
+
+The launcher runs on MiSTer FPGA, which has **no GPU**. Anything that
+needs a shader or effect crashes or renders as a grey box. Stick to
+this palette:
+
+Allowed:
+`Rectangle`, `Image`, `Text`, `Repeater`, `Item`, `NumberAnimation`,
+`ColorAnimation`, `Behavior`.
+
+**Banned** — do not drag these from the Design Studio Components panel:
+
+- `LinearGradient`, `RadialGradient`, `ConicalGradient`
+- `DropShadow`, `Glow`, `InnerShadow`
+- `OpacityMask`, `ColorOverlay`, `FastBlur`, `GaussianBlur`
+- `MultiEffect`, anything from `Qt5Compat.GraphicalEffects`
+- Qt Quick **Studio Components**: `Pie`, `Arc`, `Triangle`,
+  `Regular Polygon`, `Star`, `Svg Path Item`
+- Any shader‑backed effect
+
+If an effect is essential, talk to an engineer first — there's often a
+flat `Rectangle` / `Image` combo that gets you 80% of the way.
+
+## Sizing — never hardcode pixels
+
+The launcher scales from 240p (CRT) to 1080p. Use the helpers exposed
+as the `Sizing` singleton (import `Zaparoo.Theme`):
+
+- `Sizing.pctH(n)` — `n` percent of screen height.
+- `Sizing.pctW(n)` — `n` percent of screen width.
+- `Sizing.fontSize(n)` — percent-of-height font size, floored at 8 px.
+
+At the designer canvas of 1280×720, `Sizing.pctH(10)` previews as 72 px.
+
+## Handing work back
+
+1. Commit your changes to a branch (`design/<feature>`).
+2. Open a PR, or hand the `.qml` diffs to an engineer.
+3. Do not edit `CMakeLists.txt`, `.cpp`, `.rs`, or anything under
+   `rust/` — those are engineering concerns.
+
+## If the Design tab stays greyed out in Qt *Creator*
+
+That's expected. Qt Creator 6+ ships its QML visual designer disabled
+because it was superseded by Qt Design Studio. Open the project in
+**Design Studio**, not Creator.
+
+## Troubleshooting
+
+- **Red error banners on `Zaparoo.Browse.*`** — `build/qml/` is
+  missing or stale. Rerun `just build`.
+- **Red error banners on `Zaparoo.Ui` / `Zaparoo.Theme`** — same
+  cause; `just build` populates those too.
+- **Carousel is empty** — the mock ListModels seed four entries; if
+  all carousels are empty, `mocks/` isn't being resolved. Check that
+  `importPaths` in `launcher.qmlproject` still lists `mocks` first.
+- **"Cannot find type XYZ"** — probably a Qt Quick Studio Component.
+  Don't use them; see the banned list above.

--- a/design/README.md
+++ b/design/README.md
@@ -13,7 +13,7 @@ launcher binary — it's a designer-only sidecar.
 2. **Build the launcher once** from the repo root so the generated
    QML modules exist:
 
-   ```
+   ```sh
    just build
    ```
 
@@ -23,7 +23,7 @@ launcher binary — it's a designer-only sidecar.
    under `design/mocks/`.
 3. **Open the project** in Qt Design Studio:
 
-   ```
+   ```text
    design/launcher.qmlproject
    ```
 
@@ -66,14 +66,17 @@ Allowed:
 If an effect is essential, talk to an engineer first — there's often a
 flat `Rectangle` / `Image` combo that gets you 80% of the way.
 
-## Sizing — never hardcode pixels
+## Sizing — never hardcode pixels or element counts
 
 The launcher scales from 240p (CRT) to 1080p. Use the helpers exposed
-as the `Sizing` singleton (import `Zaparoo.Theme`):
+as the `Sizing` singleton (import `Zaparoo.Theme`) — never hardcode
+pixel values or element counts:
 
 - `Sizing.pctH(n)` — `n` percent of screen height.
 - `Sizing.pctW(n)` — `n` percent of screen width.
 - `Sizing.fontSize(n)` — percent-of-height font size, floored at 8 px.
+- `Sizing.visibleCovers` — element count for carousels and similar
+  repeaters; drops at very low resolutions to avoid crowding.
 
 At the designer canvas of 1280×720, `Sizing.pctH(10)` previews as 72 px.
 

--- a/design/launcher.qmlproject
+++ b/design/launcher.qmlproject
@@ -1,0 +1,32 @@
+// Zaparoo Launcher — Qt Design Studio project file.
+// Designer-facing only; the CMake build ignores this entirely.
+// The designer must run `just build` once so the real Zaparoo.App /
+// Zaparoo.Ui / Zaparoo.Theme modules exist under ../build/qml.
+
+import QmlProject
+
+Project {
+    mainFile: "previews/MainPreview.qml"
+
+    // Order matters: the Zaparoo.Browse mocks are listed before the real
+    // build/qml tree, so Design Studio resolves Browse.* to the design-time
+    // stubs (plain QML) instead of the Rust cxx-qt plugin (which it cannot
+    // load).
+    importPaths: [
+        "mocks",
+        "../build/qml"
+    ]
+
+    mockImports: [ "mocks" ]
+
+    Files { directory: "previews";             filter: "*.qml" }
+    Files { directory: "mocks";                filter: "*.qml;qmldir" }
+    Files { directory: "../src/ui/app";        filter: "*.qml" }
+    Files { directory: "../src/ui/components"; filter: "*.qml" }
+    Files { directory: "../src/ui/theme";      filter: "*.qml" }
+    Files { directory: "../resources";         filter: "*.png;*.ttf" }
+
+    qtForMCUs: false
+    widthOverride: 1280
+    heightOverride: 720
+}

--- a/design/mocks/Zaparoo/Browse/AppState.qml
+++ b/design/mocks/Zaparoo/Browse/AppState.qml
@@ -1,0 +1,9 @@
+// Design-time only. Not compiled into the launcher.
+// Mirrors the AppState persistence singleton exposed from Rust.
+pragma Singleton
+
+import QtQuick
+
+QtObject {
+    property string active_screen: "hub"
+}

--- a/design/mocks/Zaparoo/Browse/BrowseModel.qml
+++ b/design/mocks/Zaparoo/Browse/BrowseModel.qml
@@ -1,0 +1,7 @@
+// Design-time only. Dormant placeholder matching the Rust BrowseModel
+// singleton registration — currently unused from QML.
+pragma Singleton
+
+import QtQuick
+
+QtObject {}

--- a/design/mocks/Zaparoo/Browse/CategoriesModel.qml
+++ b/design/mocks/Zaparoo/Browse/CategoriesModel.qml
@@ -1,0 +1,24 @@
+// Design-time only. Not compiled into the launcher.
+// Mirrors the API surface of the Rust CategoriesModel singleton so
+// Qt Design Studio can render Main.qml without a running Rust plugin.
+pragma Singleton
+
+import QtQuick
+
+ListModel {
+    ListElement { name: "Arcade" }
+    ListElement { name: "Console" }
+    ListElement { name: "Computer" }
+    ListElement { name: "Handheld" }
+
+    function category_at(index: int): string {
+        return index >= 0 && index < count ? get(index).name : ""
+    }
+
+    function index_for_category(name: string): int {
+        for (let i = 0; i < count; ++i)
+            if (get(i).name === name)
+                return i
+        return -1
+    }
+}

--- a/design/mocks/Zaparoo/Browse/GamesModel.qml
+++ b/design/mocks/Zaparoo/Browse/GamesModel.qml
@@ -13,6 +13,8 @@ ListModel {
 
     property bool loading: false
     property string error_message: ""
+    property bool has_next_page: false
+    property string current_system_id: ""
 
     function set_system(_system_id: string): void {}
     function launch_at(_index: int): void {}

--- a/design/mocks/Zaparoo/Browse/GamesModel.qml
+++ b/design/mocks/Zaparoo/Browse/GamesModel.qml
@@ -1,0 +1,34 @@
+// Design-time only. Not compiled into the launcher.
+// Mirrors the API surface of the Rust GamesModel singleton.
+pragma Singleton
+
+import QtQuick
+
+ListModel {
+    ListElement { name: "Super Mario World";    path: "/mock/smw.sfc" }
+    ListElement { name: "Sonic the Hedgehog";   path: "/mock/sonic.md" }
+    ListElement { name: "The Legend of Zelda";  path: "/mock/zelda.nes" }
+    ListElement { name: "Tetris";               path: "/mock/tetris.gb" }
+    ListElement { name: "Street Fighter II";    path: "/mock/sf2.zip" }
+
+    property bool loading: false
+    property string error_message: ""
+
+    function set_system(_system_id: string): void {}
+    function launch_at(_index: int): void {}
+
+    function name_at(index: int): string {
+        return index >= 0 && index < count ? get(index).name : ""
+    }
+
+    function path_at(index: int): string {
+        return index >= 0 && index < count ? get(index).path : ""
+    }
+
+    function index_for_game_path(path: string): int {
+        for (let i = 0; i < count; ++i)
+            if (get(i).path === path)
+                return i
+        return -1
+    }
+}

--- a/design/mocks/Zaparoo/Browse/GamesState.qml
+++ b/design/mocks/Zaparoo/Browse/GamesState.qml
@@ -1,0 +1,10 @@
+// Design-time only. Not compiled into the launcher.
+// Mirrors the GamesState persistence singleton exposed from Rust.
+pragma Singleton
+
+import QtQuick
+
+QtObject {
+    property string system_id: "snes"
+    property string game_path: ""
+}

--- a/design/mocks/Zaparoo/Browse/HubState.qml
+++ b/design/mocks/Zaparoo/Browse/HubState.qml
@@ -1,0 +1,11 @@
+// Design-time only. Not compiled into the launcher.
+// Mirrors the HubState persistence singleton exposed from Rust.
+pragma Singleton
+
+import QtQuick
+
+QtObject {
+    property string category: "Console"
+    property string system_id: "snes"
+    property string focus: "categories"
+}

--- a/design/mocks/Zaparoo/Browse/SystemsModel.qml
+++ b/design/mocks/Zaparoo/Browse/SystemsModel.qml
@@ -1,0 +1,31 @@
+// Design-time only. Not compiled into the launcher.
+// Mirrors the API surface of the Rust SystemsModel singleton.
+pragma Singleton
+
+import QtQuick
+
+ListModel {
+    ListElement { system_id: "snes";     name: "Super Nintendo" }
+    ListElement { system_id: "megadrive"; name: "Mega Drive" }
+    ListElement { system_id: "nes";      name: "Nintendo" }
+    ListElement { system_id: "gameboy";  name: "Game Boy" }
+
+    function set_category(_category: string): void {
+        // No-op in the mock — full list stays visible regardless of category.
+    }
+
+    function system_id_at(index: int): string {
+        return index >= 0 && index < count ? get(index).system_id : ""
+    }
+
+    function system_name_at(index: int): string {
+        return index >= 0 && index < count ? get(index).name : ""
+    }
+
+    function index_for_system_id(id: string): int {
+        for (let i = 0; i < count; ++i)
+            if (get(i).system_id === id)
+                return i
+        return -1
+    }
+}

--- a/design/mocks/Zaparoo/Browse/qmldir
+++ b/design/mocks/Zaparoo/Browse/qmldir
@@ -1,0 +1,9 @@
+module Zaparoo.Browse
+singleton CategoriesModel 1.0 CategoriesModel.qml
+singleton SystemsModel 1.0 SystemsModel.qml
+singleton GamesModel 1.0 GamesModel.qml
+singleton AppState 1.0 AppState.qml
+singleton HubState 1.0 HubState.qml
+singleton GamesState 1.0 GamesState.qml
+singleton BrowseModel 1.0 BrowseModel.qml
+depends QtQuick

--- a/design/previews/MainPreview.qml
+++ b/design/previews/MainPreview.qml
@@ -1,0 +1,15 @@
+// Design-time entry point. Opens MainLayout at a fixed 1280×720 canvas
+// so Qt Design Studio has something deterministic to render.
+import QtQuick
+import Zaparoo.App
+import Zaparoo.Theme
+
+MainLayout {
+    width: 1280
+    height: 720
+
+    Component.onCompleted: {
+        Sizing.screenWidth = width
+        Sizing.screenHeight = height
+    }
+}

--- a/justfile
+++ b/justfile
@@ -51,6 +51,9 @@ lint: lint-cpp lint-rust
 lint-cpp: build
     cmake --build build --target lint
 
+lint-qml: build
+    cmake --build build --target all_qmllint
+
 lint-rust:
     cd rust && cargo fmt --all --check
     cd rust && cargo clippy --workspace --all-targets -- -D warnings

--- a/src/ui/app/CMakeLists.txt
+++ b/src/ui/app/CMakeLists.txt
@@ -23,7 +23,9 @@ qt_add_qml_module(
     zaparoo_ui_app
     URI Zaparoo.App
     VERSION 1.0
-    QML_FILES Main.qml
+    QML_FILES
+        Main.qml
+        MainLayout.qml
     RESOURCES ${_APP_RESOURCES}
     IMPORTS
         Zaparoo.Ui

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -4,34 +4,22 @@
 
 import QtQuick
 import QtQuick.Window
-import QtQuick.Controls
-import Zaparoo.Ui
 import Zaparoo.Theme
 import Zaparoo.Browse as Browse
 
 // cxx-qt 0.7 doesn't emit FINAL markers in plugin.qmltypes, so qmllint
 // flags every call on a Zaparoo.Browse singleton as "can be shadowed".
-// Nearly every statement in this file touches one, so silence the whole
-// category here rather than sprinkling block pragmas. Remove after the
-// cxx-qt 0.8 upgrade (which fixes the qmltypes emission).
+// Remove after the cxx-qt 0.8 upgrade.
 // qmllint disable compiler
 
-ApplicationWindow {
+// Runtime wrapper around MainLayout. The visual tree lives in
+// MainLayout.qml (editable by designers in Qt Design Studio); this
+// file carries the state machine, key input, and persistence.
+MainLayout {
     id: root
-
-    // Screen/focus state constants — use these instead of bare string literals.
-    readonly property string screenHub: "hub"
-    readonly property string screenGames: "games"
-    readonly property string focusCategories: "categories"
-    readonly property string focusSystems: "systems"
-
-    property bool fullScreen: false
 
     width: Screen.width
     height: Screen.height
-    visible: true
-    visibility: fullScreen ? Window.FullScreen : Window.Windowed
-    title: "Zaparoo Launcher"
 
     onWidthChanged: {
         Sizing.screenWidth = width
@@ -62,20 +50,6 @@ ApplicationWindow {
             root.restoreFromCategoriesReset()
     }
 
-    // Screen state.
-    property string activeScreen: root.screenHub       // screenHub | screenGames
-    property string hubFocus: root.focusCategories     // focusCategories | focusSystems
-
-    // Drives the hub↔games slide transition. 0 = hub centred; width = games centred.
-    property real screenOffset: root.activeScreen === root.screenGames ? width : 0
-
-    Behavior on screenOffset {
-        NumberAnimation {
-            duration: 220
-            easing.type: Easing.OutCubic
-        }
-    }
-
     // Seed carousel indices from persisted state when models deliver new data.
     // A miss (category renamed, ROM deleted) falls back to index 0 and leaves
     // the saved identifier untouched on disk — so the user's intent survives
@@ -91,7 +65,7 @@ ApplicationWindow {
         const idx = savedCategory === "" ? -1 : Browse.CategoriesModel.index_for_category(savedCategory)
         const chosenIndex = idx >= 0 ? idx : 0
         const chosenCategory = idx >= 0 ? savedCategory : Browse.CategoriesModel.category_at(chosenIndex)
-        categoriesCarousel.currentIndex = chosenIndex
+        root.categoriesCarousel.currentIndex = chosenIndex
         Browse.SystemsModel.set_category(chosenCategory)
     }
 
@@ -115,7 +89,7 @@ ApplicationWindow {
                 ? (Browse.GamesState.system_id !== "" ? Browse.GamesState.system_id : Browse.HubState.system_id)
                 : Browse.HubState.system_id
             const idx = savedSystem === "" ? -1 : Browse.SystemsModel.index_for_system_id(savedSystem)
-            systemsCarousel.currentIndex = idx >= 0 ? idx : 0
+            root.systemsCarousel.currentIndex = idx >= 0 ? idx : 0
             if (idx >= 0)
                 Browse.GamesModel.set_system(savedSystem)
         }
@@ -125,191 +99,8 @@ ApplicationWindow {
         function onModelReset(): void {
             const savedPath = Browse.GamesState.game_path
             const idx = savedPath === "" ? -1 : Browse.GamesModel.index_for_game_path(savedPath)
-            gamesCarousel.currentIndex = idx >= 0 ? idx : 0
+            root.gamesCarousel.currentIndex = idx >= 0 ? idx : 0
         }
-    }
-
-    // ── Background ────────────────────────────────────────────────────────────
-
-    Rectangle {
-        anchors.fill: parent
-        color: Theme.bgDeep
-    }
-
-    // ── Logo ──────────────────────────────────────────────────────────────────
-
-    Image {
-        anchors.left: parent.left
-        anchors.top: parent.top
-        anchors.leftMargin: Sizing.pctW(2)
-        anchors.topMargin: Sizing.pctH(2)
-        height: Sizing.pctH(7)
-        fillMode: Image.PreserveAspectFit
-        source: "qrc:/qt/qml/Zaparoo/App/resources/images/logo.png"
-    }
-
-    // ── Hub screen ────────────────────────────────────────────────────────────
-
-    Item {
-        id: hubContainer
-        x: -root.screenOffset
-        width: parent.width
-        height: parent.height
-
-        Carousel {
-            id: categoriesCarousel
-
-            anchors.horizontalCenter: parent.horizontalCenter
-            width: parent.width
-            height: Sizing.pctH(20)
-            y: root.hubFocus === root.focusSystems ? Sizing.pctH(12) : Sizing.pctH(35)
-            coverWidth: Sizing.pctH(20)
-            coverHeight: Sizing.pctH(20)
-            coverSpacing: Sizing.pctH(23)
-
-            model: Browse.CategoriesModel
-            delegate: TextTileDelegate {}
-            placeholderCover: ""
-
-            Behavior on y {
-                NumberAnimation {
-                    duration: 250
-                    easing.type: Easing.OutQuad
-                }
-            }
-        }
-
-        Carousel {
-            id: systemsCarousel
-
-            anchors.horizontalCenter: parent.horizontalCenter
-            width: parent.width
-            height: Sizing.pctH(20)
-            y: Sizing.pctH(36)
-            visible: root.hubFocus === root.focusSystems
-            coverWidth: Sizing.pctH(20)
-            coverHeight: Sizing.pctH(20)
-            coverSpacing: Sizing.pctH(23)
-
-            model: Browse.SystemsModel
-            delegate: TextTileDelegate {}
-            placeholderCover: ""
-        }
-
-        Text {
-            anchors.horizontalCenter: parent.horizontalCenter
-            y: systemsCarousel.y + systemsCarousel.height + Sizing.pctH(1)
-            visible: root.hubFocus === root.focusSystems
-            text: {
-                Browse.SystemsModel.count
-                return Browse.SystemsModel.system_name_at(systemsCarousel.currentIndex)
-            }
-            font.family: Theme.fontRetro
-            font.pixelSize: Sizing.fontSize(4)
-            color: Theme.textPrimary
-            renderType: Text.NativeRendering
-        }
-    }
-
-    // ── Games screen ──────────────────────────────────────────────────────────
-
-    Item {
-        id: gamesContainer
-        x: parent.width - root.screenOffset
-        width: parent.width
-        height: parent.height
-
-        Carousel {
-            id: gamesCarousel
-
-            anchors.horizontalCenter: parent.horizontalCenter
-            y: Sizing.pctH(12)
-            width: parent.width
-            height: Sizing.pctH(55)
-            opacity: Browse.GamesModel.loading ? 0.5 : 1.0
-            model: root.activeScreen === root.screenGames ? Browse.GamesModel : null
-            delegate: CoverDelegate {}
-            placeholderCover: "qrc:/qt/qml/Zaparoo/App/resources/images/placeholder/cover_generic.png"
-
-            Behavior on opacity {
-                NumberAnimation {
-                    duration: 100
-                }
-            }
-        }
-
-        Text {
-            anchors.centerIn: gamesCarousel
-            visible: (Browse.GamesModel.error_message ?? "") !== ""
-            text: Browse.GamesModel.error_message ?? ""
-            font.family: Theme.fontRetro
-            font.pixelSize: Sizing.fontSize(3)
-            color: Theme.textDim
-            wrapMode: Text.WordWrap
-            horizontalAlignment: Text.AlignHCenter
-            width: parent.width * 0.7
-            renderType: Text.NativeRendering
-        }
-
-        Text {
-            anchors.horizontalCenter: parent.horizontalCenter
-            anchors.top: gamesCarousel.bottom
-            anchors.topMargin: Sizing.pctH(1)
-            text: {
-                Browse.GamesModel.count
-                return Browse.GamesModel.name_at(gamesCarousel.currentIndex)
-            }
-            font.family: Theme.fontRetro
-            font.pixelSize: Sizing.fontSize(4)
-            color: Theme.textPrimary
-            renderType: Text.NativeRendering
-        }
-    }
-
-    // ── FPS counter ───────────────────────────────────────────────────────────
-
-    FpsCounter {
-        anchors.top: parent.top
-        anchors.right: parent.right
-        anchors.topMargin: Sizing.pctH(1)
-        anchors.rightMargin: Sizing.pctW(1)
-        z: 200
-    }
-
-    // ── Instructions bar ──────────────────────────────────────────────────────
-
-    Rectangle {
-        id: instructionsBar
-
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.bottom: parent.bottom
-        height: Sizing.pctH(6)
-        color: Theme.bgBar
-        border.width: 1
-        border.color: Theme.borderSubtle
-
-        Text {
-            anchors.centerIn: parent
-            text: {
-                if (root.activeScreen === root.screenGames)
-                    return "[<>] GAME  [OK] PLAY  [ESC] BACK"
-                if (root.hubFocus === root.focusSystems)
-                    return "[<>] SYSTEM  [OK] GAMES  [ESC] BACK"
-                return "[<>] CATEGORY  [OK] SELECT  [ESC] QUIT"
-            }
-            font.family: Theme.fontRetro
-            font.pixelSize: Sizing.fontSize(2.5)
-            color: Theme.textDim
-            renderType: Text.NativeRendering
-        }
-    }
-
-    // ── Keyboard input ────────────────────────────────────────────────────────
-
-    Item {
-        focus: true
-        Keys.onPressed: event => root.handleKey(event.key)
     }
 
     // Returns true if the carousel actually moved. Callers use this to gate
@@ -331,21 +122,21 @@ ApplicationWindow {
     function handleKey(key) {
         if (root.activeScreen === root.screenGames) {
             if (key === Qt.Key_Left) {
-                if (navigateCarousel(gamesCarousel, -1))
-                    Browse.GamesState.game_path = Browse.GamesModel.path_at(gamesCarousel.currentIndex)
+                if (navigateCarousel(root.gamesCarousel, -1))
+                    Browse.GamesState.game_path = Browse.GamesModel.path_at(root.gamesCarousel.currentIndex)
             } else if (key === Qt.Key_Right) {
-                if (navigateCarousel(gamesCarousel, 1))
-                    Browse.GamesState.game_path = Browse.GamesModel.path_at(gamesCarousel.currentIndex)
+                if (navigateCarousel(root.gamesCarousel, 1))
+                    Browse.GamesState.game_path = Browse.GamesModel.path_at(root.gamesCarousel.currentIndex)
             } else if (key === Qt.Key_Return || key === Qt.Key_Enter) {
-                if (gamesCarousel.itemCount > 0) {
+                if (root.gamesCarousel.itemCount > 0) {
                     // Persist before handing control away. Left/Right already
                     // writes game_path on every move, but the user may press
                     // Enter on the first highlighted game without navigating,
                     // leaving game_path stale from a prior system. Writing
                     // here makes the commit explicit so a kill during launch
                     // resumes on the correct game.
-                    Browse.GamesState.game_path = Browse.GamesModel.path_at(gamesCarousel.currentIndex)
-                    Browse.GamesModel.launch_at(gamesCarousel.currentIndex)
+                    Browse.GamesState.game_path = Browse.GamesModel.path_at(root.gamesCarousel.currentIndex)
+                    Browse.GamesModel.launch_at(root.gamesCarousel.currentIndex)
                 }
             } else if (key === Qt.Key_Escape || key === Qt.Key_Backspace) {
                 root.activeScreen = root.screenHub
@@ -353,14 +144,14 @@ ApplicationWindow {
             }
         } else if (root.hubFocus === root.focusSystems) {
             if (key === Qt.Key_Left) {
-                if (navigateCarousel(systemsCarousel, -1))
-                    Browse.HubState.system_id = Browse.SystemsModel.system_id_at(systemsCarousel.currentIndex)
+                if (navigateCarousel(root.systemsCarousel, -1))
+                    Browse.HubState.system_id = Browse.SystemsModel.system_id_at(root.systemsCarousel.currentIndex)
             } else if (key === Qt.Key_Right) {
-                if (navigateCarousel(systemsCarousel, 1))
-                    Browse.HubState.system_id = Browse.SystemsModel.system_id_at(systemsCarousel.currentIndex)
+                if (navigateCarousel(root.systemsCarousel, 1))
+                    Browse.HubState.system_id = Browse.SystemsModel.system_id_at(root.systemsCarousel.currentIndex)
             } else if (key === Qt.Key_Return || key === Qt.Key_Enter) {
-                if (systemsCarousel.itemCount > 0) {
-                    const chosen = Browse.SystemsModel.system_id_at(systemsCarousel.currentIndex)
+                if (root.systemsCarousel.itemCount > 0) {
+                    const chosen = Browse.SystemsModel.system_id_at(root.systemsCarousel.currentIndex)
                     Browse.GamesModel.set_system(chosen)
                     Browse.HubState.system_id = chosen
                     Browse.GamesState.system_id = chosen
@@ -373,14 +164,14 @@ ApplicationWindow {
             }
         } else {
             if (key === Qt.Key_Left) {
-                if (navigateCarousel(categoriesCarousel, -1))
-                    Browse.HubState.category = Browse.CategoriesModel.category_at(categoriesCarousel.currentIndex)
+                if (navigateCarousel(root.categoriesCarousel, -1))
+                    Browse.HubState.category = Browse.CategoriesModel.category_at(root.categoriesCarousel.currentIndex)
             } else if (key === Qt.Key_Right) {
-                if (navigateCarousel(categoriesCarousel, 1))
-                    Browse.HubState.category = Browse.CategoriesModel.category_at(categoriesCarousel.currentIndex)
+                if (navigateCarousel(root.categoriesCarousel, 1))
+                    Browse.HubState.category = Browse.CategoriesModel.category_at(root.categoriesCarousel.currentIndex)
             } else if (key === Qt.Key_Return || key === Qt.Key_Enter) {
-                if (categoriesCarousel.itemCount > 0) {
-                    const chosen = Browse.CategoriesModel.category_at(categoriesCarousel.currentIndex)
+                if (root.categoriesCarousel.itemCount > 0) {
+                    const chosen = Browse.CategoriesModel.category_at(root.categoriesCarousel.currentIndex)
                     Browse.SystemsModel.set_category(chosen)
                     Browse.HubState.category = chosen
                 }
@@ -390,5 +181,10 @@ ApplicationWindow {
                 Qt.quit()
             }
         }
+    }
+
+    Item {
+        focus: true
+        Keys.onPressed: event => root.handleKey(event.key)
     }
 }

--- a/src/ui/app/MainLayout.qml
+++ b/src/ui/app/MainLayout.qml
@@ -1,0 +1,241 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+import QtQuick
+import QtQuick.Window
+import QtQuick.Controls
+import Zaparoo.Ui
+import Zaparoo.Theme
+import Zaparoo.Browse as Browse
+
+// cxx-qt 0.7 doesn't emit FINAL markers in plugin.qmltypes, so qmllint
+// flags every call on a Zaparoo.Browse singleton as "can be shadowed".
+// Nearly every binding in this form touches one, so silence the whole
+// category here. Remove after the cxx-qt 0.8 upgrade (which fixes the
+// qmltypes emission).
+// qmllint disable compiler
+
+// Visual tree. Edit this file in Qt Design Studio; the state machine
+// and side-effects live in Main.qml which extends this layout. Keep
+// this file declarative — property bindings and child objects only,
+// no imperative JS or signal-handler bodies, so the designer sees
+// everything in the 2D view.
+ApplicationWindow {
+    id: root
+
+    // Screen/focus state constants — referenced by bindings below and
+    // by Main.qml. Declared here so the layout's own bindings resolve
+    // without depending on the wrapper.
+    readonly property string screenHub: "hub"
+    readonly property string screenGames: "games"
+    readonly property string focusCategories: "categories"
+    readonly property string focusSystems: "systems"
+
+    // Runtime state the wrapper mutates; the layout binds against them.
+    property bool fullScreen: false
+    property string activeScreen: root.screenHub
+    property string hubFocus: root.focusCategories
+
+    // Drives the hub↔games slide transition. 0 = hub centred; width = games centred.
+    property real screenOffset: root.activeScreen === root.screenGames ? root.width : 0
+
+    // Defaults keep the design canvas at a sensible aspect for Design
+    // Studio. Main.qml overrides these at runtime with Screen.width /
+    // Screen.height, so the live launcher still fills the screen.
+    width: 1280
+    height: 720
+    visible: true
+    visibility: root.fullScreen ? Window.FullScreen : Window.Windowed
+    title: "Zaparoo Launcher"
+
+    // Aliases so the Main.qml wrapper can drive the carousels (ids
+    // declared inside this file aren't visible from the extending file).
+    property alias categoriesCarousel: categoriesCarousel
+    property alias systemsCarousel: systemsCarousel
+    property alias gamesCarousel: gamesCarousel
+
+    Behavior on screenOffset {
+        NumberAnimation {
+            duration: 220
+            easing.type: Easing.OutCubic
+        }
+    }
+
+    // ── Background ────────────────────────────────────────────────────────────
+
+    Rectangle {
+        anchors.fill: parent
+        color: Theme.bgDeep
+    }
+
+    // ── Logo ──────────────────────────────────────────────────────────────────
+
+    Image {
+        anchors.left: parent.left
+        anchors.top: parent.top
+        anchors.leftMargin: Sizing.pctW(2)
+        anchors.topMargin: Sizing.pctH(2)
+        height: Sizing.pctH(7)
+        fillMode: Image.PreserveAspectFit
+        source: "qrc:/qt/qml/Zaparoo/App/resources/images/logo.png"
+    }
+
+    // ── Hub screen ────────────────────────────────────────────────────────────
+
+    Item {
+        id: hubContainer
+        x: -root.screenOffset
+        width: parent.width
+        height: parent.height
+
+        Carousel {
+            id: categoriesCarousel
+
+            anchors.horizontalCenter: parent.horizontalCenter
+            width: parent.width
+            height: Sizing.pctH(20)
+            y: root.hubFocus === root.focusSystems ? Sizing.pctH(12) : Sizing.pctH(35)
+            coverWidth: Sizing.pctH(20)
+            coverHeight: Sizing.pctH(20)
+            coverSpacing: Sizing.pctH(23)
+
+            model: Browse.CategoriesModel
+            delegate: TextTileDelegate {}
+            placeholderCover: ""
+
+            Behavior on y {
+                NumberAnimation {
+                    duration: 250
+                    easing.type: Easing.OutQuad
+                }
+            }
+        }
+
+        Carousel {
+            id: systemsCarousel
+
+            anchors.horizontalCenter: parent.horizontalCenter
+            width: parent.width
+            height: Sizing.pctH(20)
+            y: Sizing.pctH(36)
+            visible: root.hubFocus === root.focusSystems
+            coverWidth: Sizing.pctH(20)
+            coverHeight: Sizing.pctH(20)
+            coverSpacing: Sizing.pctH(23)
+
+            model: Browse.SystemsModel
+            delegate: TextTileDelegate {}
+            placeholderCover: ""
+        }
+
+        Text {
+            anchors.horizontalCenter: parent.horizontalCenter
+            y: systemsCarousel.y + systemsCarousel.height + Sizing.pctH(1)
+            visible: root.hubFocus === root.focusSystems
+            // Reading Browse.SystemsModel.count registers the binding for
+            // model resets; the comparison is always true so the result
+            // is the system name at the current carousel index.
+            text: Browse.SystemsModel.count >= 0
+                  ? Browse.SystemsModel.system_name_at(systemsCarousel.currentIndex)
+                  : ""
+            font.family: Theme.fontRetro
+            font.pixelSize: Sizing.fontSize(4)
+            color: Theme.textPrimary
+            renderType: Text.NativeRendering
+        }
+    }
+
+    // ── Games screen ──────────────────────────────────────────────────────────
+
+    Item {
+        id: gamesContainer
+        x: parent.width - root.screenOffset
+        width: parent.width
+        height: parent.height
+
+        Carousel {
+            id: gamesCarousel
+
+            anchors.horizontalCenter: parent.horizontalCenter
+            y: Sizing.pctH(12)
+            width: parent.width
+            height: Sizing.pctH(55)
+            opacity: Browse.GamesModel.loading ? 0.5 : 1.0
+            model: root.activeScreen === root.screenGames ? Browse.GamesModel : null
+            delegate: CoverDelegate {}
+            placeholderCover: "qrc:/qt/qml/Zaparoo/App/resources/images/placeholder/cover_generic.png"
+
+            Behavior on opacity {
+                NumberAnimation {
+                    duration: 100
+                }
+            }
+        }
+
+        Text {
+            anchors.centerIn: gamesCarousel
+            visible: (Browse.GamesModel.error_message ?? "") !== ""
+            text: Browse.GamesModel.error_message ?? ""
+            font.family: Theme.fontRetro
+            font.pixelSize: Sizing.fontSize(3)
+            color: Theme.textDim
+            wrapMode: Text.WordWrap
+            horizontalAlignment: Text.AlignHCenter
+            width: parent.width * 0.7
+            renderType: Text.NativeRendering
+        }
+
+        Text {
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.top: gamesCarousel.bottom
+            anchors.topMargin: Sizing.pctH(1)
+            // See _selectedSystemName note above — reading count here
+            // registers the binding for model-reset updates.
+            text: Browse.GamesModel.count >= 0
+                  ? Browse.GamesModel.name_at(gamesCarousel.currentIndex)
+                  : ""
+            font.family: Theme.fontRetro
+            font.pixelSize: Sizing.fontSize(4)
+            color: Theme.textPrimary
+            renderType: Text.NativeRendering
+        }
+    }
+
+    // ── FPS counter ───────────────────────────────────────────────────────────
+
+    FpsCounter {
+        anchors.top: parent.top
+        anchors.right: parent.right
+        anchors.topMargin: Sizing.pctH(1)
+        anchors.rightMargin: Sizing.pctW(1)
+        z: 200
+    }
+
+    // ── Instructions bar ──────────────────────────────────────────────────────
+
+    Rectangle {
+        id: instructionsBar
+
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        height: Sizing.pctH(6)
+        color: Theme.bgBar
+        border.width: 1
+        border.color: Theme.borderSubtle
+
+        Text {
+            anchors.centerIn: parent
+            text: root.activeScreen === root.screenGames
+                  ? "[<>] GAME  [OK] PLAY  [ESC] BACK"
+                  : (root.hubFocus === root.focusSystems
+                     ? "[<>] SYSTEM  [OK] GAMES  [ESC] BACK"
+                     : "[<>] CATEGORY  [OK] SELECT  [ESC] QUIT")
+            font.family: Theme.fontRetro
+            font.pixelSize: Sizing.fontSize(2.5)
+            color: Theme.textDim
+            renderType: Text.NativeRendering
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Splits `src/ui/app/Main.qml` into a declarative `MainLayout.qml` (visual tree + property aliases + bindings) and a thin `Main.qml` wrapper that extends it with the state machine, `Connections`, and `Keys` handling. Designers can now tweak the layout without touching state logic.
- Adds a `design/` sidecar with `launcher.qmlproject`, QML mock singletons for the cxx-qt-backed `Zaparoo.Browse` module (Categories/Systems/GamesModel + App/Hub/GamesState + dormant BrowseModel), a `MainPreview` wrapper, and a designer README (install Qt Design Studio, banned types list, `Sizing` helpers, handoff workflow). `mocks` is listed before `../build/qml` in `importPaths` so Design Studio resolves to the plain-QML mocks instead of the Rust plugin.
- Adds a `just lint-qml` recipe for QML-only linting without running the full lint suite.

Nothing under `design/` is compiled into the launcher binary; `just build` / `just run` behave unchanged.

## Test plan
- [x] `just build` clean
- [x] `just lint` — zero warnings (C++, Rust, QML)
- [x] `just lint-qml` — new recipe, clean
- [x] `just test` — 42/42 Rust, 32/32 UI
- [x] Desktop smoke run (offscreen) — no QML warnings
- [x] MiSTer smoke — confirmed working by @wizzo on hardware
- [ ] Designer opens `design/launcher.qmlproject` in Qt Design Studio and verifies the 2D view renders `MainPreview.qml` with populated mock carousels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Launcher UI split into a reusable layout component exposing carousel controls, focus states, FPS counter and an instructions bar.

* **Documentation**
  * Designer-facing guide and a deterministic preview setup for editing and previewing the launcher, plus troubleshooting and rendering constraints for low-GPU targets.
  * Added design-time mock data/models to enable realistic previews in the design tool.

* **Refactor**
  * Main launcher entry simplified to delegate visual structure to the new layout.

* **Chores**
  * Added a QML lint task to the build recipes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->