### PR TITLE
UI polish: tile captions, focus ring AA, cover prefetch fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,8 +83,9 @@ raw cargo as the default path; the justfile carries the expected environment.
   the rest of the scene stay static. See `docs/qml-gotchas.md` →
   "Software-renderer animation costs".
 - Do not hardcode pixel sizes or fixed element counts in UI. Use
-  `Sizing.pctH()`, `Sizing.pctW()`, `Sizing.fontSize()`, and
-  `Sizing.visibleCovers`.
+  `Sizing.pctH()`, `Sizing.pctW()`, `Sizing.fontSize()`,
+  `Sizing.visibleCovers`, and `Sizing.cornerRadius` (for any rounded-square
+  surface — see `docs/style.md`).
 - Do not add Qt5 compatibility code or `#if QT_VERSION` guards. This project is
   Qt 6.7+ only.
 - Do not change `BUILD_SHARED_LIBS`. Desktop needs `ON`; the ARM32 toolchain
@@ -202,6 +203,7 @@ starts our `launcher`; do not replace that flow with a new wrapper script.
 - `docs/architecture.md` — module graph, data flow, runtime/platform split
 - `docs/building.md` — build matrix, ARM32 toolchain, deploy bundle
 - `docs/qml-gotchas.md` — QML issues qmllint often catches late
+- `docs/style.md` — corner-radius token, tile aspect, pill vs. sharp shapes
 - `docs/cxx-qt-bridge.md` — cxx-qt 0.8 bridge constraints
 - `docs/translations.md` — `qsTr()`/`tr()` pipeline and locale catalogs
 - `design/README.md` — Qt Design Studio workflow and designer boundaries

--- a/docs/style.md
+++ b/docs/style.md
@@ -1,0 +1,62 @@
+# UI Style
+
+Standard tokens and shape conventions for the Zaparoo Launcher UI. Anything
+not covered here defers to `Theme.qml` (colors, fonts) and `Sizing.qml`
+(percentage helpers).
+
+## Corner radius
+
+One token, one value: `Sizing.cornerRadius` (`pctH(3.5)`). Every rounded-square
+surface in the app uses it.
+
+| Surface | Code |
+|---|---|
+| Tile card body | `radius: Sizing.cornerRadius` |
+| Tile focus ring | `radius: Sizing.cornerRadius - root._outlineGap` |
+| Settings row surface | `radius: Sizing.cornerRadius` |
+
+The focus ring is computed from the token (not hardcoded to a smaller value)
+so the ring stays concentric with the card if the token changes.
+
+When adding a new rounded-square surface, use the token. Don't introduce a
+second radius value — the visual language is one shape, one radius.
+
+## Pills
+
+Toggle controls (`SettingsField.qml` track + thumb) use `height/2` and
+`width/2`. They're pills, not rounded squares — a deliberately different
+shape for binary on/off controls (same convention as iOS toggles). They do
+not use `Sizing.cornerRadius` and shouldn't be made to.
+
+## Sharp corners
+
+`Modal.qml` is intentionally sharp. Modals are attention-demanding and the
+visual contrast against rounded surfaces is part of the design. Don't add
+radius unless the design changes.
+
+## Tile aspect
+
+| Surface | Aspect |
+|---|---|
+| Hub categories row | 1:1 (square, `cellHeight = cellWidth`) |
+| Hub action row | 1:1 (mirrors categories row metrics) |
+| Systems grid | Aspect driven by `PagedGrid` available height |
+| Games grid | Aspect driven by `PagedGrid` available height |
+
+The hub uses square tiles because the icons are simple silhouettes that read
+fine at 1:1. Cover-art surfaces (systems, games) get taller cells from
+`PagedGrid` because logos and box-art benefit from vertical room.
+
+## True squircles aren't achievable
+
+A super-ellipse curve needs `Shape` + `PathSvg` or shaders. The MiSTer build
+runs Qt Quick's software adaptation — no GPU, no shaders, no `Shape`,
+no `MultiEffect`. See `qml-gotchas.md`. The large `Rectangle.radius` value is
+a circular-arc approximation; close enough at this scale that the lack of
+super-ellipse curvature is invisible at typical viewing distances.
+
+## Consistency rule
+
+If a new surface has rounded corners, it picks `Sizing.cornerRadius` or it
+joins the pill family. There is no third option. Inconsistent radii were the
+problem this token was introduced to solve.

--- a/resources/images/icons/File.svg
+++ b/resources/images/icons/File.svg
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="24px" height="24px" color="#000000" fill="none" version="1.1" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
- <path d="M4 21.4V2.6C4 2.26863 4.26863 2 4.6 2H16.2515C16.4106 2 16.5632 2.06321 16.6757 2.17574L19.8243 5.32426C19.9368 5.43679 20 5.5894 20 5.74853V21.4C20 21.7314 19.7314 22 19.4 22H4.6C4.26863 22 4 21.7314 4 21.4Z" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
- <path d="M16 2V5.4C16 5.73137 16.2686 6 16.6 6H20" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+ <path d="M7 19.4V4.6C7 4.26863 7.26863 4 7.6 4H16.4C16.7314 4 17 4.26863 17 4.6V19.4C17 19.7314 16.7314 20 16.4 20H7.6C7.26863 20 7 19.7314 7 19.4Z" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+ <path d="M14 20V22.5" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+ <path d="M10 20V22.5" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+ <path d="M14 4V1.5" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+ <path d="M10 4V1.5" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+ <path d="M7 12H4.5" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+ <path d="M19.5 12H17" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+ <path d="M7 6.5H4.5" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+ <path d="M19.5 6.5H17" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+ <path d="M7 17.5H4.5" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+ <path d="M19.5 17.5H17" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
 </svg>

--- a/resources/images/icons/ScrollDown.svg
+++ b/resources/images/icons/ScrollDown.svg
@@ -1,0 +1,3 @@
+<svg width="24px" height="24px" color="#000000" fill="none" stroke-width="1.5" version="1.1" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+ <path d="m5.3071 8.713c0.11609-0.28026 0.38957-0.46299 0.69291-0.46299h12c0.3034 0 0.5768 0.18273 0.6929 0.46299 0.1161 0.28025 0.052 0.60284-0.1625 0.81734l-6 6c-0.2929 0.2929-0.7678 0.2929-1.0607 0l-6-6c-0.2145-0.2145-0.27866-0.53709-0.16258-0.81734z" clip-rule="evenodd" fill="#fff" fill-rule="evenodd" stroke="#fff"/>
+</svg>

--- a/resources/images/icons/ScrollUp.svg
+++ b/resources/images/icons/ScrollUp.svg
@@ -1,0 +1,3 @@
+<svg width="24px" height="24px" color="#000000" fill="none" stroke-width="1.5" version="1.1" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+ <path d="m5.3071 15.287c0.11609 0.2803 0.38957 0.463 0.69291 0.463h12c0.3034 0 0.5768-0.1827 0.6929-0.463 0.1161-0.2802 0.052-0.6028-0.1625-0.8173l-6-6c-0.2929-0.29289-0.7678-0.29289-1.0607 0l-6 6c-0.2145 0.2145-0.27866 0.5371-0.16258 0.8173z" clip-rule="evenodd" fill="#fff" fill-rule="evenodd" stroke="#fff"/>
+</svg>

--- a/rust/launcher/src/media_image_cache.rs
+++ b/rust/launcher/src/media_image_cache.rs
@@ -75,6 +75,20 @@ const CACHE_CAP_BYTES: usize = 64 * 1024 * 1024;
 /// memo.
 const MAX_FETCH_ATTEMPTS: u8 = 3;
 
+/// Number of parallel fetch worker tasks pulling from the shared
+/// LIFO queue. The Zaparoo Core WebSocket multiplexes JSON-RPC calls
+/// by id so concurrent `media.image` requests are safe at the wire;
+/// however, Core itself currently serializes its `media.image`
+/// handler at roughly one response per 250–400 ms. Empirically all
+/// four workers spend most of their time parked on `oneshot`
+/// receivers waiting for Core's serial output — so the *immediate*
+/// throughput floor is set by Core, not by us. Four workers is kept
+/// as an upper bound that costs nothing under the current cadence
+/// (idle workers parked on `Notify` are free) and turns into an
+/// instant win the moment Core gains concurrency in its image
+/// handler. Don't drop this back to 1.
+const FETCH_DRIVER_WORKERS: usize = 4;
+
 /// Hard cap on pending enqueues in the LIFO fetch queue. New pushes
 /// spill the **oldest** entry off the front, on the assumption that
 /// whatever the user enqueued ~2 pages ago is no longer interesting
@@ -308,12 +322,29 @@ impl CacheState {
 pub struct MediaImageCache {
     state: Arc<RwLock<CacheState>>,
     /// LIFO queue of pending fetches. `enqueue` pushes to the back,
-    /// the fetch driver pops from the back: newest enqueues (the page
-    /// the user is actively looking at) drain first, while enqueues
-    /// from a page they've already navigated past wait at the front
-    /// rather than blocking the work the user can see. Plain
-    /// `std::sync::Mutex` because every critical section is a single
-    /// `push_back`/`pop_back` with no awaits in between.
+    /// the fetch driver pops from the back: newest enqueues drain
+    /// first, while enqueues from a page the user has already
+    /// navigated past wait at the front rather than blocking the
+    /// work the user can see. Plain `std::sync::Mutex` because every
+    /// critical section is a single `push_back`/`pop_back` with no
+    /// awaits in between.
+    ///
+    /// **Look-ahead intentionally rides the same queue at the same
+    /// priority.** Under Core's current ~250–400 ms serial cadence
+    /// for `media.image`, the LIFO drain order ends up servicing
+    /// page N+1's prefetched covers between page N's first burst
+    /// (the visual top of the page, enqueued in reverse so it pops
+    /// first) and page N's tail (the bottom rows the user is least
+    /// likely to read before paginating). By the time the user
+    /// navigates forward, page N+1 is warm; the few unfilled tiles
+    /// at the bottom of page N continue to land in the background.
+    /// Treating look-ahead as a "low priority" lane that drains
+    /// *after* the visible page strictly worsens the experience: the
+    /// visible page consumes the entire serial throughput in front
+    /// of the user (which reads as "covers loading slowly one at a
+    /// time"), and page N+1 doesn't start until the visible page is
+    /// fully cached, which is well after a fast-moving user has
+    /// already paginated. Don't reintroduce a priority split here.
     queue: Arc<Mutex<VecDeque<MediaKey>>>,
     /// Single-permit signal that wakes the driver when a fresh key
     /// hits the queue. Drained by `notified().await` and rearmed by
@@ -336,10 +367,10 @@ impl MediaImageCache {
         spawn_fetch_driver(
             runtime,
             cap_bytes,
-            state.clone(),
-            updates_tx.clone(),
-            queue.clone(),
-            queue_notify.clone(),
+            &state,
+            &updates_tx,
+            &queue,
+            &queue_notify,
             store_factory,
         );
 
@@ -473,96 +504,113 @@ impl MediaImageCache {
 fn spawn_fetch_driver<F>(
     runtime: &Arc<Runtime>,
     cap_bytes: usize,
-    state: Arc<RwLock<CacheState>>,
-    updates_tx: broadcast::Sender<MediaImageUpdate>,
-    queue: Arc<Mutex<VecDeque<MediaKey>>>,
-    queue_notify: Arc<Notify>,
+    state: &Arc<RwLock<CacheState>>,
+    updates_tx: &broadcast::Sender<MediaImageUpdate>,
+    queue: &Arc<Mutex<VecDeque<MediaKey>>>,
+    queue_notify: &Arc<Notify>,
     store_factory: F,
 ) where
     F: Fn() -> Arc<Store> + Send + Sync + 'static,
 {
-    runtime.spawn(async move {
-        loop {
-            let next_key = {
-                #[allow(clippy::unwrap_used, reason = "Mutex poisoning is unrecoverable")]
-                let mut q = queue.lock().unwrap();
-                q.pop_back()
-            };
-            let Some(key) = next_key else {
-                queue_notify.notified().await;
-                continue;
-            };
-            let store = store_factory();
-            let outcome = fetch_one(&store, &key).await;
-            let is_transient = matches!(outcome, FetchOutcome::Transient);
-            let update = finish_fetch(&state, cap_bytes, &key, outcome);
-            if is_transient {
-                let attempts = {
-                    #[allow(clippy::unwrap_used, reason = "RwLock poisoning is unrecoverable")]
-                    let mut s = state.write().unwrap();
-                    let entry = s.attempts.entry(key.clone()).or_insert(0);
-                    *entry = entry.saturating_add(1);
-                    *entry
+    // One Arc'd factory shared across the worker pool — `F` is only
+    // `Fn`, not `Clone`, so wrapping it once and cloning the Arc gives
+    // every worker a cheap handle into the same underlying closure.
+    let store_factory: Arc<F> = Arc::new(store_factory);
+    for _ in 0..FETCH_DRIVER_WORKERS {
+        let state = state.clone();
+        let updates_tx = updates_tx.clone();
+        let queue = queue.clone();
+        let queue_notify = queue_notify.clone();
+        let store_factory = store_factory.clone();
+        runtime.spawn(async move {
+            loop {
+                let next_key = {
+                    #[allow(clippy::unwrap_used, reason = "Mutex poisoning is unrecoverable")]
+                    let mut q = queue.lock().unwrap();
+                    q.pop_back()
                 };
-                if attempts < MAX_FETCH_ATTEMPTS {
-                    // Re-enter `pending` and re-enqueue at the back.
-                    // Fresh-page enqueues that arrive in the meantime
-                    // still drain ahead because we always pop from
-                    // the back; this retry waits behind anything the
-                    // user is actively looking at.
-                    {
+                let Some(key) = next_key else {
+                    queue_notify.notified().await;
+                    continue;
+                };
+                let store = store_factory();
+                let outcome = fetch_one(&store, &key).await;
+                let is_transient = matches!(outcome, FetchOutcome::Transient);
+                let update = finish_fetch(&state, cap_bytes, &key, outcome);
+                if is_transient {
+                    let attempts = {
                         #[allow(clippy::unwrap_used, reason = "RwLock poisoning is unrecoverable")]
                         let mut s = state.write().unwrap();
-                        s.pending.insert(key.clone());
+                        let entry = s.attempts.entry(key.clone()).or_insert(0);
+                        *entry = entry.saturating_add(1);
+                        *entry
+                    };
+                    if attempts < MAX_FETCH_ATTEMPTS {
+                        // Re-enter `pending` and re-enqueue at the back.
+                        // Fresh-page enqueues that arrive in the meantime
+                        // still drain ahead because we always pop from
+                        // the back; this retry waits behind anything the
+                        // user is actively looking at.
+                        {
+                            #[allow(
+                                clippy::unwrap_used,
+                                reason = "RwLock poisoning is unrecoverable"
+                            )]
+                            let mut s = state.write().unwrap();
+                            s.pending.insert(key.clone());
+                        }
+                        {
+                            #[allow(
+                                clippy::unwrap_used,
+                                reason = "Mutex poisoning is unrecoverable"
+                            )]
+                            let mut q = queue.lock().unwrap();
+                            q.push_back(key);
+                        }
+                        queue_notify.notify_one();
+                    } else {
+                        // Bounded give-up: clear the counter, no negative
+                        // memo. The next user-driven enqueue (page
+                        // revisit) gets a fresh `MAX_FETCH_ATTEMPTS`
+                        // budget via `enqueue`'s `attempts.remove`.
+                        #[allow(clippy::unwrap_used, reason = "RwLock poisoning is unrecoverable")]
+                        state.write().unwrap().attempts.remove(&key);
+                        info!(
+                            system_id = %key.system_id,
+                            path = %key.path,
+                            attempts,
+                            "media_image_cache: giving up after transient failures",
+                        );
                     }
-                    {
-                        #[allow(clippy::unwrap_used, reason = "Mutex poisoning is unrecoverable")]
-                        let mut q = queue.lock().unwrap();
-                        q.push_back(key);
-                    }
-                    queue_notify.notify_one();
-                } else {
-                    // Bounded give-up: clear the counter, no negative
-                    // memo. The next user-driven enqueue (page
-                    // revisit) gets a fresh `MAX_FETCH_ATTEMPTS`
-                    // budget via `enqueue`'s `attempts.remove`.
+                    continue;
+                }
+                // Success or NoImage: clear the attempts counter and
+                // broadcast the resolved state.
+                {
                     #[allow(clippy::unwrap_used, reason = "RwLock poisoning is unrecoverable")]
-                    state.write().unwrap().attempts.remove(&key);
-                    info!(
-                        system_id = %key.system_id,
-                        path = %key.path,
-                        attempts,
-                        "media_image_cache: giving up after transient failures",
-                    );
+                    let mut s = state.write().unwrap();
+                    s.attempts.remove(&key);
                 }
-                continue;
-            }
-            // Success or NoImage: clear the attempts counter and
-            // broadcast the resolved state.
-            {
-                #[allow(clippy::unwrap_used, reason = "RwLock poisoning is unrecoverable")]
-                let mut s = state.write().unwrap();
-                s.attempts.remove(&key);
-            }
-            if let Some(update) = update {
-                if let Some(ext) = update.ext {
-                    info!(
-                        system_id = %key.system_id,
-                        path = %key.path,
-                        ext,
-                        "media_image_cache: cached image",
-                    );
-                } else {
-                    info!(
-                        system_id = %key.system_id,
-                        path = %key.path,
-                        "media_image_cache: no image (negative memo)",
-                    );
+                if let Some(update) = update {
+                    if let Some(ext) = update.ext {
+                        info!(
+                            system_id = %key.system_id,
+                            path = %key.path,
+                            ext,
+                            "media_image_cache: cached image",
+                        );
+                    } else {
+                        info!(
+                            system_id = %key.system_id,
+                            path = %key.path,
+                            "media_image_cache: no image (negative memo)",
+                        );
+                    }
+                    let _ = updates_tx.send(update);
                 }
-                let _ = updates_tx.send(update);
             }
-        }
-    });
+        });
+    }
 }
 
 #[derive(Debug)]

--- a/rust/launcher/src/models/games.rs
+++ b/rust/launcher/src/models/games.rs
@@ -690,11 +690,27 @@ fn cover_key_for_with(entry: &BrowseEntry, key: Option<&MediaKey>, cached: bool)
 /// for already-cached, already-pending, or negatively-memoised keys are
 /// dropped — so spamming this from `apply_initial_page`/
 /// `apply_append_page` is cheap.
+///
+/// Iterates `entries` in reverse so the LIFO fetch queue drains in
+/// visual order: the last entry we push is `entries[0]`, which the
+/// driver then pops first. Forward iteration starves the top of the
+/// page — e.g. for a 10-tile page the driver lands rows 9..6 before
+/// the user advances, leaving rows 0..3 (the most prominent slots)
+/// showing the fallback icon.
+///
+/// Look-ahead prefetch (`apply_initial_page` → `fetch_more`) calls
+/// this exactly the same way as the visible page does. Under Core's
+/// serial `media.image` cadence (~one response per 250–400 ms) the
+/// LIFO drain order ends up servicing page N+1 *between* page N's
+/// first burst and its tail, so by the time the user navigates
+/// forward, page N+1 is warm. See the doc comment on
+/// `MediaImageCache::queue` for the full rationale on why a separate
+/// "low priority" lane for look-ahead is the wrong knob.
 fn enqueue_cover_fetches(entries: &[BrowseEntry]) {
     let cache = global_media_image_cache();
     let mut media_total = 0usize;
     let mut enqueued = 0usize;
-    for entry in entries {
+    for entry in entries.iter().rev() {
         if entry.is_folder() {
             continue;
         }
@@ -944,6 +960,22 @@ fn apply_initial_page(mut model: Pin<&mut ffi::GamesModel>, result: MediaBrowseR
     // so a page advance never triggers a visible "Loading more…" pause.
     // `fetch_more` is itself guarded by `has_next_page` and
     // `loading_more`, so a no-op call is cheap and safe.
+    //
+    // Look-ahead intentionally enqueues onto the same LIFO queue as
+    // the visible page at the same priority. Core serializes
+    // `media.image` responses at ~one per 250–400 ms; with that
+    // cadence, the LIFO drain order (newest-pushed pops first) ends
+    // up servicing page N+1's covers *between* page N's first burst
+    // and its tail. By the time the user navigates forward, page N+1
+    // is warm, while the bottom couple of tiles on page N — which
+    // the user is least likely to dwell on before paginating —
+    // continue to land in the background. Treating look-ahead as a
+    // low-priority lane that drains *after* the visible page strictly
+    // worsens this: page N then consumes the entire serial throughput
+    // before page N+1 begins, which is exactly what shipped briefly
+    // and looked like "covers loading slowly one at a time" with the
+    // next page no longer instant on navigate. See the doc comment on
+    // `MediaImageCache::queue` for the full rationale.
     if has_next_page && !model.loading_more {
         model.as_mut().fetch_more();
     }

--- a/src/LICENSES/Iconoir-ATTRIBUTION.txt
+++ b/src/LICENSES/Iconoir-ATTRIBUTION.txt
@@ -26,6 +26,8 @@ fill="none"):
   resources/images/icons/NavLeft.svg
   resources/images/icons/NavRight.svg
   resources/images/icons/NavUp.svg
+  resources/images/icons/ScrollDown.svg
+  resources/images/icons/ScrollUp.svg
   resources/images/icons/Settings.svg
   resources/images/status/Bluetooth.svg
   resources/images/status/WiFi.svg

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -702,6 +702,14 @@ MainLayout {
 
         LoadingIndicator {
             anchors.centerIn: parent
+            text: {
+                switch (root.pendingTransition) {
+                case "systems": return qsTr("Loading systems…")
+                case "games":   return qsTr("Loading games…")
+                case "recents": return qsTr("Loading recently played…")
+                default:        return qsTr("Loading…")
+                }
+            }
         }
     }
 

--- a/src/ui/app/MainLayout.qml
+++ b/src/ui/app/MainLayout.qml
@@ -293,8 +293,14 @@ ApplicationWindow {
         // sit on a single line. Without this Row height tracks the
         // tallest child, which is the Text element (font ascender +
         // descender) — that pushes icons up and out of alignment.
+        // Clock pixelSize runs larger than the icon box because a font's
+        // cap-height is ~0.7× pixelSize, so matching pixelSize to icon
+        // height makes glyphs look small next to the square SVGs; bumping
+        // the clock font to ~1.4× the icon size lands their visual weight
+        // on par. Row height takes the max so neither child clips.
         readonly property real _iconSize: Sizing.fontSize(2.4)
-        height: topHud._iconSize
+        readonly property real _clockFontSize: Sizing.fontSize(3.4)
+        height: Math.max(topHud._iconSize, topHud._clockFontSize)
 
         StatusIcon {
             anchors.verticalCenter: parent.verticalCenter
@@ -335,12 +341,12 @@ ApplicationWindow {
 
             anchors.verticalCenter: parent.verticalCenter
             height: parent.height
-            width: topHud._iconSize * 3
+            width: topHud._clockFontSize * 3
             verticalAlignment: Text.AlignVCenter
             horizontalAlignment: Text.AlignRight
             text: clockLabel.currentTime
             font.family: Theme.fontUi
-            font.pixelSize: topHud._iconSize
+            font.pixelSize: topHud._clockFontSize
             color: Theme.textPrimary
             renderType: Text.NativeRendering
 

--- a/src/ui/components/PagedGrid.qml
+++ b/src/ui/components/PagedGrid.qml
@@ -12,13 +12,22 @@ pragma ComponentBehavior: Bound
 import QtQuick
 import Zaparoo.Theme
 
-// Paged grid of tiles. Items flow row-major within a page; reaching the
-// rightmost column on a non-last page swaps in the next page instantly,
-// crossing past the last page wraps back to page 0 (mirror for left).
+// Paged grid of tiles. Items flow row-major within a page; pages stack
+// **vertically** — pressing Down at the bottom row swaps in the next
+// page instantly (same column, top row), Up at the top row swaps in
+// the previous page (same column, bottom row). Crossing past the last
+// page wraps to page 0; mirror for Up at page 0. Left/Right wrap
+// **within the current row** and never change pages, so a partial last
+// row cycles among its own filled cells.
+//
 // Selection is `currentIndex` over the source model; (page, row, col)
 // are derived. Cells size themselves to the available container minus
 // reserved chrome — callers pass a model and delegate, the grid
-// handles layout.
+// handles layout. The right gutter renders a scroll indicator (up/down
+// arrows + free-floating thumb) sized and positioned from
+// `totalItemsOverride` (with `itemCount` fallback), so paginated
+// callers like `GamesScreen` get a thumb that reflects the dataset's
+// true total page count rather than the loaded slice.
 //
 // Page changes are instant cuts (no fade, no slide). On Qt Quick's
 // Software adaptation the renderer cannot keep up with a per-frame
@@ -71,20 +80,57 @@ Item {
     readonly property int currentColumn: (currentIndex % pageSize) % columns
     readonly property int currentRow: Math.floor((currentIndex % pageSize) / columns)
 
+    // Page-stack indicators. Used by the right-gutter scroll cue (and
+    // by callers that want to drive their own indicator) to gate the
+    // up/down arrows. Both are false on a single-page dataset.
+    // These intentionally track loaded `pageCount` — they reflect what
+    // the user can actually navigate to right now, not a paginated
+    // model's reported total.
+    readonly property bool hasPagesAbove: currentPage > 0
+    readonly property bool hasPagesBelow: currentPage < pageCount - 1
+
+    // Caller-supplied total item count, used by the scroll thumb so its
+    // size and position reflect the full dataset rather than the loaded
+    // slice. Default -1 means "fall back to itemCount" — fine for
+    // non-paginated models (Systems, Categories, Recents) where the
+    // loaded count IS the total. Paginated callers (GamesScreen) bind
+    // this to their model's authoritative total so the thumb stays
+    // stable while `fetch_more` grows the slice in the background.
+    property int totalItemsOverride: -1
+    readonly property int totalItems:
+        totalItemsOverride >= 0 ? totalItemsOverride : itemCount
+    readonly property int totalPageCount:
+        Math.max(1, Math.ceil(totalItems / pageSize))
+
     // Reserved chrome around the cell area. Vertical insets must be
     // large enough to contain the focused tile's 1.06× scale bleed
     // (~3% of cellHeight per side) — without them, top-row and
-    // bottom-row tiles get clipped when focused. Matches the hub's
-    // `verticalPadding` value.
-    readonly property int sideInset: Sizing.pctW(5)
+    // bottom-row tiles get clipped when focused. The scrollbar gutter
+    // (`gutterWidth`) is treated as part of the grid for edge-spacing
+    // purposes: it sits inboard of `rightInset` (which matches
+    // `leftInset` so the cells+gutter block has equal margin on each
+    // screen edge) with `gutterGap` of breathing room between the
+    // rightmost cell and the gutter. `gutterGap` is intentionally
+    // tighter than `cellSpacingX` — the scrollbar reads as chrome,
+    // not as another cell, so a full inter-cell gap looks like wasted
+    // space next to it. The gutter stays reserved on a single page
+    // (just hidden) so cells don't reflow when paging activates.
+    readonly property int leftInset: Sizing.pctW(5)
+    readonly property int rightInset: Sizing.pctW(5)
+    readonly property int gutterWidth: Sizing.pctW(3)
+    readonly property int gutterGap: Sizing.pctW(1.5)
     readonly property int topInset: Sizing.pctH(2)
     readonly property int bottomInset: Sizing.pctH(2)
     readonly property int cellSpacingX: Sizing.pctW(3)
     readonly property int cellSpacingY: Sizing.pctH(4)
 
     // Computed cell dimensions — fill the available area, divided by
-    // gridColumns × gridRows. Callers don't override.
-    readonly property int _availableWidth: Math.max(0, width - 2 * sideInset)
+    // gridColumns × gridRows. Callers don't override. The cell area
+    // also reserves `gutterGap + gutterWidth` on the right for the
+    // tight-gap-then-scrollbar layout described above.
+    readonly property int _availableWidth:
+        Math.max(0,
+                 width - leftInset - rightInset - gutterGap - gutterWidth)
     readonly property int _availableHeight:
         Math.max(0, height - topInset - bottomInset)
     readonly property int cellWidth:
@@ -108,7 +154,7 @@ Item {
         const col = local % root.columns
         const p = root.mapToItem(
             target,
-            root.sideInset + col * (root.cellWidth + root.cellSpacingX),
+            root.leftInset + col * (root.cellWidth + root.cellSpacingX),
             root.topInset + row * (root.cellHeight + root.cellSpacingY))
         return Qt.rect(p.x, p.y, root.cellWidth, root.cellHeight)
     }
@@ -150,84 +196,100 @@ Item {
     }
 
     // Step the selection by (dCol, dRow). Returns true if the index
-    // actually moved.
+    // actually moved. Cardinal moves only — diagonals (dCol and dRow
+    // both nonzero) are not produced by any caller and behaviour for
+    // them is undefined.
     //
-    // - dCol < 0 at column 0: snap to last column of the previous page.
-    //   On page 0 this wraps to (lastPage, currentRow, lastCol).
-    // - dCol > 0 at last column: snap to column 0 of the next page. On
-    //   the last page this wraps to (page 0, currentRow, 0).
-    // - dRow < 0 at row 0: snap to last row of the same page (column
-    //   preserved). Same-page cycle so Down/Up on a single screen
-    //   stays predictable; Esc is the cross-screen back path.
-    // - dRow > 0 at last row: snap to row 0 of the same page.
-    // - Crossing a page boundary into a partial target page: clamp to
-    //   the last existing item on that page (NOT necessarily on
-    //   currentRow) so right at a page edge always advances rather
-    //   than refusing on a hole.
-    // - Wrapping vertically onto a hole on a partial last page (e.g.
-    //   Down on the only filled row of a 1-row last page): clamp to
-    //   the last existing item on the same page rather than refusing.
+    // Horizontal axis — within-row wrap, never changes page or row:
+    // - dCol > 0 at the row's last filled column: wrap to col 0.
+    // - dCol < 0 at column 0: wrap to the row's last filled column.
+    //   On a partial last row, the "last filled column" is bounded by
+    //   the row's actual item count so wraps land on real cells.
+    //
+    // Vertical axis — page advance/retreat with wrap and partial-page
+    // clamp:
+    // - dRow > 0 past the last *filled* row on the current page:
+    //   advance to (next page, row 0, same col). On the last page, wrap
+    //   to (page 0, row 0, same col). On a partial last page this
+    //   triggers as soon as Down would step into the empty rows below
+    //   the content, not just when stepping off the grid grid-shape.
+    // - dRow < 0 above row 0: retreat to (previous page, last row,
+    //   same col). On page 0, wrap to (last page, last row, same col).
+    // - Landing on a hole on a partial target page (column doesn't
+    //   exist there): clamp to the last existing item on the target
+    //   page so the user always moves rather than sticking on a hole.
     function moveSelection(dCol: int, dRow: int): bool {
         if (root.itemCount <= 0)
             return false
-        const newColAbs = root.currentColumn + dCol
+
         let newPage = root.currentPage
-        let newCol = newColAbs
-        if (newColAbs < 0) {
-            // Wrap to last column of the previous page; on page 0, wrap
-            // all the way to the last column of the last page.
-            newPage = root.currentPage === 0
-                      ? root.pageCount - 1
-                      : root.currentPage - 1
-            newCol = root.columns - 1
-        } else if (newColAbs >= root.columns) {
-            // Wrap to column 0 of the next page; on the last page, wrap
-            // back to column 0 of page 0.
-            newPage = root.currentPage === root.pageCount - 1
-                      ? 0
-                      : root.currentPage + 1
-            newCol = 0
+        let newRow = root.currentRow
+        let newCol = root.currentColumn
+
+        // Horizontal wrap stays on the source row; clamp the wrap target
+        // to the row's actual filled span so a partial last row cycles
+        // among its own items rather than walking through a hole.
+        if (dCol !== 0) {
+            const rowFirstIndex =
+                root.currentPage * root.pageSize
+                + root.currentRow * root.columns
+            const rowLastIndex =
+                Math.min(root.itemCount - 1,
+                         rowFirstIndex + root.columns - 1)
+            const maxColOnRow = rowLastIndex - rowFirstIndex
+            const colCandidate = root.currentColumn + dCol
+            if (colCandidate < 0)
+                newCol = maxColOnRow
+            else if (colCandidate > maxColOnRow)
+                newCol = 0
+            else
+                newCol = colCandidate
         }
-        const newRowAbs = root.currentRow + dRow
-        let newRow = newRowAbs
-        if (newRowAbs < 0)
-            newRow = root.rows - 1
-        else if (newRowAbs >= root.rows)
-            newRow = 0
+
+        // Vertical wrap crosses page boundaries; the partial-page hole
+        // clamp below covers the case where the target column doesn't
+        // exist on the destination page.
+        //
+        // A Down step that lands in an empty row of a partial last
+        // page (rowCandidate fits inside `rows` but is past the page's
+        // last filled row) must trigger the same page advance as
+        // stepping off the grid — otherwise the hole-clamp at the end
+        // of this function lands on the user's current cell and the
+        // press appears to do nothing.
+        if (dRow !== 0) {
+            const rowCandidate = root.currentRow + dRow
+            const itemsOnPage = Math.min(
+                root.pageSize,
+                root.itemCount - root.currentPage * root.pageSize)
+            const lastFilledRowOnPage =
+                Math.floor((itemsOnPage - 1) / root.columns)
+            if (rowCandidate < 0) {
+                newPage = root.currentPage === 0
+                          ? root.pageCount - 1
+                          : root.currentPage - 1
+                newRow = root.rows - 1
+            } else if (rowCandidate >= root.rows
+                       || rowCandidate > lastFilledRowOnPage) {
+                newPage = root.currentPage === root.pageCount - 1
+                          ? 0
+                          : root.currentPage + 1
+                newRow = 0
+            } else {
+                newRow = rowCandidate
+            }
+        }
+
         let newIndex = newPage * root.pageSize + newRow * root.columns + newCol
         if (newIndex < 0)
             return false
         if (newIndex >= root.itemCount) {
-            if (newPage !== root.currentPage) {
-                // Page-change overshoot — partial target page. Land on
-                // its last existing item rather than refusing.
-                const lastIdxOnPage =
-                    Math.min((newPage + 1) * root.pageSize, root.itemCount) - 1
-                if (lastIdxOnPage < 0)
-                    return false
-                newIndex = lastIdxOnPage
-            } else if (dCol > 0) {
-                // Stepped past the dataset's last item without crossing
-                // a page (last page didn't reach the right column) —
-                // wrap forward to item 0.
-                newIndex = 0
-            } else if (dCol < 0) {
-                // Single-page partial row: left-wrap from col 0 lands
-                // out of bounds on the same page. Wrap to last item.
-                newIndex = root.itemCount - 1
-            } else if (dRow !== 0) {
-                // Row wrap on a partial last page that doesn't have a
-                // slot at this column. Clamp to the page's last
-                // existing item so the user still moves rather than
-                // sticking on a hole.
-                const lastIdxOnPage =
-                    Math.min((newPage + 1) * root.pageSize, root.itemCount) - 1
-                if (lastIdxOnPage < 0)
-                    return false
-                newIndex = lastIdxOnPage
-            } else {
+            // Target slot is a hole on a partial page. Clamp to the
+            // page's last existing item.
+            const lastIdxOnPage =
+                Math.min((newPage + 1) * root.pageSize, root.itemCount) - 1
+            if (lastIdxOnPage < 0)
                 return false
-            }
+            newIndex = lastIdxOnPage
         }
         if (newIndex === root.currentIndex) {
             // Selection didn't move because the user is at an edge with
@@ -298,7 +360,7 @@ Item {
 
                 width: root.cellWidth
                 height: root.cellHeight
-                x: root.sideInset
+                x: root.leftInset
                    + cellCol * (root.cellWidth + root.cellSpacingX)
                 y: root.topInset
                    + cellRow * (root.cellHeight + root.cellSpacingY)
@@ -334,6 +396,92 @@ Item {
                         root.itemClicked(cellItem.index)
                     }
                 }
+            }
+        }
+    }
+
+    // ── Right-gutter scroll indicator ────────────────────────────────────
+    // Up arrow at the top, down arrow at the bottom, free-floating thumb
+    // in between. No painted track — the indicator is just the arrows
+    // and the thumb. Hidden when the dataset fits on a single page.
+    // Snaps page-by-page; no animation on the thumb (matches the instant
+    // page flip and keeps the software renderer's dirty rect off the
+    // cell area). Sits after the cell `track` in the visual tree so the
+    // indicator paints on top of any focus-scale bleed at the right edge.
+    Item {
+        id: scrollGutter
+
+        anchors.right: parent.right
+        anchors.rightMargin: root.rightInset
+        anchors.top: parent.top
+        anchors.topMargin: root.topInset
+        anchors.bottom: parent.bottom
+        anchors.bottomMargin: root.bottomInset
+        width: root.gutterWidth
+        visible: root.totalPageCount > 1
+
+        readonly property int arrowSize:
+            Math.min(width, Sizing.pctH(4))
+
+        Image {
+            id: upArrow
+            source: Resources.iconUrl("ScrollUp")
+            width: scrollGutter.arrowSize
+            height: scrollGutter.arrowSize
+            anchors.top: parent.top
+            anchors.horizontalCenter: parent.horizontalCenter
+            fillMode: Image.PreserveAspectFit
+            smooth: true
+            visible: root.hasPagesAbove
+        }
+
+        Image {
+            id: downArrow
+            source: Resources.iconUrl("ScrollDown")
+            width: scrollGutter.arrowSize
+            height: scrollGutter.arrowSize
+            anchors.bottom: parent.bottom
+            anchors.horizontalCenter: parent.horizontalCenter
+            fillMode: Image.PreserveAspectFit
+            smooth: true
+            visible: root.hasPagesBelow
+        }
+
+        // Geometry-only Item between the arrows; nothing paints.
+        // `scrollThumb` derives its size and position from this region's
+        // height and the grid's `totalPageCount` / `currentPage`.
+        Item {
+            id: scrollRegion
+            anchors.top: parent.top
+            anchors.topMargin: scrollGutter.arrowSize + Sizing.pctH(1)
+            anchors.bottom: parent.bottom
+            anchors.bottomMargin: scrollGutter.arrowSize + Sizing.pctH(1)
+            anchors.horizontalCenter: parent.horizontalCenter
+
+            // Standard paginated-scrollbar formulas (cf. Qt
+            // `ScrollBar.size`/`position`, GTK `Gtk.Scrollbar`, Apple
+            // HIG): thumb length = trackLen * (visible / total) with one
+            // page visible at a time, position = (page / (total - 1)) *
+            // remaining range. Floor on thumb height keeps it visible
+            // when `totalPageCount` is large.
+            readonly property int _minThumbHeight: Sizing.pctH(4)
+            readonly property int _thumbHeight:
+                Math.max(_minThumbHeight,
+                         Math.round(scrollRegion.height / root.totalPageCount))
+            readonly property real _thumbY:
+                root.totalPageCount <= 1
+                    ? 0
+                    : (root.currentPage / (root.totalPageCount - 1))
+                      * (scrollRegion.height - _thumbHeight)
+
+            Rectangle {
+                id: scrollThumb
+                width: Sizing.pctW(1.2)
+                height: scrollRegion._thumbHeight
+                anchors.horizontalCenter: parent.horizontalCenter
+                y: scrollRegion._thumbY
+                color: Theme.textPrimary
+                radius: width / 2
             }
         }
     }

--- a/src/ui/components/PagedGrid.qml
+++ b/src/ui/components/PagedGrid.qml
@@ -71,9 +71,14 @@ Item {
     readonly property int currentColumn: (currentIndex % pageSize) % columns
     readonly property int currentRow: Math.floor((currentIndex % pageSize) / columns)
 
-    // Reserved chrome around the cell area.
+    // Reserved chrome around the cell area. Vertical insets must be
+    // large enough to contain the focused tile's 1.06× scale bleed
+    // (~3% of cellHeight per side) — without them, top-row and
+    // bottom-row tiles get clipped when focused. Matches the hub's
+    // `verticalPadding` value.
     readonly property int sideInset: Sizing.pctW(5)
-    readonly property int topInset: Sizing.pctH(1)
+    readonly property int topInset: Sizing.pctH(2)
+    readonly property int bottomInset: Sizing.pctH(2)
     readonly property int cellSpacingX: Sizing.pctW(3)
     readonly property int cellSpacingY: Sizing.pctH(4)
 
@@ -81,7 +86,7 @@ Item {
     // gridColumns × gridRows. Callers don't override.
     readonly property int _availableWidth: Math.max(0, width - 2 * sideInset)
     readonly property int _availableHeight:
-        Math.max(0, height - topInset)
+        Math.max(0, height - topInset - bottomInset)
     readonly property int cellWidth:
         Math.max(0,
                  Math.floor((root._availableWidth - (root.columns - 1) * root.cellSpacingX)

--- a/src/ui/components/ScreenStateOverlay.qml
+++ b/src/ui/components/ScreenStateOverlay.qml
@@ -26,6 +26,7 @@ Item {
     property string errorMessage: ""
     property int count: 0
     property string emptyText: qsTr("Nothing here")
+    property string loadingText: qsTr("Loading…")
 
     // Named `viewState` rather than `state` — `Item.state` is a
     // built-in slot wired to `states:` / `transitions:`, and shadowing
@@ -50,6 +51,7 @@ Item {
         LoadingIndicator {
             anchors.horizontalCenter: parent.horizontalCenter
             visible: overlay.viewState === "loading"
+            text: overlay.loadingText
         }
 
         Text {

--- a/src/ui/components/SettingsField.qml
+++ b/src/ui/components/SettingsField.qml
@@ -40,7 +40,7 @@ Item {
         id: surface
 
         anchors.fill: parent
-        radius: Sizing.pctH(1.2)
+        radius: Sizing.cornerRadius
         color: root.isFocused ? Theme.surfaceCard : "transparent"
         border.color: root.isFocused ? Theme.textPrimary : Theme.borderSubtle
         border.width: root.isFocused ? Sizing.pctH(0.4) : 1

--- a/src/ui/components/Tile.qml
+++ b/src/ui/components/Tile.qml
@@ -95,7 +95,7 @@ Item {
     // unified-Tile contract: every grid renders the same shape.
     Rectangle {
         anchors.fill: parent
-        radius: Sizing.pctH(1.2)
+        radius: Sizing.cornerRadius
         color: Theme.surfaceCard
     }
 
@@ -118,7 +118,7 @@ Item {
         border.width: root._outlineWidth
         // Card radius minus the inset margin keeps the ring concentric
         // with the card corners.
-        radius: Sizing.pctH(0.8)
+        radius: Sizing.cornerRadius - root._outlineGap
         visible: root._focusedSelection
     }
 

--- a/src/ui/components/Tile.qml
+++ b/src/ui/components/Tile.qml
@@ -7,13 +7,23 @@ import Zaparoo.Theme
 
 // Unified grid tile. Solid card with a centered icon area filling the
 // card body, plus a white outline ring around the card when this tile
-// is the focused selection. The focused tile's display name renders
-// below the grid via ActiveLabel.qml — no label inside the tile —
-// because per-tile labels duplicate identity already carried by the
-// curated logo and force long names to wrap/elide inside cramped
-// cells. Used by every tile surface in the launcher — hub categories
-// row, systems grid, games grid — so the vocabulary is identical
-// across screens.
+// is the focused selection. Used by every tile surface in the launcher
+// — hub categories row, systems grid, games grid, recents grid — so
+// the vocabulary is identical across screens.
+//
+// Two layout modes, gated by `showCaption`:
+//   - off (default): full-bleed icon, no in-tile label. Used by Hub
+//     and Systems where a curated logo already carries identity.
+//   - on: cover slot shrinks vertically to free a thin band along the
+//     bottom edge for a one-line elided name caption. Used by Games
+//     and Recents because a long shelf of similar boxart needs
+//     per-tile labelling — the focused-tile caption below the grid
+//     (ActiveLabel) only identifies one cell at a time.
+//
+// In caption mode the loading-state fallback is an hourglass glyph,
+// not the wrapping-name text used in non-caption mode — the bottom
+// caption already shows the name, so the centred-text fallback would
+// just read it twice.
 //
 // Parent contract — Tile must be loaded inside a host that exposes:
 //   - isSelected: bool   — true when this tile is the focused selection
@@ -58,9 +68,16 @@ Item {
         // qmllint enable missing-property compiler
     }
 
+    // Opt-in per-tile name caption. Off by default so Hub and Systems
+    // keep their full-bleed logo layout. Cover-art screens (Games,
+    // Recents) flip this on at the delegate template.
+    property bool showCaption: false
+
     readonly property int _padding: Sizing.pctH(3)
     readonly property int _outlineGap: Sizing.pctH(0.4)
     readonly property int _outlineWidth: Sizing.pctH(0.6)
+    readonly property int _captionHeight: Sizing.pctH(3.5)
+    readonly property int _captionGap: Sizing.pctH(0.8)
 
     readonly property bool _focusedSelection:
         root.delegateIsSelected && root.delegateIsFocused
@@ -110,15 +127,36 @@ Item {
     // top; the icon padding (`_padding = pctH(3)`) is far larger than
     // the inset (`_outlineGap = pctH(0.4)`), so the ring never overlaps
     // content.
+    // Focus ring drawn as two stacked *filled* rounded rectangles — an
+    // outer white pill and an inner surfaceCard mask that punches the
+    // centre back, leaving a uniform outline. Equivalent to the older
+    // single-Rectangle `border.color` + `border.width` approach but
+    // significantly smoother on the corners under Qt's software
+    // adaptation: filled rounded rects honour the AA path, while thin
+    // rounded *borders* are tessellated without subpixel coverage and
+    // step visibly at the corners (see QTBUG-123210). Both rectangles
+    // are still inside the card edge by `_outlineGap`, so the ring
+    // never bleeds past the cell bounds.
     Rectangle {
+        id: focusRingOuter
         anchors.fill: parent
         anchors.margins: root._outlineGap
-        color: "transparent"
-        border.color: Theme.textPrimary
-        border.width: root._outlineWidth
-        // Card radius minus the inset margin keeps the ring concentric
-        // with the card corners.
+        color: Theme.textPrimary
         radius: Sizing.cornerRadius - root._outlineGap
+        antialiasing: true
+        visible: root._focusedSelection
+    }
+    Rectangle {
+        anchors.fill: focusRingOuter
+        anchors.margins: root._outlineWidth
+        color: Theme.surfaceCard
+        // Inner radius shrinks to keep the visible ring's outer edge
+        // and inner edge concentric with the card corners. Floor at 0
+        // so very small tiles (where _outlineWidth approaches the
+        // outer radius) collapse to a sharp inner mask rather than
+        // negative-radius garbage.
+        radius: Math.max(0, focusRingOuter.radius - root._outlineWidth)
+        antialiasing: true
         visible: root._focusedSelection
     }
 
@@ -133,7 +171,12 @@ Item {
             top: parent.top
             topMargin: root._padding
             bottom: parent.bottom
-            bottomMargin: root._padding
+            // In caption mode the cover slot shrinks to leave a strip
+            // for the bottom caption; otherwise it fills body-padding.
+            bottomMargin: root.showCaption
+                          ? root._padding + root._captionHeight
+                            + root._captionGap
+                          : root._padding
             horizontalCenter: parent.horizontalCenter
         }
         width: parent.width - 2 * root._padding
@@ -151,10 +194,40 @@ Item {
         opacity: root._hasCover ? 1.0 : 0.0
     }
 
-    // Procedural fallback. Sits at the same geometry as the cover and
-    // snaps to the cover the moment Image.status hits Ready; the brief
-    // Loading window shows the fallback text rather than crossfading.
-    // Cache hits skip Loading entirely and snap directly.
+    // Caption-mode loading cue. Centred hourglass glyph that paints
+    // only during the Image.Loading window — once the cover lands the
+    // glyph hides and the cover paints in. Error/Null cover state
+    // also hides the glyph (a stuck hourglass on a permanently failed
+    // cover would mislead) and the bottom caption still identifies
+    // the tile. Bundled qrc asset, decode is cheap, no animation.
+    Image {
+        id: loadingGlyph
+        anchors.centerIn: cover
+        width: Sizing.pctH(10)
+        height: Sizing.pctH(10)
+        source: Resources.iconUrl("Loading")
+        // Loading.svg has a 24×24 native viewBox; without sourceSize
+        // Qt rasterises at that intrinsic size and bilinear-upscales
+        // to the rendered box, which reads as soft on every screen
+        // taller than ~240 px. Pinning sourceSize to the rendered
+        // dimensions makes the SVG renderer rasterise at target size
+        // — same pattern StatusIcon.qml and LoadingIndicator.qml use.
+        sourceSize.width: width
+        sourceSize.height: height
+        fillMode: Image.PreserveAspectFit
+        smooth: true
+        asynchronous: false
+        visible: root.showCaption && cover.status === Image.Loading
+    }
+
+    // Non-caption procedural fallback. Sits at the same geometry as
+    // the cover and snaps to the cover the moment Image.status hits
+    // Ready; the brief Loading window shows the fallback text rather
+    // than crossfading. Cache hits skip Loading entirely and snap
+    // directly. In caption mode this is suppressed — the bottom
+    // caption already shows the name and the hourglass above signals
+    // load progress, so a wrapping copy of the name in this slot is
+    // redundant.
     Text {
         anchors.fill: cover
         text: root.delegateName
@@ -168,7 +241,33 @@ Item {
         horizontalAlignment: Text.AlignHCenter
         verticalAlignment: Text.AlignVCenter
         renderType: Text.NativeRendering
-        opacity: root._hasCover ? 0.0 : 1.0
+        opacity: (!root.showCaption && !root._hasCover) ? 1.0 : 0.0
         clip: true
+    }
+
+    // Bottom caption strip (caption mode only). Single line, ellipsised
+    // when long. Same focus-tinted colouring as the non-caption
+    // fallback so the focused tile's caption brightens with the rest
+    // of the focus cue.
+    Text {
+        id: caption
+        anchors {
+            left: parent.left
+            right: parent.right
+            bottom: parent.bottom
+            leftMargin: root._padding
+            rightMargin: root._padding
+            bottomMargin: root._padding
+        }
+        height: root._captionHeight
+        visible: root.showCaption
+        text: root.delegateName
+        font.family: Theme.fontUi
+        font.pixelSize: Sizing.fontSize(1.7)
+        color: root._focusedSelection ? Theme.textPrimary : Theme.textLabel
+        elide: Text.ElideRight
+        horizontalAlignment: Text.AlignHCenter
+        verticalAlignment: Text.AlignVCenter
+        renderType: Text.NativeRendering
     }
 }

--- a/src/ui/components/TopStatusStrip.qml
+++ b/src/ui/components/TopStatusStrip.qml
@@ -13,9 +13,9 @@ import Zaparoo.Theme
 // titles) can't collide on a 240p MiSTer screen.
 //
 // Slots:
-//   left   — "Page N / M" counter (visible when `totalPages > 1`)
+//   left   — total-count badge (visible when `totalText !== ""`)
 //   center — screen title (category / system name)
-//   right  — total-count badge (visible when `totalText !== ""`)
+//   right  — "Page N / M" counter (visible when `totalPages > 1`)
 //
 // Software-rendering safe: only Item + Text, no transforms, no shaders.
 Item {
@@ -35,17 +35,15 @@ Item {
     // chips. Counter/total drop one step in font size so the title
     // stays the visual anchor.
     Text {
-        id: pageCounter
-        visible: status.totalPages > 1
+        id: totalBadge
+        visible: status.totalText !== ""
         anchors.left: parent.left
         anchors.leftMargin: status._slotMargin
         anchors.bottom: titleText.bottom
         width: status._slotWidth - status._slotMargin
         elide: Text.ElideRight
         horizontalAlignment: Text.AlignLeft
-        text: qsTr("Page %1 / %2")
-                .arg(status.currentPage + 1)
-                .arg(status.totalPages)
+        text: status.totalText
         font.family: Theme.fontUi
         font.pixelSize: Sizing.fontSize(3)
         color: Theme.textPrimary
@@ -68,15 +66,17 @@ Item {
     }
 
     Text {
-        id: totalBadge
-        visible: status.totalText !== ""
+        id: pageCounter
+        visible: status.totalPages > 1
         anchors.right: parent.right
         anchors.rightMargin: status._slotMargin
         anchors.bottom: titleText.bottom
         width: status._slotWidth - status._slotMargin
         elide: Text.ElideRight
         horizontalAlignment: Text.AlignRight
-        text: status.totalText
+        text: qsTr("Page %1 / %2")
+                .arg(status.currentPage + 1)
+                .arg(status.totalPages)
         font.family: Theme.fontUi
         font.pixelSize: Sizing.fontSize(3)
         color: Theme.textPrimary

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -250,7 +250,7 @@ Item {
         anchors.verticalCenter: activeLabel.verticalCenter
         visible: Browse.GamesModel.loading_more
         z: 1
-        text: qsTr("Loading more…")
+        text: qsTr("Loading more games…")
     }
 
     ScreenStateOverlay {
@@ -261,5 +261,6 @@ Item {
         errorMessage: Browse.GamesModel.error_message ?? ""
         count: Browse.GamesModel.count
         emptyText: qsTr("No games in this system")
+        loadingText: qsTr("Loading games…")
     }
 }

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -209,7 +209,7 @@ Item {
         anchors.bottom: parent.bottom
         anchors.bottomMargin: Sizing.pctH(15)
         model: Browse.GamesModel
-        delegate: Tile {}
+        delegate: Tile { showCaption: true }
         // Cover-art tiles run taller than systems logos, so a 5x3
         // layout starves vertical space. Games gets its own
         // gamesGridColumns/Rows in Sizing — 5x2 on desktop, narrower

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -178,7 +178,7 @@ Item {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: parent.top
-        anchors.topMargin: Sizing.pctH(9)
+        anchors.topMargin: Sizing.pctH(11)
         height: Sizing.pctH(7)
         title: {
             const sid = Browse.GamesModel.current_system_id
@@ -206,7 +206,6 @@ Item {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: topStrip.bottom
-        anchors.topMargin: Sizing.pctH(2)
         anchors.bottom: parent.bottom
         anchors.bottomMargin: Sizing.pctH(15)
         model: Browse.GamesModel
@@ -217,6 +216,11 @@ Item {
         // branches at low resolutions match the systems grid logic.
         columnsOverride: Sizing.gamesGridColumns
         rowsOverride: Sizing.gamesGridRows
+        // Stable scroll-thumb sizing while `fetch_more` grows the loaded
+        // slice: feed PagedGrid the dataset's true total entry count
+        // (same expression the top strip uses for `totalPages`).
+        totalItemsOverride: Browse.GamesModel.dir_count
+                            + Browse.GamesModel.total_files
         onLoadMoreRequested: Browse.GamesModel.fetch_more()
         onItemHovered: (index) => games._focusIndex(index)
         onItemClicked: (index) => {
@@ -234,23 +238,10 @@ Item {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: gamesGrid.bottom
-        anchors.topMargin: Sizing.pctH(1)
         height: Sizing.pctH(7)
         text: gamesGrid.itemCount > 0
               ? Browse.GamesModel.name_at(gamesGrid.currentIndex)
               : ""
-    }
-
-    // "Loading more…" cue, parked on the left edge of the active-label
-    // band so the focused-entry name and the pagination cue read as a
-    // single bottom strip. Hidden until a fetch is in flight.
-    LoadingIndicator {
-        anchors.left: parent.left
-        anchors.leftMargin: Sizing.pctW(5)
-        anchors.verticalCenter: activeLabel.verticalCenter
-        visible: Browse.GamesModel.loading_more
-        z: 1
-        text: qsTr("Loading more games…")
     }
 
     ScreenStateOverlay {

--- a/src/ui/screens/HubScreen.qml
+++ b/src/ui/screens/HubScreen.qml
@@ -57,6 +57,24 @@ Item {
     signal requestRecentsScreen()
     signal requestSettingsScreen()
 
+    // Vertically center the (categories row + actions row + activeLabel)
+    // block in the band between the logo bottom (pctH(9)) and the help
+    // bar top (hub.height - pctH(6)). `_blockHeight` mirrors the
+    // anchor chain below: each row is `cellHeight + 2*verticalPadding`,
+    // the gap between them collapses the focus-bleed padding (see
+    // `actionsRow.anchors.topMargin`), and the label sits pctH(3) below
+    // the actions row at pctH(7) tall.
+    readonly property int _blockHeight:
+        2 * (categoriesRow.cellHeight + 2 * categoriesRow.verticalPadding)
+        + (categoriesRow.spacing
+           - categoriesRow.verticalPadding
+           - actionsRow.verticalPadding)
+        + Sizing.pctH(3)
+        + Sizing.pctH(7)
+    readonly property int _blockY:
+        Math.round((Sizing.pctH(9) + hub.height - Sizing.pctH(6)
+                    - hub._blockHeight) / 2)
+
     // Static action-row data. Three fixed entries; order matches
     // left-to-right reading. The `qsTr()` calls live directly in this
     // binding so a `LanguageChange` event re-evaluates `actionEntries`
@@ -289,9 +307,10 @@ Item {
         anchors.horizontalCenter: parent.horizontalCenter
         width: parent.width
         height: cellHeight + 2 * verticalPadding
-        // Sits high enough that the second row + activeLabel stay
-        // clear of the help bar at the bottom.
-        y: Sizing.pctH(14)
+        // Vertically centered with actionsRow + activeLabel as one
+        // block in the band between the logo and the help bar. See
+        // `_blockHeight` / `_blockY` on the hub root for the math.
+        y: hub._blockY
 
         // Hide the tiles while the router holds us here on a forward
         // transition so the centred "Loading…" cue (painted from

--- a/src/ui/screens/HubScreen.qml
+++ b/src/ui/screens/HubScreen.qml
@@ -274,9 +274,10 @@ Item {
                 ? Math.floor((width - 2 * sideInset - (n - 1) * spacing) / n)
                 : 0
         readonly property int cellWidth: Math.min(maxCellWidth, rawCellWidth)
-        // Square cell with a hair of breathing room top and bottom
-        // for the focused tile's 1.06× scale bleed.
-        readonly property int cellHeight: Sizing.pctH(22) + Sizing.pctH(2)
+        // Square cells (1:1) for the main menu. The focused tile's
+        // 1.06× scale bleed is absorbed by `verticalPadding` on the
+        // row Item, not by inflating the cell.
+        readonly property int cellHeight: cellWidth
         readonly property int totalRowWidth:
             n > 0 ? n * cellWidth + (n - 1) * spacing : 0
         readonly property int rowOriginX: (width - totalRowWidth) / 2

--- a/src/ui/screens/RecentsScreen.qml
+++ b/src/ui/screens/RecentsScreen.qml
@@ -183,7 +183,7 @@ Item {
         anchors.verticalCenter: activeLabel.verticalCenter
         visible: Browse.RecentsModel.loading_more
         z: 1
-        text: qsTr("Loading more…")
+        text: qsTr("Loading more entries…")
     }
 
     ScreenStateOverlay {
@@ -194,5 +194,6 @@ Item {
         errorMessage: Browse.RecentsModel.error_message ?? ""
         count: Browse.RecentsModel.count
         emptyText: qsTr("Nothing played yet")
+        loadingText: qsTr("Loading recently played…")
     }
 }

--- a/src/ui/screens/RecentsScreen.qml
+++ b/src/ui/screens/RecentsScreen.qml
@@ -128,7 +128,7 @@ Item {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: parent.top
-        anchors.topMargin: Sizing.pctH(9)
+        anchors.topMargin: Sizing.pctH(11)
         height: Sizing.pctH(7)
         title: qsTr("Recently Played")
         currentPage: recentsGrid.currentPage
@@ -145,7 +145,6 @@ Item {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: topStrip.bottom
-        anchors.topMargin: Sizing.pctH(2)
         anchors.bottom: parent.bottom
         anchors.bottomMargin: Sizing.pctH(15)
         model: Browse.RecentsModel
@@ -168,22 +167,10 @@ Item {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: recentsGrid.bottom
-        anchors.topMargin: Sizing.pctH(1)
         height: Sizing.pctH(7)
         text: recentsGrid.itemCount > 0
               ? Browse.RecentsModel.name_at(recentsGrid.currentIndex)
               : ""
-    }
-
-    // "Loading more…" cue, parked on the left edge of the active-label
-    // band — same placement as GamesScreen so users see the same pattern.
-    LoadingIndicator {
-        anchors.left: parent.left
-        anchors.leftMargin: Sizing.pctW(5)
-        anchors.verticalCenter: activeLabel.verticalCenter
-        visible: Browse.RecentsModel.loading_more
-        z: 1
-        text: qsTr("Loading more entries…")
     }
 
     ScreenStateOverlay {

--- a/src/ui/screens/RecentsScreen.qml
+++ b/src/ui/screens/RecentsScreen.qml
@@ -148,7 +148,7 @@ Item {
         anchors.bottom: parent.bottom
         anchors.bottomMargin: Sizing.pctH(15)
         model: Browse.RecentsModel
-        delegate: Tile {}
+        delegate: Tile { showCaption: true }
         // Match games-grid layout (taller cover-art tiles); the systems
         // grid's 5x3 starves vertical space on these covers.
         columnsOverride: Sizing.gamesGridColumns

--- a/src/ui/screens/SystemsScreen.qml
+++ b/src/ui/screens/SystemsScreen.qml
@@ -151,7 +151,7 @@ Item {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: parent.top
-        anchors.topMargin: Sizing.pctH(9)
+        anchors.topMargin: Sizing.pctH(11)
         height: Sizing.pctH(7)
         title: Browse.SystemsModel.current_category
         currentPage: systemsGrid.currentPage
@@ -173,7 +173,6 @@ Item {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: topStrip.bottom
-        anchors.topMargin: Sizing.pctH(2)
         anchors.bottom: parent.bottom
         anchors.bottomMargin: Sizing.pctH(15)
         model: Browse.SystemsModel
@@ -199,7 +198,6 @@ Item {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: systemsGrid.bottom
-        anchors.topMargin: Sizing.pctH(1)
         height: Sizing.pctH(7)
         text: systemsGrid.itemCount > 0
               ? Browse.SystemsModel.system_name_at(systemsGrid.currentIndex)

--- a/src/ui/screens/SystemsScreen.qml
+++ b/src/ui/screens/SystemsScreen.qml
@@ -215,5 +215,6 @@ Item {
         errorMessage: Browse.SystemsModel.error_message ?? ""
         count: Browse.SystemsModel.count
         emptyText: qsTr("No systems in this category")
+        loadingText: qsTr("Loading systems…")
     }
 }

--- a/src/ui/theme/Sizing.qml
+++ b/src/ui/theme/Sizing.qml
@@ -35,6 +35,12 @@ QtObject {
                                             : 5
     readonly property int gamesGridRows: 2
 
+    // Standard corner radius for rounded surfaces — tile cards, focus
+    // rings (computed as `cornerRadius - outlineGap`), settings rows.
+    // Pill controls (toggle track/thumb) use `height/2` instead and
+    // are intentionally a different shape. See docs/style.md.
+    readonly property int cornerRadius: pctH(3.5)
+
     function pctH(percent: real): int {
         return Math.round(screenHeight * percent / 100)
     }

--- a/tests/ui/tst_paged_grid.qml
+++ b/tests/ui/tst_paged_grid.qml
@@ -8,9 +8,8 @@ import Zaparoo.Theme
 import Zaparoo.Ui
 
 // Direct moveSelection coverage. PagedGrid wraps in surprising ways
-// (page-overshoot lands on last existing item, single-page wraps,
-// vertical wrap stays within the current page), so each branch needs
-// its own explicit case.
+// (within-row Left/Right wrap, vertical page advance/retreat, partial
+// last-page hole clamps), so each branch needs its own explicit case.
 //
 // Test geometry pinned to 1280×480, which makes Sizing yield a 4×3
 // grid (pageSize=12). All test indices below assume that layout.
@@ -90,118 +89,169 @@ TestCase {
         compare(grid.currentIndex, 4)
     }
 
-    function test_up_at_top_row_wraps_to_bottom_of_same_page(): void {
-        fillModel(20)
-        // currentIndex 0 → page 0, row 0, col 0. Up wraps to row 2,
-        // col 0 on the same page → index 8.
+    // ── Vertical paging (Up/Down crosses page boundaries) ───────────────
+
+    function test_down_at_bottom_row_advances_to_next_page(): void {
+        // 24 items, two full pages. From (page 0, row 2, col 0) = 8,
+        // Down advances to (page 1, row 0, col 0) = 12.
+        fillModel(24)
+        grid.setCurrentIndexImmediate(8)
+        compare(grid.moveSelection(0, 1), true)
+        compare(grid.currentIndex, 12)
+    }
+
+    function test_up_at_top_row_retreats_to_previous_page(): void {
+        // 24 items. From (page 1, row 0, col 0) = 12, Up retreats to
+        // (page 0, row 2, col 0) = 8.
+        fillModel(24)
+        grid.setCurrentIndexImmediate(12)
         compare(grid.moveSelection(0, -1), true)
         compare(grid.currentIndex, 8)
     }
 
-    function test_down_at_bottom_row_wraps_to_top_of_same_page(): void {
-        fillModel(20)
-        grid.setCurrentIndexImmediate(8) // (page 0, row 2, col 0)
-        compare(grid.currentRow, 2)
+    function test_down_at_last_page_last_row_wraps_to_page_zero(): void {
+        // 24 items. From (page 1, row 2, col 0) = 20, Down wraps to
+        // (page 0, row 0, col 0) = 0.
+        fillModel(24)
+        grid.setCurrentIndexImmediate(20)
         compare(grid.moveSelection(0, 1), true)
-        // Wraps to (page 0, row 0, col 0) → index 0.
         compare(grid.currentIndex, 0)
     }
 
-    function test_down_into_partial_page_hole_clamps_to_last_existing(): void {
-        // 14 items: page 1 has rows 0 (cells 12..15) — but only 12, 13
-        // exist (indices 12, 13). Standing at (page 1, row 0, col 1)
-        // = index 13 and pressing down would land on (page 1, row 1,
-        // col 1) = index 17, which doesn't exist. Clamps to the last
-        // item on page 1 (13). No move, returns false.
-        fillModel(14)
-        grid.setCurrentIndexImmediate(13)
-        compare(grid.moveSelection(0, 1), false)
-        compare(grid.currentIndex, 13)
+    function test_up_at_page_zero_first_row_wraps_to_last_page(): void {
+        // 24 items. From (page 0, row 0, col 0) = 0, Up wraps to
+        // (page 1, row 2, col 0) = 20.
+        fillModel(24)
+        compare(grid.moveSelection(0, -1), true)
+        compare(grid.currentIndex, 20)
     }
 
-    function test_up_into_partial_page_hole_clamps_to_last_existing(): void {
-        // 14 items as above. From (page 1, row 0, col 1) = 13, up wraps
-        // to (page 1, row 2, col 1) = 21 — doesn't exist. Clamps to the
-        // last item on page 1 (13). No move, returns false.
-        fillModel(14)
-        grid.setCurrentIndexImmediate(13)
-        compare(grid.moveSelection(0, -1), false)
-        compare(grid.currentIndex, 13)
+    function test_up_at_page_zero_wraps_to_partial_last_page_clamped(): void {
+        // 20 items: page 1 has rows 0..1 (12..19). Up from index 0
+        // would land on (page 1, row 2, col 0) = 20 — a hole. Clamp
+        // to the last item on the partial last page (19).
+        fillModel(20)
+        compare(grid.moveSelection(0, -1), true)
+        compare(grid.currentIndex, 19)
     }
 
-    function test_right_crosses_page_boundary_to_full_target(): void {
-        // 24 items = exactly 2 pages. Right at (0, row 0, col 3) lands
-        // at (1, row 0, col 0).
+    function test_down_overshoot_to_partial_page_clamps_to_last_existing(): void {
+        // 13 items: page 1 has only index 12 (row 0, col 0). From
+        // (page 0, row 2, col 3) = 11, Down would land on (page 1,
+        // row 0, col 3) = 15 — a hole. Clamp to last item on the
+        // partial page (12).
+        fillModel(13)
+        grid.setCurrentIndexImmediate(11)
+        compare(grid.moveSelection(0, 1), true)
+        compare(grid.currentIndex, 12)
+    }
+
+    function test_down_below_last_filled_row_on_partial_page_wraps_to_page_zero(): void {
+        // 14 items: standing at (page 1, row 0, col 1) = 13 (the last
+        // item; row 1 of this page is empty). Down advances off the
+        // last filled row — same as overflowing the grid, so on the
+        // last page it wraps to (page 0, row 0, same col) = 1.
+        fillModel(14)
+        grid.setCurrentIndexImmediate(13)
+        compare(grid.moveSelection(0, 1), true)
+        compare(grid.currentIndex, 1)
+    }
+
+    function test_up_from_partial_page_retreats_to_previous_page(): void {
+        // 14 items: page 1 has indices 12, 13. From (page 1, row 0,
+        // col 1) = 13, Up retreats to (page 0, row 2, col 1) = 9
+        // (a real cell on the full prev page).
+        fillModel(14)
+        grid.setCurrentIndexImmediate(13)
+        compare(grid.moveSelection(0, -1), true)
+        compare(grid.currentIndex, 9)
+    }
+
+    // ── Single-page Up/Down (wraps within the page) ─────────────────────
+
+    function test_single_page_up_wraps_to_last_row_same_page(): void {
+        // 12 items, single full page. From (row 0, col 0) = 0,
+        // Up wraps to (row 2, col 0) = 8.
+        fillModel(12)
+        compare(grid.pageCount, 1)
+        compare(grid.moveSelection(0, -1), true)
+        compare(grid.currentIndex, 8)
+    }
+
+    function test_single_page_down_at_partial_last_row_wraps_to_top(): void {
+        // 6 items, single partial page. From (row 1, col 1) = 5, Down
+        // steps below the last filled row, which on the only (=last)
+        // page wraps to (row 0, same col) = 1. Mirrors the full-page
+        // single-page Down-wrap so partial pages aren't a special case.
+        fillModel(6)
+        grid.setCurrentIndexImmediate(5)
+        compare(grid.pageCount, 1)
+        compare(grid.moveSelection(0, 1), true)
+        compare(grid.currentIndex, 1)
+    }
+
+    // ── Horizontal within-row wrap (Left/Right never changes page) ──────
+
+    function test_right_at_last_col_wraps_within_row(): void {
+        // 24 items. From (page 0, row 0, col 3) = 3, Right wraps to
+        // (page 0, row 0, col 0) = 0. No page change.
         fillModel(24)
         grid.setCurrentIndexImmediate(3)
+        compare(grid.moveSelection(1, 0), true)
+        compare(grid.currentIndex, 0)
+    }
+
+    function test_left_at_first_col_wraps_within_row(): void {
+        // 24 items. From (page 0, row 0, col 0) = 0, Left wraps to
+        // (page 0, row 0, col 3) = 3. No page change.
+        fillModel(24)
+        compare(grid.moveSelection(-1, 0), true)
+        compare(grid.currentIndex, 3)
+    }
+
+    function test_right_on_partial_row_wraps_within_filled(): void {
+        // 14 items: page 1 row 0 has (12, 13). From idx 13, Right
+        // wraps within the row to col 0 = 12.
+        fillModel(14)
+        grid.setCurrentIndexImmediate(13)
         compare(grid.moveSelection(1, 0), true)
         compare(grid.currentIndex, 12)
     }
 
-    function test_right_overshoot_to_partial_page_lands_on_last_existing(): void {
-        // 20 items: page 1 has 8 items (12..19). Right from (page 0,
-        // row 2, col 3) overshoots a hole on (page 1, row 2, col 0)
-        // and clamps to the last item on the partial page (19).
-        fillModel(20)
-        grid.setCurrentIndexImmediate(11)
-        compare(grid.moveSelection(1, 0), true)
-        compare(grid.currentIndex, 19)
-    }
-
-    function test_left_at_first_column_wraps_to_previous_page(): void {
-        fillModel(24)
-        grid.setCurrentIndexImmediate(12) // (page 1, row 0, col 0)
+    function test_left_on_partial_row_wraps_within_filled(): void {
+        // 14 items. From idx 12 (page 1, row 0, col 0), Left wraps
+        // to last filled col on the row = idx 13.
+        fillModel(14)
+        grid.setCurrentIndexImmediate(12)
         compare(grid.moveSelection(-1, 0), true)
-        // (page 0, row 0, last col) → 0*12 + 0*4 + 3 = 3
-        compare(grid.currentIndex, 3)
-    }
-
-    function test_left_at_page_zero_wraps_to_last_page(): void {
-        fillModel(24)
-        compare(grid.currentIndex, 0)
-        compare(grid.moveSelection(-1, 0), true)
-        // (last page = 1, row 0, last col) → 1*12 + 0*4 + 3 = 15
-        compare(grid.currentIndex, 15)
-    }
-
-    function test_right_at_last_page_wraps_to_first(): void {
-        fillModel(24)
-        grid.setCurrentIndexImmediate(15) // (page 1, row 0, col 3)
-        compare(grid.moveSelection(1, 0), true)
-        // Wraps to (page 0, row 0, col 0)
-        compare(grid.currentIndex, 0)
-    }
-
-    function test_single_page_right_wrap_from_last_item(): void {
-        // 6 items = single page (page 0, rows 0..1, only col 0..1 on row 1).
-        fillModel(6)
-        grid.setCurrentIndexImmediate(5) // (page 0, row 1, col 1)
-        compare(grid.pageCount, 1)
-        compare(grid.moveSelection(1, 0), true)
-        // Single-page wrap: lands at item 0.
-        compare(grid.currentIndex, 0)
+        compare(grid.currentIndex, 13)
     }
 
     function test_single_page_left_wrap_to_last_col_when_row_full(): void {
         // 6 items at 4-cols: row 0 is full (0..3), row 1 partial (4..5).
-        // Left-wrap from index 0 lands on (row 0, col 3) → index 3.
-        // Item 3 exists, so no overshoot adjustment fires.
+        // From idx 0, Left wraps to last col on full row 0 = idx 3.
         fillModel(6)
-        compare(grid.currentIndex, 0)
         compare(grid.pageCount, 1)
         compare(grid.moveSelection(-1, 0), true)
         compare(grid.currentIndex, 3)
     }
 
     function test_single_page_left_wrap_partial_row_clamps_to_last_item(): void {
-        // 2 items at 4-cols: row 0 is partial (0..1). Left-wrap from
-        // index 0 would land on (row 0, col 3) = index 3, which doesn't
-        // exist; the dCol<0 branch then clamps to the last item (1).
+        // 2 items at 4-cols: row 0 partial (0..1). From idx 0, Left
+        // wraps to last filled col on this row (col 1) = idx 1.
         fillModel(2)
-        compare(grid.currentIndex, 0)
         compare(grid.pageCount, 1)
         compare(grid.moveSelection(-1, 0), true)
         compare(grid.currentIndex, 1)
+    }
+
+    function test_single_page_right_at_last_filled_wraps_to_row_start(): void {
+        // 6 items. From (row 1, col 1) = 5, Right wraps within the
+        // partial row to col 0 = idx 4.
+        fillModel(6)
+        grid.setCurrentIndexImmediate(5)
+        compare(grid.moveSelection(1, 0), true)
+        compare(grid.currentIndex, 4)
     }
 
     function test_no_movement_returns_false(): void {
@@ -219,5 +269,76 @@ TestCase {
         model.remove(10, 10)
         tryCompare(grid, "itemCount", 10)
         compare(grid.currentIndex, 9)
+    }
+
+    // ── pageBy (L/R shoulder shortcut, unchanged) ────────────────────────
+
+    function test_pageBy_advances_one_page(): void {
+        fillModel(24)
+        grid.setCurrentIndexImmediate(2) // (row 0, col 2)
+        compare(grid.pageBy(1), true)
+        compare(grid.currentPage, 1)
+        // Preserves (row, col): (page 1, row 0, col 2) = 14.
+        compare(grid.currentIndex, 14)
+    }
+
+    function test_pageBy_wraps_negative(): void {
+        fillModel(24)
+        compare(grid.pageBy(-1), true)
+        compare(grid.currentPage, 1)
+    }
+
+    function test_pageBy_single_page_returns_false(): void {
+        fillModel(6)
+        compare(grid.pageCount, 1)
+        compare(grid.pageBy(1), false)
+        compare(grid.pageBy(-1), false)
+    }
+
+    function test_pageBy_partial_target_clamps_to_last_item(): void {
+        // 14 items, currentIndex 5 (row 1, col 1) on page 0. pageBy(1)
+        // targets (page 1, row 1, col 1) = 17 — a hole. Clamps to
+        // last on page 1 (13).
+        fillModel(14)
+        grid.setCurrentIndexImmediate(5)
+        compare(grid.pageBy(1), true)
+        compare(grid.currentIndex, 13)
+    }
+
+    // ── Page-stack flags (gutter arrows / scrollbar derivations) ─────────
+
+    function test_hasPages_flags_track_currentPage(): void {
+        fillModel(36) // 3 pages
+        grid.setCurrentIndexImmediate(0)
+        compare(grid.hasPagesAbove, false)
+        compare(grid.hasPagesBelow, true)
+        grid.setCurrentIndexImmediate(12) // page 1
+        compare(grid.hasPagesAbove, true)
+        compare(grid.hasPagesBelow, true)
+        grid.setCurrentIndexImmediate(24) // page 2
+        compare(grid.hasPagesAbove, true)
+        compare(grid.hasPagesBelow, false)
+    }
+
+    function test_hasPages_flags_single_page_dataset(): void {
+        fillModel(6)
+        compare(grid.pageCount, 1)
+        compare(grid.hasPagesAbove, false)
+        compare(grid.hasPagesBelow, false)
+    }
+
+    // ── Scroll thumb sizing (totalItemsOverride) ─────────────────────────
+
+    function test_totalPageCount_uses_override(): void {
+        // 24 items loaded — 2 pages on the 4×3 grid. With an override
+        // saying total is 60 (5 pages), totalPageCount must reflect 5
+        // so the scroll thumb sizes from the dataset's true total
+        // rather than the loaded slice.
+        fillModel(24)
+        compare(grid.pageCount, 2)
+        grid.totalItemsOverride = 60
+        compare(grid.totalPageCount, 5)
+        grid.totalItemsOverride = -1
+        compare(grid.totalPageCount, 2)
     }
 }


### PR DESCRIPTION
## Summary

Bundles a round of UI polish on top of `main` plus a fix for the cover-prefetch ordering that shipped briefly with the pagination redesign.

- **Pagination + grid polish (#37 line):** redesigned page indicator/status strip, grid layout tightening, contextual loading text per destination, square hub tiles + corner-radius standardization, focus-clip fix, `File.svg` glyph swap.
- **Per-tile captions on cover-art grids:** `Tile` gains an opt-in `showCaption` mode used by Games and Recents — thin elided name caption along the bottom edge, hourglass glyph during the `Image.Loading` window in place of the wrapping-name fallback. Hub and Systems keep the full-bleed logo layout.
- **Focus ring AA:** swapped the rounded `border` ring for two stacked filled rounded rects (outer white pill + inner `surfaceCard` mask). Filled rounded rects honour Qt's software-adaptation AA path; thin rounded borders are tessellated without subpixel coverage and step visibly at the corners (QTBUG-123210).
- **Cover prefetch — drop priority lane, lean into LIFO inversion:** Zaparoo Core serializes `media.image` responses at ~one per 250–400 ms. A "low priority" lane for look-ahead drains the visible page first and starves page N+1 — the practical effect is "covers loading slowly one at a time" and the next page no longer warm on navigate. Single-lane LIFO with reverse iteration restores the prior emergent behavior: visual top of page N pops first, page N+1 rides the back of the queue and warms between page N's first burst and its tail, page N's bottom rows fill in last. The 4-worker fetch pool stays in place — idle workers parked on `Notify` cost nothing and turn into an immediate win the moment Core stops serializing.

## Test plan

- [ ] `just lint` clean
- [ ] `just test` — full 261-test gate passes
- [ ] Open a cover-art folder: visual top 4 covers warm in ~1 s; page 2 ready by ~3 s; navigate forward — page 2 reads as instant
- [ ] Confirm Games/Recents show per-tile bottom captions; Hub/Systems still show full-bleed logos
- [ ] Confirm focus ring renders without corner stepping under software rendering (desktop run is enough; MiSTer is the harder target)
- [ ] Smoke check the pagination/status strip changes against the screens that were touched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added scrolling indicators and navigation arrows for paginated content grids
  * Implemented tile captions displaying item information during media loading

* **UI Improvements**
  * Context-aware loading messages for systems, games, and recent items screens
  * Enhanced layout spacing and alignment refinements
  * Standardized rounded corners throughout the interface
  * Repositioned status bar counter to the right side

<!-- end of auto-generated comment: release notes by coderabbit.ai -->