### PR TITLE
[codex] add game details screen

### DIFF
--- a/rust/zaparoo-core/src/input_actions.rs
+++ b/rust/zaparoo-core/src/input_actions.rs
@@ -66,6 +66,7 @@ pub fn default_bindings() -> HashMap<String, Vec<String>> {
         vec!["Escape".into(), "Backspace".into()],
     );
     map.insert(actions::WRITE_CARD.into(), vec!["Tab".into()]);
+    map.insert(actions::DETAILS.into(), vec!["Space".into()]);
     map.insert(actions::PAGE_PREV.into(), vec!["PageUp".into()]);
     map.insert(actions::PAGE_NEXT.into(), vec!["PageDown".into()]);
     map
@@ -140,6 +141,10 @@ mod tests {
         assert_eq!(
             map.get(&qt_key_code("Tab").unwrap()).map(String::as_str),
             Some(actions::WRITE_CARD),
+        );
+        assert_eq!(
+            map.get(&qt_key_code("Space").unwrap()).map(String::as_str),
+            Some(actions::DETAILS),
         );
     }
 

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -69,6 +69,7 @@ MainLayout {
         // data arrives.
         const savedScreen = Browse.AppState.active_screen
         if (savedScreen === root.screenGames
+            || savedScreen === root.screenGameDetails
             || savedScreen === root.screenSystems
             || savedScreen === root.screenHub)
             root.activeScreen = savedScreen
@@ -108,7 +109,9 @@ MainLayout {
         // GamesState, or we'd override the user's position with a stale
         // games target from a prior escape-back-up-the-stack.
         function onModelReset(): void {
-            const savedSystem = root.activeScreen === root.screenGames
+            const savedSystem =
+                (root.activeScreen === root.screenGames
+                 || root.activeScreen === root.screenGameDetails)
                 ? (Browse.GamesState.system_id !== "" ? Browse.GamesState.system_id : Browse.SystemsState.system_id)
                 : Browse.SystemsState.system_id
             const idx = savedSystem === "" ? -1 : Browse.SystemsModel.index_for_system_id(savedSystem)
@@ -134,7 +137,8 @@ MainLayout {
                 const top = stack.length > 0 ? stack[stack.length - 1] : ""
                 if (top !== "")
                     Browse.GamesModel.set_path(top)
-            } else if (root.activeScreen === root.screenGames
+            } else if ((root.activeScreen === root.screenGames
+                       || root.activeScreen === root.screenGameDetails)
                        && Browse.SystemsModel.count > 0) {
                 // Games-screen restore where the saved id is missing
                 // (renamed system, ROM deleted): drive GamesModel from
@@ -423,6 +427,15 @@ MainLayout {
             root.beginCardWrite("games")
             Browse.GamesModel.write_card_at(index)
         }
+        function onRequestGameDetails(): void {
+            root._goto(root.screenGameDetails)
+        }
+    }
+    Connections {
+        target: root.gameDetailsScreen
+        function onRequestGamesScreen(): void {
+            root._goto(root.screenGames)
+        }
     }
 
     onActiveCardWritePendingChanged: root.handleCardWriteStatus()
@@ -504,7 +517,9 @@ MainLayout {
             // above rather than leak it to the root screen.
             return
         }
-        if (root.activeScreen === root.screenGames) {
+        if (root.activeScreen === root.screenGameDetails) {
+            root.gameDetailsScreen.handleAction(action)
+        } else if (root.activeScreen === root.screenGames) {
             root.gamesScreen.handleAction(action)
         } else if (root.activeScreen === root.screenSystems) {
             root.systemsScreen.handleAction(action)

--- a/src/ui/app/MainLayout.qml
+++ b/src/ui/app/MainLayout.qml
@@ -30,6 +30,7 @@ ApplicationWindow {
     readonly property string screenHub: ScreenManager.screenHub
     readonly property string screenSystems: ScreenManager.screenSystems
     readonly property string screenGames: ScreenManager.screenGames
+    readonly property string screenGameDetails: ScreenManager.screenGameDetails
 
     // Runtime state. `activeScreen` mirrors ScreenManager's property
     // (two-way synced below so direct assignment from tests still
@@ -53,6 +54,7 @@ ApplicationWindow {
     property alias hubScreen: hubScreen
     property alias systemsScreen: systemsScreen
     property alias gamesScreen: gamesScreen
+    property alias gameDetailsScreen: gameDetailsScreen
 
     property bool cardWriteModalVisible: false
     property bool cardWriteFailed: false
@@ -197,6 +199,13 @@ ApplicationWindow {
             id: gamesScreen
             anchors.fill: parent
             visible: root.activeScreen === root.screenGames
+        }
+
+        GameDetailsScreen {
+            id: gameDetailsScreen
+            anchors.fill: parent
+            visible: root.activeScreen === root.screenGameDetails
+            gameTitle: gamesScreen.selectedGameTitle
         }
     }
 
@@ -387,6 +396,8 @@ ApplicationWindow {
                 return [{ button: "ButtonB", label: qsTr("Cancel") }];
             if (root.pendingTransition !== "")
                 return [];
+            if (root.activeScreen === root.screenGameDetails)
+                return [{ button: "ButtonB", label: qsTr("Back") }];
             if (root.activeScreen === root.screenHub) {
                 if (root.hubScreenState === "ready")
                     return [
@@ -434,10 +445,12 @@ ApplicationWindow {
                              { button: "ButtonR", label: qsTr("Next page") });
                 row.push({ button: "ButtonA", label: qsTr("Open") });
                 // Drop the Flash card cue on directory/root rows —
-                // write_card no-ops there, so advertising the bind
-                // would mislead.
-                if (root.gamesScreen.currentEntryWritable)
+                // write_card/details no-op there, so advertising the
+                // binds would mislead.
+                if (root.gamesScreen.currentEntryWritable) {
+                    row.push({ button: "ButtonY", label: qsTr("Details") });
                     row.push({ button: "ButtonX", label: qsTr("Flash card") });
+                }
                 row.push({ button: "ButtonB", label: qsTr("Back") });
                 return row;
             }

--- a/src/ui/screens/CMakeLists.txt
+++ b/src/ui/screens/CMakeLists.txt
@@ -18,6 +18,7 @@ qt_add_qml_module(
         HubScreen.qml
         SystemsScreen.qml
         GamesScreen.qml
+        GameDetailsScreen.qml
     IMPORTS
         Zaparoo.Ui
         Zaparoo.Theme

--- a/src/ui/screens/GameDetailsScreen.qml
+++ b/src/ui/screens/GameDetailsScreen.qml
@@ -1,0 +1,36 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+import QtQuick
+import Zaparoo.Theme
+
+// Minimal game details screen. For now it displays only the selected
+// game title and lets Escape return to the games grid.
+Item {
+    id: details
+
+    property bool active: false
+    property string gameTitle: ""
+
+    signal requestGamesScreen()
+
+    function handleAction(action: string): void {
+        if (action === "cancel")
+            details.requestGamesScreen()
+    }
+
+    Text {
+        anchors.horizontalCenter: parent.horizontalCenter
+        y: Sizing.pctH(11)
+        width: parent.width * 0.86
+        text: details.gameTitle
+        font.family: Theme.fontUi
+        font.pixelSize: Sizing.fontSize(5)
+        font.weight: Font.Medium
+        color: Theme.textPrimary
+        wrapMode: Text.WordWrap
+        horizontalAlignment: Text.AlignHCenter
+        renderType: Text.NativeRendering
+    }
+}

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -27,6 +27,13 @@ Item {
     // a second Escape from there pops to Hub).
     signal requestSystemsScreen()
     signal requestGameCardWrite(int index)
+    signal requestGameDetails()
+
+    readonly property string selectedGameTitle:
+        gamesGrid.currentIndex >= 0
+        && gamesGrid.currentIndex < Browse.GamesModel.count
+        ? Browse.GamesModel.name_at(gamesGrid.currentIndex)
+        : ""
 
     // Emitted when the user accepts a directory or root entry — Main.qml
     // pushes the level onto GamesState and drives the model into the new
@@ -153,6 +160,16 @@ Item {
                     games.requestGameCardWrite(idx)
                 }
             }
+        } else if (action === "details") {
+            if (games.gamesGrid.itemCount > 0) {
+                const idx = games.gamesGrid.currentIndex
+                const entryType = Browse.GamesModel.entry_type_at(idx)
+                if (entryType !== "directory" && entryType !== "root") {
+                    Browse.GamesState.set_selected_at_top(
+                        Browse.GamesModel.path_at(idx))
+                    games.requestGameDetails()
+                }
+            }
         } else if (action === "cancel") {
             if (games._atFolderLevel())
                 games.requestNavigateOutOfFolder()
@@ -235,9 +252,7 @@ Item {
         anchors.top: gamesGrid.bottom
         anchors.topMargin: Sizing.pctH(1)
         height: Sizing.pctH(7)
-        text: gamesGrid.itemCount > 0
-              ? Browse.GamesModel.name_at(gamesGrid.currentIndex)
-              : ""
+        text: games.selectedGameTitle
     }
 
     // "Loading more…" cue, parked on the left edge of the active-label

--- a/src/ui/screens/ScreenManager.qml
+++ b/src/ui/screens/ScreenManager.qml
@@ -17,6 +17,7 @@ QtObject {
     readonly property string screenHub: "hub"
     readonly property string screenSystems: "systems"
     readonly property string screenGames: "games"
+    readonly property string screenGameDetails: "game_details"
 
     // Currently-focused root screen. Persistence lives in
     // Browse.AppState — write there via Main.qml's orchestration, not

--- a/tests/ui/tst_navigation.qml
+++ b/tests/ui/tst_navigation.qml
@@ -31,6 +31,7 @@ TestCase {
         compare(main.hubScreen.visible, true)
         compare(main.systemsScreen.visible, false)
         compare(main.gamesScreen.visible, false)
+        compare(main.gameDetailsScreen.visible, false)
     }
 
     // Hard-cut peer screens: only the active screen is visible at any
@@ -41,6 +42,7 @@ TestCase {
         compare(main.systemsScreen.visible, true)
         compare(main.hubScreen.visible, false)
         compare(main.gamesScreen.visible, false)
+        compare(main.gameDetailsScreen.visible, false)
     }
 
     function test_activating_games_screen_makes_games_visible(): void {
@@ -48,6 +50,15 @@ TestCase {
         compare(main.gamesScreen.visible, true)
         compare(main.hubScreen.visible, false)
         compare(main.systemsScreen.visible, false)
+        compare(main.gameDetailsScreen.visible, false)
+    }
+
+    function test_activating_game_details_screen_makes_details_visible(): void {
+        main.activeScreen = main.screenGameDetails
+        compare(main.gameDetailsScreen.visible, true)
+        compare(main.hubScreen.visible, false)
+        compare(main.systemsScreen.visible, false)
+        compare(main.gamesScreen.visible, false)
     }
 
     // Enter on hub categories drills into systems screen.
@@ -81,6 +92,22 @@ TestCase {
         main.activeScreen = main.screenGames
         main.handleKey(Qt.Key_Escape)
         compare(main.activeScreen, main.screenSystems)
+    }
+
+    function test_escape_on_game_details_returns_to_games(): void {
+        main.activeScreen = main.screenGameDetails
+        main.handleKey(Qt.Key_Escape)
+        compare(main.activeScreen, main.screenGames)
+    }
+
+    function test_game_details_round_trip_preserves_games_grid_index(): void {
+        main.activeScreen = main.screenGames
+        main.gamesScreen.gamesGrid.currentIndex = 7
+        main.activeScreen = main.screenGameDetails
+        compare(main.gamesScreen.gamesGrid.currentIndex, 7)
+        main.handleKey(Qt.Key_Escape)
+        compare(main.activeScreen, main.screenGames)
+        compare(main.gamesScreen.gamesGrid.currentIndex, 7)
     }
 
     // Escape on systems goes back to hub.


### PR DESCRIPTION
Adds a game details route from the games grid. The details screen currently shows the selected game title and returns to the games grid with Escape/Back.

What changed:
- add a `game_details` screen and minimal `GameDetailsScreen` QML
- wire the existing `details` action to Space / ButtonY-style help text
- keep the games grid object alive so returning from details preserves page and selected card position
- add navigation coverage for details visibility, back behavior, and selection preservation

Validation:
- `./scripts/build-arm32.sh` (Docker ARM32 build)
- `file output/launcher` reports an ARM 32-bit EABI5 executable

Not done:
- no MiSTer deploy/upload; the device is off.