### PR TITLE
refactor(rust): post-foundation hygiene bundle

### DIFF
--- a/rust/launcher/src/models/app_state.rs
+++ b/rust/launcher/src/models/app_state.rs
@@ -7,6 +7,7 @@
 // lives in its own singleton (`Browse.HubState`, `Browse.GamesState`)
 // so a screen can evolve its schema without touching the others.
 
+use crate::models::{with_persist_mut, with_persist_read};
 use cxx_qt::{CxxQtType, Initialize};
 use cxx_qt_lib::QString;
 use std::pin::Pin;
@@ -41,11 +42,7 @@ pub mod ffi {
 
 impl Initialize for ffi::AppState {
     fn initialize(mut self: Pin<&mut Self>) {
-        let shared = crate::models::persist_state();
-        let snapshot = {
-            let guard = shared.lock().expect("persist mutex poisoned");
-            guard.active_screen.clone()
-        };
+        let snapshot = with_persist_read(|s| s.active_screen.clone());
         self.as_mut().rust_mut().active_screen = QString::from(snapshot.as_str());
         // No *_changed emits here: QML bindings haven't attached yet
         // during Initialize, and Main.qml reads the property directly
@@ -66,11 +63,9 @@ impl ffi::AppState {
 }
 
 fn persist_active_screen(value: String) {
-    let shared = crate::models::persist_state();
-    let snapshot = {
-        let mut guard = shared.lock().expect("persist mutex poisoned");
-        guard.active_screen = value;
-        guard.clone()
-    };
+    let snapshot = with_persist_mut(|s| {
+        s.active_screen = value;
+        s.clone()
+    });
     persist::save(&snapshot);
 }

--- a/rust/launcher/src/models/browse.rs
+++ b/rust/launcher/src/models/browse.rs
@@ -3,10 +3,12 @@
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 //
 // Minimal BrowseModel stub — dormant, kept to satisfy the Zaparoo.Browse QML
-// module registration. Full implementation deferred to a future phase.
+// module registration. Full implementation deferred to a future phase. The
+// `enter` / `go_back` / `launch_at` / etc. methods are intentionally absent
+// from the QML surface so a stray call fails at `qmllint` time instead of
+// silently no-opping at runtime.
 
 use cxx_qt_lib::{QByteArray, QHash, QHashPair_i32_QByteArray, QModelIndex, QString, QVariant};
-use std::pin::Pin;
 
 #[derive(Default)]
 pub struct BrowseModelRust {
@@ -44,27 +46,6 @@ pub mod ffi {
         #[qproperty(QString, error_message)]
         type BrowseModel = super::BrowseModelRust;
 
-        #[qinvokable]
-        fn enter(self: Pin<&mut BrowseModel>, index: i32);
-
-        #[qinvokable]
-        fn go_back(self: Pin<&mut BrowseModel>);
-
-        #[qinvokable]
-        fn refresh(self: Pin<&mut BrowseModel>);
-
-        #[qinvokable]
-        fn launch_at(self: Pin<&mut BrowseModel>, index: i32);
-
-        #[qinvokable]
-        fn set_selected_index(self: Pin<&mut BrowseModel>, index: i32);
-
-        #[qinvokable]
-        fn name_at(self: &BrowseModel, index: i32) -> QString;
-
-        #[qinvokable]
-        fn is_folder_at(self: &BrowseModel, index: i32) -> bool;
-
         #[cxx_name = "rowCount"]
         fn row_count(self: &BrowseModel, parent: &QModelIndex) -> i32;
         fn data(self: &BrowseModel, index: &QModelIndex, role: i32) -> QVariant;
@@ -94,19 +75,5 @@ impl ffi::BrowseModel {
         h.insert(256 + 4, QByteArray::from("fileCount"));
         h.insert(256 + 5, QByteArray::from("isFolder"));
         h
-    }
-
-    fn enter(self: Pin<&mut Self>, _index: i32) {}
-    fn go_back(self: Pin<&mut Self>) {}
-    fn refresh(self: Pin<&mut Self>) {}
-    fn launch_at(self: Pin<&mut Self>, _index: i32) {}
-    fn set_selected_index(self: Pin<&mut Self>, _index: i32) {}
-
-    fn name_at(&self, _index: i32) -> QString {
-        QString::default()
-    }
-
-    fn is_folder_at(&self, _index: i32) -> bool {
-        false
     }
 }

--- a/rust/launcher/src/models/games_state.rs
+++ b/rust/launcher/src/models/games_state.rs
@@ -7,6 +7,7 @@
 // highlighted game path. Schema version is checked independently
 // from other screens on load (see `zaparoo_core::persist`).
 
+use crate::models::{with_persist_mut, with_persist_read};
 use cxx_qt::{CxxQtType, Initialize};
 use cxx_qt_lib::QString;
 use std::pin::Pin;
@@ -46,11 +47,7 @@ pub mod ffi {
 
 impl Initialize for ffi::GamesState {
     fn initialize(mut self: Pin<&mut Self>) {
-        let shared = crate::models::persist_state();
-        let snapshot: GamesState = {
-            let guard = shared.lock().expect("persist mutex poisoned");
-            guard.games.clone()
-        };
+        let snapshot: GamesState = with_persist_read(|s| s.games.clone());
         self.as_mut().rust_mut().system_id = QString::from(snapshot.system_id.as_str());
         self.as_mut().rust_mut().game_path = QString::from(snapshot.game_path.as_str());
     }
@@ -79,11 +76,9 @@ impl ffi::GamesState {
 }
 
 fn persist_games<F: FnOnce(&mut GamesState)>(mutator: F) {
-    let shared = crate::models::persist_state();
-    let snapshot = {
-        let mut guard = shared.lock().expect("persist mutex poisoned");
-        mutator(&mut guard.games);
-        guard.clone()
-    };
+    let snapshot = with_persist_mut(|s| {
+        mutator(&mut s.games);
+        s.clone()
+    });
     persist::save(&snapshot);
 }

--- a/rust/launcher/src/models/hub_state.rs
+++ b/rust/launcher/src/models/hub_state.rs
@@ -7,6 +7,7 @@
 // the user last left the hub. Schema version is checked independently
 // from other screens on load (see `zaparoo_core::persist`).
 
+use crate::models::{with_persist_mut, with_persist_read};
 use cxx_qt::{CxxQtType, Initialize};
 use cxx_qt_lib::QString;
 use std::pin::Pin;
@@ -51,11 +52,7 @@ pub mod ffi {
 
 impl Initialize for ffi::HubState {
     fn initialize(mut self: Pin<&mut Self>) {
-        let shared = crate::models::persist_state();
-        let snapshot: HubState = {
-            let guard = shared.lock().expect("persist mutex poisoned");
-            guard.hub.clone()
-        };
+        let snapshot: HubState = with_persist_read(|s| s.hub.clone());
         self.as_mut().rust_mut().focus = QString::from(snapshot.focus.as_str());
         self.as_mut().rust_mut().category = QString::from(snapshot.category.as_str());
         self.as_mut().rust_mut().system_id = QString::from(snapshot.system_id.as_str());
@@ -95,11 +92,9 @@ impl ffi::HubState {
 }
 
 fn persist_hub<F: FnOnce(&mut HubState)>(mutator: F) {
-    let shared = crate::models::persist_state();
-    let snapshot = {
-        let mut guard = shared.lock().expect("persist mutex poisoned");
-        mutator(&mut guard.hub);
-        guard.clone()
-    };
+    let snapshot = with_persist_mut(|s| {
+        mutator(&mut s.hub);
+        s.clone()
+    });
     persist::save(&snapshot);
 }

--- a/rust/launcher/src/models/mod.rs
+++ b/rust/launcher/src/models/mod.rs
@@ -36,6 +36,7 @@ pub mod systems;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, OnceLock};
 use tokio::runtime::Runtime;
+use tracing::error;
 use zaparoo_core::{persist::PersistedState, store::Store};
 
 static RUNTIME: OnceLock<Arc<Runtime>> = OnceLock::new();
@@ -83,4 +84,27 @@ pub fn persist_state() -> Arc<Mutex<PersistedState>> {
         .get()
         .expect("PERSIST_STATE not initialized")
         .clone()
+}
+
+/// Read the persisted state under a closure. Centralises the
+/// lock + log + panic-on-poison chain so the 5+ persist call sites
+/// can't drift in their error message or skip the log breadcrumb.
+pub fn with_persist_read<R>(f: impl FnOnce(&PersistedState) -> R) -> R {
+    let shared = persist_state();
+    let guard = shared
+        .lock()
+        .inspect_err(|e| error!("persist mutex poisoned: {e}"))
+        .expect("persist mutex poisoned");
+    f(&guard)
+}
+
+/// Mutate the persisted state under a closure. Same poisoning
+/// contract as `with_persist_read`.
+pub fn with_persist_mut<R>(f: impl FnOnce(&mut PersistedState) -> R) -> R {
+    let shared = persist_state();
+    let mut guard = shared
+        .lock()
+        .inspect_err(|e| error!("persist mutex poisoned: {e}"))
+        .expect("persist mutex poisoned");
+    f(&mut guard)
 }

--- a/rust/launcher/src/models/systems.rs
+++ b/rust/launcher/src/models/systems.rs
@@ -2,15 +2,9 @@
 // Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
-#![allow(
-    clippy::unwrap_used,
-    reason = "RwLock poisoning signals another thread panicked with the lock held; state is unrecoverable"
-)]
-
 use cxx_qt::CxxQtType;
 use cxx_qt_lib::{QByteArray, QHash, QHashPair_i32_QByteArray, QModelIndex, QString, QVariant};
 use std::pin::Pin;
-use std::sync::{Arc, RwLock};
 use zaparoo_core::endpoints::catalog::CatalogEndpoint;
 use zaparoo_core::remote_resource::ResourceStatus;
 use zaparoo_core::systems_catalog::CatalogData;
@@ -25,25 +19,18 @@ pub struct SystemInfo {
     pub category: String,
 }
 
+#[derive(Default)]
 pub struct SystemsModelRust {
     systems: Vec<SystemInfo>,
     count: i32,
     current_category: QString,
     error_message: QString,
-    // Shared catalog owned by the background task; model reads it on setCategory
-    catalog: Arc<RwLock<Option<CatalogData>>>,
-}
-
-impl Default for SystemsModelRust {
-    fn default() -> Self {
-        Self {
-            systems: Vec::new(),
-            count: 0,
-            current_category: QString::default(),
-            error_message: QString::default(),
-            catalog: Arc::new(RwLock::new(None)),
-        }
-    }
+    // Last-known-good catalog. Updated by `apply_state` on every
+    // `Ready`; never cleared on `Loading`/`Errored`. Lets
+    // `set_category` keep populating rows during a transient refetch
+    // instead of wiping the carousel until the catalog returns to
+    // `Ready`.
+    last_ready: Option<CatalogData>,
 }
 
 #[cxx_qt::bridge]
@@ -121,33 +108,35 @@ fn project(status: &ResourceStatus<CatalogData>) -> (Option<CatalogData>, String
     }
 }
 
+/// Filter `catalog`'s systems to the named category and re-shape them
+/// into the local row type. Returns empty when `catalog` is `None` so
+/// `set_category` and `apply_state` share one filter+map definition.
+fn rows_for_category(catalog: Option<&CatalogData>, cat: &str) -> Vec<SystemInfo> {
+    catalog.map_or_else(Vec::new, |c| {
+        c.systems_by_category(cat)
+            .into_iter()
+            .map(|s| SystemInfo {
+                id: s.id,
+                name: s.name,
+                category: s.category,
+            })
+            .collect()
+    })
+}
+
 fn apply_state(mut model: Pin<&mut ffi::SystemsModel>, (data, err): (Option<CatalogData>, String)) {
     if let Some(data) = data {
-        // Rebuild visible rows directly from `data` — if the user has
-        // already picked a category — *before* moving it into the
-        // shared catalog cache, so we don't have to re-acquire the
-        // read lock to look at what we just wrote.
         let cat = model.rust().current_category.to_string();
         if !cat.is_empty() {
-            let systems = data.systems_by_category(&cat);
-            let count = systems.len() as i32;
-            let rows: Vec<SystemInfo> = systems
-                .into_iter()
-                .map(|s| SystemInfo {
-                    id: s.id,
-                    name: s.name,
-                    category: s.category,
-                })
-                .collect();
+            let rows = rows_for_category(Some(&data), &cat);
+            let count = rows.len() as i32;
             model.as_mut().begin_reset_model();
             model.as_mut().rust_mut().systems = rows;
             model.as_mut().rust_mut().count = count;
             model.as_mut().end_reset_model();
             model.as_mut().count_changed();
         }
-        // Refresh the shared catalog cache that `set_category` reads
-        // so subsequent category switches see the latest data.
-        *model.rust().catalog.write().unwrap() = Some(data);
+        model.as_mut().rust_mut().last_ready = Some(data);
     }
     let qerr = QString::from(err.as_str());
     if model.error_message != qerr {
@@ -187,23 +176,12 @@ impl ffi::SystemsModel {
 
     fn set_category(mut self: Pin<&mut Self>, category: QString) {
         let cat = category.to_string();
-        let systems = self
-            .rust()
-            .catalog
-            .read()
-            .unwrap()
-            .as_ref()
-            .map(|c| c.systems_by_category(&cat))
-            .unwrap_or_default();
-        let count = systems.len() as i32;
-        let rows: Vec<SystemInfo> = systems
-            .into_iter()
-            .map(|s| SystemInfo {
-                id: s.id,
-                name: s.name,
-                category: s.category,
-            })
-            .collect();
+        // Read from `last_ready` rather than the live `ResourceStatus`
+        // so a transient `Loading` (a refetch in flight) doesn't wipe
+        // the carousel between the user's category change and the
+        // refetch completing.
+        let rows = rows_for_category(self.rust().last_ready.as_ref(), &cat);
+        let count = rows.len() as i32;
         self.as_mut().begin_reset_model();
         self.as_mut().rust_mut().systems = rows;
         self.as_mut().rust_mut().count = count;
@@ -236,5 +214,108 @@ impl ffi::SystemsModel {
             .iter()
             .position(|s| s.id == needle)
             .map_or(-1, |i| i as i32)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(
+        clippy::expect_used,
+        clippy::unwrap_used,
+        clippy::panic,
+        reason = "tests should fail-fast on unexpected errors"
+    )]
+
+    use super::{project, rows_for_category};
+    use zaparoo_core::media_types::SystemInfo as MediaSystemInfo;
+    use zaparoo_core::remote_resource::ResourceStatus;
+    use zaparoo_core::systems_catalog::CatalogData;
+
+    fn sys(id: &str, name: &str, category: &str) -> MediaSystemInfo {
+        MediaSystemInfo {
+            id: id.into(),
+            name: name.into(),
+            category: category.into(),
+        }
+    }
+
+    fn catalog_with(systems: Vec<MediaSystemInfo>) -> CatalogData {
+        CatalogData {
+            systems,
+            categories: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn idle_projects_to_no_data_no_error() {
+        let (data, err) = project(&ResourceStatus::Idle);
+        assert!(data.is_none());
+        assert!(err.is_empty());
+    }
+
+    #[test]
+    fn loading_projects_to_no_data_no_error() {
+        let (data, err) = project(&ResourceStatus::Loading);
+        assert!(data.is_none());
+        assert!(err.is_empty());
+    }
+
+    #[test]
+    fn ready_projects_data_and_no_error() {
+        let catalog = catalog_with(vec![sys("smb", "SMB", "Consoles")]);
+        let (data, err) = project(&ResourceStatus::Ready(catalog));
+        assert!(data.is_some());
+        assert!(err.is_empty());
+        assert_eq!(data.unwrap().systems.len(), 1);
+    }
+
+    #[test]
+    fn errored_projects_message_and_no_data() {
+        let status: ResourceStatus<CatalogData> = ResourceStatus::Errored {
+            message: "boom".into(),
+            retrying: false,
+        };
+        let (data, err) = project(&status);
+        assert!(data.is_none());
+        assert_eq!(err, "boom");
+    }
+
+    #[test]
+    fn errored_with_retrying_still_propagates_message() {
+        let status: ResourceStatus<CatalogData> = ResourceStatus::Errored {
+            message: "reconnecting".into(),
+            retrying: true,
+        };
+        let (data, err) = project(&status);
+        assert!(data.is_none());
+        assert_eq!(err, "reconnecting");
+    }
+
+    #[test]
+    fn rows_for_category_none_returns_empty() {
+        let rows = rows_for_category(None, "Arcade");
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn rows_for_category_filters_and_reshapes() {
+        let catalog = catalog_with(vec![
+            sys("smb", "Super Mario Bros", "Consoles"),
+            sys("snk", "SNK Heroes", "Arcade"),
+            sys("zelda", "Zelda", "Consoles"),
+        ]);
+        let rows = rows_for_category(Some(&catalog), "Consoles");
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].id, "smb");
+        assert_eq!(rows[0].name, "Super Mario Bros");
+        assert_eq!(rows[0].category, "Consoles");
+        assert_eq!(rows[1].id, "zelda");
+    }
+
+    #[test]
+    fn rows_for_category_unknown_returns_empty() {
+        let catalog = catalog_with(vec![sys("smb", "SMB", "Consoles")]);
+        let rows = rows_for_category(Some(&catalog), "DoesNotExist");
+        assert!(rows.is_empty());
     }
 }

--- a/rust/zaparoo-core/src/endpoints/run.rs
+++ b/rust/zaparoo-core/src/endpoints/run.rs
@@ -10,7 +10,7 @@
 
 use crate::client::{Client, ClientError};
 use crate::media_types::RunParams;
-use crate::store::{Mutation, Tag};
+use crate::store::Mutation;
 use futures_util::future::BoxFuture;
 use std::sync::Arc;
 
@@ -26,9 +26,5 @@ impl Mutation for RunMutation {
         args: Self::Args,
     ) -> BoxFuture<'static, Result<Self::Output, ClientError>> {
         Box::pin(async move { client.run(args).await })
-    }
-
-    fn invalidates(_args: &Self::Args, _result: &Self::Output) -> Vec<Tag> {
-        Vec::new()
     }
 }

--- a/rust/zaparoo-core/src/store/mod.rs
+++ b/rust/zaparoo-core/src/store/mod.rs
@@ -488,6 +488,23 @@ mod tests {
         }
     }
 
+    /// Mutation whose `invalidates` targets one specific id rather than
+    /// the whole kind. Used to drive the discriminating-match path.
+    struct SpecificInvalidatingMutation;
+    impl Mutation for SpecificInvalidatingMutation {
+        type Args = ();
+        type Output = ();
+        fn run(
+            _client: Arc<Client>,
+            _args: Self::Args,
+        ) -> BoxFuture<'static, Result<Self::Output, ClientError>> {
+            Box::pin(async { Ok(()) })
+        }
+        fn invalidates(_args: &Self::Args, _result: &Self::Output) -> Vec<Tag> {
+            vec![Tag::specific("Dummy", "id1")]
+        }
+    }
+
     #[test]
     fn run_mutation_refetches_entry_with_matching_provides() {
         let store = test_store();
@@ -551,6 +568,86 @@ mod tests {
         });
 
         assert_eq!(counter.load(AtomicOrdering::SeqCst), 0);
+    }
+
+    #[test]
+    fn run_mutation_refetches_every_matching_entry_at_once() {
+        // Per-entry matching is unit-tested above; this asserts the
+        // dispatch loop in `Store::invalidate` invokes *every* matching
+        // entry's `refetch` closure (across endpoints) for a single
+        // mutation, and leaves non-matching entries alone. The closure
+        // is the test fixture's counter bump, not the real
+        // `RemoteResource::refetch` notify pulse — covered separately.
+        let store = test_store();
+
+        let key_match_any = CacheKey::new::<DummyEndpoint>(&"alpha".to_string());
+        let key_match_specific = CacheKey::new::<OtherEndpoint>(&"alpha".to_string());
+        let key_unrelated = CacheKey::new::<DummyEndpoint>(&"beta".to_string());
+
+        let counter_match_any =
+            install_entry_with_provides(&store, key_match_any, vec![Tag::any("Dummy")]);
+        let counter_match_specific = install_entry_with_provides(
+            &store,
+            key_match_specific,
+            vec![Tag::specific("Dummy", "id1")],
+        );
+        let counter_unrelated =
+            install_entry_with_provides(&store, key_unrelated, vec![Tag::any("Other")]);
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build runtime");
+        runtime.block_on(async {
+            store
+                .run_mutation::<InvalidatingMutation>(())
+                .await
+                .expect("mutation runs");
+        });
+
+        // `InvalidatingMutation::invalidates` returns `Tag::any("Dummy")`,
+        // which matches both `Tag::any("Dummy")` and
+        // `Tag::specific("Dummy", _)` via the wildcard rule in
+        // `tags_match`.
+        assert_eq!(counter_match_any.load(AtomicOrdering::SeqCst), 1);
+        assert_eq!(counter_match_specific.load(AtomicOrdering::SeqCst), 1);
+        assert_eq!(counter_unrelated.load(AtomicOrdering::SeqCst), 0);
+    }
+
+    #[test]
+    fn specific_mutation_refetches_only_same_id_and_any_of_kind() {
+        // Companion to `run_mutation_refetches_every_matching_entry_at_once`:
+        // exercises the discriminating-match side of `tags_match` through
+        // the dispatch loop. A `Tag::specific("Dummy","id1")` mutation
+        // should hit the same-id entry and any `Tag::any("Dummy")` entry,
+        // but skip a sibling `Tag::specific("Dummy","id2")` entry.
+        let store = test_store();
+
+        let key_same_id = CacheKey::new::<DummyEndpoint>(&"id1".to_string());
+        let key_other_id = CacheKey::new::<DummyEndpoint>(&"id2".to_string());
+        let key_any_of_kind = CacheKey::new::<OtherEndpoint>(&"alpha".to_string());
+
+        let counter_same_id =
+            install_entry_with_provides(&store, key_same_id, vec![Tag::specific("Dummy", "id1")]);
+        let counter_other_id =
+            install_entry_with_provides(&store, key_other_id, vec![Tag::specific("Dummy", "id2")]);
+        let counter_any_of_kind =
+            install_entry_with_provides(&store, key_any_of_kind, vec![Tag::any("Dummy")]);
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build runtime");
+        runtime.block_on(async {
+            store
+                .run_mutation::<SpecificInvalidatingMutation>(())
+                .await
+                .expect("mutation runs");
+        });
+
+        assert_eq!(counter_same_id.load(AtomicOrdering::SeqCst), 1);
+        assert_eq!(counter_any_of_kind.load(AtomicOrdering::SeqCst), 1);
+        assert_eq!(counter_other_id.load(AtomicOrdering::SeqCst), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Low-level hygiene bundle following the foundation rework. Self-contained
backend/test items that `just lint` and `just test` fully verify.

- **Drop `SystemsModel`'s shadow catalog cache** — replace the
  `Arc<RwLock<Option<CatalogData>>>` mirror with a plain
  `Option<CatalogData>` on the model. Both reads and writes already
  happened on the Qt main thread, so the lock added no real
  synchronisation; it just carried two `.unwrap()` panics and a
  file-level `clippy::unwrap_used` allow. Bonus: the carousel no
  longer wipes during a transient `Loading` between user input and
  refetch. With the mirror gone, `bind_to_endpoint!` is sufficient
  again — no hand-rolled `Initialize`. Adds 8 unit tests covering
  `project()` for all four `ResourceStatus` variants and the
  extracted `rows_for_category` helper.
- **Centralise persist mutex lock+log+panic** — collapse six
  copies of the lock+log+expect chain across `AppState`,
  `GamesState`, `HubState` into `with_persist_read` /
  `with_persist_mut` closure helpers in `models/mod.rs`. Each call
  site is now a one-liner. Behaviour unchanged: poisoning still
  logs via tracing then panics, just from one place.
- **Hide dormant `BrowseModel` qinvokables** — the `enter`,
  `go_back`, `launch_at`, etc. methods are not wired to anything
  yet. Drop `#[qinvokable]` so a stray QML call fails at `qmllint`
  time instead of silently no-opping at runtime.
- **Tidy `RunMutation::invalidates`** — drop the redundant explicit
  `vec![]` override (the trait default returns the same) and
  tighten the header comment so the empty case reads as
  load-bearing-on-purpose, not a forgotten TODO.
- **Cover Store invalidation seam** — adds two integration tests
  for the gap between per-endpoint and per-mutation tests:
  multi-entry refetch under a single mutation, plus a discriminating
  `Tag::specific` case that proves same-id matches and a different
  same-kind id does not.

## Test plan

- [x] `just lint` — zero warnings
- [x] `just test` — 114/114 passing
- [ ] Manual smoke check on a non-mobile session (hub → games flow)
      to confirm `SystemsModel` seed regression isn't lurking
      behind the test coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Fixed category rows disappearing during loading and refresh operations

**Refactor**
- Centralized state persistence access patterns across the application for improved code maintainability
- Removed unused placeholder API implementations that were not actively used
- Enhanced consistency in error handling for persisted state operations across multiple components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->