### PR TITLE
docs: humanize and update project documentation

### DIFF
--- a/.github/CLA.md
+++ b/.github/CLA.md
@@ -2,22 +2,20 @@
 
 **Version:** 1.0 · effective 2026-04-25
 
-Thank you for your interest in contributing to Zaparoo Launcher.
+Thank you for contributing to Zaparoo Launcher.
 
-This Contributor License Agreement ("CLA") records the rights you grant
-to **Wizzo Pty Ltd** (the "Company") when you contribute code,
-documentation, translations, or other material to this project. You
-sign it once, on your first contribution, and it covers every
-contribution you make afterward.
+This Contributor License Agreement ("CLA") records the rights you grant to
+**Wizzo Pty Ltd** (the "Company") when you contribute code, documentation,
+translations, or other material to this project. You sign it once, on your
+first contribution, and it covers every contribution you make afterward.
 
 ## Why we ask for this
 
-Zaparoo Launcher is published under the PolyForm Noncommercial License
-1.0.0. The Company separately grants commercial licenses to partners
-who want to use the software commercially. For the Company to be able
-to grant those commercial licenses without having to renegotiate with
-every past contributor, each contributor gives the Company broad
-licensing rights to their contribution.
+Zaparoo Launcher is published under the PolyForm Noncommercial License 1.0.0.
+The Company separately grants commercial licenses to partners who want to use
+the software commercially. To grant those licenses without renegotiating with
+every past contributor, the Company needs broad licensing rights to each
+contribution.
 
 **You keep the copyright on your own work.** This is a license, not a
 transfer.
@@ -25,8 +23,8 @@ transfer.
 ## 1. Definitions
 
 - **"Contribution"** means any code, documentation, translation, asset,
-  configuration, or other material you submit to the project in any
-  form (pull request, patch, issue comment containing code, etc.).
+  configuration, or other material you submit to the project in any form (pull
+  request, patch, issue comment containing code, etc.).
 - **"You"** means the individual signing this CLA. If you are
   contributing on behalf of an employer, "You" means both you and
   your employer, and you confirm you have authority to sign on their
@@ -40,9 +38,8 @@ anyone else, or including it in other projects.
 
 ## 3. Copyright license to the Company
 
-You grant Wizzo Pty Ltd a perpetual, worldwide, non-exclusive,
-royalty-free, irrevocable copyright license to use your Contribution
-in any way, including:
+You grant Wizzo Pty Ltd a perpetual, worldwide, non-exclusive, royalty-free,
+irrevocable copyright license to use your Contribution in any way, including:
 
 - reproducing, modifying, distributing, performing, and displaying it;
 - preparing derivative works from it;
@@ -52,28 +49,26 @@ in any way, including:
 
 ## 4. Patent license to the Company
 
-You grant Wizzo Pty Ltd a perpetual, worldwide, non-exclusive,
-royalty-free, irrevocable patent license — with the right to
-sublicense — to make, have made, use, sell, offer to sell, import, and
-otherwise transfer your Contribution and any combination of your
-Contribution with the project. This patent license covers only those
-patent claims you own or control that are necessarily infringed by your
-Contribution or by that combination.
+You grant Wizzo Pty Ltd a perpetual, worldwide, non-exclusive, royalty-free,
+irrevocable patent license — with the right to sublicense — to make, have made,
+use, sell, offer to sell, import, and otherwise transfer your Contribution and
+any combination of your Contribution with the project. This patent license
+covers only those patent claims you own or control that are necessarily
+infringed by your Contribution or by that combination.
 
 ## 5. No trademark license
 
-Nothing in sections 3 or 4 grants you, or anyone the Company sublicenses
-to, any rights to use the Company's or the Zaparoo Project's names,
-logos, or trademarks. Trademark use is handled separately and is outside
-the scope of this CLA.
+Nothing in sections 3 or 4 grants you, or anyone the Company sublicenses to,
+any rights to use the Company's or the Zaparoo Project's names, logos, or
+trademarks. Trademark use is handled separately and is outside the scope of
+this CLA.
 
 ## 6. Moral rights
 
-To the extent the law allows, you consent to the Company and its
-sublicensees using your Contribution without personally attributing it
-to you, and you agree not to bring any moral-rights claim against the
-Company or its sublicensees about how your Contribution is used or
-modified.
+To the extent the law allows, you consent to the Company and its sublicensees
+using your Contribution without personally attributing it to you, and you agree
+not to bring any moral-rights claim against the Company or its sublicensees
+about how your Contribution is used or modified.
 
 ## 7. You have the right to grant this
 
@@ -90,16 +85,16 @@ You confirm that:
 
 ## 8. No warranty, no obligation
 
-You provide your Contribution "as is", without any warranty. Signing
-this CLA does not obligate you or the Company to maintain, support, or
-distribute anything.
+You provide your Contribution "as is", without any warranty. Signing this CLA
+does not obligate you or the Company to maintain, support, or distribute
+anything.
 
 ## 9. Public release
 
-Your Contribution will be released to the public under the same license
-as the rest of the project (currently PolyForm Noncommercial 1.0.0).
-The Company may also sublicense it to specific partners under different
-terms, as permitted by sections 3 and 4 above.
+Your Contribution will be released to the public under the same license as the
+rest of the project (currently PolyForm Noncommercial 1.0.0). The Company may
+also sublicense it to specific partners under different terms, as permitted by
+sections 3 and 4 above.
 
 ## Signing
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,20 +1,20 @@
-<!-- Thanks for sending a pull request! Fill this out before requesting review. -->
+<!-- Thanks for the pull request. Please fill this out before requesting review. -->
 
 ## Summary
 
-<!-- What does this PR change, and why? One or two sentences is usually enough. -->
+<!-- What changed, and why? One or two sentences is usually enough. -->
 
 ## Motivation
 
-<!-- Link to the issue being fixed or the discussion this came out of. Delete this section if neither applies. -->
+<!-- Link the issue or discussion that led to this. Delete this section if it does not apply. -->
 
 ## Screenshots / recordings
 
-<!-- Required for any visual change. Include the FPS counter reading at 720p and, if possible, 240p. -->
+<!-- Required for visual changes. Include the FPS counter at 720p and, if possible, 240p. -->
 
 ## Test plan
 
-<!-- How did you verify this works? Bullet list of manual steps or automated tests. -->
+<!-- How did you verify this? Manual steps and automated tests are both fine. -->
 
 ## Checklist
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,129 +1,143 @@
-# Zaparoo Launcher — Agent Instructions
+# Zaparoo Launcher Agent Guide
 
-Zaparoo Launcher is a Qt/QML game launcher for Zaparoo Core. It targets two
-environments: MiSTer FPGA (ARM32, Linux framebuffer, no GPU, software
-rendering) and desktop Linux (x86_64, windowed). The hard rendering
-constraint shapes every visual decision. See @docs/architecture.md for the
-module graph and @docs/building.md for the full build matrix.
+Zaparoo Launcher is a Qt/QML frontend for Zaparoo Core. It runs on desktop
+Linux and on MiSTer FPGA (ARM32, Linux framebuffer, software rendering). The
+MiSTer target is the hard constraint: assume no GPU, process kills without
+notice, and a small ARM CPU.
 
-## Constraints
-
-### NEVER
-
-- Use shaders, `LinearGradient`, `RadialGradient`, `DropShadow`, `Glow`,
-  `OpacityMask`, `MultiEffect`, `Qt5Compat.GraphicalEffects`, or any other
-  GPU-dependent QML type. MiSTer renders in software on a framebuffer.
-  Stick to `Rectangle`, `Image`, `Text`, `Repeater`, `NumberAnimation`,
-  `ColorAnimation`. "Basic" `QQuickStyle` is mandatory.
-- Hardcode pixel values. The UI runs 240p (CRT) → 1080p; use
-  `Sizing.pctH()`, `Sizing.pctW()`, `Sizing.fontSize()`, and
-  `Sizing.visibleCovers` for every dimension and element count.
-- Add Qt5 compatibility code or `#if QT_VERSION` guards. Qt 6.7+ only.
-- Change `BUILD_SHARED_LIBS` — `ON` on desktop is required for LGPL
-  compliance; `OFF` on ARM32/MiSTer is set by the Docker toolchain.
-- Hold in-memory-only application state. MiSTer's launcher script kills
-  and relaunches the binary freely; every piece of user-visible state
-  (selected game, carousel position, menu state, settings) must be
-  serializable to disk and restored before the first frame paints.
-- Leave a lint warning or failing test unresolved.
-- `cd rust/` or invoke raw cmake/cargo. Drive every workflow from the
-  repo root via `just`.
-- Write a bare English literal in QML (or a `tr()`-less literal in C++)
-  for anything the user might read. Wrap it in `qsTr()` and pass runtime
-  values via `%1`/`%2` so translators can reorder — e.g. `qsTr("%1
-  FPS").arg(fps)`, not `qsTr("FPS: ") + fps`. Enum tags, QRC URLs, log
-  strings, and other non-user-facing literals stay bare. See
-  @docs/translations.md for the full pipeline.
-- Use `tokio::sync::broadcast` to publish *state* (connection state,
-  catalog status, anything a subscriber needs to know the current
-  value of). Broadcast channels silently drop messages sent before a
-  receiver subscribes, so a late subscriber — e.g. a QML singleton
-  whose `initialize()` runs after the WebSocket task has already sent
-  `Connecting` → `Connected` — sees nothing and sits on its hardcoded
-  initial value forever. Use `tokio::sync::watch` for state: it
-  retains the latest value, and subscribers seed via `borrow()` then
-  await `changed()`. Reserve `broadcast` for fan-out of *events*
-  where missing the early ones is acceptable.
-- Inline a `watch::Sender::borrow()` (or any read-borrow) in the
-  scrutinee of an `if let` / `match` / `while let` whose body then
-  calls `send_replace`/`send`/any write on the same channel.
-  Temporaries in the scrutinee live until the end of the body, so
-  the read lock outlives the entire block and deadlocks the write.
-  Bind the borrow to a local in an inner scope first:
-  `let next = { let cur = tx.borrow(); fsm.step(&cur) };` then
-  match on `next`. Same gotcha applies to any `RwLock`-backed
-  read guard held across a write call.
-
-### ASK
-
-- Before adding or changing a `Client` method in
-  `rust/zaparoo-core/src/client.rs` — cross-check
-  https://zaparoo.org/docs/core/api/ first. Method names, param shapes,
-  and return types must match upstream.
-
-### ALWAYS
-
-- Write comments and documentation in American English.
-- After editing any C++, Rust, or QML file: run `just lint` (zero
-  warnings is the bar) and `just test` if the change can affect runtime
-  behavior.
-- Watch `src/ui/components/FpsCounter.qml` when changing visuals —
-  it must stay green (≥55) at 720p+ and not fall red (<30) at 240p.
+Keep this file focused on commands, traps, and rules that are hard to infer
+from the tree. Use the docs for longer explanations.
 
 ## Commands
 
-Run `just --list` for the full menu. The `justfile` is the source of
-truth — `.cargo/config.toml` and `CMakePresets.json` are tuned to it.
+Run every workflow from the repo root with `just`. Do not `cd rust/` and run
+raw cargo as the default path; the justfile carries the expected environment.
 
-    just build | run                   desktop cmake + run
-    just test | test-qml | test-rust   ctest + cargo nextest
-    just lint | lint-cpp | lint-rust   clang-format/tidy + qmllint +
-                                       rustfmt + clippy + cargo-deny
-    just fmt                           pre-commit + cargo fmt
-    just arm32 | deploy-mister         cross-build + SCP to MiSTer
+| Task | Command |
+|---|---|
+| Desktop build | `just build` |
+| Desktop run | `just run` |
+| Dev run against mock Core | `just mock-core` in one terminal, `just run-dev` in another |
+| Full test gate | `just test` |
+| QML/C++ tests only | `just test-qml` |
+| Rust tests only | `just test-rust` |
+| Full lint gate | `just lint` |
+| Rust lint only | `just lint-rust` |
+| Format | `just fmt` |
+| MiSTer ARM32 build | `just arm32` |
+| Deploy to MiSTer | `just deploy-mister` |
 
-## Deploy to MiSTer
+`just --list` is the source of truth. `CMakePresets.json` and
+`rust/.cargo/config.toml` are tuned for those recipes.
 
-`./scripts/deploy-mister.sh` — reads `MISTER_IP` from a `.env` in the
-project root (create with `echo 'MISTER_IP=<ip>' > .env`). Non-obvious
-context: `/media/fat/MiSTer_Zaparoo` is a pre-existing integration binary
-shipped with MiSTer that is responsible for launching our `launcher`; the
-deploy script restarts it, which picks up the newly-SCP'd binary
-automatically. User-editable resolution and endpoint overrides live at
-`/media/fat/zaparoo/launcher.toml` (example in @docs/building.md).
+## Stack Facts
 
-## Module Map
+- Qt 6.7+ with Qt Quick, QuickControls2, QML, QuickTest, and LinguistTools.
+- C++17 executable at `src/app/main.cpp`; Rust static library linked through
+  Corrosion and cxx-qt.
+- Rust workspace is under `rust/`, edition 2021, MSRV 1.90, cxx-qt 0.7.
+- Desktop builds link Qt dynamically for LGPL compliance.
+- MiSTer ARM32 builds use the Docker toolchain and static Qt.
 
-| Directory | URI | Contents |
-|---|---|---|
-| `src/ui/theme/` | `Zaparoo.Theme` | `Theme`, `Sizing` singletons |
-| `src/ui/components/` | `Zaparoo.Ui` | `Carousel`, `CoverDelegate`, `TextTileDelegate`, `FpsCounter` |
-| `src/ui/app/` | `Zaparoo.App` | `Main.qml` + embedded fonts and images |
-| `rust/launcher/src/models/` | `Zaparoo.Browse` | `CategoriesModel`, `SystemsModel`, `GamesModel`, `BrowseModel` (dormant) — Rust QML singletons via cxx-qt |
-| `rust/zaparoo-core/` | — | `client`, `config`, `logger`, `systems_catalog`, `media_types`, `platform_paths` (no Qt dependency) |
+## Always
 
-Import QML modules as `import Zaparoo.Theme`, `import Zaparoo.Ui`, etc.
-Resources are embedded at `qrc:/qt/qml/Zaparoo/App/resources/...`.
-`compile_commands.json` is generated in `build/` unconditionally.
+- Keep comments and docs in American English.
+- After editing C++, Rust, or QML, run `just lint`. Run `just test` when the
+  change can affect runtime behavior.
+- Keep user-visible state persistent. Selected screen, carousel positions,
+  focus, settings, and similar state must be serialized to disk and restored
+  before the first frame. MiSTer's wrapper can kill and relaunch the process at
+  any time.
+- Wrap user-visible QML strings in `qsTr()` and C++ strings in `tr()`. Use
+  `%1`/`%2` placeholders for runtime values so translators can reorder text.
+- Check `src/ui/components/FpsCounter.qml` after visual changes. It must stay
+  green (>=55 FPS) at 720p+ and not fall red (<30 FPS) at 240p.
 
-## Logging
+## Ask First
 
-Use `tracing::{info,debug,warn,error}!` in Rust. Two sinks write
-simultaneously: stderr (RFC-3339 human-readable) and JSONL file at
-`platform_paths::log_file_path()` — `/tmp/zaparoo/launcher.log` on MiSTer,
-`~/.local/share/zaparoo/logs/launcher.log` on desktop. Qt messages route
-through `zaparoo_log_qt` (`rust/launcher/src/lib.rs`) with `target="qt"`,
-so Qt warnings land in the same file.
+- Before adding or changing a `Client` method in
+  `rust/zaparoo-core/src/client.rs`, check the upstream API docs:
+  <https://zaparoo.org/docs/core/api/>. Method names, params, and return types
+  must match Core.
+- Before changing `Sizing.qml` behavior or the persisted state schema, confirm
+  the migration/reset behavior.
+- Before adding dependencies, changing CI, or touching license/trademark text,
+  confirm the intended policy.
 
-Debug level is filtered out by default. Enable with `[logging] debug =
-true` in `launcher.toml`, or `ZAPAROO_DEBUG=1` env var (takes effect
-before config loads, useful for debugging startup).
+## Never
+
+- Do not use shader-backed or GPU-dependent QML: `LinearGradient`,
+  `RadialGradient`, `DropShadow`, `Glow`, `OpacityMask`, `MultiEffect`,
+  `Qt5Compat.GraphicalEffects`, Qt Quick Studio shapes, or custom shaders.
+  Stick to software-rendering-safe types such as `Rectangle`, `Image`, `Text`,
+  `Repeater`, `Item`, `NumberAnimation`, and `ColorAnimation`.
+- Do not hardcode pixel sizes or fixed element counts in UI. Use
+  `Sizing.pctH()`, `Sizing.pctW()`, `Sizing.fontSize()`, and
+  `Sizing.visibleCovers`.
+- Do not add Qt5 compatibility code or `#if QT_VERSION` guards. This project is
+  Qt 6.7+ only.
+- Do not change `BUILD_SHARED_LIBS`. Desktop needs `ON`; the ARM32 toolchain
+  sets static linking for MiSTer.
+- Do not publish state with `tokio::sync::broadcast` when late subscribers need
+  the current value. Use `tokio::sync::watch` for state and reserve broadcast
+  for lossy events.
+- Do not inline a `watch::Sender::borrow()` or any read guard in an `if let`,
+  `match`, or `while let` scrutinee when the body writes to the same channel or
+  lock. Bind the read in an inner scope first:
+  `let next = { let cur = tx.borrow(); fsm.step(&cur) };`.
+- Do not leave lint warnings, failing tests, or untranslated user-facing text
+  behind.
+
+## Project Map
+
+| Path | Purpose |
+|---|---|
+| `src/app/main.cpp` | Thin Qt entry point, translator install, QML engine, Qt log bridge |
+| `src/ui/app/Main.qml` | Runtime router: input, persistence orchestration, screen transitions |
+| `src/ui/app/MainLayout.qml` | Designer-editable visual tree |
+| `src/ui/screens/` | `Zaparoo.Screens`: `ScreenManager`, `HubScreen`, `GamesScreen` |
+| `src/ui/components/` | `Zaparoo.Ui`: carousel, delegates, FPS counter |
+| `src/ui/theme/` | `Zaparoo.Theme`: `Theme`, `Sizing` singletons |
+| `rust/launcher/src/models/` | `Zaparoo.Browse` cxx-qt singletons and models |
+| `rust/launcher/src/bind.rs` | Endpoint-to-QML binding macro with synchronous seed |
+| `rust/zaparoo-core/src/client.rs` | WebSocket JSON-RPC client for Zaparoo Core |
+| `rust/zaparoo-core/src/store/` | Endpoint cache, tags, mutations, invalidation |
+| `rust/zaparoo-core/src/persist.rs` | Atomic persisted UI state |
+| `rust/zaparoo-core/src/platform_paths.rs` | Config, log, and state paths per runtime |
+
+QML module URIs are `Zaparoo.App`, `Zaparoo.Screens`, `Zaparoo.Ui`,
+`Zaparoo.Theme`, and `Zaparoo.Browse`. Resources are embedded under
+`qrc:/qt/qml/Zaparoo/App/resources/...`. `compile_commands.json` is generated
+in `build/` by default.
+
+## Runtime Notes
+
+- `Runtime` answers where the launcher binary is running. `Platform` answers
+  where Zaparoo Core is running. Do not collapse them.
+- Desktop config: `~/.config/zaparoo/launcher.toml`.
+- Desktop state: `~/.config/zaparoo/state.toml`.
+- Desktop log: `~/.local/share/zaparoo/logs/launcher.log`.
+- MiSTer config: `/media/fat/zaparoo/launcher.toml`.
+- MiSTer state/log: `/tmp/zaparoo/state.toml`, `/tmp/zaparoo/launcher.log`.
+- `ZAPAROO_CORE_ENDPOINT` overrides `[core] endpoint`; `ZAPAROO_STATE_FILE`
+  redirects state for tests and ad-hoc runs.
+- Debug logging is enabled with `[logging] debug = true` or `ZAPAROO_DEBUG=1`.
+
+## MiSTer Deploy
+
+`just deploy-mister` reads `MISTER_IP` from `.env`, builds the ARM32 binary,
+copies it to `/media/fat/zaparoo/launcher`, restarts `/media/fat/MiSTer_Zaparoo`,
+and clears `/tmp/zaparoo/launcher.log`.
+
+`/media/fat/MiSTer_Zaparoo` is the integration binary shipped with MiSTer. It
+starts our `launcher`; do not replace that flow with a new wrapper script.
 
 ## Further Reading
 
-- @docs/architecture.md — module graph, data-flow, LGPL notes
-- @docs/building.md — full build matrix, ARM32 toolchain, sanitizers, deploy bundle
-- @docs/qml-gotchas.md — QML pitfalls qmllint only catches post-hoc (read when writing QML)
-- @docs/cxx-qt-bridge.md — cxx-qt 0.7 bridge gotchas (read when editing Rust QML models)
-- @docs/translations.md — `qsTr()` pipeline, adding locales, build-time mechanics
+- `docs/architecture.md` — module graph, data flow, runtime/platform split
+- `docs/building.md` — build matrix, ARM32 toolchain, deploy bundle
+- `docs/qml-gotchas.md` — QML issues qmllint often catches late
+- `docs/cxx-qt-bridge.md` — cxx-qt 0.7 bridge constraints
+- `docs/translations.md` — `qsTr()`/`tr()` pipeline and locale catalogs
+- `design/README.md` — Qt Design Studio workflow and designer boundaries
 - `src/LICENSES/` — Qt LGPL notices

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,68 +1,62 @@
 # Contributing to Zaparoo Launcher
 
-Thanks for your interest. This doc covers the practical bits: signing
-the CLA, getting a dev environment running, and what we expect before
-you open a pull request.
+Thanks for taking the time to contribute. This guide covers the parts that
+matter before a pull request: the CLA, local setup, and the checks we expect
+you to run.
 
 ## Contributor License Agreement
 
-Every contributor signs a one-time [CLA](.github/CLA.md). It grants
-**Wizzo Pty Ltd** (the legal entity behind the project) a broad license
-to use and sublicense your contribution. You keep the copyright; this
-is a license, not a transfer. The CLA exists so the company can grant
-commercial licenses to friendly partners without renegotiating with
-every past contributor each time.
+Every contributor signs the [CLA](.github/CLA.md) once. It gives
+**Wizzo Pty Ltd** (the legal entity behind the project) the license it needs
+to use and sublicense your contribution. You keep your copyright; this is not a
+copyright transfer. The CLA lets the company offer commercial licenses to
+friendly partners without renegotiating every past contribution.
 
-To sign, open your first pull request and post this exact comment on
-it:
+To sign, open your first pull request and post this exact comment:
 
 > I have read the CLA Document and I hereby sign the CLA
 
-The CLA Assistant Lite bot records your signature in
-`.github/contributors/signatures.json`. You only need to sign once;
-future PRs are recognized automatically.
+CLA Assistant Lite records your signature in
+`.github/contributors/signatures.json`. After that, future PRs are recognized
+automatically.
 
 ## Development setup
 
-See [`docs/quickstart.md`](docs/quickstart.md) for the fastest path
-from a fresh clone to a running launcher. You do not need MiSTer
-hardware: the repo ships a mock Zaparoo Core you can run locally with
-`just mock-core`.
+Use [`docs/quickstart.md`](docs/quickstart.md) to get from a fresh clone to a
+running launcher. You do not need MiSTer hardware. The repo includes a mock
+Zaparoo Core you can start with `just mock-core`.
 
-For full build details (MiSTer ARM32 cross-build, sanitizer builds,
-deployment), see [`docs/building.md`](docs/building.md).
+For the MiSTer ARM32 cross-build, sanitizer builds, and deployment, see
+[`docs/building.md`](docs/building.md).
 
 ### Supported host platforms
 
-- **Linux (x86_64)** is the primary development target and fully
-  supported.
-- **macOS** is best-effort. It should work, but CI does not cover it.
-  Report breakage; patches welcome.
-- **Windows** is not tested or actively supported. Use WSL2.
+- **Linux (x86_64)** is the main development target.
+- **macOS** is best-effort. It should work, but CI does not cover it. Report
+  breakage; patches welcome.
+- **Windows** is not tested or actively supported. Use WSL2 instead.
 
 ## Before you open a pull request
 
-Run these locally. CI runs the same checks and will block merge if
-they fail.
+Run these locally. CI runs the same checks and blocks merge when they fail.
 
 ```bash
 just lint    # clang-format, clang-tidy, qmllint, rustfmt, clippy, cargo-deny
 just test    # ctest + cargo nextest
 ```
 
-Zero lint warnings is the bar. If a rule is wrong for your change,
-don't disable it; raise it in the PR and we'll discuss.
+Zero lint warnings is the bar. If a rule is wrong for the change you are
+making, do not disable it quietly; call it out in the PR.
 
 ## Pull request conventions
 
-The [PR template](.github/pull_request_template.md) prompts for
-everything we want to see. The two things worth calling out up front:
+The [PR template](.github/pull_request_template.md) asks for the details we
+need. Two points matter most:
 
-- **Explain the why, not just the what.** The diff already shows the
-  what.
-- **Screenshots or recordings for visual changes**, with the FPS
-  counter reading at 720p and, ideally, 240p. It must stay green
-  (≥55) at 720p+ and not go red (<30) at 240p.
+- **Explain why the change exists.** The diff already shows what changed.
+- **Include screenshots or recordings for visual changes**, with the FPS
+  counter visible at 720p and, if possible, 240p. It must stay green (≥55) at
+  720p+ and not go red (<30) at 240p.
 
 ### Commit messages
 
@@ -75,21 +69,21 @@ We use [Conventional Commits](https://www.conventionalcommits.org/):
 - `test:` for adding or updating tests
 - `chore:` for build, tooling, deps, or other housekeeping
 
-Scopes are optional but encouraged when they sharpen the summary:
+Scopes are optional. Use one when it makes the summary clearer:
 `feat(ui): add settings screen`, `fix(rust): handle empty catalog`.
 
 ### Branch naming
 
-`feat/<short-description>`, `fix/<short-description>`,
-`docs/<short-description>`, etc. Keep it readable; hyphens not
+Use `feat/<short-description>`, `fix/<short-description>`,
+`docs/<short-description>`, etc. Keep it readable; use hyphens, not
 underscores.
 
 ## Main branch is protected
 
-`main` accepts changes only via pull request. Every PR needs:
+`main` only accepts changes through pull requests. Every PR needs:
 
-1. All CI jobs green (`rust-lint`, `rust-test`, `desktop-build`,
-   `arm32-build`, and the CLA check).
+1. All CI jobs green: Rust lint, Rust tests, desktop build + ctest + lint,
+   ARM32 cross-build, and the CLA check.
 2. A CLA signature recorded for the PR author.
 3. At least one approving review from a maintainer other than the PR
    author.
@@ -99,15 +93,15 @@ Force-pushing and direct pushes to `main` are blocked.
 
 ## Bugs and feature requests
 
-Open a GitHub issue. For bugs, include repro steps, expected vs actual
-behavior, whether it reproduces on desktop and/or MiSTer, and a log
-excerpt (`~/.local/share/zaparoo/logs/launcher.log` on desktop;
-`/tmp/zaparoo/launcher.log` on MiSTer). For features, say what you
-want and why; if you plan to implement it yourself, say so and we'll
-align on scope first.
+Open a GitHub issue. For bugs, include repro steps, expected behavior, actual
+behavior, whether it reproduces on desktop and/or MiSTer, and a log excerpt
+(`~/.local/share/zaparoo/logs/launcher.log` on desktop;
+`/tmp/zaparoo/launcher.log` on MiSTer). For feature requests, say what you want
+and why. If you plan to implement it, say that too so we can agree on scope
+first.
 
 ## Questions?
 
-- Architecture or design questions: open a GitHub Discussion (or
-  issue) so the answer is searchable for the next person.
+- Architecture or design questions: open a GitHub Discussion or issue so the
+  answer is searchable later.
 - CLA or licensing: [legal@zaparoo.org](mailto:legal@zaparoo.org).

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # Zaparoo Launcher
 
-A game launcher frontend for [Zaparoo Core](https://zaparoo.org).
+Zaparoo Launcher is the game launcher frontend for
+[Zaparoo Core](https://zaparoo.org).
 
-## Building
+## Build
 
-See [docs/building.md](docs/building.md) for full instructions, including
-first-run system dependencies.
+Start with [docs/building.md](docs/building.md). It covers the packages you
+need on a fresh machine and the MiSTer cross-build path.
 
-Common tasks are wrapped in a [`justfile`](justfile); run `just --list` for the
-full menu.
+Most commands go through the [`justfile`](justfile). Run `just --list` if you
+need the full menu.
 
 ```bash
 just build && just run    # desktop
@@ -17,8 +18,7 @@ just test                 # ctest + cargo nextest
 just lint                 # clang-format, clang-tidy, qmllint, rustfmt, clippy, cargo-deny
 ```
 
-`just test` and `just lint` require `cargo-nextest` and `cargo-deny`. Install
-them once with:
+`just test` and `just lint` need `cargo-nextest` and `cargo-deny`:
 
 ```bash
 cargo install --locked cargo-nextest cargo-deny
@@ -26,13 +26,17 @@ cargo install --locked cargo-nextest cargo-deny
 
 ## Trademarks
 
-This repository contains Zaparoo trademarks which are explicitly licensed to the project in this location by the trademark owner. These trademarks must be removed from the project or replaced if you intend to redistribute or adapt the project in any form. See the Zaparoo [Terms of Use](https://zaparoo.org/terms/) for further details.
+This repository includes Zaparoo trademarks used here with permission from the
+trademark owner. If you redistribute or adapt the project, remove or replace
+those marks first. See the Zaparoo [Terms of Use](https://zaparoo.org/terms/)
+for the details.
 
 ## License
 
 Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 Source available under the [PolyForm Noncommercial License 1.0.0](COPYING).
-Non-commercial use only. For commercial licensing, contact [legal@zaparoo.org](mailto:legal@zaparoo.org) to discuss terms.
+Non-commercial use only. For commercial licensing, contact
+[legal@zaparoo.org](mailto:legal@zaparoo.org).
 
 Third-party components:
 

--- a/design/README.md
+++ b/design/README.md
@@ -1,15 +1,15 @@
 # Zaparoo Launcher — Designer Guide
 
-This directory lets a UX designer open the launcher UI visually in
-**Qt Design Studio**. Nothing under `design/` is compiled into the
-launcher binary — it's a designer-only sidecar.
+This directory lets a UX designer open the launcher UI in **Qt Design Studio**.
+Nothing under `design/` is compiled into the launcher binary; it exists only
+for design-time previews.
 
-## Setup (one-time)
+## Setup
 
-1. **Install Qt Design Studio.** Free, GPLv3. Fastest path: install
-   via the Qt online installer (<https://www.qt.io/download-qt-installer>)
-   and tick *Qt Design Studio*. Linux package managers sometimes ship
-   it as `qt-design-studio`.
+1. **Install Qt Design Studio.** It is free and GPLv3. The simplest route is
+   the Qt online installer (<https://www.qt.io/download-qt-installer>); select
+   *Qt Design Studio*. Some Linux package managers ship it as
+   `qt-design-studio`.
 2. **Build the launcher once** from the repo root so the generated
    QML modules exist:
 
@@ -17,43 +17,41 @@ launcher binary — it's a designer-only sidecar.
    just build
    ```
 
-   This populates `build/qml/Zaparoo/{App,Ui,Theme}/` with the real
-   QML files. Design Studio reads them directly from there. The
-   `Zaparoo.Browse` module — backed by Rust — is replaced by mocks
-   under `design/mocks/`.
+   This populates `build/qml/Zaparoo/{App,Ui,Theme}/` with the real QML files.
+   Design Studio reads them from there. The Rust-backed `Zaparoo.Browse` module
+   is replaced by mocks under `design/mocks/`.
 3. **Open the project** in Qt Design Studio:
 
    ```text
    design/launcher.qmlproject
    ```
 
-   The 2D view should render `MainPreview.qml` at 1280×720 with a
-   populated categories/systems carousel drawn from the mock
-   singletons. If carousels look empty, double-check step 2.
+   The 2D view should render `MainPreview.qml` at 1280×720 with populated
+   categories and systems carousels from the mock singletons. If the carousels
+   are empty, rebuild the launcher and reopen the project.
 
-## Editable vs. off-limits files
+## Editable files
 
 | Path                            | Touch?                                                     |
 | ------------------------------- | ---------------------------------------------------------- |
-| `src/ui/theme/Theme.qml`        | Yes — colour & font constants.                             |
+| `src/ui/theme/Theme.qml`        | Yes — colour and font constants.                           |
 | `src/ui/theme/Sizing.qml`       | Logic tweaks only; ask first.                              |
 | `src/ui/components/*.qml`       | Yes — delegates, carousel, FPS counter.                    |
 | `src/ui/app/MainLayout.qml`     | Yes — screen layout, backgrounds, anchors.                 |
-| `src/ui/app/Main.qml`           | **No.** Engineer-owned state machine. Flag changes.        |
+| `src/ui/app/Main.qml`           | **No.** Engineer-owned state machine. Ask before editing.  |
 | `design/mocks/**`               | No. Design-time stubs; edit only if engineering asks.      |
 | `design/previews/MainPreview.qml` | Change preview canvas here; don't add real UI.           |
 
-## Hard constraints — software rendering only
+## Software rendering only
 
-The launcher runs on MiSTer FPGA, which has **no GPU**. Anything that
-needs a shader or effect crashes or renders as a grey box. Stick to
-this palette:
+The launcher runs on MiSTer FPGA, which has **no GPU**. Anything shader-backed
+can crash or render as a grey box. Stay within this set:
 
 Allowed:
 `Rectangle`, `Image`, `Text`, `Repeater`, `Item`, `NumberAnimation`,
 `ColorAnimation`, `Behavior`.
 
-**Banned** — do not drag these from the Design Studio Components panel:
+**Do not use these from the Design Studio Components panel:**
 
 - `LinearGradient`, `RadialGradient`, `ConicalGradient`
 - `DropShadow`, `Glow`, `InnerShadow`
@@ -63,14 +61,14 @@ Allowed:
   `Regular Polygon`, `Star`, `Svg Path Item`
 - Any shader‑backed effect
 
-If an effect is essential, talk to an engineer first — there's often a
-flat `Rectangle` / `Image` combo that gets you 80% of the way.
+If an effect seems necessary, talk to an engineer first. A flat `Rectangle` or
+`Image` version is usually the safer MiSTer-friendly option.
 
-## Sizing — never hardcode pixels or element counts
+## Sizing
 
-The launcher scales from 240p (CRT) to 1080p. Use the helpers exposed
-as the `Sizing` singleton (import `Zaparoo.Theme`) — never hardcode
-pixel values or element counts:
+The launcher scales from 240p CRT output to 1080p. Use the helpers on the
+`Sizing` singleton (`import Zaparoo.Theme`). Do not hardcode pixel values or
+element counts:
 
 - `Sizing.pctH(n)` — `n` percent of screen height.
 - `Sizing.pctW(n)` — `n` percent of screen width.
@@ -78,7 +76,7 @@ pixel values or element counts:
 - `Sizing.visibleCovers` — element count for carousels and similar
   repeaters; drops at very low resolutions to avoid crowding.
 
-At the designer canvas of 1280×720, `Sizing.pctH(10)` previews as 72 px.
+On the 1280×720 designer canvas, `Sizing.pctH(10)` previews as 72 px.
 
 ## Handing work back
 
@@ -87,20 +85,20 @@ At the designer canvas of 1280×720, `Sizing.pctH(10)` previews as 72 px.
 3. Do not edit `CMakeLists.txt`, `.cpp`, `.rs`, or anything under
    `rust/` — those are engineering concerns.
 
-## If the Design tab stays greyed out in Qt *Creator*
+## If Qt Creator's Design tab is greyed out
 
-That's expected. Qt Creator 6+ ships its QML visual designer disabled
-because it was superseded by Qt Design Studio. Open the project in
-**Design Studio**, not Creator.
+That is expected. Qt Creator 6+ ships with its QML visual designer disabled
+because Qt Design Studio replaced it. Open this project in **Design Studio**,
+not Creator.
 
 ## Troubleshooting
 
-- **Red error banners on `Zaparoo.Browse.*`** — `build/qml/` is
-  missing or stale. Rerun `just build`.
-- **Red error banners on `Zaparoo.Ui` / `Zaparoo.Theme`** — same
-  cause; `just build` populates those too.
-- **Carousel is empty** — the mock ListModels seed four entries; if
-  all carousels are empty, `mocks/` isn't being resolved. Check that
-  `importPaths` in `launcher.qmlproject` still lists `mocks` first.
-- **"Cannot find type XYZ"** — probably a Qt Quick Studio Component.
-  Don't use them; see the banned list above.
+- **Red error banners on `Zaparoo.Browse.*`** — `build/qml/` is missing or
+  stale. Rerun `just build`.
+- **Red error banners on `Zaparoo.Ui` / `Zaparoo.Theme`** — same cause;
+  `just build` populates those too.
+- **Carousel is empty** — the mock ListModels seed four entries. If every
+  carousel is empty, `mocks/` is not being resolved. Check that `importPaths`
+  in `launcher.qmlproject` still lists `mocks` first.
+- **"Cannot find type XYZ"** — probably a Qt Quick Studio Component. Do not
+  use it; see the banned list above.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,25 +24,33 @@ src/app/main.cpp
     │     │     Compiled on all platforms; MiSTer-specific calls are gated by cfg.
     │     │
     │     ├── src/models/  [Zaparoo.Browse QML module via cxx-qt 0.7]
-    │     │     AppStatus, CategoriesModel, SystemsModel, GamesModel
-    │     │     (BrowseModel and per-screen state singletons).
+    │     │     AppStatus, CategoriesModel, SystemsModel, GamesModel,
+    │     │     AppState, HubState, GamesState, Input, BrowseModel.
     │     │     All registered via build.rs QmlModule.
     │     │
-    │     └── rust/zaparoo-core/  [non-Qt Rust crate]
-    │           client.rs           — WebSocket JSON-RPC 2.0 (tokio-tungstenite)
-    │           remote_resource.rs  — RemoteResource<T>/ResourceStatus<T>
-    │           store/              — Endpoint, Mutation, Tag, Store cache
-    │           endpoints/          — CatalogEndpoint, MediaSearchEndpoint, RunMutation
-    │           systems_catalog.rs  — CatalogData payload + by-category filter
-    │           config.rs           — TOML config (launcher.toml)
-    │           logger.rs           — tracing-subscriber: stderr + JSONL file sinks
-    │           runtime.rs          — Runtime enum: what device the launcher runs on
-    │           platform.rs         — Platform enum: what Zaparoo Core is running on
-    │           platform_paths.rs   — log/config paths routed through runtime
-    │           media_types.rs      — file-extension → media-type lookup
+    │
+    ├── rust/zaparoo-core/  [non-Qt Rust crate]
+    │     client.rs           — WebSocket JSON-RPC 2.0 (tokio-tungstenite)
+    │     remote_resource.rs  — RemoteResource<T>/ResourceStatus<T>
+    │     store/              — Endpoint, Mutation, Tag, Store cache
+    │     endpoints/          — CatalogEndpoint, MediaSearchEndpoint, RunMutation
+    │     systems_catalog.rs  — CatalogData payload + by-category filter
+    │     input_actions.rs    — action names + Qt key-code mapping
+    │     persist.rs          — write-through persisted UI state
+    │     config.rs           — TOML config (launcher.toml)
+    │     logger.rs           — tracing-subscriber: stderr + JSONL file sinks
+    │     runtime.rs          — Runtime enum: what device the launcher runs on
+    │     platform.rs         — Platform enum: what Zaparoo Core is running on
+    │     platform_paths.rs   — log/config paths routed through runtime
+    │     media_types.rs      — file-extension → media-type lookup
     │
     └── src/ui/app/  [Zaparoo.App QML module]
-          Main.qml
+          Main.qml          — runtime router: input, persistence, transitions
+          MainLayout.qml    — designer-editable visual tree
+          │
+          ├── src/ui/screens/  [Zaparoo.Screens QML module]
+          │     ScreenManager.qml, HubScreen.qml, GamesScreen.qml
+          │
           ├── src/ui/components/  [Zaparoo.Ui QML module]
           │     Carousel.qml, CoverDelegate.qml, TextTileDelegate.qml,
           │     FpsCounter.qml
@@ -58,34 +66,35 @@ src/app/main.cpp
 |---|---|---|
 | zaparoo_launcher_rs (plugin) | `Zaparoo.Browse` | `qrc:/qt/qml/Zaparoo/Browse/` |
 | zaparoo_ui_app | `Zaparoo.App` | `qrc:/qt/qml/Zaparoo/App/` |
+| zaparoo_ui_screens | `Zaparoo.Screens` | `qrc:/qt/qml/Zaparoo/Screens/` |
 | zaparoo_ui_components | `Zaparoo.Ui` | `qrc:/qt/qml/Zaparoo/Ui/` |
 | zaparoo_ui_theme | `Zaparoo.Theme` | `qrc:/qt/qml/Zaparoo/Theme/` |
 
-`engine.loadFromModule("Zaparoo.App", "Main")` is the sole entry point.
-No `qrc:/` strings anywhere else.
+`engine.loadFromModule("Zaparoo.App", "Main")` is the only entry point. Keep
+`qrc:/` strings out of the rest of the app.
 
 ## Key constraints
 
-- **Software rendering only.** MiSTer has no GPU. Never use shaders,
+- **Software rendering only.** MiSTer has no GPU. Do not use shaders,
   `LinearGradient`, `RadialGradient`, `DropShadow`, `Glow`, `OpacityMask`,
-  `MultiEffect`, or `Qt5Compat.GraphicalEffects`. Stick to `Rectangle`,
-  `Image`, `Text`, `Repeater`, `NumberAnimation`, `ColorAnimation`.
+  `MultiEffect`, or `Qt5Compat.GraphicalEffects`. Use `Rectangle`, `Image`,
+  `Text`, `Repeater`, `NumberAnimation`, and `ColorAnimation`.
 
-- **Resolution-agnostic layout.** Runs from 240p (CRT) to 1080p. Use
-  `Sizing.pctH()`, `Sizing.pctW()`, `Sizing.fontSize()` for all
-  dimensions. Never hardcode pixel values.
+- **Resolution-agnostic layout.** The UI runs from 240p CRT output to 1080p.
+  Use `Sizing.pctH()`, `Sizing.pctW()`, and `Sizing.fontSize()` for
+  dimensions. Do not hardcode pixel values.
 
-- **FPS counter is always on.** Check it stays green (≥55 FPS) at 720p+
-  and doesn't fall below 30 at 240p when changing visuals.
+- **FPS counter is always on.** When changing visuals, keep it green (≥55 FPS)
+  at 720p+ and above 30 FPS at 240p.
 
-- **Dynamic Qt on desktop, static Qt on MiSTer.** `BUILD_SHARED_LIBS=ON`
-  is the default (LGPL compliance for distribution). The ARM32 Docker
-  build passes `-DBUILD_SHARED_LIBS=OFF` via the Qt CMake toolchain.
+- **Dynamic Qt on desktop, static Qt on MiSTer.** `BUILD_SHARED_LIBS=ON` is
+  the default for LGPL-compliant desktop distribution. The ARM32 Docker build
+  passes `-DBUILD_SHARED_LIBS=OFF` through the Qt CMake toolchain.
 
 ## Runtime vs Platform
 
-Two orthogonal facts the launcher reasons about. Keep them separate —
-gating the wrong one reintroduces bugs the split was designed to prevent.
+The launcher tracks two separate facts. Do not collapse them; that is how old
+runtime/platform bugs come back.
 
 | Concept | Source of truth | Question answered |
 |---|---|---|
@@ -98,19 +107,18 @@ or vice-versa.
 
 ### When to use which
 
-- **Runtime gate** — "this code path behaves differently depending on
-  the launcher's host device." Read `runtime::current()`. Prefer runtime
-  gating for behavior.
-- **Build-time cfg `#[cfg(zaparoo_runtime = "mister")]`** — reserve for
-  code that genuinely should not compile into desktop binaries (system
-  calls, MiSTer-only dependencies). Currently only `mister_runtime.rs`
-  uses this. Set by `ZAPAROO_RUNTIME=mister` in `cmake/ZaparooRust.cmake`
-  for static-Qt (ARM32) builds.
-- **Platform gate** — "this feature depends on what Core supports."
-  Subscribe to `platform::subscribe()`; treat `None` as "unknown — don't
-  enable platform-specific features until the first `version` RPC
-  completes." Never gate on `Platform` from C++/QML directly; route the
-  decision through Rust and expose a QML property.
+- **Runtime gate** — use this when the launcher's host device changes the
+  behavior. Read `runtime::current()`. Prefer runtime gating for behavior.
+- **Build-time cfg `#[cfg(zaparoo_runtime = "mister")]`** — use this only for
+  code that should not compile into desktop binaries: system calls,
+  MiSTer-only dependencies, and similar. Currently only `mister_runtime.rs`
+  uses it. `ZAPAROO_RUNTIME=mister` is set in `cmake/ZaparooRust.cmake` for
+  static-Qt ARM32 builds.
+- **Platform gate** — use this when a feature depends on what Core supports.
+  Subscribe to `platform::subscribe()` and treat `None` as unknown; do not
+  enable platform-specific behavior until the first `version` RPC completes.
+  Do not gate on `Platform` directly from C++ or QML. Route the decision
+  through Rust and expose a QML property.
 
 **Never gate runtime behavior on `Platform`, never gate Core
 assumptions on `Runtime`.** They are independent.
@@ -124,12 +132,11 @@ License texts live in `src/LICENSES/`.
 
 ## Rust → QML data flow
 
-The data layer is RTK-Query-shaped: a single `Store` owns the
-`Client`, hands out shared `RemoteResource<T>`s keyed by
-`(endpoint NAME, args hash)`, and routes mutations through to the
-same client. QML singletons subscribe by binding to an `Endpoint`;
-the macro at `rust/launcher/src/bind.rs` emits the entire bridge
-(sync seed + qt_thread watcher + property apply).
+The data layer follows the RTK Query shape. A single `Store` owns the `Client`,
+hands out shared `RemoteResource<T>` values keyed by `(endpoint NAME, args
+hash)`, and routes mutations through the same client. QML singletons subscribe
+by binding to an `Endpoint`; `rust/launcher/src/bind.rs` emits the bridge code
+for the sync seed, the `qt_thread` watcher, and the property apply step.
 
 ```
 zaparoo_rust_init()
@@ -162,30 +169,51 @@ zaparoo_rust_init()
                       NowPlayingEndpoint can opt in by adding its tag.
 ```
 
-`RemoteResource<T>` collapses the connection FSM and per-fetch state
-into a single `ResourceStatus<T>`: `Idle`, `Loading`, `Ready(T)`,
-`Errored { message, retrying }`. Every binding seeds itself
-synchronously from the *current* status before spawning the watcher,
-which closes the MiSTer "screen never updates if Core connects before
-QML loads" race.
+`RemoteResource<T>` combines the connection FSM and per-fetch state into one
+`ResourceStatus<T>`: `Idle`, `Loading`, `Ready(T)`, or
+`Errored { message, retrying }`. Each binding reads the current status
+synchronously before it spawns the watcher. That closes the MiSTer race where
+Core can connect before QML loads and the first screen never updates.
 
-Qt message handler (`qInstallMessageHandler`) forwards all Qt log output
-to `zaparoo_log_qt()` in the Rust staticlib, which routes it through the
-same tracing registry. All log output (Rust + Qt) ends up in the same
-sinks: stderr and `launcher.log`.
+The Qt message handler (`qInstallMessageHandler`) forwards Qt log output to
+`zaparoo_log_qt()` in the Rust staticlib. From there it goes through the same
+tracing registry as Rust logs. Both end up in stderr and `launcher.log`.
 
-### Navigation state (Main.qml)
+### Navigation state
+
+`Main.qml` extends `MainLayout.qml`. The layout owns the visual tree; `Main.qml`
+owns the runtime wiring: key translation, screen transitions, and persistence.
+Screens live under `Zaparoo.Screens` so they can be tested without embedding the
+whole application shell.
 
 ```
-activeScreen: "hub" | "games"
-hubFocus:     "categories" | "systems"
+ScreenManager.activeScreen: "hub" | "games"
+HubScreen.section:          "categories" | "systems"
 ```
 
-- **hub + categories**: categoriesCarousel centered; Left/Right cycle categories;
-  Enter calls `SystemsModel.set_category()` and shifts hubFocus to "systems";
-  Escape quits.
-- **hub + systems**: categoriesCarousel swoops to top; systemsCarousel fades in
-  below; Enter calls `GamesModel.set_system()` and sets activeScreen to "games";
+Persisted state is split across Rust-backed QML singletons:
+
+| Singleton | Stored fields | Owner |
+|---|---|---|
+| `Browse.AppState` | `active_screen` | cross-screen route |
+| `Browse.HubState` | `focus`, `category`, `system_id` | hub screen selection |
+| `Browse.GamesState` | `system_id`, `game_path` | games screen selection |
+
+State is loaded before the first QML frame and written through on user actions.
+That is deliberate: MiSTer's parent process can kill and relaunch the launcher
+without warning.
+
+- **hub + categories**: `HubScreen` shows the categories carousel. Left/Right
+  cycles categories; Enter calls `SystemsModel.set_category()` and switches
+  `HubScreen.section` to `"systems"`; Escape quits.
+- **hub + systems**: the categories carousel moves to the top and systems fade
+  in below. Enter calls `GamesModel.set_system()` and requests the games screen;
   Escape returns to categories.
-- **games**: gamesCarousel visible; Enter calls `GamesModel.launch_at()`;
-  Escape returns to hub (hubFocus preserved).
+- **games**: `GamesScreen` shows the games carousel. Enter calls
+  `GamesModel.launch_at()`; Escape requests the hub screen, preserving hub
+  focus.
+
+Model reset handlers in `Main.qml` restore saved carousel indices as catalog
+data arrives. Missing IDs fall back to index 0 without erasing the saved value
+from disk, so a temporary catalog gap does not destroy the user's last
+selection.

--- a/docs/building.md
+++ b/docs/building.md
@@ -1,10 +1,10 @@
 # Building
 
-Day-to-day builds, lints, and tests are wrapped in
+Day-to-day builds, lints, and tests go through the
 [`justfile`](../justfile). `just --list` shows the full menu.
-`CMakePresets.json` and `rust/.cargo/config.toml` are tuned to the
-recipes; if you find yourself reaching for raw `cmake` or `cargo`,
-something is probably off.
+`CMakePresets.json` and `rust/.cargo/config.toml` are written for those
+recipes. If you need raw `cmake` or `cargo`, double-check that the justfile does
+not already cover the job.
 
 ## Requirements
 
@@ -47,11 +47,10 @@ If `just` isn't packaged for your distro, install it the same way:
 - x86_64 host (no emulation needed; pure cross-compilation)
 - ~8 GB disk space for the toolchain image
 
-The toolchain Docker image ships a cross-compiler-aware
-`rust/.cargo/config.toml` that sets the linker
-(`arm-linux-gnueabihf-gcc`), target
-(`armv7-unknown-linux-gnueabihf`), and `mold` on desktop for faster
-links. No manual cargo config is needed.
+The toolchain Docker image provides the ARM build environment. Cargo still gets
+its target and linker settings from `rust/.cargo/config.toml`; the desktop
+`mold` linker setting lives there too. You should not need to edit Cargo config
+by hand.
 
 ## Desktop builds
 
@@ -63,10 +62,10 @@ just build-san       # ASan + UBSan
 just run             # build then ./build/bin/launcher
 ```
 
-The first build pulls and compiles Rust + Qt dependencies. Incremental
-builds after that are fast.
+The first build pulls and compiles the Rust and Qt dependencies. Incremental
+builds are much faster after that.
 
-To skip tests for faster iteration, configure with
+For a faster local build without tests, configure with
 `-DZAPAROO_BUILD_TESTS=OFF`:
 
 ```bash
@@ -76,25 +75,24 @@ cmake --build --preset desktop-debug
 
 ## MiSTer ARM32 cross-build
 
-First time (builds Qt 6.7.2 from source, ~45 min):
+First run, building Qt from source (~45 min):
 
 ```bash
 ./scripts/build-toolchain.sh
 ```
 
-This creates the `zaparoo/qt6-arm32-mister:6.7.2` Docker image
-locally.
+This creates the local `zaparoo/qt6-arm32-mister:<version>` Docker image. The
+tag comes from `toolchain/VERSION`.
 
-Subsequent builds (under a minute):
+Later builds usually take under a minute:
 
 ```bash
 just arm32           # output/launcher
 ```
 
-If the toolchain image is missing, `build-arm32.sh` rebuilds it
-automatically.
+If the toolchain image is missing, `build-arm32.sh` rebuilds it.
 
-Verify the ARM binary:
+Check the ARM binary:
 
 ```bash
 file output/launcher
@@ -120,9 +118,9 @@ just lint-rust       # rustfmt check + clippy + cargo-deny
 just fmt             # auto-apply: pre-commit + cargo fmt
 ```
 
-`just lint` is the zero-warnings gate before opening a PR.
-`compile_commands.json` is generated unconditionally in `build/`, so
-clang-tidy and qmllint always have what they need.
+`just lint` is the zero-warnings gate before a PR. `compile_commands.json` is
+always generated in `build/`, so clang-tidy and qmllint have the project
+metadata they need.
 
 ## Deploy desktop bundle
 
@@ -132,8 +130,8 @@ just build
 ./deploy/launcher/run.sh
 ```
 
-The deploy script bundles Qt shared libraries alongside the binary.
-Qt must be on your PATH (`qmake6` or `qmake` must be findable).
+The deploy script copies Qt shared libraries next to the binary. Qt must be on
+your PATH (`qmake6` or `qmake` must be findable).
 
 ## Deploy to MiSTer
 
@@ -141,11 +139,10 @@ Qt must be on your PATH (`qmake6` or `qmake` must be findable).
 just deploy-mister
 ```
 
-The binary is self-contained on MiSTer: it sets
-`QT_QPA_PLATFORM=linuxfb` and `QT_QUICK_BACKEND=software`, runs `vmode
--r W H rgb32` (width and height from config, defaulting to
-1920×1080), and starts `/media/fat/Scripts/zaparoo.sh -service start`
-automatically. No wrapper script required.
+The MiSTer binary is self-contained. It sets `QT_QPA_PLATFORM=linuxfb` and
+`QT_QUICK_BACKEND=software`, runs `vmode -r W H rgb32` using the configured
+width and height (default `1920×1080`), and starts
+`/media/fat/Scripts/zaparoo.sh -service start`. No wrapper script is needed.
 
 User-editable config lives at `/media/fat/zaparoo/launcher.toml`.
 Example:
@@ -161,7 +158,7 @@ debug = true
 
 ## Run on framebuffer (desktop headless)
 
-Useful for reproducing MiSTer rendering paths on a desktop:
+Use this to reproduce the MiSTer rendering path on a desktop:
 
 ```bash
 QT_QPA_PLATFORM=linuxfb QT_QUICK_BACKEND=software ./build/bin/launcher
@@ -169,8 +166,8 @@ QT_QPA_PLATFORM=linuxfb QT_QUICK_BACKEND=software ./build/bin/launcher
 
 ## Underlying mechanics
 
-Reach for these only when debugging the build itself or running
-something not in the justfile.
+Use these only when debugging the build itself or doing something the justfile
+does not cover.
 
 `just build` resolves to:
 
@@ -179,9 +176,9 @@ cmake --preset desktop-debug
 cmake --build --preset desktop-debug
 ```
 
-`just lint-cpp` resolves to `cmake --build build --target lint`,
-which runs clang-format (check only), clang-tidy, and qmllint in one
-shot. Individual targets:
+`just lint-cpp` resolves to `cmake --build build --target lint`. That runs
+clang-format (check only), clang-tidy, and qmllint together. The individual
+targets are:
 
 ```bash
 cmake --build build --target format-check   # clang-format dry-run
@@ -190,9 +187,8 @@ cmake --build build --target all_qmllint    # QML linting
 ```
 
 `just test` resolves to `ctest --preset desktop-debug` plus
-`cargo nextest run --workspace` (run from inside `rust/` because
-nextest needs a workspace path; that's what the justfile does for
-you). Plain ctest works too:
+`cargo nextest run --workspace`. Nextest needs the Rust workspace path, so the
+justfile runs that command from `rust/`. Plain ctest works too:
 
 ```bash
 ctest --test-dir build --output-on-failure

--- a/docs/cxx-qt-bridge.md
+++ b/docs/cxx-qt-bridge.md
@@ -1,40 +1,37 @@
 # cxx-qt Bridge Gotchas
 
-Read this when writing Rust QML models via cxx-qt 0.7 in
+Read this before writing Rust QML models with cxx-qt 0.7 in
 `rust/launcher/src/models/`.
 
 - **`cxx = "1"` must be a direct dependency.** The `#[cxx_qt::bridge]` macro
   expands to `#[cxx::bridge]`. Rust resolves proc-macro attributes in the
   calling crate's scope, so `cxx` must appear in that crate's `[dependencies]`.
-  A transitive dep through `cxx-qt` is not sufficient.
+  The transitive dependency through `cxx-qt` is not enough.
 
-- **`#[qproperty(T, snake_case_name)]` auto-converts to camelCase** on the Qt
-  and QML side. `#[qproperty(bool, has_next_page)]` → accessible as
-  `hasNextPage` in QML.
+- **`#[qproperty(T, snake_case_name)]` becomes camelCase** on the Qt and QML
+  side. `#[qproperty(bool, has_next_page)]` is exposed as `hasNextPage` in QML.
 
-- **User-defined `#[qinvokable]` methods are exposed with their Rust name**
-  (snake_case). QML calls them as `model.set_system(id)` etc. Add
-  `#[cxx_name = "..."]` only when you need camelCase (e.g. to match a Qt
-  base-class virtual like `rowCount`, `roleNames`, `beginResetModel`).
+- **User-defined `#[qinvokable]` methods keep their Rust name** (snake_case).
+  QML calls them as `model.set_system(id)` and so on. Add
+  `#[cxx_name = "..."]` only when you need camelCase, such as matching a Qt
+  base-class virtual like `rowCount`, `roleNames`, or `beginResetModel`.
 
-- **cxx-qt plugin class name** for a `Zaparoo.Browse` module is
-  `Zaparoo_Browse_plugin` (not `Zaparoo_BrowsePlugin`). Use
+- **The cxx-qt plugin class name** for `Zaparoo.Browse` is
+  `Zaparoo_Browse_plugin`, not `Zaparoo_BrowsePlugin`. Use
   `Q_IMPORT_QML_PLUGIN(Zaparoo_Browse_plugin)` in the C++ entry point.
 
-- **Bind QML singletons to data through `bind_to_endpoint!`.** QML
-  singletons are constructed *after* `init_globals` runs, which is
-  *after* the WebSocket task has very likely already advanced past
-  `Idle`/`Disconnected`. If you only spawn an async watcher inside
-  `initialize()`, the QObject's `Default::default()` placeholder values
-  are visible to the first frame.
+- **Bind QML singletons to data through `bind_to_endpoint!`.** QML singletons
+  are constructed *after* `init_globals` runs. By then, the WebSocket task has
+  usually moved past `Idle`/`Disconnected`. If `initialize()` only spawns an
+  async watcher, the first frame can see the QObject's `Default::default()`
+  placeholder values.
 
-  The macro at `rust/launcher/src/bind.rs` emits the entire
-  `cxx_qt::Initialize` impl: it subscribes the singleton to the
-  store-cached `RemoteResource<E::Output>` for the chosen endpoint,
-  reads the current `ResourceStatus` *synchronously* before returning,
-  and only then spawns the qt_thread watcher for subsequent updates.
-  The seed bug is closed structurally — there is no place left to
-  forget it.
+  The macro at `rust/launcher/src/bind.rs` emits the full
+  `cxx_qt::Initialize` impl. It subscribes the singleton to the store-cached
+  `RemoteResource<E::Output>` for the endpoint, reads the current
+  `ResourceStatus` *synchronously* before returning, and only then spawns the
+  `qt_thread` watcher for later updates. That makes the seed step part of the
+  binding instead of something each model has to remember.
 
   ```rust
   // models/app_status.rs — full bridge for the AppStatus banner.
@@ -47,14 +44,13 @@ Read this when writing Rust QML models via cxx-qt 0.7 in
   }
   ```
 
-  `select` and `apply` are free functions (not closures) so they're
-  `Copy` and reusable across the sync seed and the async loop. For
-  per-arg endpoints (e.g. `MediaSearchEndpoint`, keyed by system id),
-  drive `Store::subscribe` directly from a `#[qinvokable]` and abort
-  the previous watcher's `JoinHandle` before installing the new one
-  (see `models/games.rs`).
+  `select` and `apply` are free functions, not closures, so they are `Copy`
+  and can be reused by the sync seed and the async loop. For per-arg endpoints,
+  such as `MediaSearchEndpoint` keyed by system id, call `Store::subscribe`
+  from a `#[qinvokable]` and abort the previous watcher's `JoinHandle` before
+  installing the next one (see `models/games.rs`).
 
-  Use `tokio::sync::watch` for any state a `RemoteResource` exposes;
-  `tokio::sync::broadcast` drops messages sent before a receiver
-  subscribes and so loses the seed value entirely (see the CLAUDE.md
-  "broadcast vs watch" note).
+  Use `tokio::sync::watch` for state exposed by `RemoteResource`.
+  `tokio::sync::broadcast` drops messages sent before a receiver subscribes,
+  which loses the seed value entirely (see the AGENTS.md "broadcast vs watch"
+  note).

--- a/docs/qml-gotchas.md
+++ b/docs/qml-gotchas.md
@@ -1,24 +1,23 @@
 # QML Gotchas
 
-Read this when writing or reviewing QML. These are pitfalls `qmllint` only
-catches *after* the code is written, so it's cheaper to avoid them up front.
+Read this before writing or reviewing QML. `qmllint` catches these after the
+fact; avoiding them is faster.
 
-- **Typed properties, not `var`.** Use `list<string>`, `list<url>`, `int`,
+- **Typed properties, not `var`.** Use `list<string>`, `list<url>`, `int`, or
   `real`. `var` produces `QVariant` warnings and blocks AOT compilation.
 
 - **`Repeater` delegates need `pragma ComponentBehavior: Bound`** at the top
-  of the file. Add `required property int index` to the delegate, plus
+  of the file. Add `required property int index` to the delegate. Add
   `required property string modelData` when the model is a list.
 
-- **Nested delegate children** that reference the delegate's properties must
-  qualify: give the delegate an `id` and use `id.modelData`, not bare
-  `modelData`.
+- **Nested delegate children** must qualify delegate properties. Give the
+  delegate an `id` and use `id.modelData`, not bare `modelData`.
 
 - **Singleton QML types** need both `pragma Singleton` in the `.qml` file
   and `set_source_files_properties(Foo.qml PROPERTIES QT_QML_SINGLETON_TYPE TRUE)`
   in CMake, or qmllint will warn "not declared as singleton in qmldir".
 
-- **Function type annotations required.** Add `: ParamType` parameters and
+- **Function type annotations are required.** Add `: ParamType` parameters and
   `: ReturnType` return types to all functions in singleton `.qml` files.
 
 - **`NumberAnimation on propName`** conflicts with `property T propName: value`.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,20 +2,21 @@
 
 ## 1. Install prerequisites
 
-One-time setup. Skip any you already have.
+Install the pieces you do not already have.
 
 ### Linux
 
 **Fedora / RHEL:**
 ```bash
 sudo dnf install qt6-qtdeclarative-devel qt6-qtquickcontrols2-devel \
-    cmake ninja-build mold clang-tools-extra just
+    qt6-qttools-devel cmake ninja-build mold clang-tools-extra just
 ```
 
 **Ubuntu / Debian:**
 ```bash
 sudo apt install qt6-declarative-dev qt6-quick-controls2-dev \
-    cmake ninja-build mold clang-tidy clang-format just
+    qt6-tools-dev qt6-l10n-tools cmake ninja-build mold \
+    clang-tidy clang-format just
 ```
 
 (If `just` isn't packaged for your distro, install it with
@@ -30,9 +31,9 @@ cargo install --locked cargo-nextest cargo-deny
 
 ### macOS / Windows
 
-macOS is best-effort and not covered in CI. See
-[`docs/building.md`](building.md) for Homebrew package names. Windows
-is not tested; use WSL2.
+macOS is best-effort and not covered in CI. Qt package names change often
+enough that Linux is the supported path unless you are prepared to debug local
+setup. Windows is not tested; use WSL2.
 
 ## 2. Clone and build
 
@@ -42,8 +43,8 @@ cd zaparoo-launcher
 just build
 ```
 
-The first build pulls and compiles Rust + Qt dependencies. After that
-incremental builds are fast.
+The first build pulls and compiles the Rust and Qt dependencies. Incremental
+builds are much faster after that.
 
 ## 3. Start the mock Core
 
@@ -59,21 +60,18 @@ You should see:
 mock-core listening on ws://127.0.0.1:27497/api/v0.1
 ```
 
-The mock serves three categories (Consoles, Handhelds, Arcade), ten
-systems, and fifty games. That's enough to drive every launcher
-screen end to end.
+The mock serves three categories (Consoles, Handhelds, Arcade), ten systems,
+and fifty games. That is enough data to exercise every launcher screen.
 
-`27497` is deliberately offset from the real Core's `7497` so a
-real Core (or other Core test instance) running on the same machine
-never clashes with the mock. The launcher's production default is
-still `7497`; `just run-dev` overrides that to the mock port via the
-`ZAPAROO_CORE_ENDPOINT` environment variable, and `just run` (the
-release-style runner) reads `~/.config/zaparoo/launcher.toml` as
-normal.
+`27497` is offset from the real Core's `7497` so a real Core, or another Core
+test instance, can run on the same machine without colliding with the mock. The
+launcher still defaults to `7497` in production. `just run-dev` points it at
+the mock through `ZAPAROO_CORE_ENDPOINT`; `just run` reads
+`~/.config/zaparoo/launcher.toml` as usual.
 
-### Picking a different port
+### Pick a different port
 
-If something else binds `27497` already, override at start:
+If something already uses `27497`, override it at startup:
 
 ```bash
 MOCK_CORE_ADDR=127.0.0.1:9000 just mock-core
@@ -90,11 +88,11 @@ In a second terminal:
 just run-dev
 ```
 
-(`run-dev` is windowed and auto-points at the mock; `just run` is the
-production-style runner that respects `~/.config/zaparoo/launcher.toml`
-and starts fullscreen.)
+`run-dev` is windowed and points at the mock. `just run` is the
+production-style runner: it respects `~/.config/zaparoo/launcher.toml` and
+starts fullscreen.
 
-## 5. What success looks like
+## 5. Check the result
 
 - The launcher window opens.
 - A **categories** carousel fills with "Arcade", "Consoles",
@@ -103,15 +101,15 @@ and starts fullscreen.)
   category.
 - Pressing Enter on a system opens the **games** carousel (five
   entries per system).
-- Pressing Enter on a game fires a `run` RPC to the mock. The mock
-  logs it with the selected game's zap script, but the launcher keeps
-  running because there's nothing actually to launch.
+- Pressing Enter on a game sends a `run` RPC to the mock. The mock logs the
+  selected game's zap script, but the launcher keeps running because nothing is
+  actually launched.
 - Escape backs out; Escape on the top level quits.
 
-The FPS counter in the corner should stay green (≥ 55). If it goes
-red, flag it; that's a regression.
+The FPS counter in the corner should stay green (≥ 55). Red means the UI fell
+below 30 FPS and needs investigation.
 
-## 6. Running tests and lints
+## 6. Run tests and lints
 
 Before you open a pull request:
 

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -1,8 +1,7 @@
 # Translations
 
-Zaparoo Launcher routes every user-visible string through Qt's
-`QTranslator` so non-English builds can ship without code changes.
-Three pieces hold the pipeline together:
+Zaparoo Launcher sends every user-visible string through Qt's `QTranslator`.
+Non-English builds should not need code changes. The pipeline has three parts:
 
 1. `qsTr()` in QML and `tr()` in C++ at every user-visible call site.
 2. `src/ui/translations/launcher_<tag>.ts` as the canonical catalog
@@ -11,8 +10,8 @@ Three pieces hold the pipeline together:
    `lrelease` at build time and bundles the resulting `.qm` files
    under `qrc:/i18n/` inside the launcher binary.
 
-At runtime, `src/app/main.cpp` installs a `QTranslator` before the QML
-engine loads and picks the `.qm` that matches the configured locale.
+At runtime, `src/app/main.cpp` installs a `QTranslator` before the QML engine
+loads, then picks the `.qm` file for the configured locale.
 
 ## Locale resolution
 
@@ -21,17 +20,16 @@ engine loads and picks the `.qm` that matches the configured locale.
 | `[general] language = "ja_JP"` in `launcher.toml` | 1: explicit override |
 | `[general] language = "auto"` or unset | 2: `QLocale::system()` |
 
-The Rust config loader (`rust/zaparoo-core/src/config.rs`) normalizes
-`"auto"` (case-insensitive) to an empty string, which `main.cpp`
-treats as the signal to call `QLocale::system()`. Anything else passes
-straight through to `QLocale(tag)`; Qt does its own tag validation.
+The Rust config loader (`rust/zaparoo-core/src/config.rs`) normalizes `"auto"`
+(case-insensitive) to an empty string. `main.cpp` treats that as the signal to
+call `QLocale::system()`. Anything else passes through to `QLocale(tag)` and Qt
+handles tag validation.
 
-The config-to-C++ handoff goes through FFI:
-`zaparoo_rust_language_code()` returns a `'static` NUL-terminated
-UTF-8 pointer cached in `LANGUAGE_CODE: OnceLock<CString>`. The main
-thread reads it once before constructing the QML engine. There is no
-reload path, so changing the locale requires a relaunch (the same
-cost as any other `launcher.toml` edit).
+The config-to-C++ handoff goes through FFI. `zaparoo_rust_language_code()`
+returns a `'static` NUL-terminated UTF-8 pointer cached in
+`LANGUAGE_CODE: OnceLock<CString>`. The main thread reads it once before
+constructing the QML engine. There is no reload path; changing the locale takes
+a relaunch, like any other `launcher.toml` edit.
 
 ## Writing translatable strings
 
@@ -48,13 +46,12 @@ text: qsTr("Core error: %1").arg(Browse.AppStatus.last_error)
 text: qsTr("Core error:") + " " + Browse.AppStatus.last_error
 ```
 
-Rule of thumb: one sentence, one `qsTr()`. Use `%1`/`%2` placeholders
-for runtime values so translators control word order around them.
+Rule of thumb: one sentence, one `qsTr()`. Use `%1` and `%2` placeholders for
+runtime values so translators can control word order.
 
-Strings that never face a human (enum tags, filesystem paths, QRC
-URLs, internal error codes routed to `tracing::error!`, QML type
-names) do **not** need wrapping. When in doubt: if it could appear in
-a screenshot, wrap it.
+Strings that never face a user do **not** need wrapping: enum tags, filesystem
+paths, QRC URLs, internal error codes routed to `tracing::error!`, QML type
+names, and similar. If it could appear in a screenshot, wrap it.
 
 ## Adding a new locale
 
@@ -67,12 +64,12 @@ a screenshot, wrap it.
 
         lupdate-qt6 src/ -ts src/ui/translations/launcher_de.ts
 
-   `lupdate` is idempotent. Re-running it reconciles new and removed
+   `lupdate` is idempotent. Re-running it adds new strings and marks removed
    strings without clobbering existing translations.
 
 3. Fill in each `<translation>` element in the `.ts` file. An empty
-   `<translation>` with `type="unfinished"` means "use the source
-   string"; Qt Linguist highlights these in the editor UI.
+   `<translation>` with `type="unfinished"` falls back to the source string;
+   Qt Linguist highlights these in the editor UI.
 
 4. Add the file path to the `TS_FILES` list in
    `cmake/ZaparooRust.cmake`'s `qt_add_translations(launcher ...)`
@@ -90,11 +87,10 @@ After adding or changing any `qsTr()` call, re-run `lupdate-qt6`:
 
     lupdate-qt6 src/ -ts src/ui/translations/launcher_en.ts
 
-Review the diff: new strings appear with empty `<translation>`
-elements, changed strings are flagged `type="unfinished"`, and removed
-strings are marked `type="obsolete"`. Commit the `.ts` changes
-alongside the QML or C++ edit that triggered them so translators have
-a clean incremental diff.
+Review the diff. New strings appear with empty `<translation>` elements,
+changed strings are flagged `type="unfinished"`, and removed strings are marked
+`type="obsolete"`. Commit the `.ts` changes with the QML or C++ edit that
+triggered them so translators get a clean incremental diff.
 
 ## Build-time mechanics
 
@@ -109,7 +105,7 @@ qt_add_translations(launcher
 )
 ```
 
-What happens:
+The build does this:
 
 - `lrelease` runs per `.ts` to produce `<name>.qm` in the build tree.
 - The `.qm` files are packed into a Qt resource bound to the
@@ -120,11 +116,10 @@ What happens:
   the default build, so every `just build` refreshes the compiled
   catalogs.
 
-`IMMEDIATE_CALL` runs the source-target collection inline. Without
-it, Qt defers collection to the end of the top-level
-`PROJECT_SOURCE_DIR` scope, which races Corrosion's late-bound Rust
-staticlib targets on parallel builds and produces missing-dependency
-errors.
+`IMMEDIATE_CALL` runs source-target collection inline. Without it, Qt defers
+collection to the end of the top-level `PROJECT_SOURCE_DIR` scope. That races
+Corrosion's late-bound Rust staticlib targets on parallel builds and can
+produce missing-dependency errors.
 
 ## Runtime loading
 
@@ -139,11 +134,10 @@ if (translator.load(locale, "launcher", "_", ":/i18n")) {
 }
 ```
 
-`QTranslator::load` walks Qt's usual fallback chain: an exact `ja_JP`
-match first, then `ja`, then the base name. A missing `.qm` is logged
-at info level, not as an error, because English-only builds ship
-exactly one catalog (a passthrough `launcher_en.qm`) and any other
-locale just falls through to the source strings.
+`QTranslator::load` uses Qt's normal fallback chain: exact `ja_JP` match, then
+`ja`, then the base name. A missing `.qm` is logged at info level, not error
+level. English-only builds ship one passthrough catalog (`launcher_en.qm`), and
+other locales fall through to the source strings.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- Rewrite public documentation in a more direct maintainer voice while preserving the existing technical content.
- Update AGENTS.md using current agent-context guidance, with commands first and current project constraints called out.
- Fix stale documentation around QML modules, persisted state, Qt Linguist packages, ARM32 toolchain tags, and CI job wording.

## Testing
- git diff --check

## Checklist
- [x] I have tested the changes locally, or explained why testing is not needed.
- [x] I have updated documentation where needed.
- [x] I have checked that any user-facing text is ready for translation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified and reorganized contributor guidelines, build instructions, and quickstart documentation for improved clarity.
  * Updated architecture and design documentation with refined explanations of core modules and workflows.
  * Enhanced guidance for translations, QML development, and bridge code implementation.
  * Improved overall documentation structure and phrasing across README, building, and architecture resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->