### PR TITLE
feat: contributor onboarding + mock core + i18n + UI architecture

### DIFF
--- a/.github/CLA.md
+++ b/.github/CLA.md
@@ -1,0 +1,108 @@
+# Zaparoo Launcher Contributor License Agreement
+
+**Version:** 1.0 · effective 2026-04-25
+
+Thank you for your interest in contributing to Zaparoo Launcher.
+
+This Contributor License Agreement ("CLA") records the rights you grant
+to **Wizzo Pty Ltd** (the "Company") when you contribute code,
+documentation, translations, or other material to this project. You
+sign it once, on your first contribution, and it covers every
+contribution you make afterwards.
+
+## Why we ask for this
+
+Zaparoo Launcher is published under the PolyForm Noncommercial License
+1.0.0. The Company separately grants commercial licences to partners
+who want to use the software commercially. For the Company to be able
+to grant those commercial licences without having to renegotiate with
+every past contributor, each contributor gives the Company broad
+licensing rights to their contribution.
+
+**You keep the copyright on your own work.** This is a licence, not a
+transfer.
+
+## 1. Definitions
+
+- **"Contribution"** means any code, documentation, translation, asset,
+  configuration, or other material you submit to the project in any
+  form (pull request, patch, issue comment containing code, etc.).
+- **"You"** means the individual signing this CLA. If you are
+  contributing on behalf of an employer, "You" means both you and
+  your employer, and you confirm you have authority to sign on their
+  behalf.
+
+## 2. You keep your rights
+
+You retain the copyright to your Contribution. Nothing in this CLA
+prevents you from using your Contribution yourself, licensing it to
+anyone else, or including it in other projects.
+
+## 3. Copyright licence to the Company
+
+You grant Wizzo Pty Ltd a perpetual, worldwide, non-exclusive,
+royalty-free, irrevocable copyright licence to use your Contribution
+in any way, including:
+
+- reproducing, modifying, distributing, performing, and displaying it;
+- preparing derivative works from it;
+- combining it with other material; and
+- **sublicensing** any or all of these rights to third parties, on any
+  terms the Company chooses (including commercial terms).
+
+## 4. Patent licence to the Company
+
+You grant Wizzo Pty Ltd a perpetual, worldwide, non-exclusive,
+royalty-free, irrevocable patent licence — with the right to
+sublicense — to make, have made, use, sell, offer to sell, import, and
+otherwise transfer your Contribution and any combination of your
+Contribution with the project. This patent licence covers only those
+patent claims you own or control that are necessarily infringed by your
+Contribution or by that combination.
+
+## 5. Moral rights
+
+To the extent the law allows, you consent to the Company and its
+sublicensees using your Contribution without personally attributing it
+to you, and you agree not to bring any moral-rights claim against the
+Company or its sublicensees about how your Contribution is used or
+modified.
+
+## 6. You have the right to grant this
+
+You confirm that:
+
+- Your Contribution is your own original work, or you have permission
+  from the copyright holder (for example, your employer) to submit it
+  under this CLA.
+- You have identified any third-party code, licences, or patents that
+  are included in or required by your Contribution, either in your pull
+  request description or in the relevant commit message.
+- Submitting your Contribution does not breach any agreement you have
+  with anyone else.
+
+## 7. No warranty, no obligation
+
+You provide your Contribution "as is", without any warranty. Signing
+this CLA does not obligate you or the Company to maintain, support, or
+distribute anything.
+
+## 8. Public release
+
+Your Contribution will be released to the public under the same licence
+as the rest of the project (currently PolyForm Noncommercial 1.0.0).
+The Company may also sublicense it to specific partners under different
+terms, as permitted by sections 3 and 4 above.
+
+## Signing
+
+To sign this CLA, post the following comment on your first pull request
+to this repository:
+
+> I have read the CLA Document and I hereby sign the CLA
+
+The CLA Assistant Lite bot will record your signature in
+`.github/contributors/signatures.json`. You only need to sign once;
+future pull requests will be recognised automatically.
+
+Questions? Email [legal@zaparoo.org](mailto:legal@zaparoo.org).

--- a/.github/CLA.md
+++ b/.github/CLA.md
@@ -13,13 +13,13 @@ contribution you make afterward.
 ## Why we ask for this
 
 Zaparoo Launcher is published under the PolyForm Noncommercial License
-1.0.0. The Company separately grants commercial licences to partners
+1.0.0. The Company separately grants commercial licenses to partners
 who want to use the software commercially. For the Company to be able
-to grant those commercial licences without having to renegotiate with
+to grant those commercial licenses without having to renegotiate with
 every past contributor, each contributor gives the Company broad
 licensing rights to their contribution.
 
-**You keep the copyright on your own work.** This is a licence, not a
+**You keep the copyright on your own work.** This is a license, not a
 transfer.
 
 ## 1. Definitions
@@ -38,10 +38,10 @@ You retain the copyright to your Contribution. Nothing in this CLA
 prevents you from using your Contribution yourself, licensing it to
 anyone else, or including it in other projects.
 
-## 3. Copyright licence to the Company
+## 3. Copyright license to the Company
 
 You grant Wizzo Pty Ltd a perpetual, worldwide, non-exclusive,
-royalty-free, irrevocable copyright licence to use your Contribution
+royalty-free, irrevocable copyright license to use your Contribution
 in any way, including:
 
 - reproducing, modifying, distributing, performing, and displaying it;
@@ -50,17 +50,17 @@ in any way, including:
 - **sublicensing** any or all of these rights to third parties, on any
   terms the Company chooses (including commercial terms).
 
-## 4. Patent licence to the Company
+## 4. Patent license to the Company
 
 You grant Wizzo Pty Ltd a perpetual, worldwide, non-exclusive,
-royalty-free, irrevocable patent licence — with the right to
+royalty-free, irrevocable patent license — with the right to
 sublicense — to make, have made, use, sell, offer to sell, import, and
 otherwise transfer your Contribution and any combination of your
-Contribution with the project. This patent licence covers only those
+Contribution with the project. This patent license covers only those
 patent claims you own or control that are necessarily infringed by your
 Contribution or by that combination.
 
-## 5. No trademark licence
+## 5. No trademark license
 
 Nothing in sections 3 or 4 grants you, or anyone the Company sublicenses
 to, any rights to use the Company's or the Zaparoo Project's names,
@@ -82,7 +82,7 @@ You confirm that:
 - Your Contribution is your own original work, or you have permission
   from the copyright holder (for example, your employer) to submit it
   under this CLA.
-- You have identified any third-party code, licences, or patents that
+- You have identified any third-party code, licenses, or patents that
   are included in or required by your Contribution, either in your pull
   request description or in the relevant commit message.
 - Submitting your Contribution does not breach any agreement you have
@@ -96,7 +96,7 @@ distribute anything.
 
 ## 9. Public release
 
-Your Contribution will be released to the public under the same licence
+Your Contribution will be released to the public under the same license
 as the rest of the project (currently PolyForm Noncommercial 1.0.0).
 The Company may also sublicense it to specific partners under different
 terms, as permitted by sections 3 and 4 above.
@@ -110,6 +110,6 @@ to this repository:
 
 The CLA Assistant Lite bot will record your signature in
 `.github/contributors/signatures.json`. You only need to sign once;
-future pull requests will be recognised automatically.
+future pull requests will be recognized automatically.
 
 Questions? Email [legal@zaparoo.org](mailto:legal@zaparoo.org).

--- a/.github/CLA.md
+++ b/.github/CLA.md
@@ -60,7 +60,14 @@ Contribution with the project. This patent licence covers only those
 patent claims you own or control that are necessarily infringed by your
 Contribution or by that combination.
 
-## 5. Moral rights
+## 5. No trademark licence
+
+Nothing in sections 3 or 4 grants you, or anyone the Company sublicenses
+to, any rights to use the Company's or the Zaparoo Project's names,
+logos, or trademarks. Trademark use is handled separately and is outside
+the scope of this CLA.
+
+## 6. Moral rights
 
 To the extent the law allows, you consent to the Company and its
 sublicensees using your Contribution without personally attributing it
@@ -68,7 +75,7 @@ to you, and you agree not to bring any moral-rights claim against the
 Company or its sublicensees about how your Contribution is used or
 modified.
 
-## 6. You have the right to grant this
+## 7. You have the right to grant this
 
 You confirm that:
 
@@ -81,13 +88,13 @@ You confirm that:
 - Submitting your Contribution does not breach any agreement you have
   with anyone else.
 
-## 7. No warranty, no obligation
+## 8. No warranty, no obligation
 
 You provide your Contribution "as is", without any warranty. Signing
 this CLA does not obligate you or the Company to maintain, support, or
 distribute anything.
 
-## 8. Public release
+## 9. Public release
 
 Your Contribution will be released to the public under the same licence
 as the rest of the project (currently PolyForm Noncommercial 1.0.0).

--- a/.github/CLA.md
+++ b/.github/CLA.md
@@ -8,7 +8,7 @@ This Contributor License Agreement ("CLA") records the rights you grant
 to **Wizzo Pty Ltd** (the "Company") when you contribute code,
 documentation, translations, or other material to this project. You
 sign it once, on your first contribution, and it covers every
-contribution you make afterwards.
+contribution you make afterward.
 
 ## Why we ask for this
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 /.github/CLA.md @ZaparooProject/admins
 /.github/CODEOWNERS @ZaparooProject/admins
 /.github/contributors/ @ZaparooProject/admins
+/.github/workflows/cla.yml @ZaparooProject/admins
 /COPYING @ZaparooProject/admins
 /src/LICENSES/ @ZaparooProject/admins

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+/.github/CLA.md @ZaparooProject/admins
+/.github/CODEOWNERS @ZaparooProject/admins
+/.github/contributors/ @ZaparooProject/admins
+/COPYING @ZaparooProject/admins
+/src/LICENSES/ @ZaparooProject/admins

--- a/.github/contributors/signatures.json
+++ b/.github/contributors/signatures.json
@@ -1,0 +1,3 @@
+{
+    "signedContributors": []
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 # Zaparoo Launcher
-# Copyright (c) 2026 The Zaparoo Project Contributors.
+# Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 # SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
 version: 2

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+<!-- Thanks for sending a pull request! Fill this out before requesting review. -->
+
+## Summary
+
+<!-- What does this PR change, and why? One or two sentences is usually enough. -->
+
+## Motivation
+
+<!-- Link to the issue being fixed or the discussion this came out of. Delete this section if neither applies. -->
+
+## Screenshots / recordings
+
+<!-- Required for any visual change. Include the FPS counter reading at 720p and, if possible, 240p. -->
+
+## Test plan
+
+<!-- How did you verify this works? Bullet list of manual steps or automated tests. -->
+
+## Checklist
+
+- [ ] `just lint` is green (zero warnings)
+- [ ] `just test` passes
+- [ ] If this touches QML, the FPS counter stays green (≥ 55) at 720p+ and ≥ 30 at 240p
+- [ ] If this could affect the MiSTer build, I considered ARM32 implications (see `docs/architecture.md`)
+- [ ] If this adds user-visible strings, they are wrapped in `qsTr()` (QML) or `tr()` (C++)
+- [ ] I have signed the [CLA](../.github/CLA.md) (first-time contributors only)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # Zaparoo Launcher
-# Copyright (c) 2026 The Zaparoo Project Contributors.
+# Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 # SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
 name: CI
@@ -159,8 +159,12 @@ jobs:
   arm32-build:
     name: ARM32 cross-build (MiSTer)
     runs-on: ubuntu-latest
+    # ensure-toolchain only runs on push-to-main (it needs packages:write).
+    # On PRs it is skipped, so arm32-build allows either outcome. The tag
+    # is read from toolchain/VERSION either way, so PRs pull whatever image
+    # main has already pushed.
     needs: [ensure-toolchain]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: ${{ needs.ensure-toolchain.result == 'success' || needs.ensure-toolchain.result == 'skipped' }}
     permissions:
       contents: read
       packages: read
@@ -171,6 +175,12 @@ jobs:
           echo "OWNER_LC=${OWNER,,}" >> "$GITHUB_ENV"
         env:
           OWNER: ${{ github.repository_owner }}
+      - name: Resolve toolchain version
+        id: toolchain
+        run: |
+          VERSION=$(tr -d '[:space:]' < toolchain/VERSION)
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Using toolchain image tag: ${VERSION}"
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
@@ -179,7 +189,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build ARM32 launcher
         env:
-          TOOLCHAIN_IMAGE: ghcr.io/${{ env.OWNER_LC }}/qt6-arm32-mister:${{ needs.ensure-toolchain.outputs.version }}
+          TOOLCHAIN_IMAGE: ghcr.io/${{ env.OWNER_LC }}/qt6-arm32-mister:${{ steps.toolchain.outputs.version }}
         run: ./scripts/build-arm32.sh
       - name: Verify ARM ELF
         run: |

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,93 @@
+# Zaparoo Launcher
+# Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+# SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+name: CLA
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+# pull_request_target is used (not pull_request) because the action needs
+# write access to commit signatures.json back to the repo. Contributor code
+# is never checked out or executed here — the action only reads metadata.
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    name: Contributor License Agreement
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA sign / recheck
+        if: |
+          (github.event_name == 'issue_comment' &&
+            (github.event.comment.body == 'recheck' ||
+             github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA')) ||
+          github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: .github/contributors/signatures.json
+          path-to-document: https://github.com/ZaparooProject/zaparoo-launcher/blob/main/.github/CLA.md
+          branch: main
+          # Bots never sign. Keep this list tight — human contributors
+          # must sign once via the magic-comment flow.
+          allowlist: dependabot[bot],github-actions[bot]
+          custom-pr-sign-comment: I have read the CLA Document and I hereby sign the CLA
+          custom-notsigned-prcomment: |
+            Thanks for opening this pull request. Before it can be merged, please read and sign the [Contributor License Agreement](https://github.com/ZaparooProject/zaparoo-launcher/blob/main/.github/CLA.md).
+
+            It takes about 30 seconds. Post the exact comment below on this PR to sign:
+          custom-allsigned-prcomment: All contributors have signed the CLA. Thank you.
+
+      # CLA Assistant Lite stores name/id/repoId/comment_id/pullRequestNo/created_at
+      # but not which version of the CLA was agreed to. We backfill cla_version
+      # (parsed from CLA.md) and cla_signed_at (mirrored from the action's
+      # created_at) on any entry missing them. Idempotent — if the push loses
+      # a race, the next signing event catches the straggler.
+      - name: Checkout main for version stamp
+        if: |
+          github.event_name == 'issue_comment' &&
+          github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Stamp CLA version on new signatures
+        if: |
+          github.event_name == 'issue_comment' &&
+          github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          cla_version=$(grep -oP '(?<=\*\*Version:\*\* )\S+' .github/CLA.md | head -n1)
+          if [ -z "$cla_version" ]; then
+            echo "::error file=.github/CLA.md::Could not parse '**Version:** <n>' from CLA.md"
+            exit 1
+          fi
+          tmp=$(mktemp)
+          jq --arg v "$cla_version" '
+            .signedContributors |= map(
+              if has("cla_version") then .
+              else . + {cla_version: $v, cla_signed_at: (.created_at // (now | todate))}
+              end
+            )
+          ' .github/contributors/signatures.json > "$tmp"
+          mv "$tmp" .github/contributors/signatures.json
+          if ! git diff --quiet -- .github/contributors/signatures.json; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add .github/contributors/signatures.json
+            git commit -m "chore(cla): stamp version $cla_version on new signatures"
+            git push origin HEAD:main
+          fi

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -89,5 +89,25 @@ jobs:
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git add .github/contributors/signatures.json
             git commit -m "chore(cla): stamp version $cla_version on new signatures"
-            git push origin HEAD:main
+            # Bounded retry: another merge may land on main between
+            # checkout and push. Rebase + retry instead of failing the
+            # job; the stamp is idempotent so a future signing event
+            # catches strays if all attempts lose the race.
+            pushed=0
+            for _ in 1 2 3; do
+              git fetch origin main
+              if ! git rebase origin/main; then
+                git rebase --abort
+                sleep 5
+                continue
+              fi
+              if git push origin HEAD:main; then
+                pushed=1
+                break
+              fi
+              sleep 5
+            done
+            if [ "$pushed" -eq 0 ]; then
+              echo "::warning::version-stamp push lost three races; retry on next CLA event"
+            fi
           fi

--- a/.github/workflows/toolchain-build.yml
+++ b/.github/workflows/toolchain-build.yml
@@ -1,5 +1,5 @@
 # Zaparoo Launcher
-# Copyright (c) 2026 The Zaparoo Project Contributors.
+# Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 # SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
 name: Build ARM32 toolchain image

--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ output/
 # AI agent tooling — local only, not shared
 CLAUDE.md
 .claude/
+.opencode/
 
 # Cargo build cache
 rust/target/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,18 @@ repos:
         files: \.qml$
         pass_filenames: true
 
+  # Rust formatting — runs cargo fmt across the whole workspace when any
+  # .rs file changes. pass_filenames is false because cargo fmt picks up
+  # the workspace targets from rust/Cargo.toml directly.
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: cargo fmt
+        entry: cargo fmt --manifest-path rust/Cargo.toml --all
+        language: system
+        types: [rust]
+        pass_filenames: false
+
   # Basic file hygiene
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,15 @@ module graph and @docs/building.md for the full build matrix.
   retains the latest value, and subscribers seed via `borrow()` then
   await `changed()`. Reserve `broadcast` for fan-out of *events*
   where missing the early ones is acceptable.
+- Inline a `watch::Sender::borrow()` (or any read-borrow) in the
+  scrutinee of an `if let` / `match` / `while let` whose body then
+  calls `send_replace`/`send`/any write on the same channel.
+  Temporaries in the scrutinee live until the end of the body, so
+  the read lock outlives the entire block and deadlocks the write.
+  Bind the borrow to a local in an inner scope first:
+  `let next = { let cur = tx.borrow(); fsm.step(&cur) };` then
+  match on `next`. Same gotcha applies to any `RwLock`-backed
+  read guard held across a write call.
 
 ### ASK
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,22 @@ module graph and @docs/building.md for the full build matrix.
 - Leave a lint warning or failing test unresolved.
 - `cd rust/` or invoke raw cmake/cargo. Drive every workflow from the
   repo root via `just`.
+- Write a bare English literal in QML (or a `tr()`-less literal in C++)
+  for anything the user might read. Wrap it in `qsTr()` and pass runtime
+  values via `%1`/`%2` so translators can reorder — e.g. `qsTr("%1
+  FPS").arg(fps)`, not `qsTr("FPS: ") + fps`. Enum tags, QRC URLs, log
+  strings, and other non-user-facing literals stay bare. See
+  @docs/translations.md for the full pipeline.
+- Use `tokio::sync::broadcast` to publish *state* (connection state,
+  catalog status, anything a subscriber needs to know the current
+  value of). Broadcast channels silently drop messages sent before a
+  receiver subscribes, so a late subscriber — e.g. a QML singleton
+  whose `initialize()` runs after the WebSocket task has already sent
+  `Connecting` → `Connected` — sees nothing and sits on its hardcoded
+  initial value forever. Use `tokio::sync::watch` for state: it
+  retains the latest value, and subscribers seed via `borrow()` then
+  await `changed()`. Reserve `broadcast` for fan-out of *events*
+  where missing the early ones is acceptable.
 
 ### ASK
 
@@ -38,9 +54,10 @@ module graph and @docs/building.md for the full build matrix.
 
 ### ALWAYS
 
+- Write comments and documentation in American English.
 - After editing any C++, Rust, or QML file: run `just lint` (zero
   warnings is the bar) and `just test` if the change can affect runtime
-  behaviour.
+  behavior.
 - Watch `src/ui/components/FpsCounter.qml` when changing visuals —
   it must stay green (≥55) at 720p+ and not fall red (<30) at 240p.
 
@@ -99,4 +116,5 @@ before config loads, useful for debugging startup).
 - @docs/building.md — full build matrix, ARM32 toolchain, sanitizers, deploy bundle
 - @docs/qml-gotchas.md — QML pitfalls qmllint only catches post-hoc (read when writing QML)
 - @docs/cxx-qt-bridge.md — cxx-qt 0.7 bridge gotchas (read when editing Rust QML models)
+- @docs/translations.md — `qsTr()` pipeline, adding locales, build-time mechanics
 - `src/LICENSES/` — Qt LGPL notices

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Zaparoo Launcher
-# Copyright (c) 2026 The Zaparoo Project Contributors.
+# Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 # SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
 cmake_minimum_required(VERSION 3.22)
@@ -33,7 +33,7 @@ include(ZaparooQmlModule)
 # Always emit compile_commands.json so clangd and clang-tidy work without extra flags.
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-find_package(Qt6 6.7 REQUIRED COMPONENTS Quick QuickControls2 Qml)
+find_package(Qt6 6.7 REQUIRED COMPONENTS Quick QuickControls2 Qml LinguistTools)
 
 if(ZAPAROO_BUILD_TESTS)
     find_package(Qt6 6.7 REQUIRED COMPONENTS QuickTest Test)
@@ -49,6 +49,7 @@ set(QML_IMPORT_PATH "${QT_QML_OUTPUT_DIRECTORY}" CACHE PATH "Extra QML import pa
 
 add_subdirectory(src/ui/theme)
 add_subdirectory(src/ui/components)
+add_subdirectory(src/ui/screens)
 add_subdirectory(src/ui/app)
 
 # All Zaparoo QML CMake targets must exist before ZaparooRust is included.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,113 @@
+# Contributing to Zaparoo Launcher
+
+Thanks for your interest. This doc covers the practical bits: signing
+the CLA, getting a dev environment running, and what we expect before
+you open a pull request.
+
+## Contributor License Agreement
+
+Every contributor signs a one-time [CLA](.github/CLA.md). It grants
+**Wizzo Pty Ltd** (the legal entity behind the project) a broad license
+to use and sublicense your contribution. You keep the copyright; this
+is a license, not a transfer. The CLA exists so the company can grant
+commercial licenses to friendly partners without renegotiating with
+every past contributor each time.
+
+To sign, open your first pull request and post this exact comment on
+it:
+
+> I have read the CLA Document and I hereby sign the CLA
+
+The CLA Assistant Lite bot records your signature in
+`.github/contributors/signatures.json`. You only need to sign once;
+future PRs are recognized automatically.
+
+## Development setup
+
+See [`docs/quickstart.md`](docs/quickstart.md) for the fastest path
+from a fresh clone to a running launcher. You do not need MiSTer
+hardware: the repo ships a mock Zaparoo Core you can run locally with
+`just mock-core`.
+
+For full build details (MiSTer ARM32 cross-build, sanitizer builds,
+deployment), see [`docs/building.md`](docs/building.md).
+
+### Supported host platforms
+
+- **Linux (x86_64)** is the primary development target and fully
+  supported.
+- **macOS** is best-effort. It should work, but CI does not cover it.
+  Report breakage; patches welcome.
+- **Windows** is not tested or actively supported. Use WSL2.
+
+## Before you open a pull request
+
+Run these locally. CI runs the same checks and will block merge if
+they fail.
+
+```bash
+just lint    # clang-format, clang-tidy, qmllint, rustfmt, clippy, cargo-deny
+just test    # ctest + cargo nextest
+```
+
+Zero lint warnings is the bar. If a rule is wrong for your change,
+don't disable it; raise it in the PR and we'll discuss.
+
+## Pull request conventions
+
+The [PR template](.github/pull_request_template.md) prompts for
+everything we want to see. The two things worth calling out up front:
+
+- **Explain the why, not just the what.** The diff already shows the
+  what.
+- **Screenshots or recordings for visual changes**, with the FPS
+  counter reading at 720p and, ideally, 240p. It must stay green
+  (≥55) at 720p+ and not go red (<30) at 240p.
+
+### Commit messages
+
+We use [Conventional Commits](https://www.conventionalcommits.org/):
+
+- `feat:` for a new user-visible feature
+- `fix:` for a bug fix
+- `refactor:` for a code change that neither fixes a bug nor adds a feature
+- `docs:` for documentation-only changes
+- `test:` for adding or updating tests
+- `chore:` for build, tooling, deps, or other housekeeping
+
+Scopes are optional but encouraged when they sharpen the summary:
+`feat(ui): add settings screen`, `fix(rust): handle empty catalog`.
+
+### Branch naming
+
+`feat/<short-description>`, `fix/<short-description>`,
+`docs/<short-description>`, etc. Keep it readable; hyphens not
+underscores.
+
+## Main branch is protected
+
+`main` accepts changes only via pull request. Every PR needs:
+
+1. All CI jobs green (`rust-lint`, `rust-test`, `desktop-build`,
+   `arm32-build`, and the CLA check).
+2. A CLA signature recorded for the PR author.
+3. At least one approving review from a maintainer other than the PR
+   author.
+4. The branch up to date with `main`.
+
+Force-pushing and direct pushes to `main` are blocked.
+
+## Bugs and feature requests
+
+Open a GitHub issue. For bugs, include repro steps, expected vs actual
+behavior, whether it reproduces on desktop and/or MiSTer, and a log
+excerpt (`~/.local/share/zaparoo/logs/launcher.log` on desktop;
+`/tmp/zaparoo/launcher.log` on MiSTer). For features, say what you
+want and why; if you plan to implement it yourself, say so and we'll
+align on scope first.
+
+## Questions?
+
+- Architecture or design questions: open a GitHub Discussion (or
+  issue) so the answer is searchable for the next person.
+- CLA or licensing: [legal@zaparoo.org](mailto:legal@zaparoo.org).

--- a/COPYING
+++ b/COPYING
@@ -1,6 +1,6 @@
 PolyForm Noncommercial License 1.0.0
 
-Required Notice: Copyright 2026 The Zaparoo Project Contributors (https://zaparoo.org)
+Required Notice: Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors (https://zaparoo.org)
 
 Acceptance
 ----------

--- a/Dockerfile.arm32
+++ b/Dockerfile.arm32
@@ -1,5 +1,5 @@
 # Zaparoo Launcher
-# Copyright (c) 2026 The Zaparoo Project Contributors.
+# Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 # SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 #
 # Cross-compiles the zaparoo-launcher application for ARM32 / MiSTer FPGA.

--- a/Dockerfile.toolchain
+++ b/Dockerfile.toolchain
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.6
 # Zaparoo Launcher
-# Copyright (c) 2026 The Zaparoo Project Contributors.
+# Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 # SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 #
 # Builds the reusable Qt + MiSTer ARM32 toolchain base image. Qt upstream
@@ -84,9 +84,16 @@ ARG QT_VERSION
 RUN git clone --depth 1 --branch v${QT_VERSION} https://github.com/qt/qtbase.git && \
     git clone --depth 1 --branch v${QT_VERSION} https://github.com/qt/qtshadertools.git && \
     git clone --depth 1 --branch v${QT_VERSION} https://github.com/qt/qtdeclarative.git && \
+    git clone --depth 1 --branch v${QT_VERSION} https://github.com/qt/qttools.git && \
     git clone --depth 1 --branch v${QT_VERSION} https://github.com/qt/qtwebsockets.git
 
 # Stage 1: Qt6 host build (provides native tools: moc, rcc, qmllint, etc.)
+# PrintSupport is intentionally enabled here even though the launcher itself
+# doesn't print: Qt's `linguist` feature has condition `TARGET Qt::PrintSupport`,
+# and qttools/src/linguist/CMakeLists.txt returns early when that feature is
+# off — taking lupdate/lrelease/lconvert and the Qt6LinguistTools CMake
+# package down with it. The ARM32 target qtbase below stays `-no-feature-
+# printsupport` since the shipping binary never needs it.
 RUN mkdir qtbase-host-build && cd qtbase-host-build && \
     ../qtbase/configure \
         -release \
@@ -97,7 +104,6 @@ RUN mkdir qtbase-host-build && cd qtbase-host-build && \
         -no-openssl \
         -no-dbus \
         -no-feature-accessibility \
-        -no-feature-printsupport \
         -no-feature-sql \
         -qt-zlib \
         -qt-libpng \
@@ -115,6 +121,30 @@ RUN mkdir qtshadertools-host-build && cd qtshadertools-host-build && \
 
 RUN mkdir qtdeclarative-host-build && cd qtdeclarative-host-build && \
     /opt/qt6-host/bin/qt-configure-module ../qtdeclarative \
+    && cmake --build . --parallel $(nproc) \
+    && cmake --install .
+
+# qttools (host only): provides lupdate/lrelease + the Qt6LinguistTools
+# CMake package that qt_add_translations() requires at configure time.
+# Feature-gated to the subset we use: Linguist command-line tools. The
+# `linguist` feature is set explicitly so a future qtbase tweak can't
+# silently disable it again — its only condition is `TARGET Qt::PrintSupport`,
+# which the host qtbase above provides. The other FEATURE_* knobs disable
+# GUI tools (assistant, designer) and CLI utilities we don't ship; pulling
+# them in would either drag QtWidgets/Network into a host build that doesn't
+# need them or build code we never invoke. Not cross-compiled for ARM32 —
+# the launcher only needs .qm files at runtime, which are architecture-
+# independent.
+RUN mkdir qttools-host-build && cd qttools-host-build && \
+    /opt/qt6-host/bin/qt-configure-module ../qttools \
+        -- \
+        -DFEATURE_linguist=ON \
+        -DFEATURE_assistant=OFF \
+        -DFEATURE_designer=OFF \
+        -DFEATURE_qtattributionsscanner=OFF \
+        -DFEATURE_qdbus=OFF \
+        -DFEATURE_qtdiag=OFF \
+        -DFEATURE_qtplugininfo=OFF \
     && cmake --build . --parallel $(nproc) \
     && cmake --install .
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This repository contains Zaparoo trademarks which are explicitly licensed to the
 
 ## License
 
-Copyright 2026 The Zaparoo Project Contributors.
+Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 Source available under the [PolyForm Noncommercial License 1.0.0](COPYING).
 Non-commercial use only. For commercial licensing, contact [legal@zaparoo.org](mailto:legal@zaparoo.org) to discuss terms.
 

--- a/cmake/SyncCxxqtQmlModules.cmake
+++ b/cmake/SyncCxxqtQmlModules.cmake
@@ -1,5 +1,5 @@
 # Zaparoo Launcher
-# Copyright (c) 2026 The Zaparoo Project Contributors.
+# Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 # SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 #
 # Sync cxx-qt-generated QML module directories (qmldir + plugin.qmltypes)

--- a/cmake/ZaparooCompileOptions.cmake
+++ b/cmake/ZaparooCompileOptions.cmake
@@ -1,5 +1,5 @@
 # Zaparoo Launcher
-# Copyright (c) 2026 The Zaparoo Project Contributors.
+# Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 # SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 #
 # Centralised warning flags, sanitizer options, and LTO for all targets.

--- a/cmake/ZaparooLint.cmake
+++ b/cmake/ZaparooLint.cmake
@@ -1,5 +1,5 @@
 # Zaparoo Launcher
-# Copyright (c) 2026 The Zaparoo Project Contributors.
+# Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 # SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 #
 # Developer lint targets. Include this AFTER all add_subdirectory() calls so
@@ -105,6 +105,7 @@ if(TARGET all_qmllint)
         foreach(_qmllint_target IN ITEMS
                 zaparoo_ui_app_qmllint
                 zaparoo_ui_components_qmllint
+                zaparoo_ui_screens_qmllint
                 zaparoo_ui_theme_qmllint
                 tst_ui_qmllint)
             if(TARGET ${_qmllint_target})

--- a/cmake/ZaparooQmlModule.cmake
+++ b/cmake/ZaparooQmlModule.cmake
@@ -1,5 +1,5 @@
 # Zaparoo Launcher
-# Copyright (c) 2026 The Zaparoo Project Contributors.
+# Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 # SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 #
 # zaparoo_add_qml_module(target URI <uri> QML_FILES ... [RESOURCES ...] [IMPORTS ...])

--- a/cmake/ZaparooRust.cmake
+++ b/cmake/ZaparooRust.cmake
@@ -1,5 +1,5 @@
 # Zaparoo Launcher
-# Copyright (c) 2026 The Zaparoo Project Contributors.
+# Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 # SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 #
 # Rust/Cargo integration via Corrosion. Builds zaparoo_launcher_rs as a
@@ -151,6 +151,23 @@ endif()
 
 set_target_properties(launcher PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
+
+# ── Translations ─────────────────────────────────────────────────────────────
+# lrelease compiles .ts → .qm and qt_add_translations embeds them into the
+# launcher binary under qrc:/i18n/ (the default RESOURCE_PREFIX). main.cpp
+# loads the locale-matching .qm with `QTranslator::load(locale, "launcher",
+# "_", ":/i18n")` before the QML engine runs.
+#
+# IMMEDIATE_CALL runs source collection inline instead of deferring to the
+# end of the top-level directory scope. Without it, qt_add_translations
+# defers until CMake finalises PROJECT_SOURCE_DIR and the generated resource
+# targets land after link-time, producing missing-dependency errors on
+# parallel builds (Corrosion-provided staticlibs are visited out of order).
+qt_add_translations(launcher
+    TS_FILES "${CMAKE_SOURCE_DIR}/src/ui/translations/launcher_en.ts"
+    RESOURCE_PREFIX "/i18n"
+    IMMEDIATE_CALL
 )
 
 # ── cxx-qt QML module sync for tooling ───────────────────────────────────────

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,27 +11,35 @@ src/app/main.cpp
     ├── rust/launcher/  [zaparoo_launcher_rs staticlib]
     │     ├── src/lib.rs
     │     │     zaparoo_rust_init()      — tokio runtime, logger, WebSocket client,
-    │     │                               systems catalog, watch channel
+    │     │                               Store, model globals
     │     │     zaparoo_rust_post_qt_start() — post-engine hooks
     │     │     zaparoo_log_qt()         — Qt message handler sink → tracing registry
+    │     │
+    │     ├── src/bind.rs
+    │     │     `bind_to_endpoint!` macro — emits the cxx_qt::Initialize
+    │     │     impl for QML singletons (sync seed + qt_thread watcher).
     │     │
     │     ├── src/mister_runtime.rs
     │     │     Pre-Qt setup on ARM32: vmode resolution switch, zaparoo.sh start.
     │     │     Compiled on all platforms; MiSTer-specific calls are gated by cfg.
     │     │
     │     ├── src/models/  [Zaparoo.Browse QML module via cxx-qt 0.7]
-    │     │     BrowseModel, CategoriesModel, SystemsModel, GamesModel
-    │     │     All four are QML singletons registered via build.rs QmlModule.
+    │     │     AppStatus, CategoriesModel, SystemsModel, GamesModel
+    │     │     (BrowseModel and per-screen state singletons).
+    │     │     All registered via build.rs QmlModule.
     │     │
     │     └── rust/zaparoo-core/  [non-Qt Rust crate]
-    │           client.rs          — WebSocket JSON-RPC 2.0 (tokio-tungstenite)
-    │           systems_catalog.rs — derives categories + systems from server data
-    │           config.rs          — TOML config (launcher.toml)
-    │           logger.rs          — tracing-subscriber: stderr + JSONL file sinks
-    │           runtime.rs         — Runtime enum: what device the launcher runs on
-    │           platform.rs        — Platform enum: what Zaparoo Core is running on
-    │           platform_paths.rs  — log/config paths routed through runtime
-    │           media_types.rs     — file-extension → media-type lookup
+    │           client.rs           — WebSocket JSON-RPC 2.0 (tokio-tungstenite)
+    │           remote_resource.rs  — RemoteResource<T>/ResourceStatus<T>
+    │           store/              — Endpoint, Mutation, Tag, Store cache
+    │           endpoints/          — CatalogEndpoint, MediaSearchEndpoint, RunMutation
+    │           systems_catalog.rs  — CatalogData payload + by-category filter
+    │           config.rs           — TOML config (launcher.toml)
+    │           logger.rs           — tracing-subscriber: stderr + JSONL file sinks
+    │           runtime.rs          — Runtime enum: what device the launcher runs on
+    │           platform.rs         — Platform enum: what Zaparoo Core is running on
+    │           platform_paths.rs   — log/config paths routed through runtime
+    │           media_types.rs      — file-extension → media-type lookup
     │
     └── src/ui/app/  [Zaparoo.App QML module]
           Main.qml
@@ -116,36 +124,50 @@ License texts live in `src/LICENSES/`.
 
 ## Rust → QML data flow
 
+The data layer is RTK-Query-shaped: a single `Store` owns the
+`Client`, hands out shared `RemoteResource<T>`s keyed by
+`(endpoint NAME, args hash)`, and routes mutations through to the
+same client. QML singletons subscribe by binding to an `Endpoint`;
+the macro at `rust/launcher/src/bind.rs` emits the entire bridge
+(sync seed + qt_thread watcher + property apply).
+
 ```
 zaparoo_rust_init()
     │
     ├── logger::install()          — tracing-subscriber (stderr + JSONL file)
     ├── Config::load()             — launcher.toml
     ├── tokio::Runtime::new()      — multi-thread executor
-    │
-    ├── tokio::sync::watch channel
-    │     Sender<CatalogSnapshot>  — written by WebSocket task
-    │     Receiver<CatalogSnapshot>— cloned into each QML singleton
-    │
-    └── WebSocket client task (tokio)
+    ├── Client::new(endpoint)      — WebSocket JSON-RPC, auto-reconnects
+    └── Store::new(client, runtime)
           │
-          ├── systems() → SystemsCatalog::from_systems()
-          │     → watch channel send(snapshot)
-          │         ├── CategoriesModel::on_catalog_changed()
-          │         │       ↓ category name list
-          │         │   categoriesCarousel in Main.qml
-          │         │
-          │         └── SystemsModel::on_catalog_changed()
-          │                 ↓ systems filtered by current category
-          │             systemsCarousel in Main.qml
+          │   subscribe::<E>(args) → Arc<RemoteResource<E::Output>>
+          │     ─ keyed cache: identical args reuse the same Arc
+          │     ─ per-entry watcher updates `provides` on each Ready
           │
-          ├── media.search() → GamesModel::on_search_result()
-          │         ↓ game list for current system (up to 100)
-          │     gamesCarousel in Main.qml
+          │   run_mutation::<M>(args) → invalidates matching tags,
+          │     each refetch pulses Notify on its RemoteResource
           │
-          └── run() invoked via GamesModel::launch_at()
-                    (game launch — no model update)
+          ├── CatalogEndpoint           Args = ()        provides: any("Catalog")
+          │     └── bound by AppStatus, CategoriesModel, SystemsModel
+          │           via `bind_to_endpoint!`
+          │
+          ├── MediaSearchEndpoint       Args = SystemId  provides: specific("MediaSearch", id)
+          │     └── GamesModel::set_system subscribes per-system; the
+          │         store keys cache entries by id so re-selecting a
+          │         system reuses its cached resource without re-fetching
+          │
+          └── RunMutation               Args = RunParams  invalidates: ()
+                └── GamesModel::launch_at → store.run_mutation::<RunMutation>
+                      Today no tags are invalidated; future
+                      NowPlayingEndpoint can opt in by adding its tag.
 ```
+
+`RemoteResource<T>` collapses the connection FSM and per-fetch state
+into a single `ResourceStatus<T>`: `Idle`, `Loading`, `Ready(T)`,
+`Errored { message, retrying }`. Every binding seeds itself
+synchronously from the *current* status before spawning the watcher,
+which closes the MiSTer "screen never updates if Core connects before
+QML loads" race.
 
 Qt message handler (`qInstallMessageHandler`) forwards all Qt log output
 to `zaparoo_log_qt()` in the Rust staticlib, which routes it through the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -92,7 +92,7 @@ or vice-versa.
 
 - **Runtime gate** — "this code path behaves differently depending on
   the launcher's host device." Read `runtime::current()`. Prefer runtime
-  gating for behaviour.
+  gating for behavior.
 - **Build-time cfg `#[cfg(zaparoo_runtime = "mister")]`** — reserve for
   code that genuinely should not compile into desktop binaries (system
   calls, MiSTer-only dependencies). Currently only `mister_runtime.rs`
@@ -104,7 +104,7 @@ or vice-versa.
   completes." Never gate on `Platform` from C++/QML directly; route the
   decision through Rust and expose a QML property.
 
-**Never gate runtime behaviour on `Platform`, never gate Core
+**Never gate runtime behavior on `Platform`, never gate Core
 assumptions on `Runtime`.** They are independent.
 
 ## LGPL compliance
@@ -159,7 +159,7 @@ activeScreen: "hub" | "games"
 hubFocus:     "categories" | "systems"
 ```
 
-- **hub + categories**: categoriesCarousel centred; Left/Right cycle categories;
+- **hub + categories**: categoriesCarousel centered; Left/Right cycle categories;
   Enter calls `SystemsModel.set_category()` and shifts hubFocus to "systems";
   Escape quits.
 - **hub + systems**: categoriesCarousel swoops to top; systemsCarousel fades in

--- a/docs/building.md
+++ b/docs/building.md
@@ -1,118 +1,154 @@
 # Building
 
+Day-to-day builds, lints, and tests are wrapped in
+[`justfile`](../justfile). `just --list` shows the full menu.
+`CMakePresets.json` and `rust/.cargo/config.toml` are tuned to the
+recipes; if you find yourself reaching for raw `cmake` or `cargo`,
+something is probably off.
+
 ## Requirements
 
 ### Desktop
 
-- Qt 6.7+ (Quick, QuickControls2, Qml)
+- Qt 6.7+ (Quick, QuickControls2, Qml, LinguistTools)
 - CMake 3.22+
 - C++17 compiler (GCC 10+, Clang 12+, MSVC 2019+)
 - Rust stable toolchain (`rustup install stable`)
 - Ninja (required; pinned by `CMakePresets.json`)
 - mold (used as linker on x86_64 Linux; pinned by `rust/.cargo/config.toml`)
+- `just`, `cargo-nextest`, `cargo-deny`
 
-On Fedora/RHEL: `sudo dnf install qt6-qtdeclarative-devel qt6-qtquickcontrols2-devel cmake ninja-build mold`
-On Ubuntu/Debian: `sudo apt install qt6-declarative-dev qt6-quick-controls2-dev cmake ninja-build mold`
+Fedora / RHEL:
+```bash
+sudo dnf install qt6-qtdeclarative-devel qt6-qtquickcontrols2-devel \
+    qt6-qttools-devel cmake ninja-build mold clang-tools-extra just
+```
 
-Install Rust via rustup: `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
+Ubuntu / Debian:
+```bash
+sudo apt install qt6-declarative-dev qt6-quick-controls2-dev \
+    qt6-tools-dev qt6-l10n-tools cmake ninja-build mold \
+    clang-tidy clang-format just
+```
+
+Install Rust via rustup, then the cargo extensions:
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+cargo install --locked cargo-nextest cargo-deny
+```
+
+If `just` isn't packaged for your distro, install it the same way:
+`cargo install --locked just`.
 
 ### MiSTer ARM32 cross-build
 
 - Docker (any recent version)
-- x86_64 host (no emulation needed, pure cross-compilation)
+- x86_64 host (no emulation needed; pure cross-compilation)
 - ~8 GB disk space for the toolchain image
 
-The toolchain Docker image ships a cross-compiler-aware `rust/.cargo/config.toml`
-that sets the correct linker (`arm-linux-gnueabihf-gcc`), target
-(`armv7-unknown-linux-gnueabihf`), and `mold` on desktop for faster links.
-No manual cargo config is needed.
+The toolchain Docker image ships a cross-compiler-aware
+`rust/.cargo/config.toml` that sets the linker
+(`arm-linux-gnueabihf-gcc`), target
+(`armv7-unknown-linux-gnueabihf`), and `mold` on desktop for faster
+links. No manual cargo config is needed.
 
-## Desktop build
+## Desktop builds
 
 ```bash
-cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
-cmake --build build
-./build/bin/launcher
+just build           # debug build (default)
+just build-release   # release build
+just build-dev       # dev preset (relwithdebinfo + extra checks)
+just build-san       # ASan + UBSan
+just run             # build then ./build/bin/launcher
 ```
 
-For a Release build:
+The first build pulls and compiles Rust + Qt dependencies. Incremental
+builds after that are fast.
+
+To skip tests for faster iteration, configure with
+`-DZAPAROO_BUILD_TESTS=OFF`:
 
 ```bash
-cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
-cmake --build build
-```
-
-### Skip tests (faster iteration)
-
-```bash
-cmake -S . -B build -DZAPAROO_BUILD_TESTS=OFF
-```
-
-### Sanitizers (Debug only)
-
-```bash
-cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug \
-    -DZAPAROO_ENABLE_ASAN=ON -DZAPAROO_ENABLE_UBSAN=ON
-cmake --build build
-./build/bin/launcher
-```
-
-### QML linting
-
-```bash
-cmake --build build --target all_qmllint
+cmake --preset desktop-debug -DZAPAROO_BUILD_TESTS=OFF
+cmake --build --preset desktop-debug
 ```
 
 ## MiSTer ARM32 cross-build
 
-**First time (builds Qt 6.7.2 from source, ~45 min):**
+First time (builds Qt 6.7.2 from source, ~45 min):
 
 ```bash
 ./scripts/build-toolchain.sh
 ```
 
-This creates the `zaparoo/qt6-arm32-mister:6.7.2` Docker image locally.
+This creates the `zaparoo/qt6-arm32-mister:6.7.2` Docker image
+locally.
 
-**Subsequent builds (< 1 min):**
+Subsequent builds (under a minute):
 
 ```bash
-./scripts/build-arm32.sh
-# Output: output/launcher
+just arm32           # output/launcher
 ```
 
-If the toolchain image is missing, `build-arm32.sh` rebuilds it automatically.
+If the toolchain image is missing, `build-arm32.sh` rebuilds it
+automatically.
 
-### Verify the ARM binary
+Verify the ARM binary:
 
 ```bash
 file output/launcher
 # Should report: ELF 32-bit LSB executable, ARM, EABI5 ...
 ```
 
+## Tests
+
+```bash
+just test            # ctest + cargo nextest
+just test-qml        # only the Qt/QML tests
+just test-rust       # only cargo nextest
+just test-san        # ASan/UBSan suite
+```
+
+## Lints
+
+```bash
+just lint            # everything
+just lint-cpp        # clang-format check + clang-tidy
+just lint-qml        # qmllint
+just lint-rust       # rustfmt check + clippy + cargo-deny
+just fmt             # auto-apply: pre-commit + cargo fmt
+```
+
+`just lint` is the zero-warnings gate before opening a PR.
+`compile_commands.json` is generated unconditionally in `build/`, so
+clang-tidy and qmllint always have what they need.
+
 ## Deploy desktop bundle
 
 ```bash
-cmake --build build
+just build
 ./packaging/deploy-desktop.sh
 ./deploy/launcher/run.sh
 ```
 
-The deploy script bundles Qt shared libraries alongside the binary. Qt
-must be on your PATH (i.e. `qmake6` or `qmake` must be findable).
+The deploy script bundles Qt shared libraries alongside the binary.
+Qt must be on your PATH (`qmake6` or `qmake` must be findable).
 
 ## Deploy to MiSTer
 
 ```bash
-./scripts/deploy-mister.sh
+just deploy-mister
 ```
 
-The binary is self-contained on MiSTer: it sets `QT_QPA_PLATFORM=linuxfb` and
-`QT_QUICK_BACKEND=software`, runs `vmode -r W H rgb32` (width/height from
-config, defaulting to 1920×1080), and starts
-`/media/fat/Scripts/zaparoo.sh -service start` automatically. Just run the
-binary; no wrapper script required.
+The binary is self-contained on MiSTer: it sets
+`QT_QPA_PLATFORM=linuxfb` and `QT_QUICK_BACKEND=software`, runs `vmode
+-r W H rgb32` (width and height from config, defaulting to
+1920×1080), and starts `/media/fat/Scripts/zaparoo.sh -service start`
+automatically. No wrapper script required.
 
-User-editable config lives at `/media/fat/zaparoo/launcher.toml`. Example:
+User-editable config lives at `/media/fat/zaparoo/launcher.toml`.
+Example:
 
 ```toml
 [video]
@@ -125,56 +161,39 @@ debug = true
 
 ## Run on framebuffer (desktop headless)
 
+Useful for reproducing MiSTer rendering paths on a desktop:
+
 ```bash
 QT_QPA_PLATFORM=linuxfb QT_QUICK_BACKEND=software ./build/bin/launcher
 ```
 
-## Running tests
+## Underlying mechanics
+
+Reach for these only when debugging the build itself or running
+something not in the justfile.
+
+`just build` resolves to:
 
 ```bash
-ctest --test-dir build --output-on-failure
+cmake --preset desktop-debug
+cmake --build --preset desktop-debug
 ```
 
-Rust unit tests (zaparoo-core):
-
-```bash
-cargo test --manifest-path rust/Cargo.toml
-```
-
-## Code quality
-
-### Run all linters
-
-```bash
-cmake --build build --target lint
-```
-
-This runs clang-format (check only), clang-tidy, and qmllint in one shot.
-`compile_commands.json` is always generated in `build/`, so no extra cmake flag is needed.
-
-### Individual lint targets
+`just lint-cpp` resolves to `cmake --build build --target lint`,
+which runs clang-format (check only), clang-tidy, and qmllint in one
+shot. Individual targets:
 
 ```bash
 cmake --build build --target format-check   # clang-format dry-run
-cmake --build build --target tidy           # clang-tidy static analysis
+cmake --build build --target tidy           # clang-tidy
 cmake --build build --target all_qmllint    # QML linting
 ```
 
-### Rust linting
+`just test` resolves to `ctest --preset desktop-debug` plus
+`cargo nextest run --workspace` (run from inside `rust/` because
+nextest needs a workspace path; that's what the justfile does for
+you). Plain ctest works too:
 
 ```bash
-cargo fmt --manifest-path rust/Cargo.toml --check   # format check
-cargo clippy --manifest-path rust/Cargo.toml         # static analysis
-```
-
-### Auto-format C++ files
-
-```bash
-clang-format -i src/**/*.{cpp,h} tests/**/*.cpp
-```
-
-### Format all files (pre-commit)
-
-```bash
-pre-commit run --all-files
+ctest --test-dir build --output-on-failure
 ```

--- a/docs/cxx-qt-bridge.md
+++ b/docs/cxx-qt-bridge.md
@@ -20,3 +20,41 @@ Read this when writing Rust QML models via cxx-qt 0.7 in
 - **cxx-qt plugin class name** for a `Zaparoo.Browse` module is
   `Zaparoo_Browse_plugin` (not `Zaparoo_BrowsePlugin`). Use
   `Q_IMPORT_QML_PLUGIN(Zaparoo_Browse_plugin)` in the C++ entry point.
+
+- **Bind QML singletons to data through `bind_to_endpoint!`.** QML
+  singletons are constructed *after* `init_globals` runs, which is
+  *after* the WebSocket task has very likely already advanced past
+  `Idle`/`Disconnected`. If you only spawn an async watcher inside
+  `initialize()`, the QObject's `Default::default()` placeholder values
+  are visible to the first frame.
+
+  The macro at `rust/launcher/src/bind.rs` emits the entire
+  `cxx_qt::Initialize` impl: it subscribes the singleton to the
+  store-cached `RemoteResource<E::Output>` for the chosen endpoint,
+  reads the current `ResourceStatus` *synchronously* before returning,
+  and only then spawns the qt_thread watcher for subsequent updates.
+  The seed bug is closed structurally — there is no place left to
+  forget it.
+
+  ```rust
+  // models/app_status.rs — full bridge for the AppStatus banner.
+  crate::bind_to_endpoint! {
+      for ffi::AppStatus,
+      endpoint = CatalogEndpoint,
+      args = (),
+      select = project,       // fn(&ResourceStatus<CatalogData>) -> Projected
+      apply  = apply_state,   // fn(Pin<&mut Self>, Projected)
+  }
+  ```
+
+  `select` and `apply` are free functions (not closures) so they're
+  `Copy` and reusable across the sync seed and the async loop. For
+  per-arg endpoints (e.g. `MediaSearchEndpoint`, keyed by system id),
+  drive `Store::subscribe` directly from a `#[qinvokable]` and abort
+  the previous watcher's `JoinHandle` before installing the new one
+  (see `models/games.rs`).
+
+  Use `tokio::sync::watch` for any state a `RemoteResource` exposes;
+  `tokio::sync::broadcast` drops messages sent before a receiver
+  subscribes and so loses the seed value entirely (see the CLAUDE.md
+  "broadcast vs watch" note).

--- a/docs/qml-gotchas.md
+++ b/docs/qml-gotchas.md
@@ -22,4 +22,4 @@ catches *after* the code is written, so it's cheaper to avoid them up front.
   `: ReturnType` return types to all functions in singleton `.qml` files.
 
 - **`NumberAnimation on propName`** conflicts with `property T propName: value`.
-  Drop the `: value` initialiser; the animation takes over immediately.
+  Drop the `: value` initializer; the animation takes over immediately.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,136 @@
+# Quickstart
+
+## 1. Install prerequisites
+
+One-time setup. Skip any you already have.
+
+### Linux
+
+**Fedora / RHEL:**
+```bash
+sudo dnf install qt6-qtdeclarative-devel qt6-qtquickcontrols2-devel \
+    cmake ninja-build mold clang-tools-extra just
+```
+
+**Ubuntu / Debian:**
+```bash
+sudo apt install qt6-declarative-dev qt6-quick-controls2-dev \
+    cmake ninja-build mold clang-tidy clang-format just
+```
+
+(If `just` isn't packaged for your distro, install it with
+`cargo install --locked just` after Rust is set up.)
+
+### Rust
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+cargo install --locked cargo-nextest cargo-deny
+```
+
+### macOS / Windows
+
+macOS is best-effort and not covered in CI. See
+[`docs/building.md`](building.md) for Homebrew package names. Windows
+is not tested; use WSL2.
+
+## 2. Clone and build
+
+```bash
+git clone git@github.com:ZaparooProject/zaparoo-launcher.git
+cd zaparoo-launcher
+just build
+```
+
+The first build pulls and compiles Rust + Qt dependencies. After that
+incremental builds are fast.
+
+## 3. Start the mock Core
+
+In one terminal:
+
+```bash
+just mock-core
+```
+
+You should see:
+
+```
+mock-core listening on ws://127.0.0.1:27497/api/v0.1
+```
+
+The mock serves three categories (Consoles, Handhelds, Arcade), ten
+systems, and fifty games. That's enough to drive every launcher
+screen end to end.
+
+`27497` is deliberately offset from the real Core's `7497` so a
+real Core (or other Core test instance) running on the same machine
+never clashes with the mock. The launcher's production default is
+still `7497`; `just run-dev` overrides that to the mock port via the
+`ZAPAROO_CORE_ENDPOINT` environment variable, and `just run` (the
+release-style runner) reads `~/.config/zaparoo/launcher.toml` as
+normal.
+
+### Picking a different port
+
+If something else binds `27497` already, override at start:
+
+```bash
+MOCK_CORE_ADDR=127.0.0.1:9000 just mock-core
+ZAPAROO_CORE_ENDPOINT=ws://127.0.0.1:9000/api/v0.1 just run-dev
+```
+
+`ZAPAROO_CORE_ENDPOINT` always wins over `~/.config/zaparoo/launcher.toml`.
+
+## 4. Run the launcher
+
+In a second terminal:
+
+```bash
+just run-dev
+```
+
+(`run-dev` is windowed and auto-points at the mock; `just run` is the
+production-style runner that respects `~/.config/zaparoo/launcher.toml`
+and starts fullscreen.)
+
+## 5. What success looks like
+
+- The launcher window opens.
+- A **categories** carousel fills with "Arcade", "Consoles",
+  "Handhelds". Left/Right cycles between them.
+- Pressing Enter drops you into the **systems** carousel for that
+  category.
+- Pressing Enter on a system opens the **games** carousel (five
+  entries per system).
+- Pressing Enter on a game fires a `run` RPC to the mock. The mock
+  logs it with the selected game's zap script, but the launcher keeps
+  running because there's nothing actually to launch.
+- Escape backs out; Escape on the top level quits.
+
+The FPS counter in the corner should stay green (≥ 55). If it goes
+red, flag it; that's a regression.
+
+## 6. Running tests and lints
+
+Before you open a pull request:
+
+```bash
+just lint    # clang-format, clang-tidy, qmllint, rustfmt, clippy, cargo-deny
+just test    # ctest + cargo nextest
+```
+
+Zero warnings is the bar.
+
+## Next steps
+
+- [`docs/building.md`](building.md): sanitizer builds, ARM32
+  cross-build for MiSTer, deployment.
+- [`docs/architecture.md`](architecture.md): module graph, Rust↔QML
+  data flow, Runtime vs Platform distinction.
+- [`docs/qml-gotchas.md`](qml-gotchas.md): QML pitfalls that `qmllint`
+  only catches after the fact.
+- [`docs/cxx-qt-bridge.md`](cxx-qt-bridge.md): cxx-qt 0.7 bridge
+  constraints when editing Rust QML models.
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md): CLA flow, PR expectations,
+  branch-protection rules.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -37,7 +37,7 @@ is not tested; use WSL2.
 ## 2. Clone and build
 
 ```bash
-git clone git@github.com:ZaparooProject/zaparoo-launcher.git
+git clone https://github.com/ZaparooProject/zaparoo-launcher.git
 cd zaparoo-launcher
 just build
 ```
@@ -55,7 +55,7 @@ just mock-core
 
 You should see:
 
-```
+```text
 mock-core listening on ws://127.0.0.1:27497/api/v0.1
 ```
 

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -1,0 +1,157 @@
+# Translations
+
+Zaparoo Launcher routes every user-visible string through Qt's
+`QTranslator` so non-English builds can ship without code changes.
+Three pieces hold the pipeline together:
+
+1. `qsTr()` in QML and `tr()` in C++ at every user-visible call site.
+2. `src/ui/translations/launcher_<tag>.ts` as the canonical catalog
+   (one per locale, XML, checked into git).
+3. `qt_add_translations` in `cmake/ZaparooRust.cmake`, which runs
+   `lrelease` at build time and bundles the resulting `.qm` files
+   under `qrc:/i18n/` inside the launcher binary.
+
+At runtime, `src/app/main.cpp` installs a `QTranslator` before the QML
+engine loads and picks the `.qm` that matches the configured locale.
+
+## Locale resolution
+
+| Source | Precedence |
+|---|---|
+| `[general] language = "ja_JP"` in `launcher.toml` | 1: explicit override |
+| `[general] language = "auto"` or unset | 2: `QLocale::system()` |
+
+The Rust config loader (`rust/zaparoo-core/src/config.rs`) normalizes
+`"auto"` (case-insensitive) to an empty string, which `main.cpp`
+treats as the signal to call `QLocale::system()`. Anything else passes
+straight through to `QLocale(tag)`; Qt does its own tag validation.
+
+The config-to-C++ handoff goes through FFI:
+`zaparoo_rust_language_code()` returns a `'static` NUL-terminated
+UTF-8 pointer cached in `LANGUAGE_CODE: OnceLock<CString>`. The main
+thread reads it once before constructing the QML engine. There is no
+reload path, so changing the locale requires a relaunch (the same
+cost as any other `launcher.toml` edit).
+
+## Writing translatable strings
+
+Every literal a user might read belongs in `qsTr()`:
+
+```qml
+// Good: translator can reorder the units.
+text: qsTr("%1 FPS").arg(root.fps)
+
+// Good: entire sentence is one translation unit.
+text: qsTr("Core error: %1").arg(Browse.AppStatus.last_error)
+
+// Bad: splits the sentence; German, Japanese, etc. can't reorder it.
+text: qsTr("Core error:") + " " + Browse.AppStatus.last_error
+```
+
+Rule of thumb: one sentence, one `qsTr()`. Use `%1`/`%2` placeholders
+for runtime values so translators control word order around them.
+
+Strings that never face a human (enum tags, filesystem paths, QRC
+URLs, internal error codes routed to `tracing::error!`, QML type
+names) do **not** need wrapping. When in doubt: if it could appear in
+a screenshot, wrap it.
+
+## Adding a new locale
+
+1. Copy the English catalog:
+
+        cp src/ui/translations/launcher_en.ts src/ui/translations/launcher_de.ts
+
+2. Run `lupdate-qt6` against the full source tree so every `qsTr()`
+   call site populates the new catalog:
+
+        lupdate-qt6 src/ -ts src/ui/translations/launcher_de.ts
+
+   `lupdate` is idempotent. Re-running it reconciles new and removed
+   strings without clobbering existing translations.
+
+3. Fill in each `<translation>` element in the `.ts` file. An empty
+   `<translation>` with `type="unfinished"` means "use the source
+   string"; Qt Linguist highlights these in the editor UI.
+
+4. Add the file path to the `TS_FILES` list in
+   `cmake/ZaparooRust.cmake`'s `qt_add_translations(launcher ...)`
+   call. CMake will pick up the `.qm` on the next build.
+
+5. Configure a dev launcher to test it:
+
+        # launcher.toml
+        [general]
+        language = "de"
+
+## Updating existing catalogs
+
+After adding or changing any `qsTr()` call, re-run `lupdate-qt6`:
+
+    lupdate-qt6 src/ -ts src/ui/translations/launcher_en.ts
+
+Review the diff: new strings appear with empty `<translation>`
+elements, changed strings are flagged `type="unfinished"`, and removed
+strings are marked `type="obsolete"`. Commit the `.ts` changes
+alongside the QML or C++ edit that triggered them so translators have
+a clean incremental diff.
+
+## Build-time mechanics
+
+`qt_add_translations` is called in `cmake/ZaparooRust.cmake` right
+after the `launcher` target is created:
+
+```cmake
+qt_add_translations(launcher
+    TS_FILES "${CMAKE_SOURCE_DIR}/src/ui/translations/launcher_en.ts"
+    RESOURCE_PREFIX "/i18n"
+    IMMEDIATE_CALL
+)
+```
+
+What happens:
+
+- `lrelease` runs per `.ts` to produce `<name>.qm` in the build tree.
+- The `.qm` files are packed into a Qt resource bound to the
+  `launcher` target at `qrc:/i18n/`.
+- An `update_translations` target is registered for `cmake --build .
+  --target update_translations`, which runs `lupdate` on demand.
+- A `release_translations` target is also registered and wired into
+  the default build, so every `just build` refreshes the compiled
+  catalogs.
+
+`IMMEDIATE_CALL` runs the source-target collection inline. Without
+it, Qt defers collection to the end of the top-level
+`PROJECT_SOURCE_DIR` scope, which races Corrosion's late-bound Rust
+staticlib targets on parallel builds and produces missing-dependency
+errors.
+
+## Runtime loading
+
+`src/app/main.cpp` wires the translator before the QML engine:
+
+```cpp
+const QString langCode = QString::fromUtf8(zaparoo_rust_language_code());
+const QLocale locale = langCode.isEmpty() ? QLocale::system() : QLocale(langCode);
+QTranslator translator;
+if (translator.load(locale, "launcher", "_", ":/i18n")) {
+    QCoreApplication::installTranslator(&translator);
+}
+```
+
+`QTranslator::load` walks Qt's usual fallback chain: an exact `ja_JP`
+match first, then `ja`, then the base name. A missing `.qm` is logged
+at info level, not as an error, because English-only builds ship
+exactly one catalog (a passthrough `launcher_en.qm`) and any other
+locale just falls through to the source strings.
+
+## Requirements
+
+- **Desktop build**: `qt6-qttools-devel` (Fedora) or `qt6-tools-dev` +
+  `qt6-l10n-tools` (Debian). These provide the `Qt6LinguistTools`
+  CMake package plus the `lupdate` and `lrelease` binaries. Configure
+  fails early if either is missing.
+- **ARM32 cross-build**: `qttools` is built for host Qt in
+  `Dockerfile.toolchain` (host-only; `.qm` files are
+  architecture-independent and bundled into the target resource by
+  the host build).

--- a/justfile
+++ b/justfile
@@ -31,6 +31,13 @@ run: build
 run-dev: build-dev
     ./build-dev/bin/launcher
 
+# Run a local mock Zaparoo Core (ws://127.0.0.1:27497/api/v0.1).
+# Deliberately offset from the real Core's 7497 so dev never collides
+# with a running Core. `just run-dev` automatically points the launcher
+# here via ZAPAROO_CORE_ENDPOINT. See docs/quickstart.md.
+mock-core:
+    cd rust && cargo run --bin mock-core
+
 # --- test ---
 test: build
     ctest --preset desktop-debug

--- a/packaging/deploy-desktop.sh
+++ b/packaging/deploy-desktop.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Zaparoo Launcher
-# Copyright (c) 2026 The Zaparoo Project Contributors.
+# Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 # SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 #
 # Bundle Qt shared libraries for LGPL-compliant desktop distribution.

--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -1,5 +1,5 @@
 # Zaparoo Launcher
-# Copyright (c) 2026 The Zaparoo Project Contributors.
+# Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 # SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
 # Desktop: use system C compiler as the linker driver. Rust's default

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -703,6 +703,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mock-core"
+version = "0.1.0"
+dependencies = [
+ "futures-util",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,6 +995,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1152,6 +1175,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,9 +1,9 @@
 # Zaparoo Launcher
-# Copyright (c) 2026 The Zaparoo Project Contributors.
+# Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 # SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
 [workspace]
-members = ["launcher", "zaparoo-core"]
+members = ["launcher", "mock-core", "zaparoo-core"]
 resolver = "2"
 
 [workspace.package]
@@ -11,7 +11,7 @@ version      = "0.1.0"
 edition      = "2021"
 rust-version = "1.90"
 license      = "LicenseRef-PolyForm-Noncommercial-1.0.0"
-authors      = ["The Zaparoo Project Contributors"]
+authors      = ["Wizzo Pty Ltd and the Zaparoo Project contributors"]
 
 [workspace.dependencies]
 cxx             = "1"

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -1,5 +1,5 @@
 # Zaparoo Launcher
-# Copyright (c) 2026 The Zaparoo Project Contributors.
+# Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 # SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
 [graph]

--- a/rust/launcher/Cargo.toml
+++ b/rust/launcher/Cargo.toml
@@ -1,5 +1,5 @@
 # Zaparoo Launcher
-# Copyright (c) 2026 The Zaparoo Project Contributors.
+# Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 # SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
 [package]

--- a/rust/launcher/build.rs
+++ b/rust/launcher/build.rs
@@ -1,5 +1,5 @@
 // Zaparoo Launcher
-// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
 use cxx_qt_build::{CxxQtBuilder, QmlModule};
@@ -28,8 +28,10 @@ fn main() {
                 "src/models/games.rs",
                 "src/models/browse.rs",
                 "src/models/app_state.rs",
+                "src/models/app_status.rs",
                 "src/models/hub_state.rs",
                 "src/models/games_state.rs",
+                "src/models/input.rs",
             ],
             qml_files: &[],
             ..Default::default()

--- a/rust/launcher/src/bind.rs
+++ b/rust/launcher/src/bind.rs
@@ -1,0 +1,78 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+//
+// `bind_to_endpoint!` — boilerplate eliminator for QML singletons that
+// surface a `Store` endpoint's `ResourceStatus<T>` to the UI.
+//
+// Without it, every singleton hand-rolled the same five-step dance:
+// subscribe to the catalog watch, sync-seed from `borrow_and_update()`
+// (the contract in `docs/cxx-qt-bridge.md`), capture a `qt_thread`,
+// spawn a tokio task that listens for changes, and route each change
+// through `qt_thread.queue` so property setters fire on the GUI
+// thread. Forgetting the sync-seed step caused the recurring MiSTer
+// "screen never updates if Core connects before QML loads" race.
+//
+// The macro takes two free functions:
+//   `select`: project the resource status into a Send + 'static value
+//             (e.g. `(i32, String)` for the connection-state banner).
+//   `apply`:  consume the projected value plus `Pin<&mut Target>` and
+//             update QProperties / call beginResetModel / etc.
+//
+// Both functions run twice: once synchronously during `initialize()`
+// for the seed, then once per change inside the `qt_thread.queue`
+// callback. Using free fn paths (rather than closures) keeps them
+// `Copy` so they can be reused across the two call sites without any
+// `Fn`/`Send`/`Sync` gymnastics.
+//
+// Per-arg endpoints (currently just `MediaSearchEndpoint`, used by
+// `GamesModel::set_system`) are hand-rolled rather than driven by
+// this macro. The shape is the same — sync-seed, qt_thread watcher
+// — plus two extras: aborting the previous watcher's `JoinHandle`
+// and a monotonic ticket so callbacks queued by the previous args
+// don't apply to the new args (`JoinHandle::abort` does not drain
+// callbacks already on the Qt event loop). With one such call site,
+// a hand-rolled implementation with inline comments is clearer than
+// a macro that bakes in guesses about which parts are generic.
+// Revisit when a second per-arg endpoint appears (BrowseModel,
+// NowPlayingForSystem, …) — at that point factor the
+// abort+ticket+seed+spawn dance into `bind_to_arg_endpoint!` so the
+// stale-callback bug class is closed structurally rather than by
+// convention.
+
+/// Generate `Initialize` for a cxx-qt QML singleton bound to a `Store`
+/// endpoint. See module docs for the contract; the seed is automatic.
+#[macro_export]
+macro_rules! bind_to_endpoint {
+    (
+        for $target:ty,
+        endpoint = $endpoint:ty,
+        args = $args:expr,
+        select = $select:path,
+        apply = $apply:path $(,)?
+    ) => {
+        impl ::cxx_qt::Initialize for $target {
+            fn initialize(mut self: ::std::pin::Pin<&mut Self>) {
+                use ::cxx_qt::Threading;
+                let mut rx = $crate::models::global_store()
+                    .subscribe::<$endpoint>($args)
+                    .subscribe();
+
+                // Sync seed: project the current resource status and
+                // apply it before spawning the watcher, so the first
+                // QML frame sees real state rather than the
+                // `Default::default()` placeholder.
+                let projected = $select(&*rx.borrow_and_update());
+                $apply(self.as_mut(), projected);
+
+                let qt_thread = self.qt_thread();
+                $crate::models::global_runtime().spawn(async move {
+                    while rx.changed().await.is_ok() {
+                        let projected = $select(&*rx.borrow_and_update());
+                        let _ = qt_thread.queue(move |m| $apply(m, projected));
+                    }
+                });
+            }
+        }
+    };
+}

--- a/rust/launcher/src/lib.rs
+++ b/rust/launcher/src/lib.rs
@@ -2,6 +2,8 @@
 // Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
+#[macro_use]
+mod bind;
 mod mister_runtime;
 mod models;
 
@@ -35,7 +37,7 @@ use std::ffi::{c_char, c_int, CString};
 use std::sync::{Arc, Mutex, OnceLock};
 use zaparoo_core::{
     client::Client, config::load_config, logger::install, persist, platform,
-    platform_paths::config_file_path, systems_catalog,
+    platform_paths::config_file_path, store::Store,
 };
 
 /// Resolved language override, cached after [`zaparoo_rust_init`] so the
@@ -88,7 +90,8 @@ fn install_panic_hook() {
 
 /// Called by the C++ main before `QGuiApplication` is constructed.
 /// Sets up logging, tokio runtime, `MiSTer` pre-Qt env/vmode, WebSocket
-/// client, `SystemsCatalog`, and model globals. Returns 0 on success.
+/// client, `Store` (which owns the endpoint cache), and model globals.
+/// Returns 0 on success.
 #[no_mangle]
 pub extern "C" fn zaparoo_rust_init() -> c_int {
     let config_path = config_file_path();
@@ -127,21 +130,17 @@ pub extern "C" fn zaparoo_rust_init() -> c_int {
 
     let client = Client::new(config.core_endpoint.clone(), &runtime);
     platform::spawn_fetcher(client.clone(), &runtime);
-    let channels = systems_catalog::spawn(client.clone(), &runtime);
+    let store = Store::new(client.clone(), runtime.clone());
 
     // Load persisted UI state up front so per-screen singletons can seed
     // their properties from a consistent snapshot during Initialize.
     let persist_state = Arc::new(Mutex::new(persist::load()));
 
     // init_globals stores Arcs — runtime keeps running after this fn returns.
-    models::init_globals(
-        runtime,
-        client,
-        channels.data,
-        channels.status,
-        persist_state,
-        config.key_to_action.clone(),
-    );
+    // The `Client` is owned by the `Store` (and the platform fetcher
+    // task), so `init_globals` no longer takes it directly; singletons
+    // reach the client through `global_store()`.
+    models::init_globals(runtime, store, persist_state, config.key_to_action.clone());
 
     0
 }

--- a/rust/launcher/src/lib.rs
+++ b/rust/launcher/src/lib.rs
@@ -1,5 +1,5 @@
 // Zaparoo Launcher
-// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
 mod mister_runtime;
@@ -31,12 +31,60 @@ pub unsafe extern "C" fn zaparoo_log_qt(level: u8, msg_ptr: *const u8, msg_len: 
     }
 }
 
-use std::ffi::c_int;
-use std::sync::{Arc, Mutex};
+use std::ffi::{c_char, c_int, CString};
+use std::sync::{Arc, Mutex, OnceLock};
 use zaparoo_core::{
     client::Client, config::load_config, logger::install, persist, platform,
     platform_paths::config_file_path, systems_catalog,
 };
+
+/// Resolved language override, cached after [`zaparoo_rust_init`] so the
+/// C++ side can pull it via [`zaparoo_rust_language_code`] without re-
+/// loading config. An empty string means "use `QLocale::system()`".
+static LANGUAGE_CODE: OnceLock<CString> = OnceLock::new();
+
+/// Returns the resolved UI language override as a NUL-terminated UTF-8
+/// string. An empty string signals "follow `QLocale::system()`"; any
+/// other value is a BCP-47 tag passed straight to `QLocale(code)` in
+/// C++. The pointer is valid for the process lifetime.
+///
+/// Called before [`zaparoo_rust_init`] returns an empty string, since
+/// the `OnceLock` has not yet been populated.
+#[no_mangle]
+pub extern "C" fn zaparoo_rust_language_code() -> *const c_char {
+    LANGUAGE_CODE
+        .get()
+        .map_or_else(|| c"".as_ptr(), |s| s.as_ptr())
+}
+
+/// Installs a panic hook that routes Rust panics through the tracing
+/// registry so they land in the same stderr + JSONL sinks as normal log
+/// output. Without this, a panic on a tokio worker goes to raw stderr
+/// only — invisible on `MiSTer` where stderr is not captured. The hook
+/// chains to the previous default, preserving abort-on-panic semantics.
+fn install_panic_hook() {
+    let default = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let payload = info.payload();
+        let msg = payload
+            .downcast_ref::<&str>()
+            .copied()
+            .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+            .unwrap_or("<non-string panic payload>");
+        let location = info.location().map_or_else(
+            || "<unknown>".to_string(),
+            |l| format!("{}:{}:{}", l.file(), l.line(), l.column()),
+        );
+        let thread = std::thread::current();
+        let thread_name = thread.name().unwrap_or("<unnamed>");
+        let backtrace = std::backtrace::Backtrace::capture();
+        tracing::error!(
+            target: "panic",
+            "thread '{thread_name}' panicked at {location}: {msg}\n{backtrace}"
+        );
+        default(info);
+    }));
+}
 
 /// Called by the C++ main before `QGuiApplication` is constructed.
 /// Sets up logging, tokio runtime, `MiSTer` pre-Qt env/vmode, WebSocket
@@ -46,10 +94,21 @@ pub extern "C" fn zaparoo_rust_init() -> c_int {
     let config_path = config_file_path();
     let config = load_config(&config_path);
 
+    // Cache the language override so `zaparoo_rust_language_code` (called
+    // from main.cpp before the QML engine loads) can return it without
+    // re-parsing the TOML. `CString::new` only fails on interior NULs,
+    // which a valid BCP-47 tag or the empty sentinel cannot contain —
+    // fall back to empty ("use QLocale::system()") if a user manages it.
+    let _ = LANGUAGE_CODE.set(CString::new(config.language.clone()).unwrap_or_default());
+
     // Leak the guard — it must live for the process lifetime to keep the
     // file-appender thread running. The OS reclaims it on exit.
     let guard = install(&config);
     Box::leak(Box::new(guard));
+
+    // Install after logging so panics go through the same sinks; before
+    // tokio / client setup so a panic during those lines is captured.
+    install_panic_hook();
 
     tracing::info!("Zaparoo Launcher starting");
 
@@ -68,14 +127,21 @@ pub extern "C" fn zaparoo_rust_init() -> c_int {
 
     let client = Client::new(config.core_endpoint.clone(), &runtime);
     platform::spawn_fetcher(client.clone(), &runtime);
-    let catalog_tx = systems_catalog::spawn(client.clone(), &runtime);
+    let channels = systems_catalog::spawn(client.clone(), &runtime);
 
     // Load persisted UI state up front so per-screen singletons can seed
     // their properties from a consistent snapshot during Initialize.
     let persist_state = Arc::new(Mutex::new(persist::load()));
 
     // init_globals stores Arcs — runtime keeps running after this fn returns.
-    models::init_globals(runtime, client, catalog_tx, persist_state);
+    models::init_globals(
+        runtime,
+        client,
+        channels.data,
+        channels.status,
+        persist_state,
+        config.key_to_action.clone(),
+    );
 
     0
 }

--- a/rust/launcher/src/mister_runtime.rs
+++ b/rust/launcher/src/mister_runtime.rs
@@ -1,5 +1,5 @@
 // Zaparoo Launcher
-// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
 use zaparoo_core::config::Config;

--- a/rust/launcher/src/models/app_state.rs
+++ b/rust/launcher/src/models/app_state.rs
@@ -1,5 +1,5 @@
 // Zaparoo Launcher
-// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 //
 // `Browse.AppState` — top-level singleton for launch-resume routing.

--- a/rust/launcher/src/models/app_status.rs
+++ b/rust/launcher/src/models/app_status.rs
@@ -1,0 +1,188 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+//
+// `Browse.AppStatus` — ephemeral connection / catalog health, exposed
+// to QML so the UI can render a status strip when Core is unreachable
+// or the initial catalog fetch failed. State is not persisted: it is
+// recomputed from the live client and catalog channels on every start.
+//
+// `connection_state` constants:
+//   0 DISCONNECTED — no active ws link and not currently attempting one
+//   1 CONNECTING   — ws handshake in flight, or ws up with catalog RPC
+//                    pending (same user-facing meaning: "waiting on Core")
+//   2 READY        — ws up and catalog loaded; UI has data
+//   3 ERROR        — catalog RPC errored, or ws reconnect exceeded the
+//                    client's retry threshold (see client::ConnectionState)
+
+use cxx_qt::{Initialize, Threading};
+use cxx_qt_lib::QString;
+use std::pin::Pin;
+use zaparoo_core::client::ConnectionState;
+use zaparoo_core::systems_catalog::CatalogStatus;
+
+pub const DISCONNECTED: i32 = 0;
+pub const CONNECTING: i32 = 1;
+pub const READY: i32 = 2;
+pub const ERROR: i32 = 3;
+
+pub struct AppStatusRust {
+    connection_state: i32,
+    last_error: QString,
+}
+
+impl Default for AppStatusRust {
+    fn default() -> Self {
+        Self {
+            connection_state: DISCONNECTED,
+            last_error: QString::default(),
+        }
+    }
+}
+
+#[cxx_qt::bridge]
+pub mod ffi {
+    unsafe extern "C++" {
+        include!("model_includes.h");
+
+        type QString = cxx_qt_lib::QString;
+    }
+
+    unsafe extern "RustQt" {
+        #[qobject]
+        #[qml_element]
+        #[qml_singleton]
+        #[qproperty(i32, connection_state)]
+        #[qproperty(QString, last_error)]
+        type AppStatus = super::AppStatusRust;
+    }
+
+    impl cxx_qt::Threading for AppStatus {}
+    impl cxx_qt::Initialize for AppStatus {}
+}
+
+impl Initialize for ffi::AppStatus {
+    fn initialize(self: Pin<&mut Self>) {
+        use crate::models::{global_client, global_runtime, subscribe_catalog_status};
+
+        let qt_thread = self.qt_thread();
+        let client = global_client();
+        let mut connection_rx = client.connection.subscribe();
+        let mut status_rx = subscribe_catalog_status();
+
+        global_runtime().spawn(async move {
+            // Seed both halves from the watches' current values so a late
+            // subscriber (this `initialize()` runs after the QML engine
+            // boots, which is after the WebSocket task has likely already
+            // transitioned through Connecting → Connected) sees the real
+            // current state instead of sitting on a hardcoded default.
+            let mut connection = connection_rx.borrow_and_update().clone();
+            let mut status = status_rx.borrow_and_update().clone();
+            push(&qt_thread, &connection, &status);
+
+            loop {
+                tokio::select! {
+                    result = connection_rx.changed() => match result {
+                        Ok(()) => {
+                            connection = connection_rx.borrow_and_update().clone();
+                            push(&qt_thread, &connection, &status);
+                        }
+                        Err(_) => break,
+                    },
+                    result = status_rx.changed() => match result {
+                        Ok(()) => {
+                            status = status_rx.borrow_and_update().clone();
+                            push(&qt_thread, &connection, &status);
+                        }
+                        Err(_) => break,
+                    }
+                }
+            }
+        });
+    }
+}
+
+fn push(
+    qt_thread: &cxx_qt::CxxQtThread<ffi::AppStatus>,
+    connection: &ConnectionState,
+    status: &CatalogStatus,
+) {
+    let (state, err) = derive(connection, status);
+    let _ = qt_thread.queue(move |mut model| {
+        if model.connection_state != state {
+            model.as_mut().set_connection_state(state);
+        }
+        let new_err = QString::from(err.as_str());
+        if model.last_error != new_err {
+            model.as_mut().set_last_error(new_err);
+        }
+    });
+}
+
+/// Merge the two sources of truth (ws link + catalog RPC) into the
+/// single `connection_state` + `last_error` pair that QML consumes.
+///
+/// Precedence: a catalog error outranks a link error outranks a link
+/// transition. A successful link with no catalog yet shows CONNECTING
+/// so the UI doesn't flicker READY between ws-up and catalog-loaded.
+fn derive(connection: &ConnectionState, status: &CatalogStatus) -> (i32, String) {
+    match (connection, status) {
+        (_, CatalogStatus::Errored(msg)) | (ConnectionState::Error(msg), _) => (ERROR, msg.clone()),
+        (ConnectionState::Disconnected, _) => (DISCONNECTED, String::new()),
+        (ConnectionState::Connecting, _) => (CONNECTING, String::new()),
+        (ConnectionState::Connected, CatalogStatus::Idle | CatalogStatus::Loading) => {
+            (CONNECTING, String::new())
+        }
+        (ConnectionState::Connected, CatalogStatus::Ready) => (READY, String::new()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn errored_catalog_outranks_connected_link() {
+        let (state, err) = derive(
+            &ConnectionState::Connected,
+            &CatalogStatus::Errored("rpc kaboom".into()),
+        );
+        assert_eq!(state, ERROR);
+        assert_eq!(err, "rpc kaboom");
+    }
+
+    #[test]
+    fn link_error_surfaces_after_retries_exhausted() {
+        let (state, err) = derive(
+            &ConnectionState::Error("connection refused".into()),
+            &CatalogStatus::Idle,
+        );
+        assert_eq!(state, ERROR);
+        assert_eq!(err, "connection refused");
+    }
+
+    #[test]
+    fn connecting_link_maps_to_connecting_banner() {
+        let (state, err) = derive(&ConnectionState::Connecting, &CatalogStatus::Idle);
+        assert_eq!(state, CONNECTING);
+        assert_eq!(err, "");
+    }
+
+    #[test]
+    fn connected_but_catalog_loading_stays_connecting() {
+        let (state, _) = derive(&ConnectionState::Connected, &CatalogStatus::Loading);
+        assert_eq!(state, CONNECTING);
+    }
+
+    #[test]
+    fn ready_requires_both_connected_and_catalog_ready() {
+        let (state, _) = derive(&ConnectionState::Connected, &CatalogStatus::Ready);
+        assert_eq!(state, READY);
+    }
+
+    #[test]
+    fn disconnected_link_overrides_stale_catalog_state() {
+        let (state, _) = derive(&ConnectionState::Disconnected, &CatalogStatus::Ready);
+        assert_eq!(state, DISCONNECTED);
+    }
+}

--- a/rust/launcher/src/models/app_status.rs
+++ b/rust/launcher/src/models/app_status.rs
@@ -5,21 +5,21 @@
 // `Browse.AppStatus` — ephemeral connection / catalog health, exposed
 // to QML so the UI can render a status strip when Core is unreachable
 // or the initial catalog fetch failed. State is not persisted: it is
-// recomputed from the live client and catalog channels on every start.
+// derived from a single `ResourceStatus<CatalogData>` watch which
+// already merges the link state and the fetch state (see
+// `RemoteResource` for the dispatch table).
 //
 // `connection_state` constants:
-//   0 DISCONNECTED — no active ws link and not currently attempting one
-//   1 CONNECTING   — ws handshake in flight, or ws up with catalog RPC
-//                    pending (same user-facing meaning: "waiting on Core")
-//   2 READY        — ws up and catalog loaded; UI has data
-//   3 ERROR        — catalog RPC errored, or ws reconnect exceeded the
-//                    client's retry threshold (see client::ConnectionState)
+//   0 DISCONNECTED — resource Idle (link not attempted yet)
+//   1 CONNECTING   — resource Loading (handshake or RPC in flight)
+//   2 READY        — resource Ready (catalog loaded)
+//   3 ERROR        — resource Errored (link unreachable or RPC failed)
 
-use cxx_qt::{Initialize, Threading};
 use cxx_qt_lib::QString;
 use std::pin::Pin;
-use zaparoo_core::client::ConnectionState;
-use zaparoo_core::systems_catalog::CatalogStatus;
+use zaparoo_core::endpoints::catalog::CatalogEndpoint;
+use zaparoo_core::remote_resource::ResourceStatus;
+use zaparoo_core::systems_catalog::CatalogData;
 
 pub const DISCONNECTED: i32 = 0;
 pub const CONNECTING: i32 = 1;
@@ -61,79 +61,37 @@ pub mod ffi {
     impl cxx_qt::Initialize for AppStatus {}
 }
 
-impl Initialize for ffi::AppStatus {
-    fn initialize(self: Pin<&mut Self>) {
-        use crate::models::{global_client, global_runtime, subscribe_catalog_status};
+crate::bind_to_endpoint! {
+    for ffi::AppStatus,
+    endpoint = CatalogEndpoint,
+    args = (),
+    select = project,
+    apply = apply_state,
+}
 
-        let qt_thread = self.qt_thread();
-        let client = global_client();
-        let mut connection_rx = client.connection.subscribe();
-        let mut status_rx = subscribe_catalog_status();
-
-        global_runtime().spawn(async move {
-            // Seed both halves from the watches' current values so a late
-            // subscriber (this `initialize()` runs after the QML engine
-            // boots, which is after the WebSocket task has likely already
-            // transitioned through Connecting → Connected) sees the real
-            // current state instead of sitting on a hardcoded default.
-            let mut connection = connection_rx.borrow_and_update().clone();
-            let mut status = status_rx.borrow_and_update().clone();
-            push(&qt_thread, &connection, &status);
-
-            loop {
-                tokio::select! {
-                    result = connection_rx.changed() => match result {
-                        Ok(()) => {
-                            connection = connection_rx.borrow_and_update().clone();
-                            push(&qt_thread, &connection, &status);
-                        }
-                        Err(_) => break,
-                    },
-                    result = status_rx.changed() => match result {
-                        Ok(()) => {
-                            status = status_rx.borrow_and_update().clone();
-                            push(&qt_thread, &connection, &status);
-                        }
-                        Err(_) => break,
-                    }
-                }
-            }
-        });
+/// Map `ResourceStatus<CatalogData>` onto the four banner states the QML
+/// side knows about. The error message is whatever the resource layer
+/// surfaced — link error (`Unreachable`) or RPC error (`Errored` while
+/// the link is still up). The UI treats them the same.
+fn project(status: &ResourceStatus<CatalogData>) -> (i32, String) {
+    match status {
+        ResourceStatus::Idle => (DISCONNECTED, String::new()),
+        ResourceStatus::Loading => (CONNECTING, String::new()),
+        ResourceStatus::Ready(_) => (READY, String::new()),
+        ResourceStatus::Errored { message, .. } => (ERROR, message.clone()),
     }
 }
 
-fn push(
-    qt_thread: &cxx_qt::CxxQtThread<ffi::AppStatus>,
-    connection: &ConnectionState,
-    status: &CatalogStatus,
-) {
-    let (state, err) = derive(connection, status);
-    let _ = qt_thread.queue(move |mut model| {
-        if model.connection_state != state {
-            model.as_mut().set_connection_state(state);
-        }
-        let new_err = QString::from(err.as_str());
-        if model.last_error != new_err {
-            model.as_mut().set_last_error(new_err);
-        }
-    });
-}
-
-/// Merge the two sources of truth (ws link + catalog RPC) into the
-/// single `connection_state` + `last_error` pair that QML consumes.
-///
-/// Precedence: a catalog error outranks a link error outranks a link
-/// transition. A successful link with no catalog yet shows CONNECTING
-/// so the UI doesn't flicker READY between ws-up and catalog-loaded.
-fn derive(connection: &ConnectionState, status: &CatalogStatus) -> (i32, String) {
-    match (connection, status) {
-        (_, CatalogStatus::Errored(msg)) | (ConnectionState::Error(msg), _) => (ERROR, msg.clone()),
-        (ConnectionState::Disconnected, _) => (DISCONNECTED, String::new()),
-        (ConnectionState::Connecting, _) => (CONNECTING, String::new()),
-        (ConnectionState::Connected, CatalogStatus::Idle | CatalogStatus::Loading) => {
-            (CONNECTING, String::new())
-        }
-        (ConnectionState::Connected, CatalogStatus::Ready) => (READY, String::new()),
+/// Apply a freshly-derived `(state, err)` to the model, suppressing
+/// `QProperty` setters whose value hasn't changed so QML doesn't see
+/// spurious `Changed` signals on every reconnect.
+fn apply_state(mut model: Pin<&mut ffi::AppStatus>, (state, err): (i32, String)) {
+    if model.connection_state != state {
+        model.as_mut().set_connection_state(state);
+    }
+    let qerr = QString::from(err.as_str());
+    if model.last_error != qerr {
+        model.as_mut().set_last_error(qerr);
     }
 }
 
@@ -141,48 +99,51 @@ fn derive(connection: &ConnectionState, status: &CatalogStatus) -> (i32, String)
 mod tests {
     use super::*;
 
-    #[test]
-    fn errored_catalog_outranks_connected_link() {
-        let (state, err) = derive(
-            &ConnectionState::Connected,
-            &CatalogStatus::Errored("rpc kaboom".into()),
-        );
-        assert_eq!(state, ERROR);
-        assert_eq!(err, "rpc kaboom");
+    fn empty_catalog() -> CatalogData {
+        CatalogData {
+            systems: Vec::new(),
+            categories: Vec::new(),
+        }
     }
 
     #[test]
-    fn link_error_surfaces_after_retries_exhausted() {
-        let (state, err) = derive(
-            &ConnectionState::Error("connection refused".into()),
-            &CatalogStatus::Idle,
-        );
-        assert_eq!(state, ERROR);
-        assert_eq!(err, "connection refused");
+    fn idle_maps_to_disconnected() {
+        let (state, err) = project(&ResourceStatus::Idle);
+        assert_eq!(state, DISCONNECTED);
+        assert_eq!(err, "");
     }
 
     #[test]
-    fn connecting_link_maps_to_connecting_banner() {
-        let (state, err) = derive(&ConnectionState::Connecting, &CatalogStatus::Idle);
+    fn loading_maps_to_connecting() {
+        let (state, err) = project(&ResourceStatus::Loading);
         assert_eq!(state, CONNECTING);
         assert_eq!(err, "");
     }
 
     #[test]
-    fn connected_but_catalog_loading_stays_connecting() {
-        let (state, _) = derive(&ConnectionState::Connected, &CatalogStatus::Loading);
-        assert_eq!(state, CONNECTING);
-    }
-
-    #[test]
-    fn ready_requires_both_connected_and_catalog_ready() {
-        let (state, _) = derive(&ConnectionState::Connected, &CatalogStatus::Ready);
+    fn ready_maps_to_ready_with_no_error() {
+        let (state, err) = project(&ResourceStatus::Ready(empty_catalog()));
         assert_eq!(state, READY);
+        assert_eq!(err, "");
     }
 
     #[test]
-    fn disconnected_link_overrides_stale_catalog_state() {
-        let (state, _) = derive(&ConnectionState::Disconnected, &CatalogStatus::Ready);
-        assert_eq!(state, DISCONNECTED);
+    fn errored_with_retrying_surfaces_message() {
+        let (state, err) = project(&ResourceStatus::Errored {
+            message: "rpc kaboom".into(),
+            retrying: true,
+        });
+        assert_eq!(state, ERROR);
+        assert_eq!(err, "rpc kaboom");
+    }
+
+    #[test]
+    fn errored_without_retrying_surfaces_message() {
+        let (state, err) = project(&ResourceStatus::Errored {
+            message: "connection refused".into(),
+            retrying: false,
+        });
+        assert_eq!(state, ERROR);
+        assert_eq!(err, "connection refused");
     }
 }

--- a/rust/launcher/src/models/browse.rs
+++ b/rust/launcher/src/models/browse.rs
@@ -1,5 +1,5 @@
 // Zaparoo Launcher
-// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 //
 // Minimal BrowseModel stub — dormant, kept to satisfy the Zaparoo.Browse QML

--- a/rust/launcher/src/models/categories.rs
+++ b/rust/launcher/src/models/categories.rs
@@ -1,5 +1,5 @@
 // Zaparoo Launcher
-// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
 use cxx_qt::{CxxQtType, Initialize, Threading};
@@ -12,6 +12,7 @@ const NAME_ROLE: i32 = 256 + 1; // Qt::UserRole + 1
 pub struct CategoriesModelRust {
     categories: Vec<String>,
     count: i32,
+    error_message: QString,
 }
 
 #[cxx_qt::bridge]
@@ -35,6 +36,7 @@ pub mod ffi {
         #[qml_element]
         #[qml_singleton]
         #[qproperty(i32, count)]
+        #[qproperty(QString, error_message)]
         type CategoriesModel = super::CategoriesModelRust;
 
         #[qinvokable]
@@ -65,9 +67,11 @@ pub mod ffi {
 
 impl Initialize for ffi::CategoriesModel {
     fn initialize(mut self: Pin<&mut Self>) {
-        use crate::models::{global_runtime, subscribe_catalog};
+        use crate::models::{global_runtime, subscribe_catalog, subscribe_catalog_status};
+        use zaparoo_core::systems_catalog::CatalogStatus;
 
         let mut catalog_rx = subscribe_catalog();
+        let mut status_rx = subscribe_catalog_status();
 
         // Apply whatever the catalog task has already loaded (handles the common
         // case where the connection is fast enough to complete before Qt starts).
@@ -81,6 +85,7 @@ impl Initialize for ffi::CategoriesModel {
         }
 
         let qt_thread = self.qt_thread();
+        let qt_thread_status = qt_thread.clone();
         global_runtime().spawn(async move {
             while catalog_rx.changed().await.is_ok() {
                 if let Some(data) = catalog_rx.borrow_and_update().clone() {
@@ -92,6 +97,24 @@ impl Initialize for ffi::CategoriesModel {
                         model.as_mut().end_reset_model();
                         model.as_mut().count_changed();
                     });
+                }
+            }
+        });
+
+        global_runtime().spawn(async move {
+            loop {
+                let err = match &*status_rx.borrow_and_update() {
+                    CatalogStatus::Errored(msg) => msg.clone(),
+                    _ => String::new(),
+                };
+                let qstr = QString::from(err.as_str());
+                let _ = qt_thread_status.queue(move |mut model| {
+                    if model.error_message != qstr {
+                        model.as_mut().set_error_message(qstr);
+                    }
+                });
+                if status_rx.changed().await.is_err() {
+                    break;
                 }
             }
         });

--- a/rust/launcher/src/models/categories.rs
+++ b/rust/launcher/src/models/categories.rs
@@ -2,9 +2,12 @@
 // Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
-use cxx_qt::{CxxQtType, Initialize, Threading};
+use cxx_qt::CxxQtType;
 use cxx_qt_lib::{QByteArray, QHash, QHashPair_i32_QByteArray, QModelIndex, QString, QVariant};
 use std::pin::Pin;
+use zaparoo_core::endpoints::catalog::CatalogEndpoint;
+use zaparoo_core::remote_resource::ResourceStatus;
+use zaparoo_core::systems_catalog::CatalogData;
 
 const NAME_ROLE: i32 = 256 + 1; // Qt::UserRole + 1
 
@@ -65,59 +68,40 @@ pub mod ffi {
     impl cxx_qt::Initialize for CategoriesModel {}
 }
 
-impl Initialize for ffi::CategoriesModel {
-    fn initialize(mut self: Pin<&mut Self>) {
-        use crate::models::{global_runtime, subscribe_catalog, subscribe_catalog_status};
-        use zaparoo_core::systems_catalog::CatalogStatus;
+crate::bind_to_endpoint! {
+    for ffi::CategoriesModel,
+    endpoint = CatalogEndpoint,
+    args = (),
+    select = project,
+    apply = apply_state,
+}
 
-        let mut catalog_rx = subscribe_catalog();
-        let mut status_rx = subscribe_catalog_status();
+/// Pull the two pieces this model cares about out of the unified
+/// `ResourceStatus`: the category list (only present on `Ready`) and the
+/// surfaced error message (empty unless `Errored`).
+fn project(status: &ResourceStatus<CatalogData>) -> (Option<Vec<String>>, String) {
+    match status {
+        ResourceStatus::Ready(data) => (Some(data.categories.clone()), String::new()),
+        ResourceStatus::Errored { message, .. } => (None, message.clone()),
+        ResourceStatus::Idle | ResourceStatus::Loading => (None, String::new()),
+    }
+}
 
-        // Apply whatever the catalog task has already loaded (handles the common
-        // case where the connection is fast enough to complete before Qt starts).
-        if let Some(data) = catalog_rx.borrow_and_update().clone() {
-            let count = data.categories.len() as i32;
-            self.as_mut().begin_reset_model();
-            self.as_mut().rust_mut().categories = data.categories;
-            self.as_mut().rust_mut().count = count;
-            self.as_mut().end_reset_model();
-            self.as_mut().count_changed();
-        }
-
-        let qt_thread = self.qt_thread();
-        let qt_thread_status = qt_thread.clone();
-        global_runtime().spawn(async move {
-            while catalog_rx.changed().await.is_ok() {
-                if let Some(data) = catalog_rx.borrow_and_update().clone() {
-                    let count = data.categories.len() as i32;
-                    let _ = qt_thread.queue(move |mut model| {
-                        model.as_mut().begin_reset_model();
-                        model.as_mut().rust_mut().categories = data.categories;
-                        model.as_mut().rust_mut().count = count;
-                        model.as_mut().end_reset_model();
-                        model.as_mut().count_changed();
-                    });
-                }
-            }
-        });
-
-        global_runtime().spawn(async move {
-            loop {
-                let err = match &*status_rx.borrow_and_update() {
-                    CatalogStatus::Errored(msg) => msg.clone(),
-                    _ => String::new(),
-                };
-                let qstr = QString::from(err.as_str());
-                let _ = qt_thread_status.queue(move |mut model| {
-                    if model.error_message != qstr {
-                        model.as_mut().set_error_message(qstr);
-                    }
-                });
-                if status_rx.changed().await.is_err() {
-                    break;
-                }
-            }
-        });
+fn apply_state(
+    mut model: Pin<&mut ffi::CategoriesModel>,
+    (categories, err): (Option<Vec<String>>, String),
+) {
+    if let Some(categories) = categories {
+        let count = categories.len() as i32;
+        model.as_mut().begin_reset_model();
+        model.as_mut().rust_mut().categories = categories;
+        model.as_mut().rust_mut().count = count;
+        model.as_mut().end_reset_model();
+        model.as_mut().count_changed();
+    }
+    let qerr = QString::from(err.as_str());
+    if model.error_message != qerr {
+        model.as_mut().set_error_message(qerr);
     }
 }
 

--- a/rust/launcher/src/models/games.rs
+++ b/rust/launcher/src/models/games.rs
@@ -1,5 +1,5 @@
 // Zaparoo Launcher
-// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
 use cxx_qt::{CxxQtType, Threading};
@@ -168,7 +168,8 @@ impl ffi::GamesModel {
                 model.as_mut().set_loading(false);
                 match result {
                     Ok(r) => {
-                        if r.has_next_page {
+                        let has_next = r.has_next_page();
+                        if has_next {
                             warn!("games list for {sid} has >100 results; only first page shown");
                         }
                         let count = r.results.len() as i32;
@@ -177,7 +178,7 @@ impl ffi::GamesModel {
                         model.as_mut().rust_mut().count = count;
                         model.as_mut().end_reset_model();
                         model.as_mut().count_changed();
-                        model.as_mut().set_has_next_page(r.has_next_page);
+                        model.as_mut().set_has_next_page(has_next);
                     }
                     Err(e) => {
                         model

--- a/rust/launcher/src/models/games.rs
+++ b/rust/launcher/src/models/games.rs
@@ -2,18 +2,25 @@
 // Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
+use crate::models::{global_runtime, global_store};
 use cxx_qt::{CxxQtType, Threading};
 use cxx_qt_lib::{QByteArray, QHash, QHashPair_i32_QByteArray, QModelIndex, QString, QVariant};
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use zaparoo_core::media_types::{MediaItem, MediaSearchParams, RunParams};
+use tokio::task::JoinHandle;
+use tracing::warn;
+use zaparoo_core::endpoints::media_search::MediaSearchEndpoint;
+use zaparoo_core::endpoints::run::RunMutation;
+use zaparoo_core::media_types::{MediaItem, MediaSearchResult, RunParams};
+use zaparoo_core::remote_resource::ResourceStatus;
 
 const NAME_ROLE: i32 = 256 + 1;
 const PATH_ROLE: i32 = 256 + 2;
 const ZAP_SCRIPT_ROLE: i32 = 256 + 3;
 const SYSTEM_ID_ROLE: i32 = 256 + 4;
 
+#[derive(Default)]
 pub struct GamesModelRust {
     items: Vec<MediaItem>,
     count: i32,
@@ -22,22 +29,20 @@ pub struct GamesModelRust {
     has_next_page: bool,
     current_system_id: QString,
     selected_index: i32,
+    // Cancellation handle for the QML-bridge watcher of the currently
+    // selected system. The `RemoteResource` itself lives in the store's
+    // cache (keyed by system id), so a re-subscribe to a previously
+    // selected system reuses the cached entry and skips the RPC.
+    // Aborting the watcher stops it from enqueuing *more* callbacks,
+    // but cannot drain ones already on the Qt event loop — `seq` below
+    // is what makes those stale callbacks no-ops.
+    watcher: Option<JoinHandle<()>>,
+    // Monotonic ticket bumped on each `set_system` call. The watcher's
+    // queued closure captures the ticket value at spawn time and bails
+    // if `seq` has advanced — closing the window where a callback
+    // queued by the old system's watcher runs on the Qt thread after
+    // the new system's state has already been applied.
     seq: Arc<AtomicU64>,
-}
-
-impl Default for GamesModelRust {
-    fn default() -> Self {
-        Self {
-            items: Vec::new(),
-            count: 0,
-            loading: false,
-            error_message: QString::default(),
-            has_next_page: false,
-            current_system_id: QString::default(),
-            selected_index: 0,
-            seq: Arc::new(AtomicU64::new(0)),
-        }
-    }
 }
 
 #[cxx_qt::bridge]
@@ -136,64 +141,61 @@ impl ffi::GamesModel {
     }
 
     fn set_system(mut self: Pin<&mut Self>, system_id: QString) {
-        use crate::models::{global_client, global_runtime};
-        use tracing::warn;
-
         let sid = system_id.to_string();
         if sid == self.current_system_id.to_string() && !self.items.is_empty() {
             return;
         }
 
+        // User-visible reset happens synchronously so QML sees fresh
+        // state immediately, before the resource has even spun up.
         self.as_mut().set_current_system_id(system_id);
         self.as_mut().set_loading(true);
         self.as_mut().set_error_message(QString::default());
+        self.as_mut().set_has_next_page(false);
 
+        // Abort the old watcher so it stops enqueuing further callbacks.
+        // Any callback already on the Qt event loop is still pending —
+        // the `seq` ticket below is what discards those stale ones.
+        if let Some(handle) = self.as_mut().rust_mut().watcher.take() {
+            handle.abort();
+        }
+
+        // Bump the ticket *before* spawning. The new watcher captures
+        // this value; any earlier-watcher callback still in the Qt
+        // queue captured the previous ticket and will bail when it sees
+        // the mismatch.
         let seq = self.rust().seq.clone();
         let ticket = seq.fetch_add(1, Ordering::SeqCst) + 1;
-        let client = global_client();
+
+        // Per-arg subscribe: the store keys its cache by system id, so
+        // toggling between systems reuses cached resources and only
+        // pays the RPC cost on first sight.
+        let resource = global_store().subscribe::<MediaSearchEndpoint>(sid);
+        let mut status_rx = resource.subscribe();
+
+        // Sync-seed runs inline on the Qt thread, so it cannot race a
+        // queued callback (Qt won't pump events until set_system
+        // returns). No ticket check needed here.
+        let snapshot = status_rx.borrow_and_update().clone();
+        apply_status(self.as_mut(), snapshot);
+
         let qt_thread = self.qt_thread();
-
-        global_runtime().spawn(async move {
-            let result = client
-                .media_search(MediaSearchParams {
-                    systems: vec![sid.clone()],
-                    max_results: 100,
-                })
-                .await;
-
-            let _ = qt_thread.queue(move |mut model| {
-                if seq.load(Ordering::SeqCst) != ticket {
-                    return;
-                }
-                model.as_mut().set_loading(false);
-                match result {
-                    Ok(r) => {
-                        let has_next = r.has_next_page();
-                        if has_next {
-                            warn!("games list for {sid} has >100 results; only first page shown");
-                        }
-                        let count = r.results.len() as i32;
-                        model.as_mut().begin_reset_model();
-                        model.as_mut().rust_mut().items = r.results;
-                        model.as_mut().rust_mut().count = count;
-                        model.as_mut().end_reset_model();
-                        model.as_mut().count_changed();
-                        model.as_mut().set_has_next_page(has_next);
+        let handle = global_runtime().spawn(async move {
+            while status_rx.changed().await.is_ok() {
+                let snapshot = status_rx.borrow_and_update().clone();
+                let seq_for_closure = seq.clone();
+                let _ = qt_thread.queue(move |model| {
+                    if seq_for_closure.load(Ordering::SeqCst) != ticket {
+                        return;
                     }
-                    Err(e) => {
-                        model
-                            .as_mut()
-                            .set_error_message(QString::from(e.message.as_str()));
-                    }
-                }
-            });
+                    apply_status(model, snapshot);
+                });
+            }
         });
+        self.as_mut().rust_mut().watcher = Some(handle);
     }
 
     fn launch_at(self: Pin<&mut Self>, index: i32) {
-        use crate::models::{global_client, global_runtime};
-        use tracing::warn;
-
         if index < 0 || index >= self.count {
             return;
         }
@@ -203,9 +205,9 @@ impl ffi::GamesModel {
         }
         let text = item.zap_script.clone();
         let name = item.name.clone();
-        let client = global_client();
+        let store = global_store();
         global_runtime().spawn(async move {
-            if let Err(e) = client.run(RunParams { text }).await {
+            if let Err(e) = store.run_mutation::<RunMutation>(RunParams { text }).await {
                 warn!("run failed for {name}: {}", e.message);
             }
         });
@@ -238,5 +240,215 @@ impl ffi::GamesModel {
 
     fn set_selected_index(mut self: Pin<&mut Self>, index: i32) {
         self.as_mut().rust_mut().selected_index = index;
+    }
+}
+
+/// Pure projection of a `ResourceStatus<MediaSearchResult>` onto the
+/// shape `apply_status` writes into the model. Splitting the match
+/// out as a free function lets the four arms be unit-tested without
+/// a Qt event loop — `apply_status` itself only touches `QObject`
+/// setters, which need a live `Pin<&mut ffi::GamesModel>` and so are
+/// only reachable from the bridge.
+#[derive(Debug)]
+enum Projection {
+    /// `Idle`/`Loading` collapse to the same view: spinner on, no
+    /// error, no pagination indicator. Items are not touched.
+    Pending,
+    /// Successful fetch — items replace the model rows wholesale.
+    Ready {
+        items: Vec<MediaItem>,
+        count: i32,
+        has_next_page: bool,
+    },
+    /// Both `retrying` and terminal errors map here; the UI treats
+    /// them the same (banner + clear loading state).
+    Errored { message: String },
+}
+
+fn project_status(status: ResourceStatus<MediaSearchResult>) -> Projection {
+    match status {
+        ResourceStatus::Idle | ResourceStatus::Loading => Projection::Pending,
+        ResourceStatus::Ready(result) => {
+            let has_next_page = result.has_next_page();
+            let count = result.results.len() as i32;
+            Projection::Ready {
+                items: result.results,
+                count,
+                has_next_page,
+            }
+        }
+        ResourceStatus::Errored { message, .. } => Projection::Errored { message },
+    }
+}
+
+/// Apply a freshly-derived `Projection` to the model. Centralising
+/// the writes here is what closes the original "lost
+/// `has_next_page` reset on the error path" bug — every arm passes
+/// through one place.
+fn apply_status(mut model: Pin<&mut ffi::GamesModel>, status: ResourceStatus<MediaSearchResult>) {
+    match project_status(status) {
+        Projection::Pending => {
+            if !model.loading {
+                model.as_mut().set_loading(true);
+            }
+            if !model.error_message.is_empty() {
+                model.as_mut().set_error_message(QString::default());
+            }
+            if model.has_next_page {
+                model.as_mut().set_has_next_page(false);
+            }
+        }
+        Projection::Ready {
+            items,
+            count,
+            has_next_page,
+        } => {
+            if has_next_page {
+                let sid = model.current_system_id.to_string();
+                warn!("games list for {sid} has >100 results; only first page shown");
+            }
+            model.as_mut().begin_reset_model();
+            model.as_mut().rust_mut().items = items;
+            model.as_mut().rust_mut().count = count;
+            model.as_mut().end_reset_model();
+            model.as_mut().count_changed();
+            model.as_mut().set_has_next_page(has_next_page);
+            if model.loading {
+                model.as_mut().set_loading(false);
+            }
+            if !model.error_message.is_empty() {
+                model.as_mut().set_error_message(QString::default());
+            }
+        }
+        Projection::Errored { message } => {
+            let qstr = QString::from(message.as_str());
+            if model.error_message != qstr {
+                model.as_mut().set_error_message(qstr);
+            }
+            if model.loading {
+                model.as_mut().set_loading(false);
+            }
+            if model.has_next_page {
+                model.as_mut().set_has_next_page(false);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(
+        clippy::expect_used,
+        clippy::unwrap_used,
+        clippy::panic,
+        reason = "tests should fail-fast on unexpected errors"
+    )]
+
+    use super::{project_status, Projection};
+    use zaparoo_core::media_types::{MediaItem, MediaSearchResult, Pagination, SystemRef};
+    use zaparoo_core::remote_resource::ResourceStatus;
+
+    fn item(name: &str, system_id: &str) -> MediaItem {
+        MediaItem {
+            name: name.into(),
+            path: format!("/p/{name}"),
+            zap_script: format!("@{system_id}/{name}"),
+            system: SystemRef {
+                id: system_id.into(),
+            },
+            tags: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn idle_projects_to_pending() {
+        match project_status(ResourceStatus::Idle) {
+            Projection::Pending => {}
+            other => panic!("expected Pending, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn loading_projects_to_pending() {
+        match project_status(ResourceStatus::Loading) {
+            Projection::Pending => {}
+            other => panic!("expected Pending, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ready_with_results_projects_count_and_items() {
+        let result = MediaSearchResult {
+            results: vec![item("smb", "nes"), item("zelda", "nes")],
+            pagination: Pagination::default(),
+        };
+        match project_status(ResourceStatus::Ready(result)) {
+            Projection::Ready {
+                items,
+                count,
+                has_next_page,
+            } => {
+                assert_eq!(count, 2);
+                assert_eq!(items.len(), 2);
+                assert_eq!(items[0].name, "smb");
+                assert!(!has_next_page);
+            }
+            other => panic!("expected Ready, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ready_empty_results_projects_zero_count() {
+        let result = MediaSearchResult::default();
+        match project_status(ResourceStatus::Ready(result)) {
+            Projection::Ready {
+                items,
+                count,
+                has_next_page,
+            } => {
+                assert_eq!(count, 0);
+                assert!(items.is_empty());
+                assert!(!has_next_page);
+            }
+            other => panic!("expected Ready, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ready_with_pagination_propagates_has_next_page() {
+        let result = MediaSearchResult {
+            results: vec![item("smb", "nes")],
+            pagination: Pagination {
+                has_next_page: true,
+                page_size: 100,
+                next_cursor: Some("c".into()),
+            },
+        };
+        match project_status(ResourceStatus::Ready(result)) {
+            Projection::Ready { has_next_page, .. } => assert!(has_next_page),
+            other => panic!("expected Ready, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn errored_with_retrying_propagates_message() {
+        match project_status(ResourceStatus::Errored {
+            message: "rpc kaboom".into(),
+            retrying: true,
+        }) {
+            Projection::Errored { message } => assert_eq!(message, "rpc kaboom"),
+            other => panic!("expected Errored, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn errored_without_retrying_propagates_message() {
+        match project_status(ResourceStatus::Errored {
+            message: "connection refused".into(),
+            retrying: false,
+        }) {
+            Projection::Errored { message } => assert_eq!(message, "connection refused"),
+            other => panic!("expected Errored, got {other:?}"),
+        }
     }
 }

--- a/rust/launcher/src/models/games.rs
+++ b/rust/launcher/src/models/games.rs
@@ -148,10 +148,22 @@ impl ffi::GamesModel {
 
         // User-visible reset happens synchronously so QML sees fresh
         // state immediately, before the resource has even spun up.
+        // Crucially, drop the prior system's rows here too — otherwise
+        // the carousel keeps painting (and accepting input on) games
+        // from the system the user just navigated away from until the
+        // new system's fetch resolves.
         self.as_mut().set_current_system_id(system_id);
         self.as_mut().set_loading(true);
         self.as_mut().set_error_message(QString::default());
         self.as_mut().set_has_next_page(false);
+        if !self.items.is_empty() {
+            self.as_mut().begin_reset_model();
+            self.as_mut().rust_mut().items.clear();
+            self.as_mut().rust_mut().count = 0;
+            self.as_mut().rust_mut().selected_index = -1;
+            self.as_mut().end_reset_model();
+            self.as_mut().count_changed();
+        }
 
         // Abort the old watcher so it stops enqueuing further callbacks.
         // Any callback already on the Qt event loop is still pending —

--- a/rust/launcher/src/models/games_state.rs
+++ b/rust/launcher/src/models/games_state.rs
@@ -1,5 +1,5 @@
 // Zaparoo Launcher
-// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 //
 // `Browse.GamesState` — persisted state owned by the games screen.

--- a/rust/launcher/src/models/hub_state.rs
+++ b/rust/launcher/src/models/hub_state.rs
@@ -1,5 +1,5 @@
 // Zaparoo Launcher
-// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 //
 // `Browse.HubState` — persisted state owned by the hub screen.

--- a/rust/launcher/src/models/input.rs
+++ b/rust/launcher/src/models/input.rs
@@ -1,0 +1,54 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+//
+// `Browse.Input` — translates raw Qt key codes into `ZaparooAction`
+// names (see `zaparoo_core::input_actions`). QML screens react to
+// actions, not keys, so gamepad / NFC sources can slot in beside the
+// keyboard without touching the UI. Bindings are seeded from the map
+// `config::Config::key_to_action` built during init.
+
+use cxx_qt::{CxxQtType, Initialize};
+use cxx_qt_lib::QString;
+use std::collections::HashMap;
+use std::pin::Pin;
+
+#[derive(Default)]
+pub struct InputRust {
+    key_to_action: HashMap<i32, String>,
+}
+
+#[cxx_qt::bridge]
+pub mod ffi {
+    unsafe extern "C++" {
+        include!("model_includes.h");
+
+        type QString = cxx_qt_lib::QString;
+    }
+
+    unsafe extern "RustQt" {
+        #[qobject]
+        #[qml_element]
+        #[qml_singleton]
+        type Input = super::InputRust;
+
+        #[qinvokable]
+        fn action_for_key(self: &Input, key: i32) -> QString;
+    }
+
+    impl cxx_qt::Initialize for Input {}
+}
+
+impl Initialize for ffi::Input {
+    fn initialize(mut self: Pin<&mut Self>) {
+        self.as_mut().rust_mut().key_to_action = crate::models::input_bindings();
+    }
+}
+
+impl ffi::Input {
+    fn action_for_key(&self, key: i32) -> QString {
+        self.key_to_action
+            .get(&key)
+            .map_or_else(QString::default, |s| QString::from(s.as_str()))
+    }
+}

--- a/rust/launcher/src/models/mod.rs
+++ b/rust/launcher/src/models/mod.rs
@@ -1,10 +1,10 @@
 // Zaparoo Launcher
-// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 //
 // Globals set by main() before the QML engine is created. Each QML singleton
 // model reads from these in its Default::default() implementation so it can
-// wire itself to the catalog broadcast without constructor-injection.
+// wire itself to the catalog watch without constructor-injection.
 //
 // The QML singletons are constructed *after* init_globals runs, so any
 // `expect`/`panic` below represents an internal wiring bug (double-init or
@@ -17,28 +17,39 @@
 )]
 
 pub mod app_state;
+pub mod app_status;
 pub mod browse;
 pub mod categories;
 pub mod games;
 pub mod games_state;
 pub mod hub_state;
+pub mod input;
 pub mod systems;
 
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex, OnceLock};
 use tokio::runtime::Runtime;
 use tokio::sync::watch;
-use zaparoo_core::{client::Client, persist::PersistedState, systems_catalog::CatalogData};
+use zaparoo_core::{
+    client::Client,
+    persist::PersistedState,
+    systems_catalog::{CatalogData, CatalogStatus},
+};
 
 static RUNTIME: OnceLock<Arc<Runtime>> = OnceLock::new();
 static CLIENT: OnceLock<Arc<Client>> = OnceLock::new();
 static CATALOG_TX: OnceLock<watch::Sender<Option<CatalogData>>> = OnceLock::new();
+static CATALOG_STATUS_TX: OnceLock<watch::Sender<CatalogStatus>> = OnceLock::new();
 static PERSIST_STATE: OnceLock<Arc<Mutex<PersistedState>>> = OnceLock::new();
+static INPUT_BINDINGS: OnceLock<HashMap<i32, String>> = OnceLock::new();
 
 pub fn init_globals(
     runtime: Arc<Runtime>,
     client: Arc<Client>,
     catalog_tx: watch::Sender<Option<CatalogData>>,
+    catalog_status_tx: watch::Sender<CatalogStatus>,
     persist_state: Arc<Mutex<PersistedState>>,
+    input_bindings: HashMap<i32, String>,
 ) {
     RUNTIME
         .set(runtime)
@@ -49,9 +60,15 @@ pub fn init_globals(
     CATALOG_TX
         .set(catalog_tx)
         .unwrap_or_else(|_| panic!("CATALOG_TX already initialized"));
+    CATALOG_STATUS_TX
+        .set(catalog_status_tx)
+        .unwrap_or_else(|_| panic!("CATALOG_STATUS_TX already initialized"));
     PERSIST_STATE
         .set(persist_state)
         .unwrap_or_else(|_| panic!("PERSIST_STATE already initialized"));
+    INPUT_BINDINGS
+        .set(input_bindings)
+        .unwrap_or_else(|_| panic!("INPUT_BINDINGS already initialized"));
 }
 
 pub fn global_runtime() -> Arc<Runtime> {
@@ -67,6 +84,20 @@ pub fn subscribe_catalog() -> watch::Receiver<Option<CatalogData>> {
         .get()
         .expect("CATALOG_TX not initialized")
         .subscribe()
+}
+
+pub fn subscribe_catalog_status() -> watch::Receiver<CatalogStatus> {
+    CATALOG_STATUS_TX
+        .get()
+        .expect("CATALOG_STATUS_TX not initialized")
+        .subscribe()
+}
+
+pub fn input_bindings() -> HashMap<i32, String> {
+    INPUT_BINDINGS
+        .get()
+        .expect("INPUT_BINDINGS not initialized")
+        .clone()
 }
 
 pub fn persist_state() -> Arc<Mutex<PersistedState>> {

--- a/rust/launcher/src/models/mod.rs
+++ b/rust/launcher/src/models/mod.rs
@@ -2,13 +2,20 @@
 // Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 //
-// Globals set by main() before the QML engine is created. Each QML singleton
-// model reads from these in its Default::default() implementation so it can
-// wire itself to the catalog watch without constructor-injection.
+// Globals set by main() before the QML engine is created. QML singletons
+// subscribe to data through `STORE` rather than receiving it via
+// constructor injection — this side-channel is the only place
+// cxx-qt's `Default::default()` boundary lets us reach into.
 //
 // The QML singletons are constructed *after* init_globals runs, so any
-// `expect`/`panic` below represents an internal wiring bug (double-init or
-// use-before-init) and is correctly fatal.
+// `expect`/`panic` below represents an internal wiring bug (double-init
+// or use-before-init) and is correctly fatal.
+//
+// `STORE` owns the `Client` and runtime and hands out shared
+// `RemoteResource`s per (endpoint, args). Singletons reach it via
+// `global_store()` — `bind_to_endpoint!` is the standard caller and
+// closes the sync-seed contract from `docs/cxx-qt-bridge.md`
+// structurally.
 
 #![allow(
     clippy::panic,
@@ -29,40 +36,25 @@ pub mod systems;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, OnceLock};
 use tokio::runtime::Runtime;
-use tokio::sync::watch;
-use zaparoo_core::{
-    client::Client,
-    persist::PersistedState,
-    systems_catalog::{CatalogData, CatalogStatus},
-};
+use zaparoo_core::{persist::PersistedState, store::Store};
 
 static RUNTIME: OnceLock<Arc<Runtime>> = OnceLock::new();
-static CLIENT: OnceLock<Arc<Client>> = OnceLock::new();
-static CATALOG_TX: OnceLock<watch::Sender<Option<CatalogData>>> = OnceLock::new();
-static CATALOG_STATUS_TX: OnceLock<watch::Sender<CatalogStatus>> = OnceLock::new();
+static STORE: OnceLock<Arc<Store>> = OnceLock::new();
 static PERSIST_STATE: OnceLock<Arc<Mutex<PersistedState>>> = OnceLock::new();
 static INPUT_BINDINGS: OnceLock<HashMap<i32, String>> = OnceLock::new();
 
 pub fn init_globals(
     runtime: Arc<Runtime>,
-    client: Arc<Client>,
-    catalog_tx: watch::Sender<Option<CatalogData>>,
-    catalog_status_tx: watch::Sender<CatalogStatus>,
+    store: Arc<Store>,
     persist_state: Arc<Mutex<PersistedState>>,
     input_bindings: HashMap<i32, String>,
 ) {
     RUNTIME
         .set(runtime)
         .unwrap_or_else(|_| panic!("RUNTIME already initialized"));
-    CLIENT
-        .set(client)
-        .unwrap_or_else(|_| panic!("CLIENT already initialized"));
-    CATALOG_TX
-        .set(catalog_tx)
-        .unwrap_or_else(|_| panic!("CATALOG_TX already initialized"));
-    CATALOG_STATUS_TX
-        .set(catalog_status_tx)
-        .unwrap_or_else(|_| panic!("CATALOG_STATUS_TX already initialized"));
+    STORE
+        .set(store)
+        .unwrap_or_else(|_| panic!("STORE already initialized"));
     PERSIST_STATE
         .set(persist_state)
         .unwrap_or_else(|_| panic!("PERSIST_STATE already initialized"));
@@ -75,22 +67,8 @@ pub fn global_runtime() -> Arc<Runtime> {
     RUNTIME.get().expect("RUNTIME not initialized").clone()
 }
 
-pub fn global_client() -> Arc<Client> {
-    CLIENT.get().expect("CLIENT not initialized").clone()
-}
-
-pub fn subscribe_catalog() -> watch::Receiver<Option<CatalogData>> {
-    CATALOG_TX
-        .get()
-        .expect("CATALOG_TX not initialized")
-        .subscribe()
-}
-
-pub fn subscribe_catalog_status() -> watch::Receiver<CatalogStatus> {
-    CATALOG_STATUS_TX
-        .get()
-        .expect("CATALOG_STATUS_TX not initialized")
-        .subscribe()
+pub fn global_store() -> Arc<Store> {
+    STORE.get().expect("STORE not initialized").clone()
 }
 
 pub fn input_bindings() -> HashMap<i32, String> {

--- a/rust/launcher/src/models/model_includes.h
+++ b/rust/launcher/src/models/model_includes.h
@@ -1,5 +1,5 @@
 // Zaparoo Launcher
-// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 //
 // Single aggregated header included by each CXX-Qt model bridge.

--- a/rust/launcher/src/models/systems.rs
+++ b/rust/launcher/src/models/systems.rs
@@ -1,5 +1,5 @@
 // Zaparoo Launcher
-// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
 #![allow(
@@ -27,6 +27,7 @@ pub struct SystemsModelRust {
     systems: Vec<SystemInfo>,
     count: i32,
     current_category: QString,
+    error_message: QString,
     // Shared catalog owned by the background task; model reads it on setCategory
     catalog: Arc<RwLock<Option<CatalogData>>>,
 }
@@ -37,6 +38,7 @@ impl Default for SystemsModelRust {
             systems: Vec::new(),
             count: 0,
             current_category: QString::default(),
+            error_message: QString::default(),
             catalog: Arc::new(RwLock::new(None)),
         }
     }
@@ -64,6 +66,7 @@ pub mod ffi {
         #[qml_singleton]
         #[qproperty(i32, count)]
         #[qproperty(QString, current_category)]
+        #[qproperty(QString, error_message)]
         type SystemsModel = super::SystemsModelRust;
 
         #[qinvokable]
@@ -99,11 +102,14 @@ pub mod ffi {
 
 impl Initialize for ffi::SystemsModel {
     fn initialize(self: Pin<&mut Self>) {
-        use crate::models::{global_runtime, subscribe_catalog};
+        use crate::models::{global_runtime, subscribe_catalog, subscribe_catalog_status};
+        use zaparoo_core::systems_catalog::CatalogStatus;
 
         let catalog_arc = self.rust().catalog.clone();
         let qt_thread = self.qt_thread();
+        let qt_thread_status = qt_thread.clone();
         let mut catalog_rx = subscribe_catalog();
+        let mut status_rx = subscribe_catalog_status();
 
         // Seed catalog arc with whatever has already loaded.
         if let Some(data) = catalog_rx.borrow_and_update().clone() {
@@ -142,6 +148,24 @@ impl Initialize for ffi::SystemsModel {
                         model.as_mut().count_changed();
                     }
                 });
+            }
+        });
+
+        global_runtime().spawn(async move {
+            loop {
+                let err = match &*status_rx.borrow_and_update() {
+                    CatalogStatus::Errored(msg) => msg.clone(),
+                    _ => String::new(),
+                };
+                let qstr = QString::from(err.as_str());
+                let _ = qt_thread_status.queue(move |mut model| {
+                    if model.error_message != qstr {
+                        model.as_mut().set_error_message(qstr);
+                    }
+                });
+                if status_rx.changed().await.is_err() {
+                    break;
+                }
             }
         });
     }

--- a/rust/launcher/src/models/systems.rs
+++ b/rust/launcher/src/models/systems.rs
@@ -7,10 +7,12 @@
     reason = "RwLock poisoning signals another thread panicked with the lock held; state is unrecoverable"
 )]
 
-use cxx_qt::{CxxQtType, Initialize, Threading};
+use cxx_qt::CxxQtType;
 use cxx_qt_lib::{QByteArray, QHash, QHashPair_i32_QByteArray, QModelIndex, QString, QVariant};
 use std::pin::Pin;
 use std::sync::{Arc, RwLock};
+use zaparoo_core::endpoints::catalog::CatalogEndpoint;
+use zaparoo_core::remote_resource::ResourceStatus;
 use zaparoo_core::systems_catalog::CatalogData;
 
 const ID_ROLE: i32 = 256 + 1;
@@ -100,74 +102,56 @@ pub mod ffi {
     impl cxx_qt::Initialize for SystemsModel {}
 }
 
-impl Initialize for ffi::SystemsModel {
-    fn initialize(self: Pin<&mut Self>) {
-        use crate::models::{global_runtime, subscribe_catalog, subscribe_catalog_status};
-        use zaparoo_core::systems_catalog::CatalogStatus;
+crate::bind_to_endpoint! {
+    for ffi::SystemsModel,
+    endpoint = CatalogEndpoint,
+    args = (),
+    select = project,
+    apply = apply_state,
+}
 
-        let catalog_arc = self.rust().catalog.clone();
-        let qt_thread = self.qt_thread();
-        let qt_thread_status = qt_thread.clone();
-        let mut catalog_rx = subscribe_catalog();
-        let mut status_rx = subscribe_catalog_status();
+/// Pull the two pieces this model cares about out of the unified
+/// `ResourceStatus`: the catalog payload (only present on `Ready`) and
+/// the surfaced error message (empty unless `Errored`).
+fn project(status: &ResourceStatus<CatalogData>) -> (Option<CatalogData>, String) {
+    match status {
+        ResourceStatus::Ready(data) => (Some(data.clone()), String::new()),
+        ResourceStatus::Errored { message, .. } => (None, message.clone()),
+        ResourceStatus::Idle | ResourceStatus::Loading => (None, String::new()),
+    }
+}
 
-        // Seed catalog arc with whatever has already loaded.
-        if let Some(data) = catalog_rx.borrow_and_update().clone() {
-            *catalog_arc.write().unwrap() = Some(data);
+fn apply_state(mut model: Pin<&mut ffi::SystemsModel>, (data, err): (Option<CatalogData>, String)) {
+    if let Some(data) = data {
+        // Rebuild visible rows directly from `data` — if the user has
+        // already picked a category — *before* moving it into the
+        // shared catalog cache, so we don't have to re-acquire the
+        // read lock to look at what we just wrote.
+        let cat = model.rust().current_category.to_string();
+        if !cat.is_empty() {
+            let systems = data.systems_by_category(&cat);
+            let count = systems.len() as i32;
+            let rows: Vec<SystemInfo> = systems
+                .into_iter()
+                .map(|s| SystemInfo {
+                    id: s.id,
+                    name: s.name,
+                    category: s.category,
+                })
+                .collect();
+            model.as_mut().begin_reset_model();
+            model.as_mut().rust_mut().systems = rows;
+            model.as_mut().rust_mut().count = count;
+            model.as_mut().end_reset_model();
+            model.as_mut().count_changed();
         }
-
-        global_runtime().spawn(async move {
-            while catalog_rx.changed().await.is_ok() {
-                if let Some(data) = catalog_rx.borrow_and_update().clone() {
-                    *catalog_arc.write().unwrap() = Some(data);
-                }
-                let _ = qt_thread.queue(move |mut model| {
-                    let cat = model.rust().current_category.to_string();
-                    if !cat.is_empty() {
-                        let systems = model
-                            .rust()
-                            .catalog
-                            .read()
-                            .unwrap()
-                            .as_ref()
-                            .map(|c| c.systems_by_category(&cat))
-                            .unwrap_or_default();
-                        let count = systems.len() as i32;
-                        let rows: Vec<SystemInfo> = systems
-                            .into_iter()
-                            .map(|s| SystemInfo {
-                                id: s.id,
-                                name: s.name,
-                                category: s.category,
-                            })
-                            .collect();
-                        model.as_mut().begin_reset_model();
-                        model.as_mut().rust_mut().systems = rows;
-                        model.as_mut().rust_mut().count = count;
-                        model.as_mut().end_reset_model();
-                        model.as_mut().count_changed();
-                    }
-                });
-            }
-        });
-
-        global_runtime().spawn(async move {
-            loop {
-                let err = match &*status_rx.borrow_and_update() {
-                    CatalogStatus::Errored(msg) => msg.clone(),
-                    _ => String::new(),
-                };
-                let qstr = QString::from(err.as_str());
-                let _ = qt_thread_status.queue(move |mut model| {
-                    if model.error_message != qstr {
-                        model.as_mut().set_error_message(qstr);
-                    }
-                });
-                if status_rx.changed().await.is_err() {
-                    break;
-                }
-            }
-        });
+        // Refresh the shared catalog cache that `set_category` reads
+        // so subsequent category switches see the latest data.
+        *model.rust().catalog.write().unwrap() = Some(data);
+    }
+    let qerr = QString::from(err.as_str());
+    if model.error_message != qerr {
+        model.as_mut().set_error_message(qerr);
     }
 }
 

--- a/rust/mock-core/Cargo.toml
+++ b/rust/mock-core/Cargo.toml
@@ -1,0 +1,29 @@
+# Zaparoo Launcher
+# Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+# SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+[package]
+name         = "mock-core"
+description  = "Mock Zaparoo Core WebSocket server for local launcher development."
+version      = { workspace = true }
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+authors      = { workspace = true }
+publish      = false
+
+[[bin]]
+name = "mock-core"
+path = "src/main.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+tokio              = { workspace = true, features = ["rt-multi-thread", "macros", "net", "sync", "time", "io-util", "signal"] }
+tokio-tungstenite  = { workspace = true }
+serde              = { workspace = true }
+serde_json         = { workspace = true }
+tracing            = { workspace = true }
+tracing-subscriber = { workspace = true }
+futures-util       = { workspace = true }

--- a/rust/mock-core/src/fixtures.rs
+++ b/rust/mock-core/src/fixtures.rs
@@ -1,0 +1,167 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+//
+// Canned fixture data for mock-core. Response shapes mirror the
+// upstream Core API: https://zaparoo.org/docs/core/api/methods/
+// 3 categories x 10 systems x 5 games each = 50 games total,
+// distributed so every system has content when the launcher drills
+// into it.
+
+use serde_json::{json, Value};
+
+pub fn version_response() -> Value {
+    json!({
+        "version": "mock-0.1.0",
+        "platform": "mock",
+    })
+}
+
+pub fn systems_response() -> Value {
+    json!({
+        "systems": [
+            { "id": "nes",     "name": "Nintendo Entertainment System", "category": "Consoles" },
+            { "id": "snes",    "name": "Super Nintendo",                "category": "Consoles" },
+            { "id": "genesis", "name": "Sega Genesis",                  "category": "Consoles" },
+            { "id": "n64",     "name": "Nintendo 64",                   "category": "Consoles" },
+            { "id": "gb",      "name": "Game Boy",                      "category": "Handhelds" },
+            { "id": "gbc",     "name": "Game Boy Color",                "category": "Handhelds" },
+            { "id": "gba",     "name": "Game Boy Advance",              "category": "Handhelds" },
+            { "id": "nds",     "name": "Nintendo DS",                   "category": "Handhelds" },
+            { "id": "mame",    "name": "MAME",                          "category": "Arcade" },
+            { "id": "neogeo",  "name": "Neo Geo",                       "category": "Arcade" },
+        ]
+    })
+}
+
+pub fn media_search_response(params: &Value) -> Value {
+    let systems = params
+        .get("systems")
+        .and_then(Value::as_array)
+        .map(|a| a.iter().filter_map(Value::as_str).collect::<Vec<_>>())
+        .unwrap_or_default();
+    let max = params
+        .get("maxResults")
+        .and_then(Value::as_u64)
+        .unwrap_or(100) as usize;
+
+    let results: Vec<Value> = games_for_systems(&systems).take(max).collect();
+    // `total` is deprecated upstream and always returns -1; pagination
+    // info now travels under the `pagination` envelope. The mock has no
+    // real pagination, so it always reports a single complete page.
+    json!({
+        "results": results,
+        "total": -1,
+        "pagination": {
+            "hasNextPage": false,
+            "pageSize": max,
+        },
+    })
+}
+
+pub fn media_browse_response(params: &Value) -> Value {
+    let path = params.get("path").and_then(Value::as_str).unwrap_or("");
+    let entries: Vec<Value> = ALL_GAMES
+        .iter()
+        .take(20)
+        .map(|(name, file, system)| {
+            json!({
+                "name": name,
+                "path": format!("{path}/{file}"),
+                "type": "media",
+                "systemId": system,
+                "zapScript": format!("**launch.system:{system}"),
+                "relativePath": file,
+            })
+        })
+        .collect();
+    let total_files = entries.len() as u64;
+    json!({
+        "path": path,
+        "entries": entries,
+        "totalFiles": total_files,
+        "pagination": {
+            "hasNextPage": false,
+            "pageSize": 100,
+        },
+    })
+}
+
+fn games_for_systems<'a>(systems: &'a [&'a str]) -> impl Iterator<Item = Value> + 'a {
+    ALL_GAMES.iter().filter_map(move |(name, file, system)| {
+        if !systems.is_empty() && !systems.contains(system) {
+            return None;
+        }
+        Some(json!({
+            "name": name,
+            "path": format!("/mock/{system}/{file}"),
+            "zapScript": format!("**launch.system:{system}"),
+            "system": { "id": system, "name": system, "category": "" },
+            "tags": [],
+        }))
+    })
+}
+
+// (display name, filename, system id)
+const ALL_GAMES: &[(&str, &str, &str)] = &[
+    // NES
+    ("Super Mario Bros.", "smb.nes", "nes"),
+    ("The Legend of Zelda", "zelda.nes", "nes"),
+    ("Metroid", "metroid.nes", "nes"),
+    ("Mega Man 2", "mm2.nes", "nes"),
+    ("Castlevania", "castlevania.nes", "nes"),
+    // SNES
+    ("Super Mario World", "smw.sfc", "snes"),
+    ("A Link to the Past", "alttp.sfc", "snes"),
+    ("Super Metroid", "sm.sfc", "snes"),
+    ("Chrono Trigger", "ct.sfc", "snes"),
+    ("F-Zero", "fzero.sfc", "snes"),
+    // Genesis
+    ("Sonic the Hedgehog", "sonic1.md", "genesis"),
+    ("Sonic the Hedgehog 2", "sonic2.md", "genesis"),
+    ("Streets of Rage 2", "sor2.md", "genesis"),
+    ("Gunstar Heroes", "gunstar.md", "genesis"),
+    ("Ecco the Dolphin", "ecco.md", "genesis"),
+    // N64
+    ("Super Mario 64", "sm64.z64", "n64"),
+    ("Ocarina of Time", "oot.z64", "n64"),
+    ("GoldenEye 007", "goldeneye.z64", "n64"),
+    ("Mario Kart 64", "mk64.z64", "n64"),
+    ("Perfect Dark", "pd.z64", "n64"),
+    // Game Boy
+    ("Tetris", "tetris.gb", "gb"),
+    ("Pokemon Red", "pokered.gb", "gb"),
+    ("Link's Awakening", "la.gb", "gb"),
+    ("Super Mario Land", "sml.gb", "gb"),
+    ("Metroid II", "metroid2.gb", "gb"),
+    // Game Boy Color
+    ("Pokemon Crystal", "pokecrystal.gbc", "gbc"),
+    ("Zelda: Oracle of Ages", "oracle_of_ages.gbc", "gbc"),
+    ("Wario Land 3", "wl3.gbc", "gbc"),
+    ("Dragon Warrior III", "dw3.gbc", "gbc"),
+    ("Shantae", "shantae.gbc", "gbc"),
+    // Game Boy Advance
+    ("Metroid Fusion", "fusion.gba", "gba"),
+    ("Castlevania: Aria of Sorrow", "aos.gba", "gba"),
+    ("Pokemon Emerald", "emerald.gba", "gba"),
+    ("Advance Wars", "aw.gba", "gba"),
+    ("Golden Sun", "gs.gba", "gba"),
+    // Nintendo DS
+    ("Super Mario 64 DS", "sm64ds.nds", "nds"),
+    ("Mario Kart DS", "mkds.nds", "nds"),
+    ("Phoenix Wright", "pw.nds", "nds"),
+    ("Pokemon Diamond", "diamond.nds", "nds"),
+    ("The World Ends With You", "twewy.nds", "nds"),
+    // MAME
+    ("Pac-Man", "pacman.zip", "mame"),
+    ("Donkey Kong", "dkong.zip", "mame"),
+    ("Galaga", "galaga.zip", "mame"),
+    ("Street Fighter II", "sf2.zip", "mame"),
+    ("Ms. Pac-Man", "mspacman.zip", "mame"),
+    // Neo Geo
+    ("Metal Slug", "mslug.neo", "neogeo"),
+    ("The King of Fighters '98", "kof98.neo", "neogeo"),
+    ("Samurai Shodown", "samsho.neo", "neogeo"),
+    ("Fatal Fury", "fatfury.neo", "neogeo"),
+    ("Garou: Mark of the Wolves", "garou.neo", "neogeo"),
+];

--- a/rust/mock-core/src/handler.rs
+++ b/rust/mock-core/src/handler.rs
@@ -1,0 +1,195 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+//
+// JSON-RPC 2.0 envelope parsing and response assembly. Response shapes
+// mirror the upstream Core API: https://zaparoo.org/docs/core/api/
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tracing::{debug, info, warn};
+
+use crate::fixtures;
+
+#[derive(Deserialize)]
+struct RpcRequest {
+    method: String,
+    #[serde(default)]
+    params: Value,
+    id: Option<Value>,
+}
+
+#[derive(Serialize)]
+struct RpcResponse {
+    jsonrpc: &'static str,
+    id: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<RpcError>,
+}
+
+#[derive(Serialize)]
+struct RpcError {
+    code: i32,
+    message: String,
+}
+
+const FALLBACK_INTERNAL_ERROR: &str = r#"{"jsonrpc":"2.0","id":null,"error":{"code":-32603,"message":"internal serialization error"}}"#;
+
+pub fn dispatch(text: &str) -> String {
+    let req: RpcRequest = match serde_json::from_str(text) {
+        Ok(r) => r,
+        Err(e) => {
+            warn!("parse error: {e}");
+            return encode(&RpcResponse {
+                jsonrpc: "2.0",
+                id: Value::Null,
+                result: None,
+                error: Some(RpcError {
+                    code: -32700,
+                    message: format!("parse error: {e}"),
+                }),
+            });
+        }
+    };
+
+    debug!(method = %req.method, "rpc");
+
+    let result = match req.method.as_str() {
+        "systems" => Some(fixtures::systems_response()),
+        "media.search" => Some(fixtures::media_search_response(&req.params)),
+        "media.browse" => Some(fixtures::media_browse_response(&req.params)),
+        "run" => {
+            let zap_script = req.params.get("text").and_then(Value::as_str).unwrap_or("");
+            info!(%zap_script, "run");
+            // Upstream returns null on success.
+            Some(Value::Null)
+        }
+        "version" => Some(fixtures::version_response()),
+        _ => None,
+    };
+
+    let response = match result {
+        Some(r) => RpcResponse {
+            jsonrpc: "2.0",
+            id: req.id.unwrap_or(Value::Null),
+            result: Some(r),
+            error: None,
+        },
+        None => RpcResponse {
+            jsonrpc: "2.0",
+            id: req.id.unwrap_or(Value::Null),
+            result: None,
+            error: Some(RpcError {
+                code: -32601,
+                message: format!("method not found: {}", req.method),
+            }),
+        },
+    };
+
+    encode(&response)
+}
+
+fn encode(response: &RpcResponse) -> String {
+    serde_json::to_string(response).unwrap_or_else(|_| FALLBACK_INTERNAL_ERROR.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(
+        clippy::expect_used,
+        clippy::unwrap_used,
+        reason = "tests should fail-fast on unexpected errors"
+    )]
+
+    use serde_json::Value;
+
+    use super::dispatch;
+
+    fn parse(text: &str) -> Value {
+        serde_json::from_str(text).expect("dispatch output must be valid JSON")
+    }
+
+    #[test]
+    fn unknown_method_returns_jsonrpc_error() {
+        let req = r#"{"jsonrpc":"2.0","id":"1","method":"not.a.method"}"#;
+        let resp = parse(&dispatch(req));
+        assert_eq!(resp["jsonrpc"], "2.0");
+        assert_eq!(resp["id"], "1");
+        assert_eq!(resp["error"]["code"], -32601);
+    }
+
+    #[test]
+    fn systems_returns_fixture_catalog() {
+        let req = r#"{"jsonrpc":"2.0","id":"1","method":"systems","params":{}}"#;
+        let resp = parse(&dispatch(req));
+        let systems = resp["result"]["systems"].as_array().expect("array");
+        assert_eq!(systems.len(), 10);
+    }
+
+    #[test]
+    fn media_search_filters_by_system() {
+        let req = r#"{"jsonrpc":"2.0","id":"1","method":"media.search","params":{"systems":["nes"],"maxResults":100}}"#;
+        let resp = parse(&dispatch(req));
+        let results = resp["result"]["results"].as_array().expect("array");
+        assert!(!results.is_empty());
+        assert!(results
+            .iter()
+            .all(|g| g["system"]["id"].as_str() == Some("nes")));
+    }
+
+    #[test]
+    fn media_search_respects_max_results() {
+        let req = r#"{"jsonrpc":"2.0","id":"1","method":"media.search","params":{"systems":[],"maxResults":3}}"#;
+        let resp = parse(&dispatch(req));
+        let results = resp["result"]["results"].as_array().expect("array");
+        assert_eq!(results.len(), 3);
+    }
+
+    #[test]
+    fn media_search_emits_pagination_envelope() {
+        let req = r#"{"jsonrpc":"2.0","id":"1","method":"media.search","params":{"systems":[],"maxResults":50}}"#;
+        let resp = parse(&dispatch(req));
+        let pagination = resp["result"]["pagination"]
+            .as_object()
+            .expect("pagination object");
+        assert_eq!(pagination["hasNextPage"], Value::Bool(false));
+        assert_eq!(pagination["pageSize"], Value::from(50));
+        // Deprecated but still present for backward compatibility.
+        assert_eq!(resp["result"]["total"], Value::from(-1));
+    }
+
+    #[test]
+    fn media_browse_emits_media_entries_with_path_and_total() {
+        let req =
+            r#"{"jsonrpc":"2.0","id":"1","method":"media.browse","params":{"path":"/games"}}"#;
+        let resp = parse(&dispatch(req));
+        assert_eq!(resp["result"]["path"], Value::from("/games"));
+        let entries = resp["result"]["entries"].as_array().expect("array");
+        assert!(!entries.is_empty());
+        for entry in entries {
+            assert_eq!(entry["type"], Value::from("media"));
+            assert!(entry["systemId"].is_string());
+            assert!(entry["zapScript"].is_string());
+            assert!(entry["relativePath"].is_string());
+        }
+        assert!(resp["result"]["totalFiles"].is_number());
+        assert!(resp["result"]["pagination"].is_object());
+    }
+
+    #[test]
+    fn run_accepts_any_text_and_returns_null() {
+        let req =
+            r#"{"jsonrpc":"2.0","id":"1","method":"run","params":{"text":"**launch.system:nes"}}"#;
+        let resp = parse(&dispatch(req));
+        assert!(resp["result"].is_null());
+    }
+
+    #[test]
+    fn parse_error_returns_null_id() {
+        let resp = parse(&dispatch("this is not json"));
+        assert_eq!(resp["id"], Value::Null);
+        assert_eq!(resp["error"]["code"], -32700);
+    }
+}

--- a/rust/mock-core/src/main.rs
+++ b/rust/mock-core/src/main.rs
@@ -1,0 +1,75 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+//
+// Mock Zaparoo Core server. WebSocket JSON-RPC 2.0. Binds a dev-only
+// port (ws://127.0.0.1:27497/api/v0.1) deliberately offset from the
+// real Core's 7497 so a developer running both side-by-side never
+// collides. The launcher's dev preset (run-dev) and `ZAPAROO_CORE_ENDPOINT`
+// override point at this address; production launcher.toml still
+// defaults to 7497.
+
+mod fixtures;
+mod handler;
+
+use futures_util::{SinkExt, StreamExt};
+use std::net::SocketAddr;
+use tokio::net::{TcpListener, TcpStream};
+use tokio_tungstenite::tungstenite::Message;
+use tracing::{info, warn};
+use tracing_subscriber::EnvFilter;
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    tracing_subscriber::fmt().with_env_filter(filter).init();
+
+    let addr = std::env::var("MOCK_CORE_ADDR").unwrap_or_else(|_| "127.0.0.1:27497".to_string());
+    let listener = TcpListener::bind(&addr).await?;
+    info!("mock-core listening on ws://{addr}/api/v0.1");
+    info!("dev port (offset from the real Core's 7497); `just run-dev` and ZAPAROO_CORE_ENDPOINT target this automatically");
+
+    loop {
+        tokio::select! {
+            accept = listener.accept() => {
+                let (stream, peer) = accept?;
+                tokio::spawn(async move {
+                    if let Err(e) = serve(stream, peer).await {
+                        warn!(%peer, "connection error: {e}");
+                    }
+                });
+            }
+            _ = tokio::signal::ctrl_c() => {
+                info!("shutdown requested");
+                return Ok(());
+            }
+        }
+    }
+}
+
+async fn serve(
+    stream: TcpStream,
+    peer: SocketAddr,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let ws = tokio_tungstenite::accept_async(stream).await?;
+    info!(%peer, "client connected");
+
+    let (mut tx, mut rx) = ws.split();
+    while let Some(msg) = rx.next().await {
+        match msg? {
+            Message::Text(text) => {
+                let response = handler::dispatch(&text);
+                tx.send(Message::Text(response)).await?;
+            }
+            Message::Ping(data) => {
+                tx.send(Message::Pong(data)).await?;
+            }
+            Message::Close(_) => {
+                info!(%peer, "client disconnected");
+                break;
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,5 +1,5 @@
 # Zaparoo Launcher
-# Copyright (c) 2026 The Zaparoo Project Contributors.
+# Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 # SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
 [toolchain]

--- a/rust/zaparoo-core/Cargo.toml
+++ b/rust/zaparoo-core/Cargo.toml
@@ -1,5 +1,5 @@
 # Zaparoo Launcher
-# Copyright (c) 2026 The Zaparoo Project Contributors.
+# Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 # SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
 [package]

--- a/rust/zaparoo-core/src/client.rs
+++ b/rust/zaparoo-core/src/client.rs
@@ -4,10 +4,14 @@
 //
 // Async WebSocket JSON-RPC 2.0 client. Mirrors ZaparooClient.{cpp,h}.
 // Runs on a tokio runtime; auto-reconnects with exponential backoff
-// (1→2→4→8→16s, capped at 30s). After RETRY_ERROR_THRESHOLD consecutive
-// connect failures the client publishes ConnectionState::Error so the UI
-// can surface "Core unreachable" instead of a transient "Disconnected"
-// banner. Public methods are async and safe to call from any tokio task.
+// (1→2→4→8→16s, capped at 30s).
+//
+// `ConnectionState` is an explicit state machine published via `watch`
+// (see the variant docs below for transitions). The outbound channel is
+// session-scoped — every successful connect installs a fresh
+// `mpsc<String>` so RPCs queued while the link is down can't replay
+// against the next session, and `call()` fails fast with `not connected`
+// instead of disappearing into a queue.
 
 use crate::media_types::{
     MediaBrowseParams, MediaBrowseResult, MediaSearchParams, MediaSearchResult, RunParams,
@@ -19,16 +23,16 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use tokio::sync::{oneshot, watch};
+use tokio::sync::{mpsc, oneshot, watch};
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 /// Consecutive connect failures after which the client advertises
-/// `ConnectionState::Error` to subscribers. The outer loop keeps retrying
-/// past this point — the threshold exists so the UI can escalate a
-/// transient drop into a "Core unreachable" banner rather than cycling
-/// endlessly through "Connecting…".
+/// `ConnectionState::Unreachable` to subscribers. The outer loop keeps
+/// retrying past this point — the threshold exists so the UI can
+/// escalate a transient drop into a "Core unreachable" banner rather
+/// than cycling endlessly through "Reconnecting…".
 const RETRY_ERROR_THRESHOLD: u32 = 10;
 
 /// Ceiling on reconnect backoff. Chosen so a laptop waking from sleep
@@ -38,24 +42,59 @@ const MAX_BACKOFF_SECS: u64 = 30;
 /// Rolling state of the WebSocket link, published via `watch` so late
 /// subscribers (QML singletons whose `initialize()` runs after the QML
 /// engine boots, post-connect) read the current value rather than
-/// silently missing transitions. UI code derives its connection banner
-/// from this plus the catalog RPC status; other tasks (catalog,
-/// platform) trigger work on `Connected`.
+/// silently missing transitions.
+///
+/// State machine:
+///
+/// ```text
+///                        ┌──────── (success) ──────────┐
+///                        ↓                              │
+///       Disconnected ──→ Connecting ──→ Connected      │
+///                          ↑                │           │
+///                          │     (drop) ────┘           │
+///                          │                            │
+///        (recover) ←───────┴──── Reconnecting ──────────┘
+///                                      │
+///                                      │ (failures ≥ RETRY_ERROR_THRESHOLD)
+///                                      ↓
+///                                Unreachable(last_err)
+///                                      │
+///                                      └─ (eventual success → Connected;
+///                                          stays Unreachable until then)
+/// ```
+///
+/// Invariants the connect loop preserves:
+/// - `Connecting` is published exactly once, on the first attempt before
+///   any successful connect.
+/// - After a successful connect that drops, the next published state is
+///   `Reconnecting`, not `Connecting`. UI code can rely on `Connecting`
+///   meaning "first-ever attempt" and `Reconnecting` meaning "lost a
+///   live link."
+/// - Once `Unreachable(msg)` is published, the loop keeps retrying
+///   internally but does not republish `Reconnecting`. Recovery is
+///   signalled by a single transition to `Connected`.
+/// - `Disconnected` is the initial state only — the loop never returns
+///   to it after the first attempt begins.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ConnectionState {
-    /// No active ws link — either never connected yet or briefly
-    /// between retry attempts.
+    /// No connect attempt has been made yet. Initial value before the
+    /// connect loop's first iteration.
     Disconnected,
-    /// `connect_async` in flight. Published at the head of every retry
-    /// loop so the UI can show a "connecting" hint even before the first
-    /// connect succeeds.
+    /// First-ever `connect_async` in flight. Replaced by `Connected` on
+    /// success or `Unreachable` after `RETRY_ERROR_THRESHOLD` consecutive
+    /// failures; UI code may treat this as "boot-time wait."
     Connecting,
     /// ws link up and service loop running.
     Connected,
-    /// Consecutive connect failures exceeded `RETRY_ERROR_THRESHOLD`.
-    /// Inner string is the last connect error. The task keeps retrying;
-    /// recovery is signalled by a later `Connected`.
-    Error(String),
+    /// Lost a previously-live link and the loop is retrying. Distinct
+    /// from `Connecting` so UI can show "lost connection, retrying"
+    /// without flickering "connecting…" every backoff cycle.
+    Reconnecting,
+    /// Threshold of consecutive connect failures hit. The inner string
+    /// is the most recent connect error. Sticky: subsequent retries do
+    /// not republish `Connecting` or `Reconnecting`; only a successful
+    /// connect (→ `Connected`) clears it.
+    Unreachable(String),
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -93,40 +132,131 @@ impl std::error::Error for ClientError {}
 
 type PendingMap = Arc<Mutex<HashMap<String, oneshot::Sender<Result<Value, ClientError>>>>>;
 
+/// Session-scoped outbound sender. `None` means no live ws session, so
+/// `call()` fails fast with `not connected` instead of queueing into a
+/// channel that might be drained against a later session.
+type OutboundSlot = Arc<Mutex<Option<mpsc::UnboundedSender<String>>>>;
+
+/// Bookkeeping for the connection state machine. Extracted from the
+/// connect loop so the transition rules can be unit-tested without
+/// driving real WebSocket I/O.
+#[derive(Debug, Default)]
+struct ConnectionFsm {
+    /// Consecutive connect failures since the last successful handshake.
+    /// Resets on `on_connected`.
+    failures: u32,
+    /// Set on the first `Connected` and never cleared. Drives
+    /// `Connecting` (first-ever attempt) vs `Reconnecting` (post-drop).
+    ever_connected: bool,
+    /// Latches the moment `Unreachable` is published so subsequent retry
+    /// attempts stay silent until a successful connect clears it. Without
+    /// this, the loop would clobber `Unreachable` with `Reconnecting` on
+    /// every backoff cycle.
+    unreachable_published: bool,
+}
+
+impl ConnectionFsm {
+    /// Returns the state to publish before the next connect attempt, or
+    /// `None` if no transition is needed (already at the right state, or
+    /// `Unreachable` has latched).
+    fn before_attempt(&self, current: &ConnectionState) -> Option<ConnectionState> {
+        if self.unreachable_published {
+            return None;
+        }
+        let trying = if self.ever_connected {
+            ConnectionState::Reconnecting
+        } else {
+            ConnectionState::Connecting
+        };
+        if *current == trying {
+            None
+        } else {
+            Some(trying)
+        }
+    }
+
+    /// Records a successful connect and returns the state to publish.
+    /// Always `Connected`; the loop should always publish this so a
+    /// recovery from `Unreachable` produces a visible transition.
+    fn on_connected(&mut self) -> ConnectionState {
+        self.failures = 0;
+        self.ever_connected = true;
+        self.unreachable_published = false;
+        ConnectionState::Connected
+    }
+
+    /// Records a failed connect attempt and returns the state to publish,
+    /// or `None` if the failure shouldn't change the published state
+    /// (below threshold, or already `Unreachable`).
+    fn on_attempt_failed(&mut self, err: String) -> Option<ConnectionState> {
+        self.failures = self.failures.saturating_add(1);
+        if self.failures >= RETRY_ERROR_THRESHOLD && !self.unreachable_published {
+            self.unreachable_published = true;
+            Some(ConnectionState::Unreachable(err))
+        } else {
+            None
+        }
+    }
+
+    fn current_failures(&self) -> u32 {
+        self.failures
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct Client {
-    tx: tokio::sync::mpsc::UnboundedSender<String>,
+    tx: OutboundSlot,
     pending: PendingMap,
     pub connection: Arc<watch::Sender<ConnectionState>>,
 }
 
 impl Client {
     pub fn new(endpoint: String, runtime: &Arc<tokio::runtime::Runtime>) -> Arc<Self> {
-        let (msg_tx, mut msg_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
         let (connection_tx, _) = watch::channel(ConnectionState::Disconnected);
         let pending: PendingMap = Arc::new(Mutex::new(HashMap::new()));
         let pending_clone = pending.clone();
         let connection_arc = Arc::new(connection_tx);
         let connection_clone = connection_arc.clone();
+        let tx_slot: OutboundSlot = Arc::new(Mutex::new(None));
+        let tx_slot_clone = tx_slot.clone();
 
         let client = Arc::new(Self {
-            tx: msg_tx,
+            tx: tx_slot,
             pending,
             connection: connection_arc,
         });
 
         runtime.spawn(async move {
-            // Consecutive connect failures since the last successful
-            // handshake. Drives `backoff_delay` and the error-surfacing
-            // threshold; reset on `Ok`.
-            let mut failures: u32 = 0;
+            let mut fsm = ConnectionFsm::default();
+
             loop {
-                connection_clone.send_replace(ConnectionState::Connecting);
+                // Bind the borrow to a local so it's dropped before
+                // `send_replace` — temporaries in the scrutinee of an
+                // `if let` outlive the body, so inlining the borrow
+                // here would hold a read lock across `send_replace`'s
+                // write lock and deadlock the connection task.
+                let next = {
+                    let current = connection_clone.borrow();
+                    fsm.before_attempt(&current)
+                };
+                if let Some(next) = next {
+                    connection_clone.send_replace(next);
+                }
+
                 match connect_async(&endpoint).await {
                     Ok((ws_stream, _)) => {
-                        failures = 0;
                         info!("connected to core at {endpoint}");
-                        connection_clone.send_replace(ConnectionState::Connected);
+
+                        // Fresh outbound channel per session — see the
+                        // OutboundSlot doc comment for why this isn't
+                        // shared across reconnects.
+                        let (msg_tx, mut msg_rx) = mpsc::unbounded_channel::<String>();
+                        #[allow(clippy::unwrap_used, reason = "mutex poisoning is unrecoverable")]
+                        {
+                            *tx_slot_clone.lock().unwrap() = Some(msg_tx);
+                        }
+                        connection_clone.send_replace(fsm.on_connected());
+
                         let (mut write, mut read) = ws_stream.split();
 
                         loop {
@@ -139,7 +269,7 @@ impl Client {
                                                 break;
                                             }
                                         }
-                                        None => return, // Client dropped
+                                        None => return, // Outbound channel dropped — only happens on shutdown.
                                     }
                                 }
                                 msg = read.next() => {
@@ -174,8 +304,15 @@ impl Client {
                             }
                         }
 
-                        connection_clone.send_replace(ConnectionState::Disconnected);
-                        // Fail all pending requests
+                        // Tear down the session: drop the outbound sender
+                        // (msg_rx is dropped at scope-exit, taking any
+                        // queued-but-unsent messages with it) and fail
+                        // every pending RPC. The next iteration publishes
+                        // `Reconnecting` automatically.
+                        #[allow(clippy::unwrap_used, reason = "mutex poisoning is unrecoverable")]
+                        {
+                            *tx_slot_clone.lock().unwrap() = None;
+                        }
                         #[allow(clippy::unwrap_used, reason = "mutex poisoning is unrecoverable")]
                         let drained: Vec<_> = pending_clone.lock().unwrap().drain().collect();
                         for (_, tx) in drained {
@@ -183,17 +320,16 @@ impl Client {
                         }
                     }
                     Err(e) => {
-                        failures = failures.saturating_add(1);
-                        let state = if failures >= RETRY_ERROR_THRESHOLD {
-                            ConnectionState::Error(e.to_string())
-                        } else {
-                            ConnectionState::Disconnected
-                        };
-                        connection_clone.send_replace(state);
-                        debug!("ws connect failed (attempt {failures}): {e}");
+                        if let Some(next) = fsm.on_attempt_failed(e.to_string()) {
+                            connection_clone.send_replace(next);
+                        }
+                        debug!(
+                            "ws connect failed (attempt {}): {e}",
+                            fsm.current_failures()
+                        );
                     }
                 }
-                tokio::time::sleep(backoff_delay(failures)).await;
+                tokio::time::sleep(backoff_delay(fsm.current_failures())).await;
             }
         });
 
@@ -212,15 +348,33 @@ impl Client {
             message: e.to_string(),
         })?;
 
+        // Snapshot the current session's sender. If `None`, no live link —
+        // fail immediately rather than queueing into a channel that will
+        // be dropped at the next disconnect or, worse, drained by the
+        // wrong session.
+        #[allow(clippy::unwrap_used, reason = "mutex poisoning is unrecoverable")]
+        let sender = self.tx.lock().unwrap().clone().ok_or_else(|| ClientError {
+            message: "not connected".into(),
+        })?;
+
         let (resp_tx, resp_rx) = oneshot::channel();
         #[allow(clippy::unwrap_used, reason = "mutex poisoning is unrecoverable")]
         {
-            self.pending.lock().unwrap().insert(id, resp_tx);
+            self.pending.lock().unwrap().insert(id.clone(), resp_tx);
         }
 
-        self.tx.send(text).map_err(|_| ClientError {
-            message: "not connected".into(),
-        })?;
+        if sender.send(text).is_err() {
+            // Receiver was dropped between the snapshot and the send —
+            // session ended in flight. Clean up the pending entry so it
+            // doesn't leak.
+            #[allow(clippy::unwrap_used, reason = "mutex poisoning is unrecoverable")]
+            {
+                self.pending.lock().unwrap().remove(&id);
+            }
+            return Err(ClientError {
+                message: "not connected".into(),
+            });
+        }
 
         resp_rx.await.map_err(|_| ClientError {
             message: "channel closed".into(),
@@ -276,13 +430,11 @@ impl Client {
     }
 
     pub async fn run(&self, params: RunParams) -> Result<(), ClientError> {
-        #[derive(Serialize)]
-        struct P {
-            text: String,
-        }
-        // Upstream returns null on success; the launcher has no use for
-        // the result body either way, so swallow it.
-        self.call("run", &P { text: params.text }).await?;
+        // `RunParams` already derives `Serialize`; forwarding it as-is
+        // means new optional fields the upstream API gains (`type`,
+        // `uid`, `data`, `unsafe`) flow through with no client edits.
+        // Upstream returns null on success; swallow it.
+        self.call("run", &params).await?;
         Ok(())
     }
 
@@ -303,7 +455,10 @@ impl Client {
 /// the delay until the cap.
 ///
 /// Sequence: 0→1, 1→1, 2→2, 3→4, 4→8, 5→16, 6→30, 7+→30 (seconds).
-fn backoff_delay(failures: u32) -> Duration {
+///
+/// `pub(crate)` so `remote_resource` can reuse the same curve for
+/// in-session RPC retry without duplicating the math.
+pub(crate) fn backoff_delay(failures: u32) -> Duration {
     let exp = failures.saturating_sub(1).min(5);
     let secs = 1u64 << exp;
     Duration::from_secs(secs.min(MAX_BACKOFF_SECS))
@@ -326,6 +481,118 @@ mod tests {
         assert_eq!(
             backoff_delay(u32::MAX),
             Duration::from_secs(MAX_BACKOFF_SECS)
+        );
+    }
+
+    /// Replays a scripted sequence of connect outcomes through
+    /// `ConnectionFsm` and returns the distinct sequence of states
+    /// published to the watch — i.e. the public-visible transitions.
+    /// `outcomes` is `Ok(())` for a successful connect or `Err(msg)` for
+    /// a failed connect attempt.
+    fn replay(outcomes: &[Result<(), &str>]) -> Vec<ConnectionState> {
+        let mut fsm = ConnectionFsm::default();
+        let mut current = ConnectionState::Disconnected;
+        let mut log = Vec::new();
+        for outcome in outcomes {
+            if let Some(next) = fsm.before_attempt(&current) {
+                current = next.clone();
+                log.push(next);
+            }
+            match outcome {
+                Ok(()) => {
+                    let next = fsm.on_connected();
+                    current = next.clone();
+                    log.push(next);
+                }
+                Err(e) => {
+                    if let Some(next) = fsm.on_attempt_failed((*e).to_string()) {
+                        current = next.clone();
+                        log.push(next);
+                    }
+                }
+            }
+        }
+        log
+    }
+
+    #[test]
+    fn first_ever_attempt_publishes_connecting_then_connected() {
+        assert_eq!(
+            replay(&[Ok(())]),
+            vec![ConnectionState::Connecting, ConnectionState::Connected],
+        );
+    }
+
+    #[test]
+    fn drop_after_connected_transitions_through_reconnecting_not_connecting() {
+        let log = replay(&[Ok(()), Err("dropped"), Ok(())]);
+        assert_eq!(
+            log,
+            vec![
+                ConnectionState::Connecting,
+                ConnectionState::Connected,
+                // The failed second attempt does not republish; the
+                // pre-attempt of the third attempt publishes Reconnecting.
+                ConnectionState::Reconnecting,
+                ConnectionState::Connected,
+            ],
+        );
+    }
+
+    #[test]
+    fn unreachable_is_sticky_until_recovery() {
+        // Ten failed first-attempts, then a successful one. Unreachable
+        // is published exactly once, and recovery clears it.
+        let mut script: Vec<Result<(), &str>> = (0..RETRY_ERROR_THRESHOLD)
+            .map(|_| Err("conn refused"))
+            .collect();
+        script.push(Ok(()));
+        let log = replay(&script);
+        assert_eq!(
+            log,
+            vec![
+                ConnectionState::Connecting,
+                ConnectionState::Unreachable("conn refused".into()),
+                ConnectionState::Connected,
+            ],
+        );
+    }
+
+    #[test]
+    fn unreachable_does_not_republish_reconnecting_during_extended_outage() {
+        // 20 failures (twice the threshold). Unreachable should appear
+        // exactly once; no Reconnecting/Connecting flapping in between.
+        let script: Vec<Result<(), &str>> = (0..20).map(|_| Err("conn refused")).collect();
+        let log = replay(&script);
+        assert_eq!(
+            log,
+            vec![
+                ConnectionState::Connecting,
+                ConnectionState::Unreachable("conn refused".into()),
+            ],
+        );
+    }
+
+    #[test]
+    fn second_unreachable_window_after_recovery_publishes_again() {
+        // Drop after Connected, fail past threshold a second time. The
+        // second Unreachable goes out because the recovery cleared the
+        // latch.
+        let mut script: Vec<Result<(), &str>> = vec![Ok(()), Err("first drop")];
+        for _ in 0..RETRY_ERROR_THRESHOLD {
+            script.push(Err("flaky"));
+        }
+        script.push(Ok(()));
+        let log = replay(&script);
+        assert_eq!(
+            log,
+            vec![
+                ConnectionState::Connecting,
+                ConnectionState::Connected,
+                ConnectionState::Reconnecting,
+                ConnectionState::Unreachable("flaky".into()),
+                ConnectionState::Connected,
+            ],
         );
     }
 }

--- a/rust/zaparoo-core/src/client.rs
+++ b/rust/zaparoo-core/src/client.rs
@@ -1,14 +1,17 @@
 // Zaparoo Launcher
-// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 //
 // Async WebSocket JSON-RPC 2.0 client. Mirrors ZaparooClient.{cpp,h}.
-// Runs on a tokio runtime; auto-reconnects every second on disconnect.
-// Public methods are async and safe to call from any tokio task.
+// Runs on a tokio runtime; auto-reconnects with exponential backoff
+// (1→2→4→8→16s, capped at 30s). After RETRY_ERROR_THRESHOLD consecutive
+// connect failures the client publishes ConnectionState::Error so the UI
+// can surface "Core unreachable" instead of a transient "Disconnected"
+// banner. Public methods are async and safe to call from any tokio task.
 
 use crate::media_types::{
     MediaBrowseParams, MediaBrowseResult, MediaSearchParams, MediaSearchResult, RunParams,
-    RunResult, SystemsParams, SystemsResult, VersionResult,
+    SystemsParams, SystemsResult, VersionResult,
 };
 use futures_util::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
@@ -16,10 +19,44 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use tokio::sync::{broadcast, oneshot};
+use tokio::sync::{oneshot, watch};
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 use tracing::{debug, info, warn};
 use uuid::Uuid;
+
+/// Consecutive connect failures after which the client advertises
+/// `ConnectionState::Error` to subscribers. The outer loop keeps retrying
+/// past this point — the threshold exists so the UI can escalate a
+/// transient drop into a "Core unreachable" banner rather than cycling
+/// endlessly through "Connecting…".
+const RETRY_ERROR_THRESHOLD: u32 = 10;
+
+/// Ceiling on reconnect backoff. Chosen so a laptop waking from sleep
+/// after hours still reconnects within half a minute.
+const MAX_BACKOFF_SECS: u64 = 30;
+
+/// Rolling state of the WebSocket link, published via `watch` so late
+/// subscribers (QML singletons whose `initialize()` runs after the QML
+/// engine boots, post-connect) read the current value rather than
+/// silently missing transitions. UI code derives its connection banner
+/// from this plus the catalog RPC status; other tasks (catalog,
+/// platform) trigger work on `Connected`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ConnectionState {
+    /// No active ws link — either never connected yet or briefly
+    /// between retry attempts.
+    Disconnected,
+    /// `connect_async` in flight. Published at the head of every retry
+    /// loop so the UI can show a "connecting" hint even before the first
+    /// connect succeeds.
+    Connecting,
+    /// ws link up and service loop running.
+    Connected,
+    /// Consecutive connect failures exceeded `RETRY_ERROR_THRESHOLD`.
+    /// Inner string is the last connect error. The task keeps retrying;
+    /// recovery is signalled by a later `Connected`.
+    Error(String),
+}
 
 #[derive(Debug, Clone, Serialize)]
 struct RpcRequest<'a, T: Serialize> {
@@ -60,30 +97,36 @@ type PendingMap = Arc<Mutex<HashMap<String, oneshot::Sender<Result<Value, Client
 pub struct Client {
     tx: tokio::sync::mpsc::UnboundedSender<String>,
     pending: PendingMap,
-    pub connected: Arc<broadcast::Sender<bool>>,
+    pub connection: Arc<watch::Sender<ConnectionState>>,
 }
 
 impl Client {
     pub fn new(endpoint: String, runtime: &Arc<tokio::runtime::Runtime>) -> Arc<Self> {
         let (msg_tx, mut msg_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
-        let (connected_tx, _) = broadcast::channel::<bool>(16);
+        let (connection_tx, _) = watch::channel(ConnectionState::Disconnected);
         let pending: PendingMap = Arc::new(Mutex::new(HashMap::new()));
         let pending_clone = pending.clone();
-        let connected_arc = Arc::new(connected_tx);
-        let connected_clone = connected_arc.clone();
+        let connection_arc = Arc::new(connection_tx);
+        let connection_clone = connection_arc.clone();
 
         let client = Arc::new(Self {
             tx: msg_tx,
             pending,
-            connected: connected_arc,
+            connection: connection_arc,
         });
 
         runtime.spawn(async move {
+            // Consecutive connect failures since the last successful
+            // handshake. Drives `backoff_delay` and the error-surfacing
+            // threshold; reset on `Ok`.
+            let mut failures: u32 = 0;
             loop {
+                connection_clone.send_replace(ConnectionState::Connecting);
                 match connect_async(&endpoint).await {
                     Ok((ws_stream, _)) => {
+                        failures = 0;
                         info!("connected to core at {endpoint}");
-                        let _ = connected_clone.send(true);
+                        connection_clone.send_replace(ConnectionState::Connected);
                         let (mut write, mut read) = ws_stream.split();
 
                         loop {
@@ -131,7 +174,7 @@ impl Client {
                             }
                         }
 
-                        let _ = connected_clone.send(false);
+                        connection_clone.send_replace(ConnectionState::Disconnected);
                         // Fail all pending requests
                         #[allow(clippy::unwrap_used, reason = "mutex poisoning is unrecoverable")]
                         let drained: Vec<_> = pending_clone.lock().unwrap().drain().collect();
@@ -140,10 +183,17 @@ impl Client {
                         }
                     }
                     Err(e) => {
-                        debug!("ws connect failed: {e}");
+                        failures = failures.saturating_add(1);
+                        let state = if failures >= RETRY_ERROR_THRESHOLD {
+                            ConnectionState::Error(e.to_string())
+                        } else {
+                            ConnectionState::Disconnected
+                        };
+                        connection_clone.send_replace(state);
+                        debug!("ws connect failed (attempt {failures}): {e}");
                     }
                 }
-                tokio::time::sleep(Duration::from_secs(1)).await;
+                tokio::time::sleep(backoff_delay(failures)).await;
             }
         });
 
@@ -225,15 +275,15 @@ impl Client {
         })
     }
 
-    pub async fn run(&self, params: RunParams) -> Result<RunResult, ClientError> {
+    pub async fn run(&self, params: RunParams) -> Result<(), ClientError> {
         #[derive(Serialize)]
         struct P {
             text: String,
         }
-        let val = self.call("run", &P { text: params.text }).await?;
-        serde_json::from_value(val).map_err(|e| ClientError {
-            message: e.to_string(),
-        })
+        // Upstream returns null on success; the launcher has no use for
+        // the result body either way, so swallow it.
+        self.call("run", &P { text: params.text }).await?;
+        Ok(())
     }
 
     pub async fn version(&self) -> Result<VersionResult, ClientError> {
@@ -243,5 +293,39 @@ impl Client {
         serde_json::from_value(val).map_err(|e| ClientError {
             message: e.to_string(),
         })
+    }
+}
+
+/// Exponential backoff between connect attempts, capped at
+/// `MAX_BACKOFF_SECS`. `failures == 0` represents "we just disconnected
+/// from a successful session" and yields a 1 s retry so a brief drop
+/// doesn't feel sluggish; each subsequent consecutive failure doubles
+/// the delay until the cap.
+///
+/// Sequence: 0→1, 1→1, 2→2, 3→4, 4→8, 5→16, 6→30, 7+→30 (seconds).
+fn backoff_delay(failures: u32) -> Duration {
+    let exp = failures.saturating_sub(1).min(5);
+    let secs = 1u64 << exp;
+    Duration::from_secs(secs.min(MAX_BACKOFF_SECS))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backoff_follows_exponential_curve_then_caps() {
+        assert_eq!(backoff_delay(0), Duration::from_secs(1));
+        assert_eq!(backoff_delay(1), Duration::from_secs(1));
+        assert_eq!(backoff_delay(2), Duration::from_secs(2));
+        assert_eq!(backoff_delay(3), Duration::from_secs(4));
+        assert_eq!(backoff_delay(4), Duration::from_secs(8));
+        assert_eq!(backoff_delay(5), Duration::from_secs(16));
+        assert_eq!(backoff_delay(6), Duration::from_secs(MAX_BACKOFF_SECS));
+        assert_eq!(backoff_delay(7), Duration::from_secs(MAX_BACKOFF_SECS));
+        assert_eq!(
+            backoff_delay(u32::MAX),
+            Duration::from_secs(MAX_BACKOFF_SECS)
+        );
     }
 }

--- a/rust/zaparoo-core/src/config.rs
+++ b/rust/zaparoo-core/src/config.rs
@@ -1,8 +1,10 @@
 // Zaparoo Launcher
-// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
+use crate::input_actions;
 use serde::Deserialize;
+use std::collections::HashMap;
 use std::path::Path;
 use tracing::warn;
 
@@ -12,6 +14,16 @@ pub struct Config {
     pub video_width: u32,
     pub video_height: u32,
     pub debug_logging: bool,
+    /// Language override for the UI, passed to `QTranslator` via the
+    /// C++ entry point. Empty string means "follow `QLocale::system()`";
+    /// any non-empty value is treated as a BCP-47 tag (e.g. `en_US`,
+    /// `ja`, `de_DE`). Populated from `[general] language` in the config
+    /// file; the literal `auto` is normalised to an empty string.
+    pub language: String,
+    /// Qt key code → action name. Built at load time by merging
+    /// `[input.keyboard]` overrides onto `input_actions::default_bindings()`
+    /// and inverting.
+    pub key_to_action: HashMap<i32, String>,
 }
 
 impl Default for Config {
@@ -21,6 +33,8 @@ impl Default for Config {
             video_width: 1920,
             video_height: 1080,
             debug_logging: false,
+            language: String::new(),
+            key_to_action: input_actions::invert(&input_actions::default_bindings()),
         }
     }
 }
@@ -28,11 +42,20 @@ impl Default for Config {
 #[derive(Deserialize, Default)]
 struct RawConfig {
     #[serde(default)]
+    general: RawGeneral,
+    #[serde(default)]
     core: RawCore,
     #[serde(default)]
     video: RawVideo,
     #[serde(default)]
     logging: RawLogging,
+    #[serde(default)]
+    input: RawInput,
+}
+
+#[derive(Deserialize, Default)]
+struct RawGeneral {
+    language: Option<String>,
 }
 
 #[derive(Deserialize, Default)]
@@ -51,6 +74,12 @@ struct RawLogging {
     debug: Option<bool>,
 }
 
+#[derive(Deserialize, Default)]
+struct RawInput {
+    #[serde(default)]
+    keyboard: HashMap<String, Vec<String>>,
+}
+
 pub fn load_config(path: &Path) -> Config {
     let mut cfg = Config::default();
     let Ok(src) = std::fs::read_to_string(path) else {
@@ -63,8 +92,26 @@ pub fn load_config(path: &Path) -> Config {
             return cfg;
         }
     };
+    if let Some(lang) = raw.general.language {
+        // "auto" is the documented opt-in to system-locale detection; treat
+        // it as an empty override so the C++ side just calls `QLocale::system()`.
+        cfg.language = if lang.eq_ignore_ascii_case("auto") {
+            String::new()
+        } else {
+            lang
+        };
+    }
     if let Some(ep) = raw.core.endpoint {
         cfg.core_endpoint = ep;
+    }
+    // Env-var override wins over both the built-in default and any
+    // launcher.toml setting. Used by run-dev.sh to point the launcher at
+    // mock-core (port 27497) without forcing the user to maintain a
+    // throwaway launcher.toml.
+    if let Ok(ep) = std::env::var("ZAPAROO_CORE_ENDPOINT") {
+        if !ep.is_empty() {
+            cfg.core_endpoint = ep;
+        }
     }
     if let Some(w) = raw.video.width {
         cfg.video_width = w;
@@ -74,6 +121,13 @@ pub fn load_config(path: &Path) -> Config {
     }
     if let Some(d) = raw.logging.debug {
         cfg.debug_logging = d;
+    }
+    if !raw.input.keyboard.is_empty() {
+        let mut merged = input_actions::default_bindings();
+        for (action, keys) in raw.input.keyboard {
+            merged.insert(action, keys);
+        }
+        cfg.key_to_action = input_actions::invert(&merged);
     }
     cfg
 }
@@ -103,6 +157,57 @@ mod tests {
         assert_eq!(cfg.video_width, 1920);
         assert_eq!(cfg.video_height, 1080);
         assert!(!cfg.debug_logging);
+        assert_eq!(cfg.language, "");
+        // Default keyboard bindings populate the map.
+        assert!(!cfg.key_to_action.is_empty());
+    }
+
+    #[test]
+    fn language_auto_is_normalised_to_empty() {
+        let f = write_tmp("[general]\nlanguage = \"auto\"\n");
+        let cfg = load_config(f.path());
+        assert_eq!(cfg.language, "");
+    }
+
+    #[test]
+    fn language_auto_is_case_insensitive() {
+        let f = write_tmp("[general]\nlanguage = \"AUTO\"\n");
+        let cfg = load_config(f.path());
+        assert_eq!(cfg.language, "");
+    }
+
+    #[test]
+    fn language_explicit_code_passes_through() {
+        let f = write_tmp("[general]\nlanguage = \"ja_JP\"\n");
+        let cfg = load_config(f.path());
+        assert_eq!(cfg.language, "ja_JP");
+    }
+
+    #[test]
+    fn keyboard_override_replaces_default_for_that_action() {
+        use crate::input_actions::{actions, qt_key_code};
+
+        let toml = r#"
+            [input.keyboard]
+            accept = ["Space"]
+        "#;
+        let f = write_tmp(toml);
+        let cfg = load_config(f.path());
+        let space = qt_key_code("Space").unwrap();
+        let enter = qt_key_code("Enter").unwrap();
+        assert_eq!(
+            cfg.key_to_action.get(&space).map(String::as_str),
+            Some(actions::ACCEPT)
+        );
+        // Enter is no longer bound to accept: the user's list replaced
+        // the default for this action entirely.
+        assert!(!cfg.key_to_action.contains_key(&enter));
+        // Cancel defaults survive untouched.
+        let escape = qt_key_code("Escape").unwrap();
+        assert_eq!(
+            cfg.key_to_action.get(&escape).map(String::as_str),
+            Some(actions::CANCEL)
+        );
     }
 
     #[test]
@@ -153,5 +258,31 @@ mod tests {
         let f = write_tmp("");
         let cfg = load_config(f.path());
         assert_eq!(cfg.video_width, Config::default().video_width);
+    }
+
+    // Single test because std::env is process-global; splitting into
+    // separate #[test]s would race when nextest runs them in parallel.
+    #[test]
+    fn env_var_overrides_endpoint_and_empty_string_is_ignored() {
+        const KEY: &str = "ZAPAROO_CORE_ENDPOINT";
+        let prior = std::env::var(KEY).ok();
+        let f = write_tmp("[core]\nendpoint = \"ws://example.com/api\"\n");
+
+        std::env::set_var(KEY, "ws://localhost:27497/api/v0.1");
+        assert_eq!(
+            load_config(f.path()).core_endpoint,
+            "ws://localhost:27497/api/v0.1"
+        );
+
+        // Empty value is treated as unset so accidentally exporting an
+        // empty ZAPAROO_CORE_ENDPOINT in a shell rc file doesn't blank
+        // out the user's launcher.toml.
+        std::env::set_var(KEY, "");
+        assert_eq!(load_config(f.path()).core_endpoint, "ws://example.com/api");
+
+        match prior {
+            Some(v) => std::env::set_var(KEY, v),
+            None => std::env::remove_var(KEY),
+        }
     }
 }

--- a/rust/zaparoo-core/src/endpoints/catalog.rs
+++ b/rust/zaparoo-core/src/endpoints/catalog.rs
@@ -113,7 +113,7 @@ mod tests {
     }
 
     #[test]
-    fn derive_categories_synthesises_other_for_empty() {
+    fn derive_categories_synthesizes_other_for_empty() {
         let systems = vec![sys("a", "A", ""), sys("b", "B", "Consoles")];
         assert_eq!(derive_categories(&systems), vec!["Consoles", "Other"]);
     }

--- a/rust/zaparoo-core/src/endpoints/catalog.rs
+++ b/rust/zaparoo-core/src/endpoints/catalog.rs
@@ -1,0 +1,132 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+//
+// `CatalogEndpoint` — single-fetch endpoint for the systems catalog.
+// `Args = ()` because the catalog is a global per-connection resource;
+// every QML singleton that needs categories or systems shares the one
+// `RemoteResource<CatalogData>` the store hands back.
+//
+// `fetch` does the same shaping the old `systems_catalog::spawn`
+// closure did: pull the systems list from Core, sort by name, derive
+// the category list. The split into `shape_catalog` exists so the unit
+// test can exercise the pipeline without a network call.
+
+use crate::client::{Client, ClientError};
+use crate::media_types::{SystemInfo, SystemsParams};
+use crate::store::Endpoint;
+use crate::systems_catalog::CatalogData;
+use futures_util::future::BoxFuture;
+use std::collections::HashSet;
+use std::sync::Arc;
+use tracing::info;
+
+#[derive(Debug)]
+pub struct CatalogEndpoint;
+
+impl Endpoint for CatalogEndpoint {
+    type Args = ();
+    type Output = CatalogData;
+    const NAME: &'static str = "Catalog";
+
+    fn fetch(
+        client: Arc<Client>,
+        _args: Self::Args,
+    ) -> BoxFuture<'static, Result<Self::Output, ClientError>> {
+        Box::pin(async move {
+            let result = client.systems(SystemsParams {}).await?;
+            Ok(shape_catalog(result.systems))
+        })
+    }
+}
+
+/// Apply the canonical sort + category derivation to a freshly-fetched
+/// systems list. Pulled out of `fetch` so tests can drive a deterministic
+/// fixture without standing up a `Client`.
+fn shape_catalog(mut systems: Vec<SystemInfo>) -> CatalogData {
+    systems.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    let categories = derive_categories(&systems);
+    info!(
+        "catalog loaded: {} systems, {} categories",
+        systems.len(),
+        categories.len()
+    );
+    CatalogData {
+        systems,
+        categories,
+    }
+}
+
+fn derive_categories(systems: &[SystemInfo]) -> Vec<String> {
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut cats: Vec<String> = Vec::new();
+    for s in systems {
+        let cat = if s.category.is_empty() {
+            "Other".to_string()
+        } else {
+            s.category.clone()
+        };
+        let lower = cat.to_lowercase();
+        if seen.insert(lower) {
+            cats.push(cat);
+        }
+    }
+    cats.sort_by_key(|a| a.to_lowercase());
+    cats
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sys(id: &str, name: &str, category: &str) -> SystemInfo {
+        SystemInfo {
+            id: id.into(),
+            name: name.into(),
+            category: category.into(),
+        }
+    }
+
+    #[test]
+    fn derive_categories_sorts_case_insensitively() {
+        let systems = vec![
+            sys("a", "A", "Handhelds"),
+            sys("b", "B", "arcade"),
+            sys("c", "C", "Consoles"),
+        ];
+        assert_eq!(
+            derive_categories(&systems),
+            vec!["arcade", "Consoles", "Handhelds"],
+        );
+    }
+
+    #[test]
+    fn derive_categories_dedupes_case_insensitively() {
+        let systems = vec![
+            sys("a", "A", "Arcade"),
+            sys("b", "B", "arcade"),
+            sys("c", "C", "ARCADE"),
+        ];
+        let cats = derive_categories(&systems);
+        assert_eq!(cats.len(), 1);
+        assert_eq!(cats[0], "Arcade"); // first encountered casing wins
+    }
+
+    #[test]
+    fn derive_categories_synthesises_other_for_empty() {
+        let systems = vec![sys("a", "A", ""), sys("b", "B", "Consoles")];
+        assert_eq!(derive_categories(&systems), vec!["Consoles", "Other"]);
+    }
+
+    #[test]
+    fn shape_catalog_snapshot_matches_fixture() {
+        let systems = vec![
+            sys("snes", "Super Nintendo", "Consoles"),
+            sys("nes", "Nintendo", "Consoles"),
+            sys("gb", "Game Boy", "Handhelds"),
+            sys("mame", "MAME", "arcade"),
+            sys("odd", "Odd One", ""),
+        ];
+        insta::assert_debug_snapshot!(shape_catalog(systems));
+    }
+}

--- a/rust/zaparoo-core/src/endpoints/media_search.rs
+++ b/rust/zaparoo-core/src/endpoints/media_search.rs
@@ -1,0 +1,44 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+//
+// `MediaSearchEndpoint` — per-system search results.
+// `Args = String` is the system id; the store hashes it into the cache
+// key so two singletons asking for the same system share one fetch task
+// and two singletons asking for different systems run independently.
+// `provides` returns `Tag::specific("MediaSearch", id)` so a future
+// `RunEndpoint` mutation that affects one system's library can
+// invalidate just that entry without touching siblings.
+
+use crate::client::{Client, ClientError};
+use crate::media_types::{MediaSearchParams, MediaSearchResult};
+use crate::store::{Endpoint, Tag};
+use futures_util::future::BoxFuture;
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub struct MediaSearchEndpoint;
+
+impl Endpoint for MediaSearchEndpoint {
+    type Args = String;
+    type Output = MediaSearchResult;
+    const NAME: &'static str = "MediaSearch";
+
+    fn fetch(
+        client: Arc<Client>,
+        system_id: Self::Args,
+    ) -> BoxFuture<'static, Result<Self::Output, ClientError>> {
+        Box::pin(async move {
+            client
+                .media_search(MediaSearchParams {
+                    systems: vec![system_id],
+                    max_results: 100,
+                })
+                .await
+        })
+    }
+
+    fn provides(args: &Self::Args, _output: &Self::Output) -> Vec<Tag> {
+        vec![Tag::specific(Self::NAME, args.clone())]
+    }
+}

--- a/rust/zaparoo-core/src/endpoints/mod.rs
+++ b/rust/zaparoo-core/src/endpoints/mod.rs
@@ -1,0 +1,11 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+//
+// One `Endpoint` (or `Mutation`) impl per file. See `crate::store` for
+// the trait surface and how endpoints participate in the cache + tag
+// invalidation system.
+
+pub mod catalog;
+pub mod media_search;
+pub mod run;

--- a/rust/zaparoo-core/src/endpoints/run.rs
+++ b/rust/zaparoo-core/src/endpoints/run.rs
@@ -1,0 +1,34 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+//
+// `RunMutation` — fire the upstream `run` RPC. Today it invalidates
+// nothing, but the wiring is in place for the future
+// `NowPlayingEndpoint` (and any other endpoint whose value depends on
+// what's currently launched). Adding the dependency later is a one-line
+// `invalidates` impl rather than a re-plumbing exercise.
+
+use crate::client::{Client, ClientError};
+use crate::media_types::RunParams;
+use crate::store::{Mutation, Tag};
+use futures_util::future::BoxFuture;
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub struct RunMutation;
+
+impl Mutation for RunMutation {
+    type Args = RunParams;
+    type Output = ();
+
+    fn run(
+        client: Arc<Client>,
+        args: Self::Args,
+    ) -> BoxFuture<'static, Result<Self::Output, ClientError>> {
+        Box::pin(async move { client.run(args).await })
+    }
+
+    fn invalidates(_args: &Self::Args, _result: &Self::Output) -> Vec<Tag> {
+        Vec::new()
+    }
+}

--- a/rust/zaparoo-core/src/endpoints/snapshots/zaparoo_core__endpoints__catalog__tests__shape_catalog_snapshot_matches_fixture.snap
+++ b/rust/zaparoo-core/src/endpoints/snapshots/zaparoo_core__endpoints__catalog__tests__shape_catalog_snapshot_matches_fixture.snap
@@ -1,6 +1,7 @@
 ---
-source: zaparoo-core/src/systems_catalog.rs
-expression: "CatalogData { systems, categories }"
+source: zaparoo-core/src/endpoints/catalog.rs
+assertion_line: 130
+expression: shape_catalog(systems)
 ---
 CatalogData {
     systems: [

--- a/rust/zaparoo-core/src/input_actions.rs
+++ b/rust/zaparoo-core/src/input_actions.rs
@@ -154,7 +154,7 @@ mod tests {
     }
 
     #[test]
-    fn unknown_key_names_are_silently_skipped_not_panicked() {
+    fn unknown_key_names_log_warning_and_are_skipped() {
         let mut b = default_bindings();
         b.insert("fictional".into(), vec!["NotAKey".into()]);
         // invert logs a warning and keeps going; the result holds no entry

--- a/rust/zaparoo-core/src/input_actions.rs
+++ b/rust/zaparoo-core/src/input_actions.rs
@@ -70,15 +70,20 @@ pub fn default_bindings() -> HashMap<String, Vec<String>> {
 }
 
 /// Inverts the bindings (action → keys) into the runtime lookup shape
-/// ([`Qt::Key`] code → action). Later bindings for the same key win — a
-/// sane collision policy for a small hand-authored table.
+/// ([`Qt::Key`] code → action). When two actions bind the same key the
+/// alphabetically-later action wins — a deterministic, hand-authored
+/// collision policy. We sort the entries before walking them because
+/// `HashMap` iteration order is randomised per process, which would
+/// otherwise let two runs disagree on which action owns a contested key.
 #[must_use]
 pub fn invert<S>(bindings: &HashMap<String, Vec<String>, S>) -> HashMap<i32, String>
 where
     S: std::hash::BuildHasher,
 {
     let mut out: HashMap<i32, String> = HashMap::new();
-    for (action, keys) in bindings {
+    let mut ordered: Vec<(&String, &Vec<String>)> = bindings.iter().collect();
+    ordered.sort_unstable_by(|(a, _), (b, _)| a.cmp(b));
+    for (action, keys) in ordered {
         for name in keys {
             if let Some(code) = qt_key_code(name) {
                 out.insert(code, action.clone());
@@ -132,6 +137,22 @@ mod tests {
         assert_eq!(
             map.get(&qt_key_code("Escape").unwrap()).map(String::as_str),
             Some(actions::CANCEL),
+        );
+    }
+
+    #[test]
+    fn collision_resolution_is_deterministic_alphabetical_winner() {
+        // Two actions bind "Return" — `accept` (alphabetically earlier)
+        // and `zzz_late` (alphabetically later). With sorted iteration
+        // the later-walked entry overwrites, so `zzz_late` must always
+        // win regardless of process-local hash seed.
+        let mut b = std::collections::HashMap::new();
+        b.insert(actions::ACCEPT.into(), vec!["Return".into()]);
+        b.insert("zzz_late".to_string(), vec!["Return".into()]);
+        let map = invert(&b);
+        assert_eq!(
+            map.get(&qt_key_code("Return").unwrap()).map(String::as_str),
+            Some("zzz_late"),
         );
     }
 

--- a/rust/zaparoo-core/src/input_actions.rs
+++ b/rust/zaparoo-core/src/input_actions.rs
@@ -2,7 +2,7 @@
 // Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 //
-// Normalised UI action catalogue and the defaulted key-bindings that map
+// Normalized UI action catalog and the defaulted key-bindings that map
 // raw Qt key codes onto those actions. Screens handle actions, not keys,
 // so gamepad / NFC reader sources can slot in beside the keyboard without
 // touching the UI tree. Inspired by RetroArch's RetroPad abstraction.
@@ -73,7 +73,7 @@ pub fn default_bindings() -> HashMap<String, Vec<String>> {
 /// ([`Qt::Key`] code → action). When two actions bind the same key the
 /// alphabetically-later action wins — a deterministic, hand-authored
 /// collision policy. We sort the entries before walking them because
-/// `HashMap` iteration order is randomised per process, which would
+/// `HashMap` iteration order is randomized per process, which would
 /// otherwise let two runs disagree on which action owns a contested key.
 #[must_use]
 pub fn invert<S>(bindings: &HashMap<String, Vec<String>, S>) -> HashMap<i32, String>
@@ -106,20 +106,17 @@ mod tests {
     use super::{actions, default_bindings, invert, qt_key_code};
 
     #[test]
-    fn defaults_cover_every_navigable_action() {
+    fn every_default_binding_is_non_empty() {
+        // Iterating the whole map (rather than a hard-coded subset)
+        // catches future drift: any action added to default_bindings()
+        // must come with at least one key, or this test fails.
         let b = default_bindings();
-        for action in [
-            actions::LEFT,
-            actions::RIGHT,
-            actions::UP,
-            actions::DOWN,
-            actions::ACCEPT,
-            actions::CANCEL,
-        ] {
-            assert!(
-                b.get(action).is_some_and(|v| !v.is_empty()),
-                "missing default binding for {action}"
-            );
+        assert!(
+            !b.is_empty(),
+            "default_bindings() must define at least one action"
+        );
+        for (action, keys) in &b {
+            assert!(!keys.is_empty(), "missing default binding for {action}");
         }
     }
 

--- a/rust/zaparoo-core/src/input_actions.rs
+++ b/rust/zaparoo-core/src/input_actions.rs
@@ -1,0 +1,147 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+//
+// Normalised UI action catalogue and the defaulted key-bindings that map
+// raw Qt key codes onto those actions. Screens handle actions, not keys,
+// so gamepad / NFC reader sources can slot in beside the keyboard without
+// touching the UI tree. Inspired by RetroArch's RetroPad abstraction.
+
+use std::collections::HashMap;
+
+pub mod actions {
+    pub const UP: &str = "up";
+    pub const DOWN: &str = "down";
+    pub const LEFT: &str = "left";
+    pub const RIGHT: &str = "right";
+    pub const ACCEPT: &str = "accept";
+    pub const CANCEL: &str = "cancel";
+    pub const DETAILS: &str = "details";
+    pub const PAGE_PREV: &str = "page_prev";
+    pub const PAGE_NEXT: &str = "page_next";
+    pub const QUIT: &str = "quit";
+}
+
+/// Resolves a `Qt::Key` name as found in `launcher.toml` (e.g. `"Left"`,
+/// `"Return"`) to the numeric key code Qt emits at runtime. Returns None
+/// for unknown names so the caller can warn and skip.
+#[must_use]
+pub fn qt_key_code(name: &str) -> Option<i32> {
+    // Subset that covers every action in the default bindings plus a few
+    // common aliases. Extend as new actions land. Values match Qt::Key.
+    match name {
+        "Left" => Some(0x0100_0012),
+        "Right" => Some(0x0100_0014),
+        "Up" => Some(0x0100_0013),
+        "Down" => Some(0x0100_0015),
+        "Return" => Some(0x0100_0004),
+        "Enter" => Some(0x0100_0005),
+        "Escape" => Some(0x0100_0000),
+        "Backspace" => Some(0x0100_0003),
+        "PageUp" => Some(0x0100_0016),
+        "PageDown" => Some(0x0100_0017),
+        "Space" => Some(0x20),
+        "Tab" => Some(0x0100_0001),
+        _ => None,
+    }
+}
+
+/// Default action → Qt-key-name list. Merged with `[input.keyboard]`
+/// overrides from `launcher.toml`: a user-provided list replaces the
+/// default for that action (not merged), so emptying a list unbinds it.
+#[must_use]
+pub fn default_bindings() -> HashMap<String, Vec<String>> {
+    let mut map: HashMap<String, Vec<String>> = HashMap::new();
+    map.insert(actions::LEFT.into(), vec!["Left".into()]);
+    map.insert(actions::RIGHT.into(), vec!["Right".into()]);
+    map.insert(actions::UP.into(), vec!["Up".into()]);
+    map.insert(actions::DOWN.into(), vec!["Down".into()]);
+    map.insert(
+        actions::ACCEPT.into(),
+        vec!["Return".into(), "Enter".into()],
+    );
+    map.insert(
+        actions::CANCEL.into(),
+        vec!["Escape".into(), "Backspace".into()],
+    );
+    map.insert(actions::PAGE_PREV.into(), vec!["PageUp".into()]);
+    map.insert(actions::PAGE_NEXT.into(), vec!["PageDown".into()]);
+    map
+}
+
+/// Inverts the bindings (action → keys) into the runtime lookup shape
+/// ([`Qt::Key`] code → action). Later bindings for the same key win — a
+/// sane collision policy for a small hand-authored table.
+#[must_use]
+pub fn invert<S>(bindings: &HashMap<String, Vec<String>, S>) -> HashMap<i32, String>
+where
+    S: std::hash::BuildHasher,
+{
+    let mut out: HashMap<i32, String> = HashMap::new();
+    for (action, keys) in bindings {
+        for name in keys {
+            if let Some(code) = qt_key_code(name) {
+                out.insert(code, action.clone());
+            } else {
+                tracing::warn!("unknown Qt key name in input binding: {name}");
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(
+        clippy::expect_used,
+        clippy::unwrap_used,
+        reason = "tests should fail-fast on unexpected errors"
+    )]
+
+    use super::{actions, default_bindings, invert, qt_key_code};
+
+    #[test]
+    fn defaults_cover_every_navigable_action() {
+        let b = default_bindings();
+        for action in [
+            actions::LEFT,
+            actions::RIGHT,
+            actions::UP,
+            actions::DOWN,
+            actions::ACCEPT,
+            actions::CANCEL,
+        ] {
+            assert!(
+                b.get(action).is_some_and(|v| !v.is_empty()),
+                "missing default binding for {action}"
+            );
+        }
+    }
+
+    #[test]
+    fn invert_produces_unique_key_to_action_map() {
+        let map = invert(&default_bindings());
+        assert_eq!(
+            map.get(&qt_key_code("Left").unwrap()).map(String::as_str),
+            Some(actions::LEFT),
+        );
+        assert_eq!(
+            map.get(&qt_key_code("Return").unwrap()).map(String::as_str),
+            Some(actions::ACCEPT),
+        );
+        assert_eq!(
+            map.get(&qt_key_code("Escape").unwrap()).map(String::as_str),
+            Some(actions::CANCEL),
+        );
+    }
+
+    #[test]
+    fn unknown_key_names_are_silently_skipped_not_panicked() {
+        let mut b = default_bindings();
+        b.insert("fictional".into(), vec!["NotAKey".into()]);
+        // invert logs a warning and keeps going; the result holds no entry
+        // for the fictional action.
+        let map = invert(&b);
+        assert!(!map.values().any(|v| v == "fictional"));
+    }
+}

--- a/rust/zaparoo-core/src/lib.rs
+++ b/rust/zaparoo-core/src/lib.rs
@@ -4,11 +4,14 @@
 
 pub mod client;
 pub mod config;
+pub mod endpoints;
 pub mod input_actions;
 pub mod logger;
 pub mod media_types;
 pub mod persist;
 pub mod platform;
 pub mod platform_paths;
+pub mod remote_resource;
 pub mod runtime;
+pub mod store;
 pub mod systems_catalog;

--- a/rust/zaparoo-core/src/lib.rs
+++ b/rust/zaparoo-core/src/lib.rs
@@ -1,9 +1,10 @@
 // Zaparoo Launcher
-// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
 pub mod client;
 pub mod config;
+pub mod input_actions;
 pub mod logger;
 pub mod media_types;
 pub mod persist;

--- a/rust/zaparoo-core/src/logger.rs
+++ b/rust/zaparoo-core/src/logger.rs
@@ -1,5 +1,5 @@
 // Zaparoo Launcher
-// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
 use crate::config::Config;

--- a/rust/zaparoo-core/src/media_types.rs
+++ b/rust/zaparoo-core/src/media_types.rs
@@ -1,5 +1,5 @@
 // Zaparoo Launcher
-// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
 use serde::{Deserialize, Serialize};
@@ -20,6 +20,13 @@ pub struct MediaSearchParams {
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
+pub struct TagInfo {
+    pub tag: String,
+    #[serde(rename = "type", default)]
+    pub tag_type: String,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MediaItem {
     pub name: String,
@@ -28,6 +35,8 @@ pub struct MediaItem {
     pub zap_script: String,
     #[serde(default)]
     pub system: SystemRef,
+    #[serde(default)]
+    pub tags: Vec<TagInfo>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -35,12 +44,32 @@ pub struct SystemRef {
     pub id: String,
 }
 
+/// Cursor-based pagination envelope shared by `media.search` and
+/// `media.browse`. Fields are all defaulted so an absent envelope (e.g.
+/// browse-root response with no file results) deserializes to "no more
+/// pages."
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct Pagination {
+    #[serde(default)]
+    pub has_next_page: bool,
+    #[serde(default)]
+    pub page_size: u32,
+    #[serde(default)]
+    pub next_cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
 pub struct MediaSearchResult {
     pub results: Vec<MediaItem>,
     #[serde(default)]
-    pub has_next_page: bool,
+    pub pagination: Pagination,
+}
+
+impl MediaSearchResult {
+    pub fn has_next_page(&self) -> bool {
+        self.pagination.has_next_page
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize)]
@@ -57,26 +86,41 @@ pub struct BrowseEntry {
     pub entry_type: String,
     #[serde(default)]
     pub file_count: u32,
+    #[serde(default)]
+    pub system_id: String,
+    #[serde(default)]
+    pub zap_script: String,
+    #[serde(default)]
+    pub relative_path: String,
+    #[serde(default)]
+    pub group: String,
 }
 
 impl BrowseEntry {
+    /// Upstream entry types are `root`, `directory`, and `media`. Both
+    /// roots and directories are navigable containers; media entries are
+    /// leaves.
     pub fn is_folder(&self) -> bool {
-        self.entry_type == "folder" || self.entry_type == "directory"
+        self.entry_type == "directory" || self.entry_type == "root"
     }
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct MediaBrowseResult {
+    #[serde(default)]
+    pub path: String,
     pub entries: Vec<BrowseEntry>,
+    #[serde(default)]
+    pub total_files: u32,
+    #[serde(default)]
+    pub pagination: Option<Pagination>,
 }
 
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct RunParams {
     pub text: String,
 }
-
-#[derive(Debug, Clone, Default, Deserialize)]
-pub struct RunResult {}
 
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct SystemsParams {}
@@ -103,30 +147,30 @@ mod tests {
         reason = "tests should fail-fast on unexpected errors"
     )]
 
-    use super::{BrowseEntry, MediaSearchResult, SystemsResult, VersionResult};
+    use super::{BrowseEntry, MediaBrowseResult, MediaSearchResult, SystemsResult, VersionResult};
 
     #[test]
-    fn is_folder_accepts_both_spellings() {
-        let folder = BrowseEntry {
-            entry_type: "folder".into(),
-            ..BrowseEntry::default()
-        };
+    fn is_folder_accepts_directory_and_root() {
         let directory = BrowseEntry {
             entry_type: "directory".into(),
             ..BrowseEntry::default()
         };
-        let file = BrowseEntry {
-            entry_type: "file".into(),
+        let root = BrowseEntry {
+            entry_type: "root".into(),
             ..BrowseEntry::default()
         };
-        assert!(folder.is_folder());
+        let media = BrowseEntry {
+            entry_type: "media".into(),
+            ..BrowseEntry::default()
+        };
         assert!(directory.is_folder());
-        assert!(!file.is_folder());
+        assert!(root.is_folder());
+        assert!(!media.is_folder());
     }
 
     #[test]
     fn is_folder_unknown_type_is_false() {
-        for entry_type in ["", "symlink", "archive", "unknown", "FOLDER"] {
+        for entry_type in ["", "folder", "file", "symlink", "archive", "DIRECTORY"] {
             let entry = BrowseEntry {
                 entry_type: entry_type.into(),
                 ..BrowseEntry::default()
@@ -155,25 +199,76 @@ mod tests {
     }
 
     #[test]
-    fn media_search_result_parses_has_next_page() {
+    fn media_search_result_parses_nested_pagination() {
         let json = r#"{
             "results": [
-                {"name":"Game","path":"/p","zapScript":"s","system":{"id":"nes"}}
+                {"name":"Game","path":"/p","zapScript":"s","system":{"id":"nes"},"tags":[]}
             ],
-            "hasNextPage": true
+            "total": -1,
+            "pagination": {
+                "hasNextPage": true,
+                "pageSize": 100,
+                "nextCursor": "abc"
+            }
         }"#;
         let result: MediaSearchResult = serde_json::from_str(json).expect("parse");
         assert_eq!(result.results.len(), 1);
-        assert!(result.has_next_page);
+        assert!(result.has_next_page());
+        assert_eq!(result.pagination.page_size, 100);
+        assert_eq!(result.pagination.next_cursor.as_deref(), Some("abc"));
         assert_eq!(result.results[0].system.id, "nes");
         assert_eq!(result.results[0].zap_script, "s");
     }
 
     #[test]
-    fn media_search_result_defaults_has_next_page() {
+    fn media_search_result_defaults_pagination_when_missing() {
         let json = r#"{"results":[]}"#;
         let result: MediaSearchResult = serde_json::from_str(json).expect("parse");
-        assert!(!result.has_next_page);
+        assert!(!result.has_next_page());
+        assert_eq!(result.pagination.page_size, 0);
+        assert!(result.pagination.next_cursor.is_none());
+    }
+
+    #[test]
+    fn media_search_item_defaults_tags_when_missing() {
+        let json =
+            r#"{"results":[{"name":"G","path":"/p","zapScript":"s","system":{"id":"nes"}}]}"#;
+        let result: MediaSearchResult = serde_json::from_str(json).expect("parse");
+        assert!(result.results[0].tags.is_empty());
+    }
+
+    #[test]
+    fn media_browse_result_parses_envelope_and_pagination() {
+        let json = r#"{
+            "path": "/games",
+            "entries": [
+                {"name":"NES","path":"/games/NES","type":"directory","fileCount":42},
+                {"name":"SMB","path":"/games/NES/smb.nes","type":"media","systemId":"nes","zapScript":"@nes/smb","relativePath":"NES/smb.nes"}
+            ],
+            "totalFiles": 150,
+            "pagination": {"hasNextPage": true, "pageSize": 100, "nextCursor": "x"}
+        }"#;
+        let result: MediaBrowseResult = serde_json::from_str(json).expect("parse");
+        assert_eq!(result.path, "/games");
+        assert_eq!(result.entries.len(), 2);
+        assert!(result.entries[0].is_folder());
+        assert!(!result.entries[1].is_folder());
+        assert_eq!(result.entries[1].system_id, "nes");
+        assert_eq!(result.entries[1].relative_path, "NES/smb.nes");
+        assert_eq!(result.total_files, 150);
+        let pagination = result.pagination.expect("pagination present");
+        assert!(pagination.has_next_page);
+        assert_eq!(pagination.next_cursor.as_deref(), Some("x"));
+    }
+
+    #[test]
+    fn media_browse_result_omits_pagination_when_no_files() {
+        let json = r#"{"entries":[{"name":"/","path":"","type":"root","fileCount":0}]}"#;
+        let result: MediaBrowseResult = serde_json::from_str(json).expect("parse");
+        assert!(result.pagination.is_none());
+        assert_eq!(result.path, "");
+        assert_eq!(result.total_files, 0);
+        assert!(result.entries[0].is_folder());
     }
 
     #[test]

--- a/rust/zaparoo-core/src/persist.rs
+++ b/rust/zaparoo-core/src/persist.rs
@@ -1,5 +1,5 @@
 // Zaparoo Launcher
-// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 //
 // Persistent UI state. MiSTer's parent process kills the launcher binary

--- a/rust/zaparoo-core/src/platform.rs
+++ b/rust/zaparoo-core/src/platform.rs
@@ -1,5 +1,5 @@
 // Zaparoo Launcher
-// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 //
 // Platform: what is the connected Zaparoo Core server running on?
@@ -8,10 +8,10 @@
 // of `runtime` (which describes the launcher binary's host).
 // See docs/architecture.md for the gating rules.
 
-use crate::client::Client;
+use crate::client::{Client, ConnectionState};
 use crate::media_types::VersionResult;
 use std::sync::{Arc, OnceLock};
-use tokio::sync::{broadcast, watch};
+use tokio::sync::watch;
 use tracing::{info, warn};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -84,24 +84,24 @@ fn publish(p: Platform) {
 /// prior value (or `None`). `systems` and other catalog fetches continue
 /// regardless.
 pub fn spawn_fetcher(client: Arc<Client>, runtime: &Arc<tokio::runtime::Runtime>) {
-    let mut connected_rx = client.connected.subscribe();
+    let mut connection_rx = client.connection.subscribe();
     runtime.spawn(async move {
+        let mut state = connection_rx.borrow_and_update().clone();
         loop {
-            match connected_rx.recv().await {
-                Ok(true) => match client.version().await {
+            if matches!(state, ConnectionState::Connected) {
+                match client.version().await {
                     Ok(VersionResult { version, platform }) => {
                         let parsed = Platform::from_api_string(&platform);
                         info!("core version: {version} platform: {parsed}");
                         publish(parsed);
                     }
                     Err(e) => warn!("version RPC failed: {}", e.message),
-                },
-                Ok(false) => {}
-                Err(broadcast::error::RecvError::Lagged(n)) => {
-                    warn!("connected channel lagged by {n}, continuing");
                 }
-                Err(broadcast::error::RecvError::Closed) => break,
             }
+            if connection_rx.changed().await.is_err() {
+                break;
+            }
+            state = connection_rx.borrow_and_update().clone();
         }
     });
 }

--- a/rust/zaparoo-core/src/platform_paths.rs
+++ b/rust/zaparoo-core/src/platform_paths.rs
@@ -1,5 +1,5 @@
 // Zaparoo Launcher
-// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
 use crate::runtime;

--- a/rust/zaparoo-core/src/remote_resource.rs
+++ b/rust/zaparoo-core/src/remote_resource.rs
@@ -1,0 +1,601 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+//
+// One shape for any RPC-backed value that the UI binds to.
+//
+// Every screen needs the same four states: nothing yet, fetching now,
+// here's the data, fetch failed. Before this module each model invented
+// its own `loading` / `error_message` / `has_*` triplet and wired it by
+// hand in every match arm; that's how `GamesModel::set_system` ended up
+// not clearing `has_next_page` on the error path. `ResourceStatus<T>`
+// makes the four states one enum so the QML translation layer is the
+// only place per-screen mapping lives, and pagination flags ride inside
+// `Ready(T)` where they can't drift.
+//
+// `RemoteResource::driven_by` ties the resource to the connection state
+// machine in `client::ConnectionState`:
+//   - `Disconnected`            → `Idle`
+//   - `Connecting`/`Reconnecting` → `Loading`
+//   - `Unreachable(msg)`        → `Errored { retrying: false, .. }`
+//   - `Connected`               → run `fetch`, retry while still
+//                                  Connected with capped backoff,
+//                                  publish `Ready(T)` on success
+//
+// Because the dispatch reads the *current* connection state on every
+// loop iteration (via `borrow_and_update`), any transition into
+// `Connected` — including from `Reconnecting` after a transient drop —
+// triggers a refetch. Refresh-on-reconnect is a property of the
+// abstraction, not a per-call-site obligation.
+//
+// `RemoteResource::refetch()` exposes an explicit invalidation pulse
+// for tag-driven re-fetching. While connected, calling it cancels any
+// in-flight fetch and starts a new one. While not connected, the
+// notification queues and fires on the next reconnect (one extra fetch
+// alongside the natural refresh-on-reconnect; harmless). Subscribers
+// don't observe the difference between an explicit refetch and a
+// reconnect refresh.
+
+use crate::client::{backoff_delay, Client, ClientError, ConnectionState};
+use std::future::Future;
+use std::sync::Arc;
+use tokio::runtime::Runtime;
+use tokio::sync::{oneshot, watch, Notify};
+use tracing::warn;
+
+/// Lifecycle of a remote-fetched value as it appears to the UI.
+///
+/// `retrying` distinguishes "we hit an error but the socket is still
+/// up so we'll try again" (yellow / spinner) from "we hit an error and
+/// the socket has gone away" (red / static). UI code can choose to
+/// render both the same; the distinction exists so it doesn't have to
+/// ask the connection layer separately.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ResourceStatus<T> {
+    Idle,
+    Loading,
+    Ready(T),
+    Errored { message: String, retrying: bool },
+}
+
+#[derive(Debug)]
+pub struct RemoteResource<T: Clone + Send + Sync + 'static> {
+    status: watch::Sender<ResourceStatus<T>>,
+    // Pulse for explicit refetch invalidation. `notify_one` queues at
+    // most one notification, so back-to-back invalidations collapse to
+    // a single re-fetch. While the connection is not Connected the
+    // pulse queues, then fires on the next reconnect (one extra fetch
+    // atop the natural refresh-on-reconnect; harmless).
+    refetch: Arc<Notify>,
+    // Held only for its Drop side-effect: when the resource is dropped,
+    // this sender drops, which fires the cancellation receiver inside
+    // the spawned task and unwinds it (cancelling any in-flight fetch
+    // future via tokio::select!). Necessary for resources with shorter
+    // lifetimes than the `Client` — e.g. per-system search resources
+    // that are replaced when the user picks a different system.
+    _cancel_tx: oneshot::Sender<()>,
+}
+
+impl<T: Clone + Send + Sync + 'static> RemoteResource<T> {
+    pub fn subscribe(&self) -> watch::Receiver<ResourceStatus<T>> {
+        self.status.subscribe()
+    }
+
+    /// Trigger a refetch outside the natural connection-change cadence.
+    /// While connected, this cancels any in-flight fetch and starts a
+    /// new one; otherwise the notification queues and fires on the
+    /// next reconnect. The store layer drives tag-based invalidation
+    /// through this method; direct callers rarely need it.
+    pub fn refetch(&self) {
+        self.refetch.notify_one();
+    }
+
+    /// Spawn a task on `runtime` that drives the resource lifecycle off
+    /// `client.connection`. `fetch` is invoked on every transition into
+    /// `Connected` (and, while still Connected, on retry after error
+    /// with capped exponential backoff).
+    ///
+    /// The returned `RemoteResource` owns the watch channel; dropping it
+    /// drops all subscribers' senders but the spawned task keeps running
+    /// until the connection watch is closed (i.e. the `Client` is
+    /// dropped). Callers wanting to cancel an in-flight fetch should
+    /// drop the `Client` or a wrapping `Arc<Client>`.
+    pub fn driven_by<F, Fut>(client: Arc<Client>, runtime: &Arc<Runtime>, fetch: F) -> Self
+    where
+        F: Fn(Arc<Client>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<T, ClientError>> + Send + 'static,
+    {
+        let connection_rx = client.connection.subscribe();
+        let fetch = move || fetch(client.clone());
+        Self::spawn_with(connection_rx, runtime, fetch)
+    }
+
+    /// Internal entry point used by `driven_by` and tests. Decoupled
+    /// from `Client` so tests can drive a synthetic `ConnectionState`
+    /// watch without standing up a real WebSocket.
+    pub(crate) fn spawn_with<F, Fut>(
+        mut connection_rx: watch::Receiver<ConnectionState>,
+        runtime: &Arc<Runtime>,
+        fetch: F,
+    ) -> Self
+    where
+        F: Fn() -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<T, ClientError>> + Send + 'static,
+    {
+        // Seed the watch from the *current* connection state so a
+        // subscriber that calls `borrow()` before the spawned task
+        // runs sees the right value. Without this seed a singleton
+        // constructed after the WebSocket has already advanced past
+        // `Disconnected` would observe the default `Idle` on the
+        // first frame and stay there until the next state transition
+        // (the MiSTer "screen never updates if Core connects before
+        // QML loads" race).
+        let initial_status = match &*connection_rx.borrow() {
+            ConnectionState::Disconnected => ResourceStatus::Idle,
+            ConnectionState::Connecting
+            | ConnectionState::Reconnecting
+            | ConnectionState::Connected => ResourceStatus::Loading,
+            ConnectionState::Unreachable(msg) => ResourceStatus::Errored {
+                message: msg.clone(),
+                retrying: false,
+            },
+        };
+        let (status_tx, _) = watch::channel(initial_status);
+        let status_for_task = status_tx.clone();
+        let (cancel_tx, mut cancel_rx) = oneshot::channel::<()>();
+        let refetch = Arc::new(Notify::new());
+        let refetch_for_task = refetch.clone();
+
+        runtime.spawn(async move {
+            loop {
+                let conn = connection_rx.borrow_and_update().clone();
+                match conn {
+                    ConnectionState::Disconnected => {
+                        status_for_task.send_replace(ResourceStatus::Idle);
+                    }
+                    ConnectionState::Connecting | ConnectionState::Reconnecting => {
+                        status_for_task.send_replace(ResourceStatus::Loading);
+                    }
+                    ConnectionState::Unreachable(msg) => {
+                        status_for_task.send_replace(ResourceStatus::Errored {
+                            message: msg,
+                            retrying: false,
+                        });
+                    }
+                    ConnectionState::Connected => {
+                        status_for_task.send_replace(ResourceStatus::Loading);
+                        // Race the connected loop against cancellation
+                        // so dropping the resource mid-fetch aborts the
+                        // in-flight RPC.
+                        tokio::select! {
+                            biased;
+                            _ = &mut cancel_rx => return,
+                            () = run_connected(
+                                &fetch,
+                                &mut connection_rx,
+                                &status_for_task,
+                                &refetch_for_task,
+                            ) => {}
+                        }
+                        // run_connected returns when the connection
+                        // state has changed; loop and dispatch the new
+                        // state.
+                        continue;
+                    }
+                }
+
+                tokio::select! {
+                    biased;
+                    _ = &mut cancel_rx => return,
+                    res = connection_rx.changed() => {
+                        if res.is_err() {
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+
+        Self {
+            status: status_tx,
+            refetch,
+            _cancel_tx: cancel_tx,
+        }
+    }
+}
+
+/// Inner loop active while the connection is `Connected`. Returns when
+/// the connection state changes (so the outer loop can dispatch the new
+/// state).
+async fn run_connected<T, F, Fut>(
+    fetch: &F,
+    connection_rx: &mut watch::Receiver<ConnectionState>,
+    status: &watch::Sender<ResourceStatus<T>>,
+    refetch: &Arc<Notify>,
+) where
+    T: Clone + Send + Sync + 'static,
+    F: Fn() -> Fut,
+    Fut: Future<Output = Result<T, ClientError>> + Send,
+{
+    let mut rpc_failures: u32 = 0;
+    loop {
+        // Race the fetch against (a) a connection-state change — abort
+        // and let the outer loop publish the appropriate state — or
+        // (b) an explicit refetch — drop the in-flight attempt and
+        // start over (RTK-Query-style invalidation).
+        let attempt = fetch();
+        tokio::pin!(attempt);
+        let result = tokio::select! {
+            biased;
+            _ = connection_rx.changed() => return,
+            () = refetch.notified() => continue,
+            r = &mut attempt => r,
+        };
+
+        match result {
+            Ok(value) => {
+                status.send_replace(ResourceStatus::Ready(value));
+                // Reset the failure count: a subsequent refetch-driven
+                // retry should not inherit the previous backoff.
+                rpc_failures = 0;
+                // Ready stays sticky until either (a) the connection
+                // transitions — outer loop re-dispatches — or (b) an
+                // explicit refetch — loop and fetch again. Dropping
+                // out of the refetch arm falls through to the next
+                // iteration of the enclosing `loop`.
+                tokio::select! {
+                    biased;
+                    _ = connection_rx.changed() => return,
+                    () = refetch.notified() => {}
+                }
+            }
+            Err(e) => {
+                rpc_failures = rpc_failures.saturating_add(1);
+                warn!(
+                    "RemoteResource fetch failed (attempt {rpc_failures}): {}",
+                    e.message
+                );
+                status.send_replace(ResourceStatus::Errored {
+                    message: e.message,
+                    retrying: true,
+                });
+                let delay = backoff_delay(rpc_failures);
+                // refetch wins over the backoff timer: explicit
+                // invalidation should retry immediately, not wait out
+                // the existing schedule. Falling through either of the
+                // non-return arms loops back to retry.
+                tokio::select! {
+                    biased;
+                    _ = connection_rx.changed() => return,
+                    () = refetch.notified() => {}
+                    () = tokio::time::sleep(delay) => {}
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(
+        clippy::expect_used,
+        clippy::unwrap_used,
+        clippy::panic,
+        clippy::manual_assert,
+        reason = "tests should fail-fast on unexpected errors"
+    )]
+
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    fn rt() -> Arc<Runtime> {
+        Arc::new(
+            tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .unwrap(),
+        )
+    }
+
+    /// Wait for the resource status to satisfy a predicate, with a
+    /// generous timeout so a stuck task fails the test rather than
+    /// hanging.
+    async fn wait_for<T, P>(
+        rx: &mut watch::Receiver<ResourceStatus<T>>,
+        mut pred: P,
+    ) -> ResourceStatus<T>
+    where
+        T: Clone + Send + Sync + 'static + std::fmt::Debug,
+        P: FnMut(&ResourceStatus<T>) -> bool,
+    {
+        timeout(Duration::from_secs(5), async {
+            loop {
+                {
+                    let cur = rx.borrow_and_update().clone();
+                    if pred(&cur) {
+                        return cur;
+                    }
+                }
+                if rx.changed().await.is_err() {
+                    panic!("watch channel closed before predicate matched");
+                }
+            }
+        })
+        .await
+        .expect("timed out waiting for resource status")
+    }
+
+    #[test]
+    fn idle_until_first_connect() {
+        let runtime = rt();
+        runtime.clone().block_on(async {
+            let (conn_tx, conn_rx) = watch::channel(ConnectionState::Disconnected);
+            let res = RemoteResource::<i32>::spawn_with(conn_rx, &runtime, || async { Ok(42) });
+            let sub = res.subscribe();
+            // Disconnected -> Idle is both the seeded initial value
+            // and the task's first publish; either way the observable
+            // status is Idle.
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            assert!(matches!(*sub.borrow(), ResourceStatus::Idle));
+            drop(conn_tx);
+        });
+    }
+
+    #[test]
+    fn connected_triggers_fetch_and_publishes_ready() {
+        let runtime = rt();
+        runtime.clone().block_on(async {
+            let (conn_tx, conn_rx) = watch::channel(ConnectionState::Disconnected);
+            let res = RemoteResource::<i32>::spawn_with(conn_rx, &runtime, || async { Ok(42) });
+            let mut sub = res.subscribe();
+            conn_tx.send_replace(ConnectionState::Connected);
+            let final_status = wait_for(&mut sub, |s| matches!(s, ResourceStatus::Ready(42))).await;
+            assert!(matches!(final_status, ResourceStatus::Ready(42)));
+            drop(conn_tx);
+        });
+    }
+
+    #[test]
+    fn reconnect_triggers_refetch() {
+        let runtime = rt();
+        runtime.clone().block_on(async {
+            let (conn_tx, conn_rx) = watch::channel(ConnectionState::Disconnected);
+            let calls = Arc::new(AtomicUsize::new(0));
+            let calls_clone = calls.clone();
+            let res = RemoteResource::<usize>::spawn_with(conn_rx, &runtime, move || {
+                let n = calls_clone.fetch_add(1, Ordering::SeqCst) + 1;
+                async move { Ok(n) }
+            });
+            let mut sub = res.subscribe();
+
+            conn_tx.send_replace(ConnectionState::Connected);
+            wait_for(&mut sub, |s| matches!(s, ResourceStatus::Ready(1))).await;
+
+            conn_tx.send_replace(ConnectionState::Reconnecting);
+            wait_for(&mut sub, |s| matches!(s, ResourceStatus::Loading)).await;
+
+            conn_tx.send_replace(ConnectionState::Connected);
+            wait_for(&mut sub, |s| matches!(s, ResourceStatus::Ready(2))).await;
+
+            assert_eq!(calls.load(Ordering::SeqCst), 2);
+            drop(conn_tx);
+        });
+    }
+
+    #[test]
+    fn error_with_socket_up_publishes_retrying_then_recovers() {
+        let runtime = rt();
+        runtime.clone().block_on(async {
+            let (conn_tx, conn_rx) = watch::channel(ConnectionState::Disconnected);
+            let calls = Arc::new(AtomicUsize::new(0));
+            let calls_clone = calls.clone();
+            let res = RemoteResource::<&'static str>::spawn_with(conn_rx, &runtime, move || {
+                let n = calls_clone.fetch_add(1, Ordering::SeqCst) + 1;
+                async move {
+                    if n == 1 {
+                        Err(ClientError {
+                            message: "transient".into(),
+                        })
+                    } else {
+                        Ok("ok")
+                    }
+                }
+            });
+            let mut sub = res.subscribe();
+
+            conn_tx.send_replace(ConnectionState::Connected);
+            // First attempt errors with retrying=true; the second
+            // succeeds (the same Connected window keeps trying after
+            // backoff).
+            wait_for(&mut sub, |s| {
+                matches!(s, ResourceStatus::Errored { retrying: true, .. })
+            })
+            .await;
+            wait_for(&mut sub, |s| matches!(s, ResourceStatus::Ready("ok"))).await;
+            drop(conn_tx);
+        });
+    }
+
+    #[test]
+    fn dropping_resource_cancels_spawned_task() {
+        let runtime = rt();
+        runtime.clone().block_on(async {
+            let (conn_tx, conn_rx) = watch::channel(ConnectionState::Connected);
+            let calls = Arc::new(AtomicUsize::new(0));
+            let calls_clone = calls.clone();
+            let res = RemoteResource::<i32>::spawn_with(conn_rx, &runtime, move || {
+                calls_clone.fetch_add(1, Ordering::SeqCst);
+                async move { Ok(0) }
+            });
+            let mut sub = res.subscribe();
+            wait_for(&mut sub, |s| matches!(s, ResourceStatus::Ready(0))).await;
+            let baseline = calls.load(Ordering::SeqCst);
+
+            // Drop the resource — its task should exit and stop reacting
+            // to subsequent connection-state changes.
+            drop(res);
+            // Give the runtime a beat to observe the cancellation.
+            tokio::time::sleep(Duration::from_millis(50)).await;
+
+            // Cycle the connection to prove the cancelled task no longer
+            // refetches.
+            conn_tx.send_replace(ConnectionState::Reconnecting);
+            conn_tx.send_replace(ConnectionState::Connected);
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            assert_eq!(
+                calls.load(Ordering::SeqCst),
+                baseline,
+                "fetch must not run after the resource is dropped"
+            );
+        });
+    }
+
+    #[test]
+    fn unreachable_publishes_non_retrying_error() {
+        let runtime = rt();
+        runtime.clone().block_on(async {
+            let (conn_tx, conn_rx) = watch::channel(ConnectionState::Disconnected);
+            let res = RemoteResource::<i32>::spawn_with(conn_rx, &runtime, || async {
+                Ok(0) // never called — Unreachable doesn't trigger fetch
+            });
+            let mut sub = res.subscribe();
+            conn_tx.send_replace(ConnectionState::Unreachable("dead".into()));
+            let status = wait_for(&mut sub, |s| {
+                matches!(
+                    s,
+                    ResourceStatus::Errored {
+                        retrying: false,
+                        ..
+                    }
+                )
+            })
+            .await;
+            match status {
+                ResourceStatus::Errored {
+                    message,
+                    retrying: false,
+                } => assert_eq!(message, "dead"),
+                other => panic!("unexpected status: {other:?}"),
+            }
+            drop(conn_tx);
+        });
+    }
+
+    #[test]
+    fn seed_loading_when_already_connected() {
+        let runtime = rt();
+        runtime.clone().block_on(async {
+            let (_conn_tx, conn_rx) = watch::channel(ConnectionState::Connected);
+            // Long-running fetch keeps the spawned task in Loading; it
+            // never publishes Ready while we're checking the seed.
+            let res = RemoteResource::<i32>::spawn_with(conn_rx, &runtime, || async {
+                tokio::time::sleep(Duration::from_secs(60)).await;
+                Ok(0)
+            });
+            let sub = res.subscribe();
+            // Without the seed fix the watch is initialised with Idle
+            // and a borrow() before the spawned task runs would observe
+            // Idle (the original MiSTer race). With the fix the seed
+            // reflects the current ConnectionState — Connected -> Loading
+            // — so borrow() is correct from the first frame.
+            let initial = sub.borrow().clone();
+            assert!(
+                matches!(initial, ResourceStatus::Loading),
+                "seed must reflect Connected state, got {initial:?}"
+            );
+        });
+    }
+
+    #[test]
+    fn seed_errored_when_unreachable() {
+        let runtime = rt();
+        runtime.clone().block_on(async {
+            let (_conn_tx, conn_rx) =
+                watch::channel(ConnectionState::Unreachable("startup-failure".into()));
+            let res = RemoteResource::<i32>::spawn_with(conn_rx, &runtime, || async { Ok(0) });
+            let sub = res.subscribe();
+            let initial = sub.borrow().clone();
+            match initial {
+                ResourceStatus::Errored {
+                    message,
+                    retrying: false,
+                } => assert_eq!(message, "startup-failure"),
+                other => panic!("expected Errored, got {other:?}"),
+            }
+        });
+    }
+
+    #[test]
+    fn refetch_notify_triggers_refetch() {
+        let runtime = rt();
+        runtime.clone().block_on(async {
+            let (conn_tx, conn_rx) = watch::channel(ConnectionState::Disconnected);
+            let calls = Arc::new(AtomicUsize::new(0));
+            let calls_clone = calls.clone();
+            let res = RemoteResource::<usize>::spawn_with(conn_rx, &runtime, move || {
+                let n = calls_clone.fetch_add(1, Ordering::SeqCst) + 1;
+                async move { Ok(n) }
+            });
+            let mut sub = res.subscribe();
+
+            conn_tx.send_replace(ConnectionState::Connected);
+            wait_for(&mut sub, |s| matches!(s, ResourceStatus::Ready(1))).await;
+            assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+            // Explicit refetch — fetch is invoked again, Ready advances.
+            res.refetch();
+            wait_for(&mut sub, |s| matches!(s, ResourceStatus::Ready(2))).await;
+            assert_eq!(calls.load(Ordering::SeqCst), 2);
+
+            drop(conn_tx);
+        });
+    }
+
+    /// Regression: pulsing `refetch()` while the connection has not
+    /// yet come up must not fire the fetch closure (there's nothing
+    /// to fetch over). The pulse is held by the `Notify` and consumed
+    /// once the dispatcher reaches the connected branch — at which
+    /// point at least one fetch must run. The risk this guards
+    /// against is a future rewire that adds `refetch.notified()` to
+    /// the disconnected arm of the outer select and silently fires
+    /// fetch with no socket.
+    #[test]
+    fn refetch_pulse_while_disconnected_does_not_fetch_until_connected() {
+        let runtime = rt();
+        runtime.clone().block_on(async {
+            let (conn_tx, conn_rx) = watch::channel(ConnectionState::Disconnected);
+            let calls = Arc::new(AtomicUsize::new(0));
+            let calls_clone = calls.clone();
+            let res = RemoteResource::<usize>::spawn_with(conn_rx, &runtime, move || {
+                let n = calls_clone.fetch_add(1, Ordering::SeqCst) + 1;
+                async move { Ok(n) }
+            });
+            let mut sub = res.subscribe();
+
+            // Pulse while still Disconnected — must not invoke fetch.
+            res.refetch();
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            assert_eq!(
+                calls.load(Ordering::SeqCst),
+                0,
+                "fetch must not run while disconnected"
+            );
+            assert!(matches!(*sub.borrow_and_update(), ResourceStatus::Idle));
+
+            // Transition to Connected — the queued pulse and the
+            // first connect both prompt fetches. We only assert at
+            // least one fetch ran (not the exact count) because the
+            // queued pulse can race the first fetch to completion.
+            conn_tx.send_replace(ConnectionState::Connected);
+            wait_for(&mut sub, |s| matches!(s, ResourceStatus::Ready(_))).await;
+            assert!(
+                calls.load(Ordering::SeqCst) >= 1,
+                "fetch must run at least once after connecting"
+            );
+
+            drop(conn_tx);
+        });
+    }
+}

--- a/rust/zaparoo-core/src/remote_resource.rs
+++ b/rust/zaparoo-core/src/remote_resource.rs
@@ -95,11 +95,14 @@ impl<T: Clone + Send + Sync + 'static> RemoteResource<T> {
     /// `Connected` (and, while still Connected, on retry after error
     /// with capped exponential backoff).
     ///
-    /// The returned `RemoteResource` owns the watch channel; dropping it
-    /// drops all subscribers' senders but the spawned task keeps running
-    /// until the connection watch is closed (i.e. the `Client` is
-    /// dropped). Callers wanting to cancel an in-flight fetch should
-    /// drop the `Client` or a wrapping `Arc<Client>`.
+    /// Lifecycle: dropping the returned `RemoteResource` cancels the
+    /// spawned task and any in-flight fetch (the held `_cancel_tx`
+    /// fires its receiver inside the `tokio::select!`). The task also
+    /// exits when the connection watch is closed — i.e. when the
+    /// `Client` is dropped — so callers don't have to manage either
+    /// lifetime end explicitly. Both shutdown paths are exercised by
+    /// `dropping_resource_cancels_spawned_task` and the surrounding
+    /// tests.
     pub fn driven_by<F, Fut>(client: Arc<Client>, runtime: &Arc<Runtime>, fetch: F) -> Self
     where
         F: Fn(Arc<Client>) -> Fut + Send + Sync + 'static,

--- a/rust/zaparoo-core/src/runtime.rs
+++ b/rust/zaparoo-core/src/runtime.rs
@@ -1,5 +1,5 @@
 // Zaparoo Launcher
-// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 //
 // Runtime: what device is the launcher binary running on?

--- a/rust/zaparoo-core/src/store/endpoint.rs
+++ b/rust/zaparoo-core/src/store/endpoint.rs
@@ -1,0 +1,63 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+//
+// `Endpoint` — a typed, cacheable RPC. Implementing types are unit
+// structs (e.g. `pub struct CatalogEndpoint;`) used as type-level keys;
+// `fetch` is dispatched statically through `Store::subscribe::<E>`.
+//
+// The trait surface mirrors RTK Query's `endpoints.builder.query(...)`:
+// `NAME` is the cache namespace and the default tag kind, `Args` is the
+// cache key, and `provides()` declares which tags the resulting data
+// carries for invalidation matching.
+
+use crate::client::{Client, ClientError};
+use crate::store::tag::Tag;
+use futures_util::future::BoxFuture;
+use std::hash::Hash;
+use std::sync::Arc;
+
+pub trait Endpoint: 'static {
+    /// Cache key for this endpoint. Two subscribers with equal `Args`
+    /// share a `RemoteResource`. `()` is the right choice for endpoints
+    /// whose data is global to the connection (e.g. the systems
+    /// catalog); use a richer type when the fetch parameters vary.
+    type Args: Clone + Eq + Hash + Send + Sync + 'static;
+
+    /// The endpoint's deserialized payload, exactly as the UI consumes
+    /// it. Must be `Clone` because every status-watch update sends a
+    /// fresh `ResourceStatus<Output>`.
+    type Output: Clone + Send + Sync + 'static;
+
+    /// Stable identifier used in cache keys and as the default tag
+    /// kind. Two endpoints with the same `NAME` share a cache namespace
+    /// and become indistinguishable to the invalidation matcher; pick a
+    /// unique string per endpoint.
+    const NAME: &'static str;
+
+    fn fetch(
+        client: Arc<Client>,
+        args: Self::Args,
+    ) -> BoxFuture<'static, Result<Self::Output, ClientError>>;
+
+    /// Tags this endpoint's data provides. The default — a single
+    /// `Tag::any(NAME)` — means any mutation invalidating
+    /// `Tag::any(NAME)` *or* `Tag::specific(NAME, _)` will refetch this
+    /// entry. Override for finer-grained tags (e.g. per-system search
+    /// results that should only invalidate when *that* system's data
+    /// changes).
+    ///
+    /// The store's per-entry watcher recomputes `provides` only on
+    /// transitions through `Ready`, and `tokio::sync::watch` is
+    /// intentionally lossy: a rapid `Ready → Loading → Ready` sequence
+    /// can collapse into a single watcher wake-up that observes the
+    /// later state. Today every implementation derives `provides`
+    /// purely from `args`, so the value is invariant across successive
+    /// fetches and the lossiness is harmless. If you derive provides
+    /// from `output` (e.g. a server-issued id), the tags must be
+    /// stable across fetches with the same args — otherwise an
+    /// invalidation matched against stale provides will miss.
+    fn provides(_args: &Self::Args, _output: &Self::Output) -> Vec<Tag> {
+        vec![Tag::any(Self::NAME)]
+    }
+}

--- a/rust/zaparoo-core/src/store/mod.rs
+++ b/rust/zaparoo-core/src/store/mod.rs
@@ -1,0 +1,566 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+//
+// `Store` is the root of the data layer. It owns the `Client` and
+// runtime, hands out shared `RemoteResource`s keyed by (endpoint, args),
+// and routes mutations through to the same client. In RTK-Query terms
+// this is the `api` slice's reducer + dispatcher. One `Store` per
+// launcher process; QML singletons subscribe through it.
+//
+// Responsibilities: cache `(endpoint NAME, args hash) → RemoteResource`,
+// hand back shared subscriptions, route mutations through to the same
+// `Client`, and refetch every cache entry whose `provides` set
+// intersects a successful mutation's `invalidates` list.
+
+mod endpoint;
+mod mutation;
+mod tag;
+
+pub use endpoint::Endpoint;
+pub use mutation::Mutation;
+pub use tag::Tag;
+
+use crate::client::{Client, ClientError};
+use crate::remote_resource::{RemoteResource, ResourceStatus};
+use std::any::Any;
+use std::collections::HashMap;
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::sync::{Arc, Mutex};
+use tokio::runtime::Runtime;
+
+/// Cache lookup key for `Store::subscribe`. Combines the endpoint's
+/// `NAME` with a hash of its `Args`. Endpoints are expected to choose
+/// unique names, so cross-endpoint collisions are a programmer error;
+/// within an endpoint a 64-bit `Args` hash collision is astronomically
+/// unlikely for the cardinalities this launcher sees (one catalog,
+/// tens of system ids).
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+struct CacheKey {
+    name: &'static str,
+    args_hash: u64,
+}
+
+impl CacheKey {
+    fn new<E: Endpoint>(args: &E::Args) -> Self {
+        let mut hasher = DefaultHasher::new();
+        args.hash(&mut hasher);
+        Self {
+            name: E::NAME,
+            args_hash: hasher.finish(),
+        }
+    }
+}
+
+/// Type-erased per-entry record. `resource` is an
+/// `Arc<RemoteResource<E::Output>>` for the endpoint that owns the slot;
+/// the `(NAME, args)` pair uniquely determines the concrete `Output`,
+/// so the downcast on subscribe is infallible in practice. `provides`
+/// is updated by a per-entry watcher each time the resource transitions
+/// to `Ready`. `refetch` is a type-erased clone of
+/// `RemoteResource::refetch` so the store can pulse invalidations
+/// without naming `E::Output`.
+struct CacheEntry {
+    resource: Arc<dyn Any + Send + Sync>,
+    provides: Vec<Tag>,
+    refetch: Arc<dyn Fn() + Send + Sync>,
+}
+
+#[derive(Default)]
+struct Inner {
+    cache: HashMap<CacheKey, CacheEntry>,
+}
+
+pub struct Store {
+    client: Arc<Client>,
+    runtime: Arc<Runtime>,
+    inner: Arc<Mutex<Inner>>,
+}
+
+impl std::fmt::Debug for Store {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Store").finish_non_exhaustive()
+    }
+}
+
+impl Store {
+    pub fn new(client: Arc<Client>, runtime: Arc<Runtime>) -> Arc<Self> {
+        Arc::new(Self {
+            client,
+            runtime,
+            inner: Arc::new(Mutex::new(Inner::default())),
+        })
+    }
+
+    /// Get (or create) the shared `RemoteResource` for endpoint `E`
+    /// with `args`. Subsequent calls with equal args return the same
+    /// `Arc`, so multiple QML singletons binding the same endpoint
+    /// share one fetch task and one publish channel.
+    #[allow(
+        clippy::unwrap_used,
+        reason = "mutex poisoning signals another thread panicked with the lock held; state is unrecoverable"
+    )]
+    pub fn subscribe<E: Endpoint>(&self, args: E::Args) -> Arc<RemoteResource<E::Output>> {
+        let key = CacheKey::new::<E>(&args);
+        let mut inner = self.inner.lock().unwrap();
+        if let Some(existing) = inner.cache.get(&key) {
+            if let Ok(resource) = existing
+                .resource
+                .clone()
+                .downcast::<RemoteResource<E::Output>>()
+            {
+                return resource;
+            }
+            // Same NAME but a different `Output` type — programmer
+            // error (two endpoints sharing a NAME). Fall through and
+            // overwrite so behaviour is deterministic, but surface
+            // the misuse loudly in dev and at least log it in release
+            // so it doesn't go unnoticed.
+            tracing::error!(
+                name = E::NAME,
+                "endpoint NAME collision: cache entry has a different Output type; \
+                 the prior entry is being orphaned"
+            );
+            debug_assert!(
+                false,
+                "endpoint NAME collision: two endpoints share NAME = {:?} but disagree on Output",
+                E::NAME
+            );
+        }
+        let runtime = self.runtime.clone();
+        let args_for_fetch = args.clone();
+        let resource = Arc::new(RemoteResource::driven_by(
+            self.client.clone(),
+            &runtime,
+            move |c| E::fetch(c, args_for_fetch.clone()),
+        ));
+        let resource_for_refetch = resource.clone();
+        let refetch: Arc<dyn Fn() + Send + Sync> = Arc::new(move || resource_for_refetch.refetch());
+        let entry = CacheEntry {
+            resource: resource.clone(),
+            // `provides` starts empty; the per-entry watcher below
+            // populates it on the first `Ready`. A mutation that fires
+            // before the resource has produced a value can't have
+            // anything meaningful to invalidate yet — refetching an
+            // entry that hasn't fetched once is a no-op for callers.
+            provides: Vec::new(),
+            refetch,
+        };
+        inner.cache.insert(key.clone(), entry);
+        drop(inner);
+
+        // Spawn a per-entry watcher that keeps `provides` in sync with
+        // the resource's last `Ready` value. Held weakly so the
+        // watcher exits as soon as the store is dropped (process
+        // teardown), without forming a cycle that would keep `Inner`
+        // alive forever.
+        //
+        // `tokio::sync::watch` is intentionally lossy — a rapid
+        // `Ready → Loading → Ready` collapses into one wake-up that
+        // observes the later state — so the watcher is *not*
+        // guaranteed to see every `Ready` transition. This is fine
+        // because (a) `Ready` is sticky, so subsequent fetches
+        // re-emit `Ready` and the watcher catches up, and (b) every
+        // current `Endpoint::provides` is output-independent. See
+        // the doc comment on `Endpoint::provides` for the constraint
+        // future endpoints must respect.
+        let inner_weak = Arc::downgrade(&self.inner);
+        let mut status_rx = resource.subscribe();
+        let key_for_watcher = key;
+        runtime.spawn(async move {
+            loop {
+                let snapshot = status_rx.borrow_and_update().clone();
+                if let ResourceStatus::Ready(output) = snapshot {
+                    let new_provides = E::provides(&args, &output);
+                    let Some(inner_arc) = inner_weak.upgrade() else {
+                        return;
+                    };
+                    let lock_result = inner_arc.lock();
+                    if let Ok(mut inner) = lock_result {
+                        if let Some(entry) = inner.cache.get_mut(&key_for_watcher) {
+                            entry.provides = new_provides;
+                        }
+                    }
+                }
+                if status_rx.changed().await.is_err() {
+                    return;
+                }
+            }
+        });
+
+        resource
+    }
+
+    /// Invoke a mutation. On success, every cache entry whose
+    /// `provides` set matches any of `M::invalidates(args, result)` is
+    /// refetched in place — the underlying `RemoteResource` keeps the
+    /// same `Arc`, so existing subscribers see the new value through
+    /// their existing watch channel without re-binding.
+    pub async fn run_mutation<M: Mutation>(&self, args: M::Args) -> Result<M::Output, ClientError> {
+        let args_for_invalidate = args.clone();
+        let result = M::run(self.client.clone(), args).await?;
+        for tag in M::invalidates(&args_for_invalidate, &result) {
+            self.invalidate(&tag);
+        }
+        Ok(result)
+    }
+
+    /// Invalidate every cache entry whose `provides` set matches `tag`.
+    /// Matching is RTK-Query-shaped: kinds must agree, and a `None` id
+    /// (the "any" tag) on either side matches any id on the other.
+    #[allow(
+        clippy::unwrap_used,
+        reason = "mutex poisoning signals another thread panicked with the lock held; state is unrecoverable"
+    )]
+    pub fn invalidate(&self, tag: &Tag) {
+        let inner = self.inner.lock().unwrap();
+        let to_refetch: Vec<Arc<dyn Fn() + Send + Sync>> = inner
+            .cache
+            .values()
+            .filter(|entry| entry.provides.iter().any(|p| tags_match(p, tag)))
+            .map(|entry| entry.refetch.clone())
+            .collect();
+        drop(inner);
+        for refetch in to_refetch {
+            refetch();
+        }
+    }
+}
+
+/// RTK-Query tag matching. Two tags match iff their kinds agree and at
+/// least one side has a `None` id (the "any" wildcard) or both sides
+/// share the same specific id. Used for both directions:
+/// `provided.matches(invalidating)` and the reverse have the same
+/// truth table, so we don't need to track which is which here.
+fn tags_match(a: &Tag, b: &Tag) -> bool {
+    if a.kind != b.kind {
+        return false;
+    }
+    match (&a.id, &b.id) {
+        (None, _) | (_, None) => true,
+        (Some(left), Some(right)) => left == right,
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, reason = "tests should fail-fast on setup errors")]
+mod tests {
+    use super::*;
+    use futures_util::future::BoxFuture;
+
+    /// Endpoint stand-in that doesn't touch the `Client`. Used by the
+    /// cache-key and subscribe tests below where end-to-end fetch
+    /// behavior is out of scope; real endpoints have their own
+    /// integration tests.
+    struct DummyEndpoint;
+    impl Endpoint for DummyEndpoint {
+        type Args = String;
+        type Output = i32;
+        const NAME: &'static str = "Dummy";
+
+        fn fetch(
+            _client: Arc<Client>,
+            _args: Self::Args,
+        ) -> BoxFuture<'static, Result<Self::Output, ClientError>> {
+            Box::pin(async { Ok(0) })
+        }
+    }
+
+    struct OtherEndpoint;
+    impl Endpoint for OtherEndpoint {
+        type Args = String;
+        type Output = i32;
+        const NAME: &'static str = "Other";
+
+        fn fetch(
+            _client: Arc<Client>,
+            _args: Self::Args,
+        ) -> BoxFuture<'static, Result<Self::Output, ClientError>> {
+            Box::pin(async { Ok(0) })
+        }
+    }
+
+    struct UnitEndpoint;
+    impl Endpoint for UnitEndpoint {
+        type Args = ();
+        type Output = i32;
+        const NAME: &'static str = "Unit";
+
+        fn fetch(
+            _client: Arc<Client>,
+            _args: Self::Args,
+        ) -> BoxFuture<'static, Result<Self::Output, ClientError>> {
+            Box::pin(async { Ok(0) })
+        }
+    }
+
+    #[test]
+    fn cache_key_equal_for_equal_args() {
+        let a = CacheKey::new::<DummyEndpoint>(&"alpha".to_string());
+        let b = CacheKey::new::<DummyEndpoint>(&"alpha".to_string());
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn cache_key_differs_for_different_args() {
+        let a = CacheKey::new::<DummyEndpoint>(&"alpha".to_string());
+        let b = CacheKey::new::<DummyEndpoint>(&"beta".to_string());
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn cache_key_differs_for_different_endpoint_names() {
+        let a = CacheKey::new::<DummyEndpoint>(&"alpha".to_string());
+        let b = CacheKey::new::<OtherEndpoint>(&"alpha".to_string());
+        // Same args produce the same hash — the NAME is the
+        // distinguishing field.
+        assert_eq!(a.args_hash, b.args_hash);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn unit_args_collapse_to_a_single_key() {
+        let a = CacheKey::new::<UnitEndpoint>(&());
+        let b = CacheKey::new::<UnitEndpoint>(&());
+        assert_eq!(a, b);
+    }
+
+    fn test_store() -> Arc<Store> {
+        let runtime = Arc::new(
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("build runtime"),
+        );
+        // The Client spawns a reconnect task against this endpoint; the
+        // test never lets the task connect, so the URL just needs to
+        // parse. `subscribe` itself doesn't await anything network-y.
+        let client = Client::new("ws://127.0.0.1:1/never".to_string(), &runtime);
+        Store::new(client, runtime)
+    }
+
+    #[test]
+    fn subscribe_with_equal_args_returns_same_arc() {
+        let store = test_store();
+        let a = store.subscribe::<DummyEndpoint>("alpha".to_string());
+        let b = store.subscribe::<DummyEndpoint>("alpha".to_string());
+        // Pointer equality — the cache must hand back the same
+        // resource Arc, not a fresh `RemoteResource` per call.
+        assert!(Arc::ptr_eq(&a, &b));
+    }
+
+    #[test]
+    fn subscribe_with_different_args_returns_different_arcs() {
+        let store = test_store();
+        let a = store.subscribe::<DummyEndpoint>("alpha".to_string());
+        let b = store.subscribe::<DummyEndpoint>("beta".to_string());
+        assert!(!Arc::ptr_eq(&a, &b));
+
+        // Each args value should occupy its own cache slot — two
+        // entries with the expected keys means the cache really did
+        // distinguish them, not just hand back fresh Arcs from one
+        // shared slot.
+        let cache = &store.inner.lock().expect("lock store inner").cache;
+        assert_eq!(cache.len(), 2);
+        let key_a = CacheKey::new::<DummyEndpoint>(&"alpha".to_string());
+        let key_b = CacheKey::new::<DummyEndpoint>(&"beta".to_string());
+        assert!(cache.contains_key(&key_a));
+        assert!(cache.contains_key(&key_b));
+
+        // Independent watch channels: each resource has its own
+        // status sender, so subscribing to one yields a receiver
+        // that is not aliased to the other's sender. Both seed to
+        // Idle (the connection is never established by the test
+        // client).
+        let mut rx_a = a.subscribe();
+        let mut rx_b = b.subscribe();
+        assert!(matches!(*rx_a.borrow_and_update(), ResourceStatus::Idle));
+        assert!(matches!(*rx_b.borrow_and_update(), ResourceStatus::Idle));
+    }
+
+    // RTK-Query tag matching parity. See `tags_match` in this module.
+
+    #[test]
+    fn any_matches_any_of_same_kind() {
+        assert!(tags_match(&Tag::any("X"), &Tag::any("X")));
+    }
+
+    #[test]
+    fn any_matches_specific_of_same_kind() {
+        // A mutation invalidating Tag::any("X") refetches both entries
+        // tagged Tag::any("X") and Tag::specific("X", id) — the broad
+        // tag invalidates everything in the namespace.
+        assert!(tags_match(&Tag::any("X"), &Tag::specific("X", "a")));
+        assert!(tags_match(&Tag::specific("X", "a"), &Tag::any("X")));
+    }
+
+    #[test]
+    fn specific_matches_specific_only_for_same_id() {
+        assert!(tags_match(
+            &Tag::specific("X", "a"),
+            &Tag::specific("X", "a"),
+        ));
+        assert!(!tags_match(
+            &Tag::specific("X", "a"),
+            &Tag::specific("X", "b"),
+        ));
+    }
+
+    #[test]
+    fn cross_kind_never_matches() {
+        assert!(!tags_match(&Tag::any("X"), &Tag::any("Y")));
+        assert!(!tags_match(
+            &Tag::specific("X", "a"),
+            &Tag::specific("Y", "a"),
+        ));
+        assert!(!tags_match(&Tag::any("X"), &Tag::specific("Y", "a")));
+    }
+
+    // run_mutation / invalidate end-to-end behaviour. These bypass
+    // `Store::subscribe`'s connection-driven resource lifecycle by
+    // populating cache entries directly, so the tests stay deterministic
+    // regardless of the `Client`'s reconnect task.
+
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+
+    fn install_entry_with_provides(
+        store: &Arc<Store>,
+        key: CacheKey,
+        provides: Vec<Tag>,
+    ) -> Arc<AtomicUsize> {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let counter_for_closure = counter.clone();
+        let refetch: Arc<dyn Fn() + Send + Sync> = Arc::new(move || {
+            counter_for_closure.fetch_add(1, AtomicOrdering::SeqCst);
+        });
+        let dummy_resource: Arc<dyn Any + Send + Sync> = Arc::new(());
+        let entry = CacheEntry {
+            resource: dummy_resource,
+            provides,
+            refetch,
+        };
+        store
+            .inner
+            .lock()
+            .expect("lock store inner")
+            .cache
+            .insert(key, entry);
+        counter
+    }
+
+    /// Mutation whose `invalidates` matches `Tag::any("Dummy")` — used to
+    /// drive the refetch path under test.
+    struct InvalidatingMutation;
+    impl Mutation for InvalidatingMutation {
+        type Args = ();
+        type Output = ();
+        fn run(
+            _client: Arc<Client>,
+            _args: Self::Args,
+        ) -> BoxFuture<'static, Result<Self::Output, ClientError>> {
+            Box::pin(async { Ok(()) })
+        }
+        fn invalidates(_args: &Self::Args, _result: &Self::Output) -> Vec<Tag> {
+            vec![Tag::any("Dummy")]
+        }
+    }
+
+    /// Mutation with no invalidates — the no-op default. Confirms that
+    /// `run_mutation` does not refetch entries when nothing is asked.
+    struct InertMutation;
+    impl Mutation for InertMutation {
+        type Args = ();
+        type Output = ();
+        fn run(
+            _client: Arc<Client>,
+            _args: Self::Args,
+        ) -> BoxFuture<'static, Result<Self::Output, ClientError>> {
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    #[test]
+    fn run_mutation_refetches_entry_with_matching_provides() {
+        let store = test_store();
+        let key = CacheKey::new::<DummyEndpoint>(&"alpha".to_string());
+        let counter = install_entry_with_provides(&store, key, vec![Tag::any("Dummy")]);
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build runtime");
+        runtime.block_on(async {
+            store
+                .run_mutation::<InvalidatingMutation>(())
+                .await
+                .expect("mutation runs");
+        });
+
+        assert_eq!(counter.load(AtomicOrdering::SeqCst), 1);
+    }
+
+    #[test]
+    fn run_mutation_skips_entry_with_unrelated_provides() {
+        let store = test_store();
+        let key = CacheKey::new::<DummyEndpoint>(&"alpha".to_string());
+        // Provides a tag from a different kind — `InvalidatingMutation`
+        // invalidates `Tag::any("Dummy")` so this entry must not match.
+        let counter = install_entry_with_provides(&store, key, vec![Tag::any("Other")]);
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build runtime");
+        runtime.block_on(async {
+            store
+                .run_mutation::<InvalidatingMutation>(())
+                .await
+                .expect("mutation runs");
+        });
+
+        assert_eq!(counter.load(AtomicOrdering::SeqCst), 0);
+    }
+
+    #[test]
+    fn run_mutation_succeeds_when_provides_not_yet_populated() {
+        let store = test_store();
+        let key = CacheKey::new::<DummyEndpoint>(&"alpha".to_string());
+        // Empty provides simulates a cache entry whose resource has not
+        // yet emitted `Ready`. The mutation still runs, and the entry
+        // is correctly skipped because no provides match.
+        let counter = install_entry_with_provides(&store, key, Vec::new());
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build runtime");
+        runtime.block_on(async {
+            store
+                .run_mutation::<InvalidatingMutation>(())
+                .await
+                .expect("mutation runs");
+        });
+
+        assert_eq!(counter.load(AtomicOrdering::SeqCst), 0);
+    }
+
+    #[test]
+    fn run_mutation_with_no_invalidates_never_refetches() {
+        let store = test_store();
+        let key = CacheKey::new::<DummyEndpoint>(&"alpha".to_string());
+        let counter = install_entry_with_provides(&store, key, vec![Tag::any("Dummy")]);
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build runtime");
+        runtime.block_on(async {
+            store
+                .run_mutation::<InertMutation>(())
+                .await
+                .expect("mutation runs");
+        });
+
+        assert_eq!(counter.load(AtomicOrdering::SeqCst), 0);
+    }
+}

--- a/rust/zaparoo-core/src/store/mod.rs
+++ b/rust/zaparoo-core/src/store/mod.rs
@@ -113,7 +113,7 @@ impl Store {
             }
             // Same NAME but a different `Output` type — programmer
             // error (two endpoints sharing a NAME). Fall through and
-            // overwrite so behaviour is deterministic, but surface
+            // overwrite so behavior is deterministic, but surface
             // the misuse loudly in dev and at least log it in release
             // so it doesn't go unnoticed.
             tracing::error!(
@@ -425,7 +425,7 @@ mod tests {
         assert!(!tags_match(&Tag::any("X"), &Tag::specific("Y", "a")));
     }
 
-    // run_mutation / invalidate end-to-end behaviour. These bypass
+    // run_mutation / invalidate end-to-end behavior. These bypass
     // `Store::subscribe`'s connection-driven resource lifecycle by
     // populating cache entries directly, so the tests stay deterministic
     // regardless of the `Client`'s reconnect task.

--- a/rust/zaparoo-core/src/store/mod.rs
+++ b/rust/zaparoo-core/src/store/mod.rs
@@ -127,6 +127,15 @@ impl Store {
                 E::NAME
             );
         }
+        // Cache entries live for the lifetime of the `Store` (which is
+        // the lifetime of the launcher process). No reclamation path:
+        // total cardinality is bounded by `endpoints × distinct args` —
+        // a handful of endpoints times a few dozen system IDs in the
+        // worst case — and each entry holds one `tokio::sync::watch`
+        // plus one watcher task, both cheap. The `Client` and `Runtime`
+        // outlive every entry by construction. Add eviction (most
+        // likely `Arc::strong_count`-driven on the per-entry watcher's
+        // drop branch) only if RAM growth shows up in the field.
         let runtime = self.runtime.clone();
         let args_for_fetch = args.clone();
         let resource = Arc::new(RemoteResource::driven_by(

--- a/rust/zaparoo-core/src/store/mutation.rs
+++ b/rust/zaparoo-core/src/store/mutation.rs
@@ -1,0 +1,35 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+//
+// `Mutation` — a write-side RPC. Mirrors RTK Query's
+// `endpoints.builder.mutation(...)`. The store invokes `run` and, on
+// success, refetches every cache entry whose `provides` set intersects
+// `invalidates(args, result)`.
+
+use crate::client::{Client, ClientError};
+use crate::store::tag::Tag;
+use futures_util::future::BoxFuture;
+use std::sync::Arc;
+
+pub trait Mutation: 'static {
+    /// `Clone` is required so `Store::run_mutation` can hand the args to
+    /// both `run` (which consumes them into the `BoxFuture`) and
+    /// `invalidates` (which inspects them after a successful run).
+    type Args: Clone + Send + 'static;
+    type Output: Send + 'static;
+
+    fn run(
+        client: Arc<Client>,
+        args: Self::Args,
+    ) -> BoxFuture<'static, Result<Self::Output, ClientError>>;
+
+    /// Tags whose cache entries should be refetched after this mutation
+    /// succeeds. Default: nothing — invalidation is opt-in per
+    /// mutation. The tag list may depend on both the input args and the
+    /// server's reply (e.g. a "create" mutation might tag with the new
+    /// id from the response).
+    fn invalidates(_args: &Self::Args, _result: &Self::Output) -> Vec<Tag> {
+        Vec::new()
+    }
+}

--- a/rust/zaparoo-core/src/store/tag.rs
+++ b/rust/zaparoo-core/src/store/tag.rs
@@ -1,0 +1,39 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+//
+// Cache invalidation tags. Modeled on RTK Query: a value is tagged
+// either with `Tag::any(K)` or `Tag::specific(K, id)`, and a mutation
+// declares which tags it invalidates. Matching is implemented in
+// `super::tags_match`; the rules are:
+//
+//   invalidate `Tag::any(K)`           → matches every entry tagged
+//                                         with kind K, regardless of id
+//   invalidate `Tag::specific(K, id)`  → matches entries tagged with
+//                                         `Tag::any(K)` *or*
+//                                         `Tag::specific(K, id)` only
+
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub struct Tag {
+    pub kind: &'static str,
+    pub id: Option<String>,
+}
+
+impl Tag {
+    /// Tag matching every entry of the given kind. Use this when an
+    /// endpoint's data isn't keyed by an identifier (e.g. the catalog).
+    #[must_use]
+    pub const fn any(kind: &'static str) -> Self {
+        Self { kind, id: None }
+    }
+
+    /// Tag matching an entry of the given kind and identifier. Use this
+    /// for per-arg endpoints whose mutations may want to invalidate one
+    /// specific entry without disturbing siblings.
+    pub fn specific(kind: &'static str, id: impl Into<String>) -> Self {
+        Self {
+            kind,
+            id: Some(id.into()),
+        }
+    }
+}

--- a/rust/zaparoo-core/src/systems_catalog.rs
+++ b/rust/zaparoo-core/src/systems_catalog.rs
@@ -2,37 +2,18 @@
 // Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 //
-// Fetches the systems list once on every connection event and publishes
-// a parsed CatalogData to subscribers (the QObject models).
+// `CatalogData` is the shape every consumer of the systems list (the
+// AppStatus banner, CategoriesModel, SystemsModel) reads from. The
+// fetch + sort + category-derivation pipeline that produces it lives
+// behind `crate::endpoints::catalog::CatalogEndpoint`, dispatched by
+// `crate::store::Store::subscribe::<CatalogEndpoint>(())`.
 
-use crate::client::{Client, ConnectionState};
-use crate::media_types::{SystemInfo, SystemsParams};
-use std::collections::HashSet;
-use std::sync::Arc;
-use tokio::sync::watch;
-use tracing::{info, warn};
+use crate::media_types::SystemInfo;
 
 #[derive(Debug, Clone)]
 pub struct CatalogData {
     pub systems: Vec<SystemInfo>,
     pub categories: Vec<String>,
-}
-
-/// Lifecycle of the catalog fetch, published alongside `CatalogData` so the
-/// UI can distinguish "waiting for Core" from "Core returned an error."
-#[derive(Debug, Clone, Default)]
-pub enum CatalogStatus {
-    #[default]
-    Idle,
-    Loading,
-    Ready,
-    Errored(String),
-}
-
-#[derive(Debug)]
-pub struct CatalogChannels {
-    pub data: watch::Sender<Option<CatalogData>>,
-    pub status: watch::Sender<CatalogStatus>,
 }
 
 impl CatalogData {
@@ -52,85 +33,9 @@ impl CatalogData {
     }
 }
 
-fn derive_categories(systems: &[SystemInfo]) -> Vec<String> {
-    let mut seen: HashSet<String> = HashSet::new();
-    let mut cats: Vec<String> = Vec::new();
-    for s in systems {
-        let cat = if s.category.is_empty() {
-            "Other".to_string()
-        } else {
-            s.category.clone()
-        };
-        let lower = cat.to_lowercase();
-        if seen.insert(lower) {
-            cats.push(cat);
-        }
-    }
-    cats.sort_by_key(|a| a.to_lowercase());
-    cats
-}
-
-pub fn spawn(client: Arc<Client>, runtime: &Arc<tokio::runtime::Runtime>) -> CatalogChannels {
-    let (data_tx, _) = watch::channel(None::<CatalogData>);
-    let (status_tx, _) = watch::channel(CatalogStatus::Idle);
-    let data = data_tx.clone();
-    let status = status_tx.clone();
-    let mut connection_rx = client.connection.subscribe();
-
-    runtime.spawn(async move {
-        // Seed from the watch's current value so we react if Core is
-        // already Connected at subscription time, then loop on changes.
-        let mut state = connection_rx.borrow_and_update().clone();
-        loop {
-            if matches!(state, ConnectionState::Connected) {
-                status.send_replace(CatalogStatus::Loading);
-                let seq_client = client.clone();
-                match seq_client.systems(SystemsParams {}).await {
-                    Ok(result) => {
-                        let mut systems = result.systems;
-                        systems.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
-                        let categories = derive_categories(&systems);
-                        info!(
-                            "catalog loaded: {} systems, {} categories",
-                            systems.len(),
-                            categories.len()
-                        );
-                        data.send_replace(Some(CatalogData {
-                            systems,
-                            categories,
-                        }));
-                        status.send_replace(CatalogStatus::Ready);
-                    }
-                    Err(e) => {
-                        warn!("systems RPC failed: {}", e.message);
-                        status.send_replace(CatalogStatus::Errored(e.message));
-                    }
-                }
-            }
-            if connection_rx.changed().await.is_err() {
-                break;
-            }
-            state = connection_rx.borrow_and_update().clone();
-        }
-    });
-
-    CatalogChannels {
-        data: data_tx,
-        status: status_tx,
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    #![allow(
-        clippy::expect_used,
-        clippy::unwrap_used,
-        clippy::panic,
-        reason = "tests should fail-fast on unexpected errors"
-    )]
-
-    use super::{derive_categories, CatalogData};
-    use crate::media_types::SystemInfo;
+    use super::*;
 
     fn sys(id: &str, name: &str, category: &str) -> SystemInfo {
         SystemInfo {
@@ -138,37 +43,6 @@ mod tests {
             name: name.into(),
             category: category.into(),
         }
-    }
-
-    #[test]
-    fn derive_categories_sorts_case_insensitively() {
-        let systems = vec![
-            sys("a", "A", "Handhelds"),
-            sys("b", "B", "arcade"),
-            sys("c", "C", "Consoles"),
-        ];
-        assert_eq!(
-            derive_categories(&systems),
-            vec!["arcade", "Consoles", "Handhelds"],
-        );
-    }
-
-    #[test]
-    fn derive_categories_dedupes_case_insensitively() {
-        let systems = vec![
-            sys("a", "A", "Arcade"),
-            sys("b", "B", "arcade"),
-            sys("c", "C", "ARCADE"),
-        ];
-        let cats = derive_categories(&systems);
-        assert_eq!(cats.len(), 1);
-        assert_eq!(cats[0], "Arcade"); // first encountered casing wins
-    }
-
-    #[test]
-    fn derive_categories_synthesises_other_for_empty() {
-        let systems = vec![sys("a", "A", ""), sys("b", "B", "Consoles")];
-        assert_eq!(derive_categories(&systems), vec!["Consoles", "Other"]);
     }
 
     #[test]
@@ -210,23 +84,5 @@ mod tests {
             categories: vec!["Arcade".into()],
         };
         assert!(data.systems_by_category("Handhelds").is_empty());
-    }
-
-    #[test]
-    fn catalog_snapshot_matches_fixture() {
-        let mut systems = vec![
-            sys("snes", "Super Nintendo", "Consoles"),
-            sys("nes", "Nintendo", "Consoles"),
-            sys("gb", "Game Boy", "Handhelds"),
-            sys("mame", "MAME", "arcade"),
-            sys("odd", "Odd One", ""),
-        ];
-        // Match the sort applied by spawn() before publishing.
-        systems.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
-        let categories = derive_categories(&systems);
-        insta::assert_debug_snapshot!(CatalogData {
-            systems,
-            categories
-        });
     }
 }

--- a/rust/zaparoo-core/src/systems_catalog.rs
+++ b/rust/zaparoo-core/src/systems_catalog.rs
@@ -1,11 +1,11 @@
 // Zaparoo Launcher
-// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 //
-// Fetches the systems list once on every connection event and broadcasts
+// Fetches the systems list once on every connection event and publishes
 // a parsed CatalogData to subscribers (the QObject models).
 
-use crate::client::Client;
+use crate::client::{Client, ConnectionState};
 use crate::media_types::{SystemInfo, SystemsParams};
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -16,6 +16,23 @@ use tracing::{info, warn};
 pub struct CatalogData {
     pub systems: Vec<SystemInfo>,
     pub categories: Vec<String>,
+}
+
+/// Lifecycle of the catalog fetch, published alongside `CatalogData` so the
+/// UI can distinguish "waiting for Core" from "Core returned an error."
+#[derive(Debug, Clone, Default)]
+pub enum CatalogStatus {
+    #[default]
+    Idle,
+    Loading,
+    Ready,
+    Errored(String),
+}
+
+#[derive(Debug)]
+pub struct CatalogChannels {
+    pub data: watch::Sender<Option<CatalogData>>,
+    pub status: watch::Sender<CatalogStatus>,
 }
 
 impl CatalogData {
@@ -53,49 +70,54 @@ fn derive_categories(systems: &[SystemInfo]) -> Vec<String> {
     cats
 }
 
-pub fn spawn(
-    client: Arc<Client>,
-    runtime: &Arc<tokio::runtime::Runtime>,
-) -> watch::Sender<Option<CatalogData>> {
-    let (catalog_tx, _) = watch::channel(None::<CatalogData>);
-    let tx = catalog_tx.clone();
-    // Subscribe before spawning: broadcast receivers miss messages sent before
-    // subscription, so if the core is already up the "connected = true" event
-    // would arrive before the async task even starts. Subscribing here on the
-    // main thread guarantees we capture it.
-    let mut connected_rx = client.connected.subscribe();
+pub fn spawn(client: Arc<Client>, runtime: &Arc<tokio::runtime::Runtime>) -> CatalogChannels {
+    let (data_tx, _) = watch::channel(None::<CatalogData>);
+    let (status_tx, _) = watch::channel(CatalogStatus::Idle);
+    let data = data_tx.clone();
+    let status = status_tx.clone();
+    let mut connection_rx = client.connection.subscribe();
 
     runtime.spawn(async move {
+        // Seed from the watch's current value so we react if Core is
+        // already Connected at subscription time, then loop on changes.
+        let mut state = connection_rx.borrow_and_update().clone();
         loop {
-            match connected_rx.recv().await {
-                Ok(true) => {
-                    let seq_client = client.clone();
-                    match seq_client.systems(SystemsParams {}).await {
-                        Ok(result) => {
-                            let mut systems = result.systems;
-                            systems
-                                .sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
-                            let categories = derive_categories(&systems);
-                            info!(
-                                "catalog loaded: {} systems, {} categories",
-                                systems.len(),
-                                categories.len()
-                            );
-                            tx.send_replace(Some(CatalogData {
-                                systems,
-                                categories,
-                            }));
-                        }
-                        Err(e) => warn!("systems RPC failed: {}", e.message),
+            if matches!(state, ConnectionState::Connected) {
+                status.send_replace(CatalogStatus::Loading);
+                let seq_client = client.clone();
+                match seq_client.systems(SystemsParams {}).await {
+                    Ok(result) => {
+                        let mut systems = result.systems;
+                        systems.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+                        let categories = derive_categories(&systems);
+                        info!(
+                            "catalog loaded: {} systems, {} categories",
+                            systems.len(),
+                            categories.len()
+                        );
+                        data.send_replace(Some(CatalogData {
+                            systems,
+                            categories,
+                        }));
+                        status.send_replace(CatalogStatus::Ready);
+                    }
+                    Err(e) => {
+                        warn!("systems RPC failed: {}", e.message);
+                        status.send_replace(CatalogStatus::Errored(e.message));
                     }
                 }
-                Ok(false) => {}
-                Err(_) => break,
             }
+            if connection_rx.changed().await.is_err() {
+                break;
+            }
+            state = connection_rx.borrow_and_update().clone();
         }
     });
 
-    catalog_tx
+    CatalogChannels {
+        data: data_tx,
+        status: status_tx,
+    }
 }
 
 #[cfg(test)]
@@ -199,7 +221,7 @@ mod tests {
             sys("mame", "MAME", "arcade"),
             sys("odd", "Odd One", ""),
         ];
-        // Match the sort applied by spawn() before broadcasting.
+        // Match the sort applied by spawn() before publishing.
         systems.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
         let categories = derive_categories(&systems);
         insta::assert_debug_snapshot!(CatalogData {

--- a/scripts/build-arm32.sh
+++ b/scripts/build-arm32.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Zaparoo Launcher
-# Copyright (c) 2026 The Zaparoo Project Contributors.
+# Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 # SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 #
 # Cross-compiles the launcher for ARM32 / MiSTer FPGA using Docker.

--- a/scripts/build-toolchain.sh
+++ b/scripts/build-toolchain.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Zaparoo Launcher
-# Copyright (c) 2026 The Zaparoo Project Contributors.
+# Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 # SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 #
 # Build the Qt + MiSTer ARM32 toolchain base image. Qt upstream version is

--- a/scripts/deploy-mister.sh
+++ b/scripts/deploy-mister.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Zaparoo Launcher
-# Copyright (c) 2026 The Zaparoo Project Contributors.
+# Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 # SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 #
 # Builds the ARM32 binary and deploys it to a MiSTer FPGA over SSH/SCP.

--- a/scripts/run-dev.sh
+++ b/scripts/run-dev.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Zaparoo Launcher
-# Copyright (c) 2026 The Zaparoo Project Contributors.
+# Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 # SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 #
 # Build and run a desktop dev build (ZAPAROO_DEV=ON).
@@ -19,5 +19,11 @@ cmake -S "${PROJECT_ROOT}" -B "${BUILD_DIR}" \
     -DZAPAROO_BUILD_TESTS=OFF
 
 cmake --build "${BUILD_DIR}"
+
+# Point the dev launcher at mock-core's port (27497) by default. The real
+# Core's 7497 stays the production default so a shipping desktop install
+# still finds a live Core unmodified. Any pre-set value (e.g. from the
+# shell, or pointing at a real Core on the network) wins.
+export ZAPAROO_CORE_ENDPOINT="${ZAPAROO_CORE_ENDPOINT:-ws://127.0.0.1:27497/api/v0.1}"
 
 exec "${BUILD_DIR}/bin/launcher"

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1,5 +1,5 @@
 // Zaparoo Launcher
-// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 //
 // Thin C++ entry point for the Rust launcher. Domain logic lives in the
@@ -8,8 +8,12 @@
 
 #include <QFontDatabase>
 #include <QGuiApplication>
+#include <QLocale>
 #include <QQmlApplicationEngine>
 #include <QQuickStyle>
+#include <QString>
+#include <QTranslator>
+#include <QUrl>
 #include <QtQml/qqmlextensionplugin.h>
 #include <cstddef>
 #include <cstdint>
@@ -17,12 +21,14 @@
 extern "C" int zaparoo_rust_init();
 extern "C" void zaparoo_rust_post_qt_start();
 extern "C" void zaparoo_log_qt(uint8_t level, const char* msg, size_t len);
+extern "C" const char* zaparoo_rust_language_code();
 
 // Pull Zaparoo QML plugin symbols into the final binary so the linker does
 // not strip their static-initializer registration functions.
 Q_IMPORT_QML_PLUGIN(Zaparoo_AppPlugin)
 Q_IMPORT_QML_PLUGIN(Zaparoo_UiPlugin)
 Q_IMPORT_QML_PLUGIN(Zaparoo_ThemePlugin)
+Q_IMPORT_QML_PLUGIN(Zaparoo_ScreensPlugin)
 Q_IMPORT_QML_PLUGIN(Zaparoo_Browse_plugin)
 
 // For static Qt builds (MiSTer ARM32): the QtQuick.Controls plugin chain and
@@ -68,14 +74,46 @@ int main(int argc, char* argv[])
     QFontDatabase::addApplicationFont(":/qt/qml/Zaparoo/App/resources/fonts/PressStart2P.ttf");
     QQuickStyle::setStyle("Basic");
 
+    // Install the locale .qm translator before constructing the QML engine
+    // so qsTr() lookups in Main.qml's initial bindings see translated text.
+    // The Rust side resolves `[general] language` from launcher.toml into a
+    // BCP-47 tag ("ja", "de_DE") or an empty string (follow system locale).
+    // Stack lifetime is fine — `translator` outlives app.exec() and all QML.
+    const QString langCode = QString::fromUtf8(zaparoo_rust_language_code());
+    const QLocale locale = langCode.isEmpty() ? QLocale::system() : QLocale(langCode);
+    QTranslator translator;
+    if (translator.load(locale, "launcher", "_", ":/i18n"))
+    {
+        QCoreApplication::installTranslator(&translator);
+    }
+    else
+    {
+        // Not an error on first run (English-only build ships a passthrough
+        // launcher_en.qm). Log at info so the sink records the resolved
+        // locale for bug reports without spamming at warn level.
+        qInfo("No translation catalog for %s in :/i18n; using source strings",
+              qUtf8Printable(locale.name()));
+    }
+
     QQmlApplicationEngine engine;
 #ifndef ZAPAROO_DEV_BUILD
     engine.setInitialProperties({{"fullScreen", true}});
 #endif
+
+    // objectCreationFailed fires before loadFromModule returns when a QML
+    // type fails to resolve or compile. Individual QML errors are already
+    // routed through qtMessageHandler → tracing; this handler adds the
+    // tying narrative ("the root object for Zaparoo.App.Main failed") so
+    // a reader of launcher.log doesn't have to infer the connection.
+    QObject::connect(
+        &engine, &QQmlApplicationEngine::objectCreationFailed, &engine, [](const QUrl& url)
+        { qCritical("QML object creation failed for %s", qUtf8Printable(url.toString())); });
+
     engine.loadFromModule("Zaparoo.App", "Main");
 
     if (engine.rootObjects().isEmpty())
     {
+        qCritical("QML engine produced no root objects; startup aborted (see earlier errors)");
         return EXIT_FAILURE;
     }
 

--- a/src/ui/app/CMakeLists.txt
+++ b/src/ui/app/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Zaparoo Launcher
-# Copyright (c) 2026 The Zaparoo Project Contributors.
+# Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 # SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
 qt_add_library(zaparoo_ui_app STATIC)
@@ -30,6 +30,7 @@ qt_add_qml_module(
     IMPORTS
         Zaparoo.Ui
         Zaparoo.Theme
+        Zaparoo.Screens
         Zaparoo.Browse
 )
 
@@ -38,6 +39,7 @@ target_link_libraries(
     PUBLIC
         Qt6::Quick
         zaparoo_ui_componentsplugin
+        zaparoo_ui_screensplugin
         zaparoo_ui_themeplugin
     PRIVATE
         Zaparoo::CompileOptions

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -1,10 +1,11 @@
 // Zaparoo Launcher
-// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
 import QtQuick
 import QtQuick.Window
 import Zaparoo.Theme
+import Zaparoo.Screens
 import Zaparoo.Browse as Browse
 
 // cxx-qt 0.7 doesn't emit FINAL markers in plugin.qmltypes, so qmllint
@@ -13,8 +14,11 @@ import Zaparoo.Browse as Browse
 // qmllint disable compiler
 
 // Runtime wrapper around MainLayout. The visual tree lives in
-// MainLayout.qml (editable by designers in Qt Design Studio); this
-// file carries the state machine, key input, and persistence.
+// MainLayout.qml (editable by designers in Qt Design Studio) and the
+// individual screens in Zaparoo.Screens; this file is a thin router
+// that translates raw Qt key events into actions, dispatches them to
+// the active screen (or topmost modal), and persists user-visible
+// navigation state across kills.
 MainLayout {
     id: root
 
@@ -47,32 +51,23 @@ MainLayout {
         // Kick the restore chain manually; the set_category cascade re-fires
         // SystemsModel.modelReset (now wired) which cascades into GamesModel.
         if (Browse.CategoriesModel.count > 0)
-            root.restoreFromCategoriesReset()
+            root.hubScreen.restoreFromCategoriesReset()
     }
 
     // Seed carousel indices from persisted state when models deliver new data.
     // A miss (category renamed, ROM deleted) falls back to index 0 and leaves
     // the saved identifier untouched on disk — so the user's intent survives
-    // a transient catalog gap. State writes only happen in handleKey (user
-    // navigation); these programmatic seeds are inert with respect to state.
+    // a transient catalog gap. State writes only happen in each screen's
+    // handleAction (user navigation); these programmatic seeds are inert.
     //
     // Always cascade into set_category (even on a miss or first-launch empty
     // HubState.category): SystemsModel is the only way to drive the next
     // onModelReset handler, and a games-screen restore depends on that chain
     // firing so GamesModel.set_system runs.
-    function restoreFromCategoriesReset(): void {
-        const savedCategory = Browse.HubState.category
-        const idx = savedCategory === "" ? -1 : Browse.CategoriesModel.index_for_category(savedCategory)
-        const chosenIndex = idx >= 0 ? idx : 0
-        const chosenCategory = idx >= 0 ? savedCategory : Browse.CategoriesModel.category_at(chosenIndex)
-        root.categoriesCarousel.currentIndex = chosenIndex
-        Browse.SystemsModel.set_category(chosenCategory)
-    }
-
     Connections {
         target: Browse.CategoriesModel
         function onModelReset(): void {
-            root.restoreFromCategoriesReset()
+            root.hubScreen.restoreFromCategoriesReset()
         }
     }
     Connections {
@@ -103,84 +98,61 @@ MainLayout {
         }
     }
 
-    // Returns true if the carousel actually moved. Callers use this to gate
-    // persistence writes — navigating an empty carousel must not overwrite
-    // saved state with "" (the `_at(-1)` or `_at(0)` fallback on an empty
-    // model).
-    function navigateCarousel(carousel, delta): bool {
-        if (carousel.itemCount <= 0)
-            return false
-        carousel.currentIndex = (carousel.currentIndex + delta + carousel.itemCount) % carousel.itemCount
-        return true
+    // Cross-screen transitions: each screen signals its intent and this
+    // router writes persistence + flips ScreenManager. Keeps the screens
+    // themselves ignorant of AppState so they can be reused in test
+    // harnesses that don't wire the full persistence layer.
+    Connections {
+        target: root.hubScreen
+        function onRequestGamesScreen(): void {
+            ScreenManager.activeScreen = root.screenGames
+            Browse.AppState.active_screen = root.screenGames
+        }
+        function onRequestQuit(): void {
+            Qt.quit()
+        }
+    }
+    Connections {
+        target: root.gamesScreen
+        function onRequestHubScreen(): void {
+            ScreenManager.activeScreen = root.screenHub
+            Browse.AppState.active_screen = root.screenHub
+        }
+    }
+    // Persist hub section flips (categories ↔ systems) — those don't
+    // trigger a cross-screen signal, but the section change is user
+    // intent we want on disk.
+    Connections {
+        target: root.hubScreen
+        function onSectionChanged(): void {
+            Browse.HubState.focus = root.hubScreen.section
+        }
     }
 
-    // Navigation key router. Called by the focus Item's Keys.onPressed and
-    // directly from tests (offscreen key routing is unreliable). Every
-    // user-initiated selection change writes through to the persisted state
-    // singletons *here* — the carousels themselves don't persist on index
-    // change, so programmatic seeds during restore leave disk state intact.
-    function handleKey(key) {
-        if (root.activeScreen === root.screenGames) {
-            if (key === Qt.Key_Left) {
-                if (navigateCarousel(root.gamesCarousel, -1))
-                    Browse.GamesState.game_path = Browse.GamesModel.path_at(root.gamesCarousel.currentIndex)
-            } else if (key === Qt.Key_Right) {
-                if (navigateCarousel(root.gamesCarousel, 1))
-                    Browse.GamesState.game_path = Browse.GamesModel.path_at(root.gamesCarousel.currentIndex)
-            } else if (key === Qt.Key_Return || key === Qt.Key_Enter) {
-                if (root.gamesCarousel.itemCount > 0) {
-                    // Persist before handing control away. Left/Right already
-                    // writes game_path on every move, but the user may press
-                    // Enter on the first highlighted game without navigating,
-                    // leaving game_path stale from a prior system. Writing
-                    // here makes the commit explicit so a kill during launch
-                    // resumes on the correct game.
-                    Browse.GamesState.game_path = Browse.GamesModel.path_at(root.gamesCarousel.currentIndex)
-                    Browse.GamesModel.launch_at(root.gamesCarousel.currentIndex)
-                }
-            } else if (key === Qt.Key_Escape || key === Qt.Key_Backspace) {
-                root.activeScreen = root.screenHub
-                Browse.AppState.active_screen = root.screenHub
-            }
-        } else if (root.hubFocus === root.focusSystems) {
-            if (key === Qt.Key_Left) {
-                if (navigateCarousel(root.systemsCarousel, -1))
-                    Browse.HubState.system_id = Browse.SystemsModel.system_id_at(root.systemsCarousel.currentIndex)
-            } else if (key === Qt.Key_Right) {
-                if (navigateCarousel(root.systemsCarousel, 1))
-                    Browse.HubState.system_id = Browse.SystemsModel.system_id_at(root.systemsCarousel.currentIndex)
-            } else if (key === Qt.Key_Return || key === Qt.Key_Enter) {
-                if (root.systemsCarousel.itemCount > 0) {
-                    const chosen = Browse.SystemsModel.system_id_at(root.systemsCarousel.currentIndex)
-                    Browse.GamesModel.set_system(chosen)
-                    Browse.HubState.system_id = chosen
-                    Browse.GamesState.system_id = chosen
-                }
-                root.activeScreen = root.screenGames
-                Browse.AppState.active_screen = root.screenGames
-            } else if (key === Qt.Key_Escape || key === Qt.Key_Backspace) {
-                root.hubFocus = root.focusCategories
-                Browse.HubState.focus = root.focusCategories
-            }
-        } else {
-            if (key === Qt.Key_Left) {
-                if (navigateCarousel(root.categoriesCarousel, -1))
-                    Browse.HubState.category = Browse.CategoriesModel.category_at(root.categoriesCarousel.currentIndex)
-            } else if (key === Qt.Key_Right) {
-                if (navigateCarousel(root.categoriesCarousel, 1))
-                    Browse.HubState.category = Browse.CategoriesModel.category_at(root.categoriesCarousel.currentIndex)
-            } else if (key === Qt.Key_Return || key === Qt.Key_Enter) {
-                if (root.categoriesCarousel.itemCount > 0) {
-                    const chosen = Browse.CategoriesModel.category_at(root.categoriesCarousel.currentIndex)
-                    Browse.SystemsModel.set_category(chosen)
-                    Browse.HubState.category = chosen
-                }
-                root.hubFocus = root.focusSystems
-                Browse.HubState.focus = root.focusSystems
-            } else if (key === Qt.Key_Escape || key === Qt.Key_Backspace) {
-                Qt.quit()
-            }
+    // Action router. Called from handleKey (which translates Qt key
+    // codes via Browse.Input.action_for_key) and directly from tests.
+    // Dispatches to the top modal if any, otherwise the active screen.
+    function handleAction(action: string): void {
+        if (ScreenManager.hasModal) {
+            // Modal overlays are a forward-looking extension; no modal
+            // components exist yet, so just swallow input while one is
+            // on the stack rather than leak it to the root screen.
+            return
         }
+        if (root.activeScreen === root.screenGames) {
+            root.gamesScreen.handleAction(action)
+        } else {
+            root.hubScreen.handleAction(action)
+        }
+    }
+
+    // Thin boundary shim kept for back-compat with tst_navigation.qml.
+    // Delegates to handleAction so the state machine has a single entry
+    // point regardless of input source.
+    function handleKey(key): void {
+        const action = Browse.Input.action_for_key(key)
+        if (action !== "")
+            root.handleAction(action)
     }
 
     Item {

--- a/src/ui/app/MainLayout.qml
+++ b/src/ui/app/MainLayout.qml
@@ -1,5 +1,5 @@
 // Zaparoo Launcher
-// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
 import QtQuick
@@ -7,13 +7,12 @@ import QtQuick.Window
 import QtQuick.Controls
 import Zaparoo.Ui
 import Zaparoo.Theme
+import Zaparoo.Screens
 import Zaparoo.Browse as Browse
 
 // cxx-qt 0.7 doesn't emit FINAL markers in plugin.qmltypes, so qmllint
 // flags every call on a Zaparoo.Browse singleton as "can be shadowed".
-// Nearly every binding in this form touches one, so silence the whole
-// category here. Remove after the cxx-qt 0.8 upgrade (which fixes the
-// qmltypes emission).
+// Remove after the cxx-qt 0.8 upgrade.
 // qmllint disable compiler
 
 // Visual tree. Edit this file in Qt Design Studio; the state machine
@@ -24,18 +23,19 @@ import Zaparoo.Browse as Browse
 ApplicationWindow {
     id: root
 
-    // Screen/focus state constants — referenced by bindings below and
-    // by Main.qml. Declared here so the layout's own bindings resolve
-    // without depending on the wrapper.
-    readonly property string screenHub: "hub"
-    readonly property string screenGames: "games"
-    readonly property string focusCategories: "categories"
-    readonly property string focusSystems: "systems"
+    // Screen/focus constants re-exported from the manager + HubScreen so
+    // tests and Main.qml can reference them without importing both.
+    readonly property string screenHub: ScreenManager.screenHub
+    readonly property string screenGames: ScreenManager.screenGames
+    readonly property string focusCategories: hubScreen.focusCategories
+    readonly property string focusSystems: hubScreen.focusSystems
 
-    // Runtime state the wrapper mutates; the layout binds against them.
+    // Runtime state. `activeScreen` mirrors ScreenManager's property
+    // (two-way synced below so direct assignment from tests still
+    // works). `hubFocus` aliases HubScreen's internal focus.
     property bool fullScreen: false
-    property string activeScreen: root.screenHub
-    property string hubFocus: root.focusCategories
+    property string activeScreen: ScreenManager.activeScreen
+    property alias hubFocus: hubScreen.section
 
     // Drives the hub↔games slide transition. 0 = hub centred; width = games centred.
     property real screenOffset: root.activeScreen === root.screenGames ? root.width : 0
@@ -47,18 +47,38 @@ ApplicationWindow {
     height: 720
     visible: true
     visibility: root.fullScreen ? Window.FullScreen : Window.Windowed
-    title: "Zaparoo Launcher"
+    title: qsTr("Zaparoo Launcher")
 
-    // Aliases so the Main.qml wrapper can drive the carousels (ids
-    // declared inside this file aren't visible from the extending file).
-    property alias categoriesCarousel: categoriesCarousel
-    property alias systemsCarousel: systemsCarousel
-    property alias gamesCarousel: gamesCarousel
+    // Aliases so Main.qml (and existing tests) can drive the carousels
+    // without reaching through nested component ids.
+    property alias categoriesCarousel: hubScreen.categoriesCarousel
+    property alias systemsCarousel: hubScreen.systemsCarousel
+    property alias gamesCarousel: gamesScreen.gamesCarousel
+
+    // Screen/manager plumbing exposed for Main.qml's orchestration.
+    property alias hubScreen: hubScreen
+    property alias gamesScreen: gamesScreen
 
     Behavior on screenOffset {
         NumberAnimation {
             duration: 220
             easing.type: Easing.OutCubic
+        }
+    }
+
+    // Two-way sync between root.activeScreen and ScreenManager.activeScreen.
+    // Binding-breaking assignments (tests setting root.activeScreen = "games")
+    // still propagate to ScreenManager; ScreenManager changes (from the
+    // screens) still update root.activeScreen.
+    onActiveScreenChanged: {
+        if (ScreenManager.activeScreen !== root.activeScreen)
+            ScreenManager.activeScreen = root.activeScreen
+    }
+    Connections {
+        target: ScreenManager
+        function onActiveScreenChanged(): void {
+            if (root.activeScreen !== ScreenManager.activeScreen)
+                root.activeScreen = ScreenManager.activeScreen
         }
     }
 
@@ -81,125 +101,21 @@ ApplicationWindow {
         source: "qrc:/qt/qml/Zaparoo/App/resources/images/logo.png"
     }
 
-    // ── Hub screen ────────────────────────────────────────────────────────────
+    // ── Screen containers ─────────────────────────────────────────────────────
 
-    Item {
-        id: hubContainer
+    HubScreen {
+        id: hubScreen
         x: -root.screenOffset
         width: parent.width
         height: parent.height
-
-        Carousel {
-            id: categoriesCarousel
-
-            anchors.horizontalCenter: parent.horizontalCenter
-            width: parent.width
-            height: Sizing.pctH(20)
-            y: root.hubFocus === root.focusSystems ? Sizing.pctH(12) : Sizing.pctH(35)
-            coverWidth: Sizing.pctH(20)
-            coverHeight: Sizing.pctH(20)
-            coverSpacing: Sizing.pctH(23)
-
-            model: Browse.CategoriesModel
-            delegate: TextTileDelegate {}
-            placeholderCover: ""
-
-            Behavior on y {
-                NumberAnimation {
-                    duration: 250
-                    easing.type: Easing.OutQuad
-                }
-            }
-        }
-
-        Carousel {
-            id: systemsCarousel
-
-            anchors.horizontalCenter: parent.horizontalCenter
-            width: parent.width
-            height: Sizing.pctH(20)
-            y: Sizing.pctH(36)
-            visible: root.hubFocus === root.focusSystems
-            coverWidth: Sizing.pctH(20)
-            coverHeight: Sizing.pctH(20)
-            coverSpacing: Sizing.pctH(23)
-
-            model: Browse.SystemsModel
-            delegate: TextTileDelegate {}
-            placeholderCover: ""
-        }
-
-        Text {
-            anchors.horizontalCenter: parent.horizontalCenter
-            y: systemsCarousel.y + systemsCarousel.height + Sizing.pctH(1)
-            visible: root.hubFocus === root.focusSystems
-            // Reading Browse.SystemsModel.count registers the binding for
-            // model resets; the comparison is always true so the result
-            // is the system name at the current carousel index.
-            text: Browse.SystemsModel.count >= 0
-                  ? Browse.SystemsModel.system_name_at(systemsCarousel.currentIndex)
-                  : ""
-            font.family: Theme.fontRetro
-            font.pixelSize: Sizing.fontSize(4)
-            color: Theme.textPrimary
-            renderType: Text.NativeRendering
-        }
     }
 
-    // ── Games screen ──────────────────────────────────────────────────────────
-
-    Item {
-        id: gamesContainer
+    GamesScreen {
+        id: gamesScreen
         x: parent.width - root.screenOffset
         width: parent.width
         height: parent.height
-
-        Carousel {
-            id: gamesCarousel
-
-            anchors.horizontalCenter: parent.horizontalCenter
-            y: Sizing.pctH(12)
-            width: parent.width
-            height: Sizing.pctH(55)
-            opacity: Browse.GamesModel.loading ? 0.5 : 1.0
-            model: root.activeScreen === root.screenGames ? Browse.GamesModel : null
-            delegate: CoverDelegate {}
-            placeholderCover: "qrc:/qt/qml/Zaparoo/App/resources/images/placeholder/cover_generic.png"
-
-            Behavior on opacity {
-                NumberAnimation {
-                    duration: 100
-                }
-            }
-        }
-
-        Text {
-            anchors.centerIn: gamesCarousel
-            visible: (Browse.GamesModel.error_message ?? "") !== ""
-            text: Browse.GamesModel.error_message ?? ""
-            font.family: Theme.fontRetro
-            font.pixelSize: Sizing.fontSize(3)
-            color: Theme.textDim
-            wrapMode: Text.WordWrap
-            horizontalAlignment: Text.AlignHCenter
-            width: parent.width * 0.7
-            renderType: Text.NativeRendering
-        }
-
-        Text {
-            anchors.horizontalCenter: parent.horizontalCenter
-            anchors.top: gamesCarousel.bottom
-            anchors.topMargin: Sizing.pctH(1)
-            // See _selectedSystemName note above — reading count here
-            // registers the binding for model-reset updates.
-            text: Browse.GamesModel.count >= 0
-                  ? Browse.GamesModel.name_at(gamesCarousel.currentIndex)
-                  : ""
-            font.family: Theme.fontRetro
-            font.pixelSize: Sizing.fontSize(4)
-            color: Theme.textPrimary
-            renderType: Text.NativeRendering
-        }
+        active: root.activeScreen === root.screenGames
     }
 
     // ── FPS counter ───────────────────────────────────────────────────────────
@@ -210,6 +126,53 @@ ApplicationWindow {
         anchors.topMargin: Sizing.pctH(1)
         anchors.rightMargin: Sizing.pctW(1)
         z: 200
+    }
+
+    // ── Connection status strip ───────────────────────────────────────────────
+    //
+    // Shown only when Core is unreachable or the catalog failed to load;
+    // otherwise the strip is hidden and takes no space. Connection state
+    // constants mirror rust/launcher/src/models/app_status.rs:
+    //   0 DISCONNECTED · 1 CONNECTING · 2 READY · 3 ERROR.
+
+    Rectangle {
+        id: statusStrip
+
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: instructionsBar.top
+        height: visible ? Sizing.pctH(4) : 0
+        visible: Browse.AppStatus.connection_state !== 2
+        color: Theme.bgBar
+        border.width: 1
+        // White border on ERROR draws the eye to the strip; the muted
+        // border on CONNECTING/DISCONNECTED keeps it informational.
+        border.color: Browse.AppStatus.connection_state === 3
+                      ? Theme.textPrimary
+                      : Theme.borderSubtle
+        z: 150
+
+        Text {
+            anchors.centerIn: parent
+            // `%1` placeholder keeps translators in charge of word order —
+            // some languages won't lead with "Core error". `last_error`
+            // is untranslated (it's the Rust-side error string) on purpose.
+            text: {
+                const state = Browse.AppStatus.connection_state;
+                if (state === 3) {
+                    const msg = Browse.AppStatus.last_error ?? "";
+                    return msg !== ""
+                        ? qsTr("Core error: %1").arg(msg)
+                        : qsTr("Core error");
+                }
+                if (state === 1) return qsTr("Connecting to Zaparoo Core…");
+                return qsTr("Disconnected from Zaparoo Core");
+            }
+            font.family: Theme.fontRetro
+            font.pixelSize: Sizing.fontSize(2.5)
+            color: Theme.textPrimary
+            renderType: Text.NativeRendering
+        }
     }
 
     // ── Instructions bar ──────────────────────────────────────────────────────
@@ -228,10 +191,10 @@ ApplicationWindow {
         Text {
             anchors.centerIn: parent
             text: root.activeScreen === root.screenGames
-                  ? "[<>] GAME  [OK] PLAY  [ESC] BACK"
+                  ? qsTr("[<>] GAME  [OK] PLAY  [ESC] BACK")
                   : (root.hubFocus === root.focusSystems
-                     ? "[<>] SYSTEM  [OK] GAMES  [ESC] BACK"
-                     : "[<>] CATEGORY  [OK] SELECT  [ESC] QUIT")
+                     ? qsTr("[<>] SYSTEM  [OK] GAMES  [ESC] BACK")
+                     : qsTr("[<>] CATEGORY  [OK] SELECT  [ESC] QUIT"))
             font.family: Theme.fontRetro
             font.pixelSize: Sizing.fontSize(2.5)
             color: Theme.textDim

--- a/src/ui/components/CMakeLists.txt
+++ b/src/ui/components/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Zaparoo Launcher
-# Copyright (c) 2026 The Zaparoo Project Contributors.
+# Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 # SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
 qt_add_library(zaparoo_ui_components STATIC)

--- a/src/ui/components/Carousel.qml
+++ b/src/ui/components/Carousel.qml
@@ -1,5 +1,5 @@
 // Zaparoo Launcher
-// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 pragma ComponentBehavior: Bound
 

--- a/src/ui/components/CoverDelegate.qml
+++ b/src/ui/components/CoverDelegate.qml
@@ -1,5 +1,5 @@
 // Zaparoo Launcher
-// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
 import QtQuick

--- a/src/ui/components/FpsCounter.qml
+++ b/src/ui/components/FpsCounter.qml
@@ -1,5 +1,5 @@
 // Zaparoo Launcher
-// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
 import QtQuick
@@ -32,7 +32,9 @@ Item {
     Text {
         anchors.top: parent.top
         anchors.right: parent.right
-        text: root.fps + " FPS"
+        // `%1 FPS` stays one string so translators can reorder ("FPS %1")
+        // without splitting the label from the number.
+        text: qsTr("%1 FPS").arg(root.fps)
         font.family: Theme.fontMono
         font.pixelSize: Sizing.fontSize(2)
         color: root.fps >= 55 ? "#00ff00" : (root.fps >= 30 ? "#ffff00" : "#ff0000")

--- a/src/ui/components/TextTileDelegate.qml
+++ b/src/ui/components/TextTileDelegate.qml
@@ -1,5 +1,5 @@
 // Zaparoo Launcher
-// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
 import QtQuick

--- a/src/ui/screens/CMakeLists.txt
+++ b/src/ui/screens/CMakeLists.txt
@@ -1,0 +1,33 @@
+# Zaparoo Launcher
+# Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+# SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+qt_add_library(zaparoo_ui_screens STATIC)
+
+set_source_files_properties(
+    ScreenManager.qml
+    PROPERTIES QT_QML_SINGLETON_TYPE TRUE
+)
+
+qt_add_qml_module(
+    zaparoo_ui_screens
+    URI Zaparoo.Screens
+    VERSION 1.0
+    QML_FILES
+        ScreenManager.qml
+        HubScreen.qml
+        GamesScreen.qml
+    IMPORTS
+        Zaparoo.Ui
+        Zaparoo.Theme
+        Zaparoo.Browse
+)
+
+target_link_libraries(
+    zaparoo_ui_screens
+    PUBLIC
+        Qt6::Quick
+        zaparoo_ui_componentsplugin
+        zaparoo_ui_themeplugin
+    PRIVATE Zaparoo::CompileOptions
+)

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -1,0 +1,113 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+import QtQuick
+import Zaparoo.Theme
+import Zaparoo.Ui
+import Zaparoo.Browse as Browse
+
+// cxx-qt 0.7 doesn't emit FINAL markers in plugin.qmltypes, so qmllint
+// flags every call on a Zaparoo.Browse singleton as "can be shadowed".
+// Remove after the cxx-qt 0.8 upgrade.
+// qmllint disable compiler
+
+// Games screen — covers carousel driven by `Browse.GamesModel`. Owns
+// the action dispatch for the games subset; emits `requestHubScreen`
+// on Escape so Main.qml can drive the cross-screen transition.
+Item {
+    id: games
+
+    property alias gamesCarousel: gamesCarousel
+
+    // Set by the compositor (MainLayout) from `ScreenManager.activeScreen`.
+    // Gates the games-model binding so the hub screen doesn't pay for
+    // delegate instantiation while it's not in view.
+    property bool active: false
+
+    // Emitted when the user presses Escape — Main.qml flips the
+    // active screen back to the hub.
+    signal requestHubScreen()
+
+    function navigateCarousel(carousel, delta): bool {
+        if (carousel.itemCount <= 0)
+            return false
+        carousel.currentIndex =
+            (carousel.currentIndex + delta + carousel.itemCount) % carousel.itemCount
+        return true
+    }
+
+    function handleAction(action: string): void {
+        if (action === "left") {
+            if (games.navigateCarousel(games.gamesCarousel, -1))
+                Browse.GamesState.game_path =
+                    Browse.GamesModel.path_at(games.gamesCarousel.currentIndex)
+        } else if (action === "right") {
+            if (games.navigateCarousel(games.gamesCarousel, 1))
+                Browse.GamesState.game_path =
+                    Browse.GamesModel.path_at(games.gamesCarousel.currentIndex)
+        } else if (action === "accept") {
+            if (games.gamesCarousel.itemCount > 0) {
+                // Persist before handing control away. Left/Right already
+                // writes game_path on every move, but the user may press
+                // Accept on the first highlighted game without navigating,
+                // leaving game_path stale from a prior system. Writing
+                // here makes the commit explicit so a kill during launch
+                // resumes on the correct game.
+                Browse.GamesState.game_path =
+                    Browse.GamesModel.path_at(games.gamesCarousel.currentIndex)
+                Browse.GamesModel.launch_at(games.gamesCarousel.currentIndex)
+            }
+        } else if (action === "cancel") {
+            games.requestHubScreen()
+        }
+    }
+
+    // ── Visual tree ───────────────────────────────────────────────────────────
+
+    Carousel {
+        id: gamesCarousel
+
+        anchors.horizontalCenter: parent.horizontalCenter
+        y: Sizing.pctH(12)
+        width: parent.width
+        height: Sizing.pctH(55)
+        opacity: Browse.GamesModel.loading ? 0.5 : 1.0
+        model: games.active ? Browse.GamesModel : null
+        delegate: CoverDelegate {}
+        placeholderCover: "qrc:/qt/qml/Zaparoo/App/resources/images/placeholder/cover_generic.png"
+
+        Behavior on opacity {
+            NumberAnimation {
+                duration: 100
+            }
+        }
+    }
+
+    Text {
+        anchors.centerIn: gamesCarousel
+        visible: (Browse.GamesModel.error_message ?? "") !== ""
+        text: Browse.GamesModel.error_message ?? ""
+        font.family: Theme.fontRetro
+        font.pixelSize: Sizing.fontSize(3)
+        color: Theme.textDim
+        wrapMode: Text.WordWrap
+        horizontalAlignment: Text.AlignHCenter
+        width: parent.width * 0.7
+        renderType: Text.NativeRendering
+    }
+
+    Text {
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: gamesCarousel.bottom
+        anchors.topMargin: Sizing.pctH(1)
+        // Reading count registers the binding for model-reset updates.
+        text: Browse.GamesModel.count >= 0
+              ? Browse.GamesModel.name_at(gamesCarousel.currentIndex)
+              : ""
+        font.family: Theme.fontRetro
+        font.pixelSize: Sizing.fontSize(4)
+        color: Theme.textPrimary
+        renderType: Text.NativeRendering
+    }
+}

--- a/src/ui/screens/HubScreen.qml
+++ b/src/ui/screens/HubScreen.qml
@@ -1,0 +1,182 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+import QtQuick
+import Zaparoo.Theme
+import Zaparoo.Ui
+import Zaparoo.Browse as Browse
+
+// cxx-qt 0.7 doesn't emit FINAL markers in plugin.qmltypes, so qmllint
+// flags every call on a Zaparoo.Browse singleton as "can be shadowed".
+// Remove after the cxx-qt 0.8 upgrade.
+// qmllint disable compiler
+
+// Hub screen — categories carousel on top, systems carousel below once
+// the user drills in. Owns its own focus state and navigation actions.
+// See `handleAction` for the state machine and the Connections blocks
+// for the persistence restore cascade.
+Item {
+    id: hub
+
+    readonly property string focusCategories: "categories"
+    readonly property string focusSystems: "systems"
+    // Named `section` — not `focus` — because `Item.focus` is a
+    // built-in bool. Redeclaring it here would override a FINAL
+    // base-class property and fail QML compile.
+    property string section: hub.focusCategories
+
+    // Exposed so MainLayout/tests can reach carousel state without
+    // reaching through nested item ids.
+    property alias categoriesCarousel: categoriesCarousel
+    property alias systemsCarousel: systemsCarousel
+
+    // Emitted when the user presses Enter on a populated systems
+    // carousel — Main.qml handles the screen flip via ScreenManager
+    // and persistence writes. Emitted on empty carousels too so the
+    // user's intent to switch screens is still honoured.
+    signal requestGamesScreen()
+
+    // Emitted when the user presses Escape from the categories focus.
+    // Main.qml decides whether to quit or dismiss a modal.
+    signal requestQuit()
+
+    // Restore the hub from the persisted `Browse.HubState.category`
+    // (or index 0 if the saved value is missing from the model). Always
+    // cascades into `SystemsModel.set_category` so the systems-model
+    // reset handler fires and drives the next step of the restore chain.
+    function restoreFromCategoriesReset(): void {
+        const savedCategory = Browse.HubState.category
+        const idx = savedCategory === ""
+                    ? -1
+                    : Browse.CategoriesModel.index_for_category(savedCategory)
+        const chosenIndex = idx >= 0 ? idx : 0
+        const chosenCategory = idx >= 0
+                               ? savedCategory
+                               : Browse.CategoriesModel.category_at(chosenIndex)
+        hub.categoriesCarousel.currentIndex = chosenIndex
+        Browse.SystemsModel.set_category(chosenCategory)
+    }
+
+    // Returns true if the carousel actually moved. Empty carousels leave
+    // disk state alone — see tst_persistence.qml for the regression
+    // guarded against.
+    function navigateCarousel(carousel, delta): bool {
+        if (carousel.itemCount <= 0)
+            return false
+        carousel.currentIndex =
+            (carousel.currentIndex + delta + carousel.itemCount) % carousel.itemCount
+        return true
+    }
+
+    function handleAction(action: string): void {
+        if (hub.section === hub.focusSystems) {
+            hub._handleSystems(action)
+        } else {
+            hub._handleCategories(action)
+        }
+    }
+
+    function _handleCategories(action: string): void {
+        if (action === "left") {
+            if (hub.navigateCarousel(hub.categoriesCarousel, -1))
+                Browse.HubState.category =
+                    Browse.CategoriesModel.category_at(hub.categoriesCarousel.currentIndex)
+        } else if (action === "right") {
+            if (hub.navigateCarousel(hub.categoriesCarousel, 1))
+                Browse.HubState.category =
+                    Browse.CategoriesModel.category_at(hub.categoriesCarousel.currentIndex)
+        } else if (action === "accept") {
+            if (hub.categoriesCarousel.itemCount > 0) {
+                const chosen =
+                    Browse.CategoriesModel.category_at(hub.categoriesCarousel.currentIndex)
+                Browse.SystemsModel.set_category(chosen)
+                Browse.HubState.category = chosen
+            }
+            hub.section = hub.focusSystems
+        } else if (action === "cancel") {
+            hub.requestQuit()
+        }
+    }
+
+    function _handleSystems(action: string): void {
+        if (action === "left") {
+            if (hub.navigateCarousel(hub.systemsCarousel, -1))
+                Browse.HubState.system_id =
+                    Browse.SystemsModel.system_id_at(hub.systemsCarousel.currentIndex)
+        } else if (action === "right") {
+            if (hub.navigateCarousel(hub.systemsCarousel, 1))
+                Browse.HubState.system_id =
+                    Browse.SystemsModel.system_id_at(hub.systemsCarousel.currentIndex)
+        } else if (action === "accept") {
+            if (hub.systemsCarousel.itemCount > 0) {
+                const chosen =
+                    Browse.SystemsModel.system_id_at(hub.systemsCarousel.currentIndex)
+                Browse.GamesModel.set_system(chosen)
+                Browse.HubState.system_id = chosen
+                Browse.GamesState.system_id = chosen
+            }
+            hub.requestGamesScreen()
+        } else if (action === "cancel") {
+            hub.section = hub.focusCategories
+        }
+    }
+
+    // ── Visual tree ───────────────────────────────────────────────────────────
+
+    Carousel {
+        id: categoriesCarousel
+
+        anchors.horizontalCenter: parent.horizontalCenter
+        width: parent.width
+        height: Sizing.pctH(20)
+        y: hub.section === hub.focusSystems ? Sizing.pctH(12) : Sizing.pctH(35)
+        coverWidth: Sizing.pctH(20)
+        coverHeight: Sizing.pctH(20)
+        coverSpacing: Sizing.pctH(23)
+
+        model: Browse.CategoriesModel
+        delegate: TextTileDelegate {}
+        placeholderCover: ""
+
+        Behavior on y {
+            NumberAnimation {
+                duration: 250
+                easing.type: Easing.OutQuad
+            }
+        }
+    }
+
+    Carousel {
+        id: systemsCarousel
+
+        anchors.horizontalCenter: parent.horizontalCenter
+        width: parent.width
+        height: Sizing.pctH(20)
+        y: Sizing.pctH(36)
+        visible: hub.section === hub.focusSystems
+        coverWidth: Sizing.pctH(20)
+        coverHeight: Sizing.pctH(20)
+        coverSpacing: Sizing.pctH(23)
+
+        model: Browse.SystemsModel
+        delegate: TextTileDelegate {}
+        placeholderCover: ""
+    }
+
+    Text {
+        anchors.horizontalCenter: parent.horizontalCenter
+        y: systemsCarousel.y + systemsCarousel.height + Sizing.pctH(1)
+        visible: hub.section === hub.focusSystems
+        // Reading Browse.SystemsModel.count registers the binding for
+        // model resets; the comparison is always true so the result
+        // is the system name at the current carousel index.
+        text: Browse.SystemsModel.count >= 0
+              ? Browse.SystemsModel.system_name_at(systemsCarousel.currentIndex)
+              : ""
+        font.family: Theme.fontRetro
+        font.pixelSize: Sizing.fontSize(4)
+        color: Theme.textPrimary
+        renderType: Text.NativeRendering
+    }
+}

--- a/src/ui/screens/ScreenManager.qml
+++ b/src/ui/screens/ScreenManager.qml
@@ -1,0 +1,47 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+pragma Singleton
+
+import QtQuick
+
+// App-wide screen + modal routing. Screens are identified by plain strings
+// so a new screen can be added without a central enum; see HubScreen.qml
+// and GamesScreen.qml for the current registrants. Modal overlays push
+// onto the stack; the top is the one currently receiving input.
+QtObject {
+    id: manager
+
+    // Screen name constants. Re-exported by MainLayout for test back-compat.
+    readonly property string screenHub: "hub"
+    readonly property string screenGames: "games"
+
+    // Currently-focused root screen. Persistence lives in
+    // Browse.AppState — write there via Main.qml's orchestration, not
+    // here, so we stay decoupled from the persistence layer.
+    property string activeScreen: manager.screenHub
+
+    // Modal stack — transient. Top of stack receives input; empty stack
+    // means the active root screen handles input.
+    property list<string> modalStack: []
+
+    readonly property int modalCount: manager.modalStack.length
+    readonly property bool hasModal: manager.modalStack.length > 0
+    readonly property string topModal: manager.modalStack.length > 0
+                                       ? manager.modalStack[manager.modalStack.length - 1]
+                                       : ""
+
+    function go(screen: string): void {
+        manager.activeScreen = screen
+    }
+
+    function pushModal(name: string): void {
+        manager.modalStack = manager.modalStack.concat([name])
+    }
+
+    function popModal(): void {
+        if (manager.modalStack.length > 0)
+            manager.modalStack = manager.modalStack.slice(0, manager.modalStack.length - 1)
+    }
+}

--- a/src/ui/theme/CMakeLists.txt
+++ b/src/ui/theme/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Zaparoo Launcher
-# Copyright (c) 2026 The Zaparoo Project Contributors.
+# Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 # SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
 qt_add_library(zaparoo_ui_theme STATIC)

--- a/src/ui/theme/Sizing.qml
+++ b/src/ui/theme/Sizing.qml
@@ -1,5 +1,5 @@
 // Zaparoo Launcher
-// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 pragma Singleton
 

--- a/src/ui/theme/Theme.qml
+++ b/src/ui/theme/Theme.qml
@@ -1,5 +1,5 @@
 // Zaparoo Launcher
-// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 pragma Singleton
 

--- a/src/ui/translations/launcher_en.ts
+++ b/src/ui/translations/launcher_en.ts
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="en" sourcelanguage="en">
+<!--
+    Zaparoo Launcher — English base translation.
+
+    This file is the canonical source of user-visible strings. Regenerate
+    with `lupdate` after adding or changing a `qsTr()` call:
+
+        lupdate src/ -ts src/ui/translations/launcher_en.ts
+
+    lrelease is invoked automatically by CMake (`qt_add_translations`)
+    at build time and embeds the compiled `.qm` into the launcher binary
+    under `qrc:/i18n/`. See docs/translations.md for the full workflow.
+
+    English strings use the source text verbatim (no <translation> needed);
+    a translation pass for another locale copies this file to
+    `launcher_<tag>.ts` and fills in each <translation> element.
+-->
+</TS>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Zaparoo Launcher
-# Copyright (c) 2026 The Zaparoo Project Contributors.
+# Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 # SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
 add_subdirectory(ui)

--- a/tests/ui/CMakeLists.txt
+++ b/tests/ui/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Zaparoo Launcher
-# Copyright (c) 2026 The Zaparoo Project Contributors.
+# Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 # SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
 qt_add_executable(tst_ui tst_main.cpp)
@@ -17,6 +17,7 @@ qt_add_qml_module(
         Zaparoo.App
         Zaparoo.Browse
         Zaparoo.Ui
+        Zaparoo.Screens
         Zaparoo.Theme
 )
 
@@ -34,6 +35,7 @@ target_link_libraries(
         zaparoo_launcher_rs
         zaparoo_ui_appplugin
         zaparoo_ui_componentsplugin
+        zaparoo_ui_screensplugin
         zaparoo_ui_themeplugin
         Qt6::QuickTest
         Qt6::Quick

--- a/tests/ui/tst_main.cpp
+++ b/tests/ui/tst_main.cpp
@@ -1,5 +1,5 @@
 // Zaparoo Launcher
-// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
 #include <QDir>

--- a/tests/ui/tst_navigation.qml
+++ b/tests/ui/tst_navigation.qml
@@ -1,5 +1,5 @@
 // Zaparoo Launcher
-// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
 import QtQuick

--- a/tests/ui/tst_persistence.qml
+++ b/tests/ui/tst_persistence.qml
@@ -1,5 +1,5 @@
 // Zaparoo Launcher
-// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
 import QtQuick

--- a/tests/ui/tst_sizing.qml
+++ b/tests/ui/tst_sizing.qml
@@ -1,5 +1,5 @@
 // Zaparoo Launcher
-// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
 import QtQuick

--- a/tests/ui/tst_smoke.qml
+++ b/tests/ui/tst_smoke.qml
@@ -1,5 +1,5 @@
 // Zaparoo Launcher
-// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
 import QtQuick


### PR DESCRIPTION
## Summary

Lands the work needed to take outside PRs cleanly. Everything below ships together because the pieces depend on each other (contributors need mock-core to run without a real Core, screens need i18n to be reviewable, AppStatus needs the broadcast→watch fix to actually work, etc.).

### CLA + repo housekeeping
- `.github/CLA.md`, `.github/contributors/signatures.json`, `cla.yml` workflow
- `CODEOWNERS`, `pull_request_template.md`
- `CONTRIBUTING.md`, `COPYING` update

### Contributor docs
- `docs/quickstart.md` — clone → build → mock-core → run path
- `docs/translations.md` — qsTr pipeline, lupdate/lrelease, locale resolution
- `docs/architecture.md`, `docs/building.md`, `docs/qml-gotchas.md` updates

### Mock Core (`rust/mock-core/`)
Standalone WebSocket server with a baked-in fixture (3 categories, 10 systems, 50 games) so contributors can run the launcher end-to-end without a real Zaparoo Core. `just mock-core` plus `just run-dev` boots the full stack against `ws://127.0.0.1:27497` (port deliberately offset from real Core's 7497).

### Translations pipeline
- `qsTr()` at every user-visible call site (QML + C++)
- `src/ui/translations/launcher_en.ts` as the canonical catalogue
- `qt_add_translations` in `cmake/ZaparooRust.cmake` bundling `.qm` under `qrc:/i18n/`
- Locale resolved from `[general] language` in `launcher.toml`; `"auto"` → `QLocale::system()`

### UI architecture
- `src/ui/screens/` module: `ScreenManager` singleton + `HubScreen` + `GamesScreen` so the visual tree splits cleanly
- `Main.qml` is now a thin router; `MainLayout.qml` is the declarative tree for Qt Design Studio editing
- `Browse.AppStatus` singleton: merges WebSocket link state + catalog RPC status into a single `connection_state` property + `last_error` string, rendered as a status strip when Core is unreachable
- `Browse.Input` singleton + `zaparoo-core` `input_actions` module: keys map to action names (`"up"`, `"accept"`) via `[input.keyboard]` in `launcher.toml` so keymap is configurable without code changes

### Correctness fixes
- **`client.connection`: `tokio::sync::broadcast` → `watch`.** Late subscribers (QML singletons whose `initialize()` runs after the WebSocket task) were missing the initial `Connected` event and sitting on `Disconnected` forever. On MiSTer the log showed `connected to core` and the catalog loaded, but the QML status strip permanently said "Disconnected from Zaparoo Core". `AGENTS.md` NEVER section now documents the rule.
- **`Dockerfile.toolchain`: enable host PrintSupport + explicit `FEATURE_linguist=ON`.** Qt's `linguist` feature has condition `TARGET Qt::PrintSupport`, and `qttools/src/linguist/CMakeLists.txt` returns early when that feature is off — taking lupdate / lrelease / lconvert and the `Qt6LinguistTools` CMake package down with it. The ARM32 target qtbase stays `-no-feature-printsupport` since the shipping binary never needs it.

### Build / lint hygiene
- `ZaparooLint.cmake`, `ZaparooCompileOptions.cmake`, `.pre-commit-config.yaml` tweaks
- `rust/deny.toml` + `cargo-deny` wired into `just lint-rust`
- `.github/workflows/ci.yml` + `toolchain-build.yml` updates

## Test plan

- [x] `just lint` — clean (zero warnings on user code)
- [x] `just test` — 68/68 cargo nextest, 1/1 ctest UI suite
- [x] `just mock-core` + `just run-dev` — desktop launcher boots, all three carousels populate from fixture, Enter on a game fires `run` RPC against the mock
- [x] `just deploy-mister` — launcher binary lands on MiSTer; restarts via `MiSTer_Zaparoo`; status strip clears once catalog finishes loading (verified after the broadcast→watch fix)
- [ ] CI green (CLA workflow, lint, tests, toolchain build) — pending PR push
- [ ] Reviewer check: confirm `Browse.AppStatus` strip behaves correctly when killing the mock-core process mid-session (should flip back to "Disconnected" / "Connecting…" / "Core error")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connection status strip showing Core state and error details
  * Initial internationalization: qsTr strings, locale catalogs, runtime locale loading and embedded translations
  * New Hub and Games screens plus ScreenManager for centralized routing and action-based input handling
  * Models now surface Core/network error messages; FPS label is translatable
* **Chores**
  * Added Contributor License Agreement, contributor guide, and PR template
  * Added local mock Core, quickstart, translations docs, and tooling/CI/workflow updates
<!-- end of auto-generated comment: release notes by coderabbit.ai -->