### PR TITLE
chore(rust): upgrade cxx-qt to 0.8.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ CLAUDE.md
 
 # Cargo build cache
 rust/target/
+
+# cxx-qt 0.8 generates this with absolute paths for qmlls/qmllint
+rust/launcher/.qmlls.ini

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ raw cargo as the default path; the justfile carries the expected environment.
 - Qt 6.7+ with Qt Quick, QuickControls2, QML, QuickTest, and LinguistTools.
 - C++17 executable at `src/app/main.cpp`; Rust static library linked through
   Corrosion and cxx-qt.
-- Rust workspace is under `rust/`, edition 2021, MSRV 1.90, cxx-qt 0.7.
+- Rust workspace is under `rust/`, edition 2021, MSRV 1.90, cxx-qt 0.8.
 - Desktop builds link Qt dynamically for LGPL compliance.
 - MiSTer ARM32 builds use the Docker toolchain and static Qt.
 
@@ -137,7 +137,7 @@ starts our `launcher`; do not replace that flow with a new wrapper script.
 - `docs/architecture.md` — module graph, data flow, runtime/platform split
 - `docs/building.md` — build matrix, ARM32 toolchain, deploy bundle
 - `docs/qml-gotchas.md` — QML issues qmllint often catches late
-- `docs/cxx-qt-bridge.md` — cxx-qt 0.7 bridge constraints
+- `docs/cxx-qt-bridge.md` — cxx-qt 0.8 bridge constraints
 - `docs/translations.md` — `qsTr()`/`tr()` pipeline and locale catalogs
 - `design/README.md` — Qt Design Studio workflow and designer boundaries
 - `src/LICENSES/` — Qt LGPL notices

--- a/cmake/SyncCxxqtQmlModules.cmake
+++ b/cmake/SyncCxxqtQmlModules.cmake
@@ -10,36 +10,12 @@
 # searches the Qt qml output root; copying makes them siblings of the
 # C++-generated App/Theme/Ui modules.
 #
-# Also patches plugin.qmltypes to work around three cxx-qt 0.7 gaps that
-# make qmllint noisy against Rust-backed singletons. Remove the patch
-# block when we upgrade to cxx-qt 0.8, which adds first-class
-# qmllint/qmlls support:
-#
-#   1. `isSingleton: true` / `isCreatable: false` for types declared
-#      `QML_SINGLETON`. The macro lands in the C++ header but
-#      qmltyperegistrar does not forward it to .qmltypes, so without the
-#      patch qmllint treats every `Browse.QAppState.property` access as
-#      a static meta-object lookup and reports [missing-property].
-#
-#   2. `::std::int32_t` → `int`. cxx-qt-gen emits the C++ typedef
-#      verbatim (upstream issue cxx-qt#60). Qt's qmllint has no mapping
-#      from `::std::int32_t` to its built-in `int` type, so every
-#      int-valued property or method return trips [unresolved-type].
-#
-#   3. `prototype: "::rust::cxxqt1::CxxQtType<T>"` /
-#      `"::rust::cxxqt1::CxxQtThreading<T>"` → `"QObject"`. The cxx-qt
-#      bridge templates inherit from QObject at the C++ level, but
-#      qmllint sees them as unresolved types and therefore refuses to
-#      use a singleton as a `Connections.target:` (expects QObject).
-#
-#   4. `isFinal: true` on every Property of a singleton Component. QML
-#      singletons can't be subclassed, so the QQmlCompiler "Member X
-#      can be shadowed" warning is a false positive — qmllint only
-#      suppresses it when the member is marked final. Methods are left
-#      untouched: the qmltypes schema has no isFinal slot for Method
-#      (qmllint itself rejects it with "Expected only name, lineNumber,
-#      ..."), so method-shadowing warnings linger until we upgrade to
-#      cxx-qt 0.8.
+# cxx-qt 0.8 emits qmllint-clean qmltypes natively for singletons, plain
+# `int`, and real C++ prototypes — the 0.7-era patches for those have been
+# removed. The remaining patch injects `isFinal: true` on properties of
+# QML_SINGLETON Components, suppressing qmllint's "Member can be shadowed"
+# false positive (singletons can't be subclassed). Methods get no patch:
+# the qmltypes schema has no isFinal slot for Method.
 #
 # Run via:
 #   cmake -DCARGO_DIR=... -DDEST_QML_DIR=... -P SyncCxxqtQmlModules.cmake
@@ -82,11 +58,13 @@ foreach(_qmldir IN LISTS _qmldirs)
     endforeach()
 endforeach()
 
-# ── Patch plugin.qmltypes for cxx-qt singletons ──────────────────────────────
-# Collect the set of QML element names declared as singletons by scanning
-# every cxx-qt-generated header for a QML_SINGLETON macro paired with a
-# Q_CLASSINFO("QML.Element", "<Name>") line. Then rewrite each synced
-# plugin.qmltypes so qmllint sees those Components as singletons.
+# ── Patch plugin.qmltypes: isFinal: true on singleton properties ─────────────
+# Collect QML_SINGLETON element names from the cxx-qt-generated headers, then
+# rewrite each synced plugin.qmltypes to mark every Property final when *all*
+# Components in the file are known singletons. Only run the patch under that
+# guard: non-singleton types can legitimately be subclassed and marking their
+# members final would be incorrect. Methods are untouched — the qmltypes
+# schema has no isFinal slot for Method.
 
 set(_singleton_names "")
 file(GLOB_RECURSE _all_cxxqt_headers "${CARGO_DIR}/*.cxxqt.h")
@@ -111,41 +89,6 @@ foreach(_qt_file IN LISTS _synced_qmltypes)
     file(READ "${_qt_file}" _qt_content)
     set(_original "${_qt_content}")
 
-    # (1) Inject isSingleton / isCreatable for each QML_SINGLETON class.
-    # Idempotent — rerunning the sync target leaves the file unchanged
-    # once all three patches have already been applied.
-    foreach(_name IN LISTS _singleton_names)
-        string(REGEX MATCH
-            "name: \"${_name}\"\n[ \t]+accessSemantics: \"reference\"\n[ \t]+isSingleton: true"
-            _already "${_qt_content}")
-        if(_already)
-            continue()
-        endif()
-        string(REGEX REPLACE
-            "(name: \"${_name}\"\n)([ \t]+)(accessSemantics: \"reference\")"
-            "\\1\\2\\3\n\\2isSingleton: true\n\\2isCreatable: false"
-            _qt_content "${_qt_content}")
-    endforeach()
-
-    # (2) ::std::int32_t → int. qmltyperegistrar emits the C++ typedef
-    # spelled exactly like this; Qt's qmllint only knows the short form.
-    string(REPLACE "::std::int32_t" "int" _qt_content "${_qt_content}")
-
-    # (3) cxx-qt bridge template → QObject. The templated C++ ancestor
-    # is a QObject mixin, but qmllint can't see through unresolved
-    # template instantiations; collapsing to the concrete base unlocks
-    # Connections.target:, signal bindings, etc.
-    string(REGEX REPLACE
-        "prototype: \"::rust::cxxqt1::CxxQt(Type|Threading)<[^\"]+>\""
-        "prototype: \"QObject\""
-        _qt_content "${_qt_content}")
-
-    # (4) isFinal: true on every Property / multi-line Method.
-    # Only run when *every* Component in the file is a known singleton —
-    # non-singleton types can legitimately be subclassed, and marking
-    # their members final would be incorrect. Today all cxx-qt-backed
-    # types we register are singletons; the guard keeps this honest if
-    # that ever changes.
     string(REGEX MATCHALL
         "    Component \\{\n[ \t]+file: \"[^\"]+\"\n[ \t]+lineNumber: [0-9]+\n[ \t]+name: \"[^\"]+\""
         _component_headers "${_qt_content}")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,7 +23,7 @@ src/app/main.cpp
     │     │     Pre-Qt setup on ARM32: vmode resolution switch, zaparoo.sh start.
     │     │     Compiled on all platforms; MiSTer-specific calls are gated by cfg.
     │     │
-    │     ├── src/models/  [Zaparoo.Browse QML module via cxx-qt 0.7]
+    │     ├── src/models/  [Zaparoo.Browse QML module via cxx-qt 0.8]
     │     │     AppStatus, CategoriesModel, SystemsModel, GamesModel,
     │     │     AppState, HubState, GamesState, Input, BrowseModel.
     │     │     All registered via build.rs QmlModule.

--- a/docs/cxx-qt-bridge.md
+++ b/docs/cxx-qt-bridge.md
@@ -1,6 +1,6 @@
 # cxx-qt Bridge Gotchas
 
-Read this before writing Rust QML models with cxx-qt 0.7 in
+Read this before writing Rust QML models with cxx-qt 0.8 in
 `rust/launcher/src/models/`.
 
 - **`cxx = "1"` must be a direct dependency.** The `#[cxx_qt::bridge]` macro

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -128,7 +128,7 @@ Zero warnings is the bar.
   data flow, Runtime vs Platform distinction.
 - [`docs/qml-gotchas.md`](qml-gotchas.md): QML pitfalls that `qmllint`
   only catches after the fact.
-- [`docs/cxx-qt-bridge.md`](cxx-qt-bridge.md): cxx-qt 0.7 bridge
+- [`docs/cxx-qt-bridge.md`](cxx-qt-bridge.md): cxx-qt 0.8 bridge
   constraints when editing Rust QML models.
 - [`CONTRIBUTING.md`](../CONTRIBUTING.md): CLA flow, PR expectations,
   branch-protection rules.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -229,9 +229,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-qt"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb4ce9106b3ee7ef85f77d5f69ec30ec3037ea1edacd3e29a61b26ff47ecc637"
+checksum = "3fdf26e5ee4375a85799d0fe436662e5a8ef099bd0964b84bce8812c35c7daea"
 dependencies = [
  "cxx",
  "cxx-qt-build",
@@ -243,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-qt-build"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a7884708e645dc34a2c475bd8c505a2ffeb7c9cb0843f5c580c002c939ea30"
+checksum = "f9a88c7f8241bfe4dfd19d27397a5845f0f275735a34ee7fb219045da81945e3"
 dependencies = [
  "cc",
  "codespan-reporting 0.11.1",
@@ -256,17 +256,17 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "version_check",
 ]
 
 [[package]]
 name = "cxx-qt-gen"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6b431dc58e4a9b7a55b675be0941331cc2cab0a494e4742ebf7bb393c3fc39"
+checksum = "9b1917c90b10117890e3794f4a0dc764a24704de40711d688ae128b0704490b8"
 dependencies = [
  "clang-format",
  "convert_case",
+ "cxx-gen",
  "indoc",
  "proc-macro2",
  "quote",
@@ -275,9 +275,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-qt-lib"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527b46c28be6bf3dd02f1567706641fe247a8798defab8268c84602955741217"
+checksum = "d7b3de184cff59ad29d657021f933380e584d9b70265247f6a96098bef964211"
 dependencies = [
  "cxx",
  "cxx-qt",
@@ -287,12 +287,13 @@ dependencies = [
 
 [[package]]
 name = "cxx-qt-macro"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "971d8811fd1c8dd06c17284edcfc8e9663dac30d7e3d52159405f836a81923f1"
+checksum = "230b0d8b20d3d02a85885742be4fabc0382fead4e382dd8c9c9ff1827f221e8c"
 dependencies = [
  "cxx-qt-gen",
  "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -373,12 +374,6 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
-
-[[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encode_unicode"
@@ -588,15 +583,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,12 +672,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -713,16 +693,6 @@ dependencies = [
  "tokio-tungstenite",
  "tracing",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -797,13 +767,15 @@ dependencies = [
 
 [[package]]
 name = "qt-build-utils"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63c7e24653d0b3084180066306b26e532b152470b13a050c2d2960284d4b9f53"
+checksum = "4d074750fd3baba12fdb47388d591ad9ed043e23864a79d129dcf3a1ef6fc8d9"
 dependencies = [
+ "anyhow",
  "cc",
+ "semver",
+ "serde",
  "thiserror 1.0.69",
- "versions",
 ]
 
 [[package]]
@@ -1413,16 +1385,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "versions"
-version = "6.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f25d498b63d1fdb376b4250f39ab3a5ee8d103957346abacd911e2d8b612c139"
-dependencies = [
- "itertools",
- "nom",
-]
 
 [[package]]
 name = "wasi"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -15,9 +15,9 @@ authors      = ["Wizzo Pty Ltd and the Zaparoo Project contributors"]
 
 [workspace.dependencies]
 cxx             = "1"
-cxx-qt          = "0.7"
-cxx-qt-lib      = "0.7"
-cxx-qt-build    = "0.7"
+cxx-qt          = "0.8"
+cxx-qt-lib      = "0.8"
+cxx-qt-build    = "0.8"
 serde           = { version = "1", features = ["derive"] }
 serde_json      = "1"
 toml            = "1.1"

--- a/rust/launcher/build.rs
+++ b/rust/launcher/build.rs
@@ -8,35 +8,43 @@ fn main() {
     // cxx_qt_build compiles the CXX-Qt bridge code and registers the
     // Zaparoo.Browse QML module. Qt is located via the QMAKE env var
     // (set by ZaparooRust.cmake for ARM32 cross) or PATH qmake6 on desktop.
-    CxxQtBuilder::new()
-        .qt_module("Core")
-        .qt_module("Gui")
-        .qt_module("Qml")
-        .qt_module("Quick")
-        .qt_module("QuickControls2")
-        // Expose the models directory so generated C++ can find model_includes.h.
-        .cc_builder(|cc| {
+    //
+    // 0.8 builder shape: new_qml_module() takes the QmlModule up front and
+    // auto-links Qt Core + Qml; .files([...]) replaces the 0.7 rust_files
+    // field on QmlModule (removed in 0.8).
+    let builder = CxxQtBuilder::new_qml_module(
+        QmlModule::new("Zaparoo.Browse")
+            .version(1, 0)
+            // QAbstractListModel-derived singletons (CategoriesModel, SystemsModel,
+            // GamesModel, BrowseModel) need this for qmllint to follow the
+            // prototype chain back to QObject.
+            .depend("QtQml.Models"),
+    )
+    .qt_module("Gui")
+    .qt_module("Quick")
+    .qt_module("QuickControls2")
+    .files([
+        "src/models/categories.rs",
+        "src/models/systems.rs",
+        "src/models/games.rs",
+        "src/models/browse.rs",
+        "src/models/app_state.rs",
+        "src/models/app_status.rs",
+        "src/models/hub_state.rs",
+        "src/models/games_state.rs",
+        "src/models/input.rs",
+    ]);
+
+    // SAFETY: cc_builder is unsafe in 0.8 because cxx-qt makes no stability
+    // guarantees about the cc::Build instance. We only adjust the include
+    // path so the generated bridge code can find model_includes.h; we do
+    // not mutate flags or sources cxx-qt depends on.
+    let builder = unsafe {
+        builder.cc_builder(|cc| {
             cc.include("src/models");
         })
-        .qml_module(QmlModule::<&str, &str> {
-            uri: "Zaparoo.Browse",
-            version_major: 1,
-            version_minor: 0,
-            rust_files: &[
-                "src/models/categories.rs",
-                "src/models/systems.rs",
-                "src/models/games.rs",
-                "src/models/browse.rs",
-                "src/models/app_state.rs",
-                "src/models/app_status.rs",
-                "src/models/hub_state.rs",
-                "src/models/games_state.rs",
-                "src/models/input.rs",
-            ],
-            qml_files: &[],
-            ..Default::default()
-        })
-        .build();
+    };
+    builder.build();
 
     println!("cargo:rerun-if-env-changed=ZAPAROO_RUNTIME");
     println!("cargo:rerun-if-env-changed=ZAPAROO_DEV_BUILD");


### PR DESCRIPTION
## Summary

- Bumps `cxx-qt`, `cxx-qt-lib`, and `cxx-qt-build` from `0.7` to `0.8.1` across the workspace. 0.8 is KDAB's "Build System Stabilization" release — stable build API and first-class `qmllint`/`qmlls` support, which is what most of the workarounds in this repo were tracking.
- Rewrites `rust/launcher/build.rs` for the 0.8 builder API (`CxxQtBuilder::new_qml_module`, Rust files via `.files()`, `unsafe { cc_builder(...) }`).
- Deletes three of the four qmltypes patches in `cmake/SyncCxxqtQmlModules.cmake` — 0.8 emits them correctly. The remaining patch (`isFinal: true` on singleton component properties) is kept because `qmllint` still warns "Member can be shadowed" without it.

## Why a fresh branch instead of #4

Dependabot's #4 only bumps `cxx-qt-build`, leaving `cxx-qt` and `cxx-qt-lib` on 0.7 — version mismatch, won't build. The full migration also touches `build.rs`, the CMake patches, docs, and `.gitignore`, so a manual PR is the cleaner path. Supersedes #4 (it should auto-close when this merges).

## Notable details

- `QmlModule::depend("QtQml.Models")` is required: 0.8 emits the real `QAbstractListModel` prototype where 0.7's patched output collapsed it to `QObject`. Without the dependency, `qmllint` can't resolve the prototype chain for `CategoriesModel`/`SystemsModel`/`GamesModel`/`BrowseModel` and fails the lint gate.
- `cc_builder` is `unsafe fn` in 0.8. The wrapper is documented with a SAFETY comment per the workspace's `undocumented_unsafe_blocks = "deny"` rule.
- `rust/launcher/.qmlls.ini` is generated by 0.8 with absolute machine-specific paths — added to `.gitignore` instead of being committed.
- Clippy `unused_self` and `unnecessary_box_returns` allows are kept: 0.8's bridge codegen still trips them on inherited Qt virtuals (`role_names(&self)`, `Box<T>` constructors).

## Test plan

- [x] `just lint` — full lint gate, clean
- [x] `just lint-qml` — QML lint clean against the synced (mostly unpatched) qmltypes tree
- [x] `just test` — 114/114 Rust + 1/1 QML
- [x] `just build` — desktop dynamic-Qt build
- [x] `just arm32` — MiSTer ARM32 cross-build via Docker (static Qt, `link_qt_object_files`)
- [x] Desktop binary launches under offscreen Qt
- [ ] Visual desktop smoke (carousel, FPS counter green at 720p+) — manual
- [ ] `just deploy-mister` and on-device navigation — manual

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded cxx-qt dependency from version 0.7 to 0.8
  * Added build artifact configuration to gitignore

* **Documentation**
  * Updated all documentation to reflect cxx-qt 0.8 reference

* **Refactor**
  * Simplified plugin type configuration behavior
  * Updated build script to use new 0.8 API patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->