### PR TITLE
perf(covers): async image provider, bulk RPC, two-tier cover gate

### DIFF
--- a/rust/launcher/src/media_image_cache.rs
+++ b/rust/launcher/src/media_image_cache.rs
@@ -318,6 +318,11 @@ impl CacheState {
             };
             if let Some(entry) = self.map.remove(&victim) {
                 self.total_bytes = self.total_bytes.saturating_sub(entry.bytes.len());
+                // Keep the `media_ids` sidecar in lock-step with
+                // `map` — without this, the hint table grows
+                // unboundedly past `cap_bytes` because the eviction
+                // pass only touches the primary cache.
+                self.media_ids.remove(&victim);
                 debug!(
                     system_id = %victim.system_id,
                     path = %victim.path,
@@ -614,10 +619,35 @@ fn process_batch_outcomes(
                     let mut s = state.write().unwrap();
                     s.pending.insert(key.clone());
                 }
-                {
+                let dropped = {
                     #[allow(clippy::unwrap_used, reason = "Mutex poisoning is unrecoverable")]
                     let mut q = queue.lock().unwrap();
                     q.push_back(key);
+                    // Mirror the `enqueue_with_media_id` cap: a
+                    // long-running burst of transient failures can
+                    // push the queue past `MAX_QUEUE_LEN` if we
+                    // re-enter without trimming. Drop the oldest
+                    // fronts and clear them from `pending` so a
+                    // future `enqueue` for the same key can re-add
+                    // it instead of being short-circuited.
+                    let mut dropped: Vec<MediaKey> = Vec::new();
+                    while q.len() > MAX_QUEUE_LEN {
+                        let Some(stale) = q.pop_front() else { break };
+                        dropped.push(stale);
+                    }
+                    dropped
+                };
+                if !dropped.is_empty() {
+                    #[allow(clippy::unwrap_used, reason = "RwLock poisoning is unrecoverable")]
+                    let mut guard = state.write().unwrap();
+                    for stale in &dropped {
+                        guard.pending.remove(stale);
+                    }
+                    debug!(
+                        dropped = dropped.len(),
+                        queue_cap = MAX_QUEUE_LEN,
+                        "media_image_cache: retry queue cap hit, dropped stale enqueues"
+                    );
                 }
                 queue_notify.notify_one();
             } else {
@@ -696,18 +726,27 @@ async fn fetch_batch(
     // Build the request, preferring `media_id` from the sidecar when
     // we have one — Core resolves the row directly without a path
     // lookup. Falls back to `(system, path)` on any key without a
-    // hint or on Cores that don't recognise the id.
-    let items: Vec<MediaImageBulkItem> = {
+    // hint or on Cores that don't recognise the id. Captures the
+    // `had_id_hint` boolean from the same guard snapshot so the
+    // post-RPC classification can't disagree with the request shape
+    // it was built from (a concurrent batch's `media_ids.remove`
+    // between two read locks would otherwise re-classify a hinted
+    // item as un-hinted).
+    let paired: Vec<(MediaImageBulkItem, bool)> = {
         #[allow(clippy::unwrap_used, reason = "RwLock poisoning is unrecoverable")]
         let guard = state.read().unwrap();
         batch
             .iter()
             .map(|k| match guard.media_ids.get(k) {
-                Some(id) => MediaImageBulkItem::for_media_id(*id),
-                None => MediaImageBulkItem::for_media(k.system_id.as_ref(), k.path.as_ref()),
+                Some(id) => (MediaImageBulkItem::for_media_id(*id), true),
+                None => (
+                    MediaImageBulkItem::for_media(k.system_id.as_ref(), k.path.as_ref()),
+                    false,
+                ),
             })
             .collect()
     };
+    let (items, id_hinted): (Vec<MediaImageBulkItem>, Vec<bool>) = paired.into_iter().unzip();
     let params = MediaImageBulkParams {
         items,
         image_types: Vec::new(),
@@ -746,21 +785,15 @@ async fn fetch_batch(
             .map(|k| (k, FetchOutcome::Transient))
             .collect();
     }
-    // Snapshot which keys were sent with a `media_id` hint so a
-    // per-item error can fall back to `(system, path)` instead of
-    // burning the row into the negative memo. Core treats `media_id`
-    // as session-ephemeral, so a stale hint after a Core restart can
-    // surface as "media not found" — we drop the sidecar entry and
-    // retry transiently, which on the next batch sends the canonical
-    // `(system, path)` and self-heals.
-    let id_hinted: Vec<bool> = {
-        #[allow(clippy::unwrap_used, reason = "RwLock poisoning is unrecoverable")]
-        let guard = state.read().unwrap();
-        batch
-            .iter()
-            .map(|k| guard.media_ids.contains_key(k))
-            .collect()
-    };
+    // The `id_hinted` snapshot captured alongside `items` above
+    // tells us, for each response slot, whether we sent a
+    // `media_id` hint. A per-item error against a hinted request
+    // falls back to `(system, path)` on retry instead of burning
+    // the row into the negative memo — Core treats `media_id` as
+    // session-ephemeral, so a stale hint after a Core restart can
+    // surface as "media not found", and we want to drop the
+    // sidecar entry and retry transiently rather than mark the row
+    // as a permanent miss.
     batch
         .iter()
         .cloned()

--- a/rust/launcher/src/media_image_cache.rs
+++ b/rust/launcher/src/media_image_cache.rs
@@ -42,7 +42,9 @@ use tokio::runtime::Runtime;
 use tokio::sync::{broadcast, Notify};
 use tracing::{debug, info, warn};
 
-use zaparoo_core::media_types::MediaImageParams;
+use zaparoo_core::media_types::{
+    MediaImageBulkItem, MediaImageBulkItemResult, MediaImageBulkParams, MEDIA_IMAGE_BATCH_MAX,
+};
 use zaparoo_core::store::Store;
 
 /// Field separator used inside the encoded key. Unit Separator (US,
@@ -256,6 +258,15 @@ struct CacheState {
     /// inside the locked state so the read/bump/decision happens
     /// atomically with the `pending` mutation that drives the retry.
     attempts: HashMap<MediaKey, u8>,
+    /// Sidecar of latest-known `media_id` hints per `MediaKey`. Used
+    /// only to populate the `mediaId` field on outgoing batched
+    /// requests when the model has one — the cache keeps identifying
+    /// rows by `(systemId, path)` because Core treats `media_id` as
+    /// session-ephemeral and the launcher must continue to work after
+    /// a Core restart that invalidates the integers. Entries get
+    /// cleaned up alongside the row in `evict_until_fits` so the
+    /// sidecar can't outgrow the rest of the cache.
+    media_ids: HashMap<MediaKey, i64>,
     /// Strictly increasing LRU clock. Bumped on every successful read
     /// or insert; the entry with the smallest value is the LRU.
     clock: u64,
@@ -269,6 +280,7 @@ impl CacheState {
             negative: NegativeMemo::default(),
             pending: HashSet::new(),
             attempts: HashMap::new(),
+            media_ids: HashMap::new(),
             clock: 0,
         }
     }
@@ -437,13 +449,24 @@ impl MediaImageCache {
     /// most likely enqueued for a page the user has already navigated
     /// past, and a future role-data lookup (or an explicit re-enqueue)
     /// can re-add them if they become relevant again.
-    pub fn enqueue(&self, key: MediaKey) {
+    ///
+    /// The optional `media_id` is a wire hint that the fetch driver
+    /// passes to Core in place of `(system, path)` on the next batched
+    /// request. Cache identity stays `(systemId, path)` and any failure
+    /// path still falls back to the canonical pair, so a stale id
+    /// (Core restart) self-heals on the next attempt. Safe to call
+    /// repeatedly: the latest non-`None` hint wins, and `None` leaves
+    /// any prior hint untouched.
+    pub fn enqueue_with_media_id(&self, key: MediaKey, media_id: Option<i64>) {
         if key.system_id.is_empty() || key.path.is_empty() {
             return;
         }
         let should_send = {
             #[allow(clippy::unwrap_used, reason = "RwLock poisoning is unrecoverable")]
             let mut guard = self.state.write().unwrap();
+            if let Some(id) = media_id {
+                guard.media_ids.insert(key.clone(), id);
+            }
             if guard.map.contains_key(&key)
                 || guard.negative.contains(&key)
                 || guard.pending.contains(&key)
@@ -524,92 +547,119 @@ fn spawn_fetch_driver<F>(
         let store_factory = store_factory.clone();
         runtime.spawn(async move {
             loop {
-                let next_key = {
+                // Drain a whole batch in one critical section so a
+                // page-fill burst of 6–10 enqueues hits Core as a
+                // single `media.image` request.
+                let batch: Vec<MediaKey> = {
                     #[allow(clippy::unwrap_used, reason = "Mutex poisoning is unrecoverable")]
                     let mut q = queue.lock().unwrap();
-                    q.pop_back()
+                    let mut out = Vec::with_capacity(MEDIA_IMAGE_BATCH_MAX);
+                    while out.len() < MEDIA_IMAGE_BATCH_MAX {
+                        let Some(k) = q.pop_back() else { break };
+                        out.push(k);
+                    }
+                    out
                 };
-                let Some(key) = next_key else {
+                if batch.is_empty() {
                     queue_notify.notified().await;
                     continue;
-                };
-                let store = store_factory();
-                let outcome = fetch_one(&store, &key).await;
-                let is_transient = matches!(outcome, FetchOutcome::Transient);
-                let update = finish_fetch(&state, cap_bytes, &key, outcome);
-                if is_transient {
-                    let attempts = {
-                        #[allow(clippy::unwrap_used, reason = "RwLock poisoning is unrecoverable")]
-                        let mut s = state.write().unwrap();
-                        let entry = s.attempts.entry(key.clone()).or_insert(0);
-                        *entry = entry.saturating_add(1);
-                        *entry
-                    };
-                    if attempts < MAX_FETCH_ATTEMPTS {
-                        // Re-enter `pending` and re-enqueue at the back.
-                        // Fresh-page enqueues that arrive in the meantime
-                        // still drain ahead because we always pop from
-                        // the back; this retry waits behind anything the
-                        // user is actively looking at.
-                        {
-                            #[allow(
-                                clippy::unwrap_used,
-                                reason = "RwLock poisoning is unrecoverable"
-                            )]
-                            let mut s = state.write().unwrap();
-                            s.pending.insert(key.clone());
-                        }
-                        {
-                            #[allow(
-                                clippy::unwrap_used,
-                                reason = "Mutex poisoning is unrecoverable"
-                            )]
-                            let mut q = queue.lock().unwrap();
-                            q.push_back(key);
-                        }
-                        queue_notify.notify_one();
-                    } else {
-                        // Bounded give-up: clear the counter, no negative
-                        // memo. The next user-driven enqueue (page
-                        // revisit) gets a fresh `MAX_FETCH_ATTEMPTS`
-                        // budget via `enqueue`'s `attempts.remove`.
-                        #[allow(clippy::unwrap_used, reason = "RwLock poisoning is unrecoverable")]
-                        state.write().unwrap().attempts.remove(&key);
-                        info!(
-                            system_id = %key.system_id,
-                            path = %key.path,
-                            attempts,
-                            "media_image_cache: giving up after transient failures",
-                        );
-                    }
-                    continue;
                 }
-                // Success or NoImage: clear the attempts counter and
-                // broadcast the resolved state.
+                let store = store_factory();
+                let outcomes = fetch_batch(&store, &state, &batch).await;
+                process_batch_outcomes(
+                    &state,
+                    cap_bytes,
+                    &updates_tx,
+                    &queue,
+                    &queue_notify,
+                    outcomes,
+                );
+            }
+        });
+    }
+}
+
+/// Apply outcomes for a finished batch: write each into the cache via
+/// `finish_fetch`, broadcast updates, and re-enqueue keys that
+/// failed transiently. Pulled out of the worker loop so the driver
+/// stays at one screen of code and the retry/give-up branches read
+/// the same as before.
+fn process_batch_outcomes(
+    state: &Arc<RwLock<CacheState>>,
+    cap_bytes: usize,
+    updates_tx: &broadcast::Sender<MediaImageUpdate>,
+    queue: &Arc<Mutex<VecDeque<MediaKey>>>,
+    queue_notify: &Arc<Notify>,
+    outcomes: Vec<(MediaKey, FetchOutcome)>,
+) {
+    for (key, outcome) in outcomes {
+        let is_transient = matches!(outcome, FetchOutcome::Transient);
+        let update = finish_fetch(state, cap_bytes, &key, outcome);
+        if is_transient {
+            let attempts = {
+                #[allow(clippy::unwrap_used, reason = "RwLock poisoning is unrecoverable")]
+                let mut s = state.write().unwrap();
+                let entry = s.attempts.entry(key.clone()).or_insert(0);
+                *entry = entry.saturating_add(1);
+                *entry
+            };
+            if attempts < MAX_FETCH_ATTEMPTS {
+                // Re-enter `pending` and re-enqueue at the back. The
+                // next batch picks it up alongside whatever the user
+                // has enqueued in the meantime; LIFO drain order
+                // means the fresh page lands first while this retry
+                // tags along behind it.
                 {
                     #[allow(clippy::unwrap_used, reason = "RwLock poisoning is unrecoverable")]
                     let mut s = state.write().unwrap();
-                    s.attempts.remove(&key);
+                    s.pending.insert(key.clone());
                 }
-                if let Some(update) = update {
-                    if let Some(ext) = update.ext {
-                        info!(
-                            system_id = %key.system_id,
-                            path = %key.path,
-                            ext,
-                            "media_image_cache: cached image",
-                        );
-                    } else {
-                        info!(
-                            system_id = %key.system_id,
-                            path = %key.path,
-                            "media_image_cache: no image (negative memo)",
-                        );
-                    }
-                    let _ = updates_tx.send(update);
+                {
+                    #[allow(clippy::unwrap_used, reason = "Mutex poisoning is unrecoverable")]
+                    let mut q = queue.lock().unwrap();
+                    q.push_back(key);
                 }
+                queue_notify.notify_one();
+            } else {
+                // Bounded give-up: clear the counter, no negative
+                // memo. The next user-driven enqueue (page revisit)
+                // gets a fresh `MAX_FETCH_ATTEMPTS` budget via
+                // `enqueue`'s `attempts.remove`.
+                #[allow(clippy::unwrap_used, reason = "RwLock poisoning is unrecoverable")]
+                state.write().unwrap().attempts.remove(&key);
+                info!(
+                    system_id = %key.system_id,
+                    path = %key.path,
+                    attempts,
+                    "media_image_cache: giving up after transient failures",
+                );
             }
-        });
+            continue;
+        }
+        // Success or NoImage: clear the attempts counter and
+        // broadcast the resolved state.
+        {
+            #[allow(clippy::unwrap_used, reason = "RwLock poisoning is unrecoverable")]
+            let mut s = state.write().unwrap();
+            s.attempts.remove(&key);
+        }
+        if let Some(update) = update {
+            if let Some(ext) = update.ext {
+                info!(
+                    system_id = %key.system_id,
+                    path = %key.path,
+                    ext,
+                    "media_image_cache: cached image",
+                );
+            } else {
+                info!(
+                    system_id = %key.system_id,
+                    path = %key.path,
+                    "media_image_cache: no image (negative memo)",
+                );
+            }
+            let _ = updates_tx.send(update);
+        }
     }
 }
 
@@ -631,27 +681,146 @@ enum FetchOutcome {
     Transient,
 }
 
-async fn fetch_one(store: &Arc<Store>, key: &MediaKey) -> FetchOutcome {
-    let result = store
-        .client()
-        .media_image(MediaImageParams::for_media(
-            key.system_id.as_ref(),
-            key.path.as_ref(),
-        ))
-        .await;
+/// Fetch a batch of media images in a single bulk JSON-RPC. Returns
+/// one outcome per input key, in the same order. A batch-level RPC
+/// failure tags every key as `Transient` so the existing retry path
+/// applies uniformly. Per-item `error` strings from Core are
+/// definitive negatives (`NoImage`) — Core only returns errors here
+/// for "system not found", "media not found", and "no image", which
+/// are all stable answers for `(systemId, path)`.
+async fn fetch_batch(
+    store: &Arc<Store>,
+    state: &Arc<RwLock<CacheState>>,
+    batch: &[MediaKey],
+) -> Vec<(MediaKey, FetchOutcome)> {
+    // Build the request, preferring `media_id` from the sidecar when
+    // we have one — Core resolves the row directly without a path
+    // lookup. Falls back to `(system, path)` on any key without a
+    // hint or on Cores that don't recognise the id.
+    let items: Vec<MediaImageBulkItem> = {
+        #[allow(clippy::unwrap_used, reason = "RwLock poisoning is unrecoverable")]
+        let guard = state.read().unwrap();
+        batch
+            .iter()
+            .map(|k| match guard.media_ids.get(k) {
+                Some(id) => MediaImageBulkItem::for_media_id(*id),
+                None => MediaImageBulkItem::for_media(k.system_id.as_ref(), k.path.as_ref()),
+            })
+            .collect()
+    };
+    let params = MediaImageBulkParams {
+        items,
+        image_types: Vec::new(),
+    };
+    let result = store.client().media_image_bulk(params).await;
     let response = match result {
         Ok(r) => r,
         Err(e) => {
             info!(
+                batch_size = batch.len(),
+                "media_image_cache: media.image (bulk) failed: {} (transient, will retry on next enqueue)",
+                e.message,
+            );
+            return batch
+                .iter()
+                .cloned()
+                .map(|k| (k, FetchOutcome::Transient))
+                .collect();
+        }
+    };
+    if response.items.len() != batch.len() {
+        // Core's batch contract guarantees one response item per
+        // request item. A length mismatch is an upstream regression
+        // we can't usefully recover from at the per-key level, so
+        // mark the whole batch as transient — the retry will either
+        // self-correct on a fresh Core build or burn through the
+        // attempt budget and stop spamming.
+        warn!(
+            requested = batch.len(),
+            received = response.items.len(),
+            "media_image_cache: media.image (bulk) length mismatch, retrying as transient",
+        );
+        return batch
+            .iter()
+            .cloned()
+            .map(|k| (k, FetchOutcome::Transient))
+            .collect();
+    }
+    // Snapshot which keys were sent with a `media_id` hint so a
+    // per-item error can fall back to `(system, path)` instead of
+    // burning the row into the negative memo. Core treats `media_id`
+    // as session-ephemeral, so a stale hint after a Core restart can
+    // surface as "media not found" — we drop the sidecar entry and
+    // retry transiently, which on the next batch sends the canonical
+    // `(system, path)` and self-heals.
+    let id_hinted: Vec<bool> = {
+        #[allow(clippy::unwrap_used, reason = "RwLock poisoning is unrecoverable")]
+        let guard = state.read().unwrap();
+        batch
+            .iter()
+            .map(|k| guard.media_ids.contains_key(k))
+            .collect()
+    };
+    batch
+        .iter()
+        .cloned()
+        .zip(response.items.into_iter())
+        .zip(id_hinted.into_iter())
+        .map(|((key, item), had_id_hint)| {
+            let outcome = classify_bulk_item(&key, item, had_id_hint);
+            if matches!(outcome, FetchOutcome::Transient) && had_id_hint {
+                // Drop the suspect hint so the retry sends
+                // `(system, path)` instead. Self-heals the rare case
+                // where Core was restarted and the id we cached
+                // points at a different (or no) row.
+                #[allow(clippy::unwrap_used, reason = "RwLock poisoning is unrecoverable")]
+                state.write().unwrap().media_ids.remove(&key);
+            }
+            (key, outcome)
+        })
+        .collect()
+}
+
+/// Map a single batched response entry onto a `FetchOutcome`. Mirrors
+/// the single-shot decode path: empty payload / unsupported format /
+/// per-item error → `NoImage`; base64 decode failure → `Transient`;
+/// otherwise `Success`. When the request item carried a stale
+/// `media_id` hint, a per-item error becomes `Transient` so the retry
+/// can fall back to `(system, path)` — the per-batch driver drops the
+/// sidecar hint before the retry runs.
+fn classify_bulk_item(
+    key: &MediaKey,
+    item: MediaImageBulkItemResult,
+    had_id_hint: bool,
+) -> FetchOutcome {
+    if let Some(err) = item.error {
+        if had_id_hint {
+            info!(
                 system_id = %key.system_id,
                 path = %key.path,
-                "media_image_cache: media.image failed: {} (transient, will retry on next enqueue)",
-                e.message,
+                "media_image_cache: media.image (bulk) error with media_id hint: {err} (transient, will retry with (system, path))",
             );
             return FetchOutcome::Transient;
         }
+        info!(
+            system_id = %key.system_id,
+            path = %key.path,
+            "media_image_cache: media.image (bulk) per-item error: {err} (treating as no image)",
+        );
+        return FetchOutcome::NoImage;
+    }
+    let Some(image) = item.image else {
+        // Defensive: Core's contract is one of `image`/`error`. An
+        // item with neither is a regression — treat it as no image so
+        // we don't loop on a phantom transient.
+        warn!(
+            system_id = %key.system_id,
+            path = %key.path,
+            "media_image_cache: media.image (bulk) item missing both image and error, treating as no image",
+        );
+        return FetchOutcome::NoImage;
     };
-    let bytes = match BASE64_STANDARD.decode(response.data.as_bytes()) {
+    let bytes = match BASE64_STANDARD.decode(image.data.as_bytes()) {
         Ok(b) => b,
         Err(e) => {
             warn!(
@@ -662,13 +831,6 @@ async fn fetch_one(store: &Arc<Store>, key: &MediaKey) -> FetchOutcome {
             return FetchOutcome::Transient;
         }
     };
-    // Defensive: a zero-length payload would land in the cache as a
-    // valid-looking entry, the provider would hand 0 bytes to QtQuick,
-    // and `QImage::loadFromData` would fail silently. Core already
-    // skips empty binaries (see `media_image.go:176`), but treating
-    // empty bytes as a negative result here closes the foot-gun
-    // permanently — the negative memo absorbs `(system_id, path)` so
-    // we don't refetch on every page revisit.
     if bytes.is_empty() {
         warn!(
             system_id = %key.system_id,
@@ -677,20 +839,17 @@ async fn fetch_one(store: &Arc<Store>, key: &MediaKey) -> FetchOutcome {
         );
         return FetchOutcome::NoImage;
     }
-    // Prefer `extension` (Core derives it from MIME or source path),
-    // fall back to `content_type`. No magic-byte sniffing — Core
-    // started populating both fields for exactly this reason.
-    let ext = response
+    let ext = image
         .extension
         .as_deref()
         .and_then(ext_from_extension_field)
-        .or_else(|| ext_for_content_type(&response.content_type));
+        .or_else(|| ext_for_content_type(&image.content_type));
     let Some(ext) = ext else {
         warn!(
             system_id = %key.system_id,
             path = %key.path,
-            extension = ?response.extension,
-            content_type = response.content_type,
+            extension = ?image.extension,
+            content_type = image.content_type,
             bytes_len = bytes.len(),
             "media_image_cache: unsupported extension/content_type, skipping cache",
         );
@@ -988,14 +1147,15 @@ mod tests {
     }
 
     #[test]
-    fn fetch_one_treats_empty_bytes_as_no_image() {
-        // `fetch_one` short-circuits to `FetchOutcome::NoImage` when
-        // base64 decoding yields zero bytes (defensive guard against a
-        // future Core regression that lets empty payloads through).
-        // We can't call `fetch_one` directly without a live Store, so
-        // exercise the downstream contract: NoImage → negative memo,
-        // no map entry, pending cleared. This locks in the behaviour
-        // that empty payloads do not pollute the cache and the
+    fn no_image_outcome_records_negative_without_map_entry() {
+        // The bulk decode path (`classify_bulk_item`) short-circuits
+        // to `FetchOutcome::NoImage` when base64 decoding yields zero
+        // bytes — a defensive guard against any future Core
+        // regression that lets empty payloads through. We can't drive
+        // the decoder directly without a live Store, so exercise the
+        // downstream contract: `NoImage` → negative memo, no map
+        // entry, pending cleared. This locks in the behaviour that
+        // empty payloads do not pollute the cache and the
         // `(system_id, path)` is suppressed from refetch.
         let state = Arc::new(RwLock::new(CacheState::new()));
         let k = key("SNES", "/empty");
@@ -1275,7 +1435,7 @@ mod tests {
         // Push MAX_QUEUE_LEN + 5 distinct keys; the first 5 must be
         // the ones that get dropped.
         for i in 0..(MAX_QUEUE_LEN + 5) {
-            cache.enqueue(key("SNES", &format!("/p/{i}")));
+            cache.enqueue_with_media_id(key("SNES", &format!("/p/{i}")), None);
         }
         let queue_len = cache.queue.lock().unwrap().len();
         assert_eq!(
@@ -1306,7 +1466,7 @@ mod tests {
         // Re-enqueueing a previously-dropped key must succeed (it's
         // no longer in pending). Verify by checking the queue grows.
         let revived = key("SNES", "/p/0");
-        cache.enqueue(revived.clone());
+        cache.enqueue_with_media_id(revived.clone(), None);
         let queue_len = cache.queue.lock().unwrap().len();
         // Pushing one extra back into a full queue truncates one
         // *other* old entry off the front, so length stays at cap.

--- a/rust/launcher/src/models/games.rs
+++ b/rust/launcher/src/models/games.rs
@@ -596,18 +596,11 @@ impl ffi::GamesModel {
         if let Some(handle) = self.as_mut().rust_mut().watcher.take() {
             handle.abort();
         }
-        // Tear down any cover gate left from the prior path: abort the
-        // timer task, clear the waiting-keys set, and bump
-        // `cover_gate_seq` so any callback the aborted timer may have
-        // already queued onto the Qt thread sees a stale ticket and
-        // bails. Without this bump, a stale callback could fire after
-        // the new path's `set_loading(true)` and prematurely release
-        // its gate.
-        if let Some(handle) = self.as_mut().rust_mut().cover_gate_timer.take() {
-            handle.abort();
-        }
-        self.as_mut().rust_mut().pending_first_paint_keys.clear();
-        self.rust().cover_gate_seq.fetch_add(1, Ordering::SeqCst);
+        // Tear down any cover gate left from the prior path. See
+        // `reset_cover_gate` for the rationale; without this teardown
+        // a stale timer callback could fire after the new path's
+        // `set_loading(true)` and prematurely release its gate.
+        reset_cover_gate(self.as_mut());
 
         let seq = self.rust().seq.clone();
         let ticket = seq.fetch_add(1, Ordering::SeqCst) + 1;
@@ -852,6 +845,20 @@ where
         .collect()
 }
 
+/// Abort any in-flight cover-gate timer, drop the waiting-keys set,
+/// and bump `cover_gate_seq` so a callback that already queued onto
+/// the Qt thread before the abort took effect sees a stale ticket and
+/// bails. Used on every browse status edge that doesn't go on to call
+/// `arm_cover_gate` itself (Pending, Errored, and the
+/// `start_initial_browse` reset).
+fn reset_cover_gate(mut model: Pin<&mut ffi::GamesModel>) {
+    if let Some(handle) = model.as_mut().rust_mut().cover_gate_timer.take() {
+        handle.abort();
+    }
+    model.as_mut().rust_mut().pending_first_paint_keys.clear();
+    model.rust().cover_gate_seq.fetch_add(1, Ordering::SeqCst);
+}
+
 /// Decide whether to hold `loading=true` until the page's covers are
 /// cached, or release immediately. Called once per `apply_initial_page`.
 ///
@@ -1027,6 +1034,12 @@ fn leading_dir_count(entries: &[BrowseEntry]) -> i32 {
 fn apply_status(mut model: Pin<&mut ffi::GamesModel>, status: ResourceStatus<MediaBrowseResult>) {
     match project_status(status) {
         Projection::Pending => {
+            // A new browse round started (or a Ready→Pending refetch
+            // is in flight). Abort any cover gate left from the
+            // previous Ready so its safety-timer callback can't race
+            // with the loading=true we're about to set and clear it
+            // mid-load.
+            reset_cover_gate(model.as_mut());
             if !model.loading {
                 model.as_mut().set_loading(true);
             }
@@ -1077,6 +1090,10 @@ fn apply_status(mut model: Pin<&mut ffi::GamesModel>, status: ResourceStatus<Med
         }
         Projection::Errored { message } => {
             warn!("media.browse errored: {message}");
+            // Errored takes us out of Ready without going through
+            // `arm_cover_gate`, so any timer left armed by the prior
+            // Ready needs to be torn down explicitly.
+            reset_cover_gate(model.as_mut());
             let qstr = QString::from(message.as_str());
             if model.error_message != qstr {
                 model.as_mut().set_error_message(qstr);

--- a/rust/launcher/src/models/games.rs
+++ b/rust/launcher/src/models/games.rs
@@ -36,9 +36,11 @@ use cxx_qt::{CxxQtType, Threading};
 use cxx_qt_lib::{
     QByteArray, QHash, QHashPair_i32_QByteArray, QList, QModelIndex, QString, QVariant,
 };
+use std::collections::HashSet;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::broadcast::error::RecvError;
 use tokio::task::JoinHandle;
 use tracing::{info, warn};
@@ -126,6 +128,22 @@ pub struct GamesModelRust {
     // `start_initial_browse` so the model singleton owns exactly one
     // subscriber for the whole process lifetime.
     cover_subscription: Option<JoinHandle<()>>,
+    // Keys whose first-paint we're still waiting on. While non-empty we
+    // hold `loading = true` so the screen-flip overlay covers the gap
+    // between "page rendered with glyphs" and "covers cached". Drained
+    // by `notify_cover_update` as each cover lands; force-cleared by
+    // the gate timer or a subsequent `start_initial_browse`.
+    pending_first_paint_keys: HashSet<MediaKey>,
+    // Safety timer that force-releases the cover gate after a bounded
+    // delay, so a stalled bulk RPC can't park the user on `Loading…`
+    // forever.
+    cover_gate_timer: Option<JoinHandle<()>>,
+    // Bumped on every cover-gate arm and on every `start_initial_browse`.
+    // The timer's queued closure compares against the current value and
+    // bails on a mismatch — necessary because aborting the JoinHandle
+    // doesn't cancel a callback that was already queued onto the Qt
+    // thread between sleep-completion and abort.
+    cover_gate_seq: Arc<AtomicU64>,
 }
 
 impl Default for GamesModelRust {
@@ -150,6 +168,9 @@ impl Default for GamesModelRust {
             auto_nav_eligible: false,
             card_write_seq: Arc::new(AtomicU64::new(0)),
             cover_subscription: None,
+            pending_first_paint_keys: HashSet::new(),
+            cover_gate_timer: None,
+            cover_gate_seq: Arc::new(AtomicU64::new(0)),
         }
     }
 }
@@ -575,6 +596,18 @@ impl ffi::GamesModel {
         if let Some(handle) = self.as_mut().rust_mut().watcher.take() {
             handle.abort();
         }
+        // Tear down any cover gate left from the prior path: abort the
+        // timer task, clear the waiting-keys set, and bump
+        // `cover_gate_seq` so any callback the aborted timer may have
+        // already queued onto the Qt thread sees a stale ticket and
+        // bails. Without this bump, a stale callback could fire after
+        // the new path's `set_loading(true)` and prematurely release
+        // its gate.
+        if let Some(handle) = self.as_mut().rust_mut().cover_gate_timer.take() {
+            handle.abort();
+        }
+        self.as_mut().rust_mut().pending_first_paint_keys.clear();
+        self.rust().cover_gate_seq.fetch_add(1, Ordering::SeqCst);
 
         let seq = self.rust().seq.clone();
         let ticket = seq.fetch_add(1, Ordering::SeqCst) + 1;
@@ -651,7 +684,7 @@ fn cover_key_for(entry: &BrowseEntry) -> String {
         // for keys we've already learned have nothing to fetch.
         if let Some(k) = media_key.as_ref() {
             if !cache.is_negative(k) {
-                cache.enqueue(k.clone());
+                cache.enqueue_with_media_id(k.clone(), entry.media_id);
             }
         }
     }
@@ -717,7 +750,7 @@ fn enqueue_cover_fetches(entries: &[BrowseEntry]) {
         media_total += 1;
         if let Some(key) = media_key_for(entry) {
             enqueued += 1;
-            cache.enqueue(key);
+            cache.enqueue_with_media_id(key, entry.media_id);
         }
     }
     info!(
@@ -731,6 +764,10 @@ fn enqueue_cover_fetches(entries: &[BrowseEntry]) {
 /// `entries` vec — pages top out at a few hundred rows after look-
 /// ahead, and the bridge runs only when the cover-cache fetch driver
 /// delivers a result.
+///
+/// Also drains `pending_first_paint_keys`: each cover landing during
+/// the gate's hold ticks the set down, and emptying the set releases
+/// the gate so the screen-flip overlay clears.
 fn notify_cover_update(mut model: Pin<&mut ffi::GamesModel>, key: &MediaKey) {
     let rows: Vec<i32> = model
         .entries
@@ -741,15 +778,141 @@ fn notify_cover_update(mut model: Pin<&mut ffi::GamesModel>, key: &MediaKey) {
         })
         .filter_map(|(i, _)| i32::try_from(i).ok())
         .collect();
-    if rows.is_empty() {
+    if !rows.is_empty() {
+        let mut roles = QList::<i32>::default();
+        roles.append(COVER_KEY_ROLE);
+        let parent = QModelIndex::default();
+        for row in rows {
+            let idx = model.index(row, 0, &parent);
+            model.as_mut().data_changed(&idx, &idx, &roles);
+        }
+    }
+    // Tick the gate's pending set down. `remove` returns false if the
+    // key wasn't gated (broadcast events fire for every cache update,
+    // including miss-recovery enqueues from `cover_key_for`); we only
+    // try to release when a gated key was actually drained.
+    let was_pending = model
+        .as_mut()
+        .rust_mut()
+        .pending_first_paint_keys
+        .remove(key);
+    if was_pending && model.pending_first_paint_keys.is_empty() && model.loading {
+        if let Some(handle) = model.as_mut().rust_mut().cover_gate_timer.take() {
+            handle.abort();
+        }
+        // Bytes are cached, but QML's `MediaImageProvider` still has to
+        // decode them. The hidden cover pre-warmer in `GamesScreen.qml`
+        // dispatches all N requests at once and the provider's 4-worker
+        // pool decodes them in ~75–150 ms; without this settle window
+        // the gate flips `loading=false` ~80 ms after the last byte
+        // lands and `gamesGrid` materialises before the last few
+        // decodes complete, painting the procedural fallback over those
+        // tiles for a frame or two. The settle uses the same seq-ticket
+        // guard as the safety timer so a folder change cancels the
+        // pending release.
+        info!("games: cover gate bytes settled — entering decode-settle window");
+        let seq = model.rust().cover_gate_seq.clone();
+        let ticket = seq.fetch_add(1, Ordering::SeqCst) + 1;
+        let qt_thread = model.qt_thread();
+        let handle = global_runtime().spawn(async move {
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            let _ = qt_thread.queue(move |mut model: Pin<&mut ffi::GamesModel>| {
+                if seq.load(Ordering::SeqCst) != ticket {
+                    return;
+                }
+                model.as_mut().rust_mut().cover_gate_timer = None;
+                if model.loading {
+                    info!("games: cover gate released after decode-settle window");
+                    model.as_mut().set_loading(false);
+                }
+            });
+        });
+        model.as_mut().rust_mut().cover_gate_timer = Some(handle);
+    }
+}
+
+/// Compute the set of media keys on the current page whose covers we
+/// must wait on before releasing the cover gate. Folders, unattributed
+/// entries, already-cached keys, and negatively-memoised keys are all
+/// excluded. Pure helper so the gate's binning logic is unit-testable
+/// without spinning up the global cache + tokio runtime.
+fn compute_unresolved_keys<F, G>(
+    entries: &[BrowseEntry],
+    is_cached: F,
+    is_negative: G,
+) -> HashSet<MediaKey>
+where
+    F: Fn(&MediaKey) -> bool,
+    G: Fn(&MediaKey) -> bool,
+{
+    entries
+        .iter()
+        .filter_map(media_key_for)
+        .filter(|k| !is_cached(k) && !is_negative(k))
+        .collect()
+}
+
+/// Decide whether to hold `loading=true` until the page's covers are
+/// cached, or release immediately. Called once per `apply_initial_page`.
+///
+/// - If every media entry is already cached or negatively-memoised
+///   (folder-only page, or revisit), set loading=false right now —
+///   there's nothing to wait on, the screen-flip overlay clears.
+/// - Otherwise, store the unresolved set on the model, arm a 3 s safety
+///   timer, and leave loading=true. `notify_cover_update` will drain
+///   the set as covers land; whichever happens first (set empties or
+///   timer fires) releases the gate.
+///
+/// The 3 s timeout is the fall-through: if the bulk RPC stalls, the
+/// user sees `Loading…` for at most 3 s before the existing
+/// "list with placeholders → covers pop in" behaviour resumes.
+fn arm_cover_gate(mut model: Pin<&mut ffi::GamesModel>) {
+    if let Some(handle) = model.as_mut().rust_mut().cover_gate_timer.take() {
+        handle.abort();
+    }
+    let cache = global_media_image_cache();
+    let unresolved = compute_unresolved_keys(
+        &model.entries,
+        |k| cache.is_cached(k),
+        |k| cache.is_negative(k),
+    );
+    if unresolved.is_empty() {
+        model.as_mut().rust_mut().pending_first_paint_keys.clear();
+        if model.loading {
+            model.as_mut().set_loading(false);
+        }
         return;
     }
-    let mut roles = QList::<i32>::default();
-    roles.append(COVER_KEY_ROLE);
-    let parent = QModelIndex::default();
-    for row in rows {
-        let idx = model.index(row, 0, &parent);
-        model.as_mut().data_changed(&idx, &idx, &roles);
+    info!(
+        pending = unresolved.len(),
+        "games: arm cover gate (holding loading until covers cached)"
+    );
+    model.as_mut().rust_mut().pending_first_paint_keys = unresolved;
+    let seq = model.rust().cover_gate_seq.clone();
+    let ticket = seq.fetch_add(1, Ordering::SeqCst) + 1;
+    let qt_thread = model.qt_thread();
+    let handle = global_runtime().spawn(async move {
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        let _ = qt_thread.queue(move |model| {
+            if seq.load(Ordering::SeqCst) != ticket {
+                return;
+            }
+            release_cover_gate_after_timeout(model);
+        });
+    });
+    model.as_mut().rust_mut().cover_gate_timer = Some(handle);
+}
+
+/// Force-release the cover gate from the safety timer. Called only via
+/// the timer's queued callback after a seq-match check; the
+/// notify-driven release path lives inline in `notify_cover_update`.
+fn release_cover_gate_after_timeout(mut model: Pin<&mut ffi::GamesModel>) {
+    let pending = model.pending_first_paint_keys.len();
+    info!(pending, "games: cover gate timed out, releasing");
+    model.as_mut().rust_mut().pending_first_paint_keys.clear();
+    model.as_mut().rust_mut().cover_gate_timer = None;
+    if model.loading {
+        model.as_mut().set_loading(false);
     }
 }
 
@@ -950,9 +1113,11 @@ fn apply_initial_page(mut model: Pin<&mut ffi::GamesModel>, result: MediaBrowseR
     model.as_mut().set_dir_count(dir_count);
     model.as_mut().set_total_files(total);
     model.as_mut().set_has_next_page(has_next_page);
-    if model.loading {
-        model.as_mut().set_loading(false);
-    }
+    // Decide whether to release `loading` immediately or hold it until
+    // covers are cached. `arm_cover_gate` flips loading off itself when
+    // the page has nothing to wait on (folder-only or fully-cached
+    // revisit); otherwise it leaves loading=true and arms the timer.
+    arm_cover_gate(model.as_mut());
     if !model.error_message.is_empty() {
         model.as_mut().set_error_message(QString::default());
     }
@@ -1058,11 +1223,12 @@ mod tests {
     )]
 
     use super::{
-        cover_key_for_with, decide_initial, display_name, entry_system_id, leading_dir_count,
-        media_key_for, position_of_game_path, project_status, transform_entries, InitialAction,
-        Projection,
+        compute_unresolved_keys, cover_key_for_with, decide_initial, display_name, entry_system_id,
+        leading_dir_count, media_key_for, position_of_game_path, project_status, transform_entries,
+        InitialAction, Projection,
     };
     use crate::media_image_cache::{MediaImageCache, MediaKey};
+    use std::collections::HashSet;
     use zaparoo_core::media_types::{BrowseEntry, MediaBrowseResult, Pagination};
     use zaparoo_core::platform::Platform;
     use zaparoo_core::remote_resource::ResourceStatus;
@@ -1481,5 +1647,69 @@ mod tests {
         let result = MediaBrowseResult::default();
         assert!(!result.has_next_page());
         assert_eq!(result.next_cursor(), None);
+    }
+
+    #[test]
+    fn compute_unresolved_keys_folder_only_page_returns_empty() {
+        let entries = vec![folder("Games", "/x/Games"), folder("Saves", "/x/Saves")];
+        let unresolved = compute_unresolved_keys(&entries, |_| false, |_| false);
+        assert!(unresolved.is_empty());
+    }
+
+    #[test]
+    fn compute_unresolved_keys_all_cached_returns_empty() {
+        let entries = vec![
+            media("smb", "/p/smb", "NES"),
+            media("zelda", "/p/zelda", "NES"),
+        ];
+        let unresolved = compute_unresolved_keys(&entries, |_| true, |_| false);
+        assert!(unresolved.is_empty());
+    }
+
+    #[test]
+    fn compute_unresolved_keys_mixed_returns_only_uncached() {
+        let cached_path = "/p/smb";
+        let entries = vec![
+            media("smb", cached_path, "NES"),
+            media("zelda", "/p/zelda", "NES"),
+            folder("Saves", "/p/Saves"),
+        ];
+        let unresolved =
+            compute_unresolved_keys(&entries, |k| k.path.as_ref() == cached_path, |_| false);
+        let expected: HashSet<MediaKey> = [MediaKey::new("NES", "/p/zelda")].into_iter().collect();
+        assert_eq!(unresolved, expected);
+    }
+
+    #[test]
+    fn compute_unresolved_keys_excludes_negative_memo() {
+        // Negative-memoised keys are "Core said no image" — gate must
+        // not wait on them, otherwise the gate stays armed until the
+        // safety timer fires every time.
+        let negative_path = "/p/no-image";
+        let entries = vec![
+            media("smb", "/p/smb", "NES"),
+            media("orphan", negative_path, "NES"),
+        ];
+        let unresolved =
+            compute_unresolved_keys(&entries, |_| false, |k| k.path.as_ref() == negative_path);
+        let expected: HashSet<MediaKey> = [MediaKey::new("NES", "/p/smb")].into_iter().collect();
+        assert_eq!(unresolved, expected);
+    }
+
+    #[test]
+    fn compute_unresolved_keys_skips_unattributed_entries() {
+        // Browse entries without enough info to key on — folder, root,
+        // unattributed media — never produce a MediaKey, so the gate
+        // doesn't wait on them.
+        let entries = vec![
+            folder("Games", "/x/Games"),
+            root("NES", "/roms/NES", "NES"),
+            BrowseEntry {
+                entry_type: "media".into(),
+                ..BrowseEntry::default()
+            },
+        ];
+        let unresolved = compute_unresolved_keys(&entries, |_| false, |_| false);
+        assert!(unresolved.is_empty());
     }
 }

--- a/rust/launcher/src/models/recents.rs
+++ b/rust/launcher/src/models/recents.rs
@@ -22,13 +22,20 @@
 // stays a fraction of the size of `GamesModel`. Card-write isn't wired
 // here yet — recents launches by `run`-ing the entry's launcher route.
 
+use crate::media_image_cache::{global_media_image_cache, MediaImageCache, MediaKey};
 use crate::models::{global_runtime, global_store};
 use cxx_qt::{CxxQtType, Threading};
-use cxx_qt_lib::{QByteArray, QHash, QHashPair_i32_QByteArray, QModelIndex, QString, QVariant};
+use cxx_qt_lib::{
+    QByteArray, QHash, QHashPair_i32_QByteArray, QList, QModelIndex, QString, QVariant,
+};
+use std::collections::HashSet;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use tracing::warn;
+use std::time::Duration;
+use tokio::sync::broadcast::error::RecvError;
+use tokio::task::JoinHandle;
+use tracing::{info, warn};
 use zaparoo_core::client::ClientError;
 use zaparoo_core::endpoints::media_history::{HistoryArgs, MediaHistoryEndpoint};
 use zaparoo_core::endpoints::run::RunMutation;
@@ -63,6 +70,27 @@ pub struct RecentsModelRust {
     // `apply_state` so any in-flight `fetch_more` callback can detect
     // its append no longer belongs to the current chain.
     seq: Arc<AtomicU64>,
+    // Long-lived bridge from `media_image_cache` broadcast updates
+    // onto `dataChanged(coverKey)` emits for matching rows. Spun up
+    // lazily on the first page apply so the model singleton owns
+    // exactly one subscriber for the whole process lifetime.
+    cover_subscription: Option<JoinHandle<()>>,
+    // Keys whose first-paint we're still waiting on. While non-empty
+    // we hold `loading = true` so the screen-flip overlay covers the
+    // gap between "page rendered with system logos" and "covers
+    // cached". Drained by `notify_cover_update` as each cover lands;
+    // force-cleared by the gate timer or a Pending/Errored transition.
+    pending_first_paint_keys: HashSet<MediaKey>,
+    // Safety timer that force-releases the cover gate after a bounded
+    // delay, so a stalled bulk RPC can't park the user on `Loading…`
+    // forever.
+    cover_gate_timer: Option<JoinHandle<()>>,
+    // Bumped on every cover-gate arm and on every Pending/Errored
+    // disarm. The timer's queued closure compares against the current
+    // value and bails on a mismatch — necessary because aborting the
+    // JoinHandle doesn't cancel a callback already queued onto the Qt
+    // thread between sleep-completion and abort.
+    cover_gate_seq: Arc<AtomicU64>,
 }
 
 #[cxx_qt::bridge]
@@ -78,6 +106,7 @@ pub mod ffi {
         type QHash_i32_QByteArray = cxx_qt_lib::QHash<cxx_qt_lib::QHashPair_i32_QByteArray>;
         type QByteArray = cxx_qt_lib::QByteArray;
         type QString = cxx_qt_lib::QString;
+        type QList_i32 = cxx_qt_lib::QList<i32>;
     }
 
     unsafe extern "RustQt" {
@@ -128,11 +157,29 @@ pub mod ffi {
         #[cxx_name = "endInsertRows"]
         fn end_insert_rows(self: Pin<&mut RecentsModel>);
 
+        // Qt signal bound as a callable so the cover-cache bridge can
+        // invoke it directly from the Qt thread when an async cover
+        // fetch completes for a row that is already on screen.
+        #[inherit]
+        #[cxx_name = "dataChanged"]
+        fn data_changed(
+            self: Pin<&mut RecentsModel>,
+            top_left: &QModelIndex,
+            bottom_right: &QModelIndex,
+            roles: &QList_i32,
+        );
+
         #[cxx_name = "rowCount"]
         fn row_count(self: &RecentsModel, parent: &QModelIndex) -> i32;
         fn data(self: &RecentsModel, index: &QModelIndex, role: i32) -> QVariant;
         #[cxx_name = "roleNames"]
         fn role_names(self: &RecentsModel) -> QHash_i32_QByteArray;
+
+        // Materialise a `QModelIndex` for `(row, column)` so the cover-
+        // cache bridge can target individual rows in `dataChanged`.
+        // Forwarded to the QAbstractListModel implementation.
+        #[inherit]
+        fn index(self: &RecentsModel, row: i32, column: i32, parent: &QModelIndex) -> QModelIndex;
     }
 
     impl cxx_qt::Threading for RecentsModel {}
@@ -178,6 +225,8 @@ fn apply_state(
         // A fresh initial page resets the cursor chain — bump `seq` so
         // any in-flight `fetch_more` sees a stale ticket and bails.
         model.as_mut().rust_mut().seq.fetch_add(1, Ordering::SeqCst);
+        model.as_mut().ensure_cover_subscription();
+        enqueue_recents_covers(&entries);
         let count = i32::try_from(entries.len()).unwrap_or(i32::MAX);
         model.as_mut().begin_reset_model();
         model.as_mut().rust_mut().entries = entries;
@@ -188,9 +237,12 @@ fn apply_state(
         if model.has_next_page != has_next_page {
             model.as_mut().set_has_next_page(has_next_page);
         }
-        if model.loading {
-            model.as_mut().set_loading(false);
-        }
+        // Decide whether to release `loading` immediately or hold it
+        // until covers are cached. `arm_cover_gate` flips loading off
+        // itself when the page has nothing to wait on (every cover
+        // already cached, or all rows unattributed); otherwise it
+        // leaves loading=true and arms the safety timer.
+        arm_cover_gate(model.as_mut());
         if model.loading_more {
             model.as_mut().set_loading_more(false);
         }
@@ -207,6 +259,9 @@ fn apply_state(
         // is re-set when Ready lands. Bump `seq` and null `next_cursor`
         // so an in-flight `fetch_more` queued during the prior Ready
         // can't slip a stale append in before the next Ready arrives.
+        // Disarm the cover gate too: a stale timer firing during the
+        // next Ready would clear loading prematurely.
+        disarm_cover_gate(model.as_mut());
         model.as_mut().rust_mut().seq.fetch_add(1, Ordering::SeqCst);
         model.as_mut().rust_mut().next_cursor = None;
         if !model.loading {
@@ -220,6 +275,7 @@ fn apply_state(
         // doesn't reset entries, so a callback queued during the prior
         // Ready could otherwise append rows that don't belong to the
         // current chain.
+        disarm_cover_gate(model.as_mut());
         model.as_mut().rust_mut().seq.fetch_add(1, Ordering::SeqCst);
         model.as_mut().rust_mut().next_cursor = None;
         if model.loading {
@@ -333,13 +389,270 @@ impl ffi::RecentsModel {
     fn index_for_path(&self, path: &QString) -> i32 {
         position_of_path(&self.entries, &path.to_string())
     }
+
+    /// Spin up the long-lived cover-cache subscriber on first use.
+    /// Subsequent calls are no-ops — the model singleton owns exactly
+    /// one subscriber for the whole process lifetime, decoupled from
+    /// `seq` because cover updates are not tied to a particular page
+    /// chain. Lagged broadcast frames are dropped silently; the
+    /// `dataChanged` we'd otherwise emit is recoverable on the next
+    /// scroll because `data()` re-reads the cache for every visible
+    /// row's `coverKey`.
+    fn ensure_cover_subscription(mut self: Pin<&mut Self>) {
+        if self.cover_subscription.is_some() {
+            return;
+        }
+        let cache = global_media_image_cache();
+        let mut rx = cache.subscribe();
+        let qt_thread = self.qt_thread();
+        let handle = global_runtime().spawn(async move {
+            loop {
+                match rx.recv().await {
+                    Ok(update) => {
+                        let _ = qt_thread.queue(move |model| {
+                            notify_cover_update(model, &update.key);
+                        });
+                    }
+                    Err(RecvError::Lagged(_)) => {}
+                    Err(RecvError::Closed) => break,
+                }
+            }
+        });
+        self.as_mut().rust_mut().cover_subscription = Some(handle);
+    }
 }
 
+/// Resolve the cover URL key for a recents row. Mirrors `GamesModel`'s
+/// path: when the in-memory cache has bytes for `(systemId, mediaPath)`
+/// we hand back the `media-image/<encoded>` key the
+/// `QQuickImageProvider` resolves to RAM bytes; otherwise we enqueue a
+/// fetch (carrying the optional `mediaId` hint) and fall back to the
+/// system logo as a nicer placeholder than the generic file glyph.
 fn cover_key_for(entry: &MediaHistoryEntry) -> String {
     if entry.system_id.is_empty() {
         return "icons/File".to_string();
     }
-    format!("systems/{}", entry.system_id)
+    let media_key = media_key_for(entry);
+    let cache = global_media_image_cache();
+    let cached = media_key.as_ref().is_some_and(|k| cache.is_cached(k));
+    if !cached {
+        // Miss-driven re-enqueue, same rationale as GamesModel's
+        // `cover_key_for`: tiles re-bound after LRU eviction or stale-
+        // enqueue truncation will hit this branch and re-arm the fetch.
+        // The negative-memo guard avoids the lock dance on keys we've
+        // already learned have nothing to fetch.
+        if let Some(k) = media_key.as_ref() {
+            if !cache.is_negative(k) {
+                cache.enqueue_with_media_id(k.clone(), entry.media_id);
+            }
+        }
+    }
+    cover_key_for_with(entry, media_key.as_ref(), cached)
+}
+
+/// Build the canonical `(systemId, mediaPath)` identifier for a history
+/// row. Returns `None` for rows without enough info to key on.
+fn media_key_for(entry: &MediaHistoryEntry) -> Option<MediaKey> {
+    if entry.system_id.is_empty() || entry.media_path.is_empty() {
+        return None;
+    }
+    Some(MediaKey::new(
+        entry.system_id.clone(),
+        entry.media_path.clone(),
+    ))
+}
+
+/// Pure helper for `cover_key_for`. Split out so tests can drive the
+/// branches (cached, uncached, unattributed) without spinning up the
+/// global cover cache and its tokio runtime.
+fn cover_key_for_with(entry: &MediaHistoryEntry, key: Option<&MediaKey>, cached: bool) -> String {
+    if entry.system_id.is_empty() {
+        return "icons/File".to_string();
+    }
+    match key {
+        Some(k) if cached => MediaImageCache::image_key_for(k),
+        _ => format!("systems/{}", entry.system_id),
+    }
+}
+
+/// Schedule a cover fetch for every history row with a non-empty
+/// `(systemId, mediaPath)`. `MediaImageCache::enqueue_with_media_id`
+/// is idempotent — already-cached, already-pending, or negatively-
+/// memoised keys are dropped — so spamming this from `apply_state` /
+/// `apply_append_page` is cheap.
+///
+/// Iterates `entries` in reverse so the LIFO fetch queue drains in
+/// visual order: the last entry pushed is `entries[0]`, which the
+/// driver pops first. Forward iteration starves the top of the page.
+fn enqueue_recents_covers(entries: &[MediaHistoryEntry]) {
+    let cache = global_media_image_cache();
+    for entry in entries.iter().rev() {
+        if let Some(key) = media_key_for(entry) {
+            cache.enqueue_with_media_id(key, entry.media_id);
+        }
+    }
+}
+
+/// Emit `dataChanged(coverKey)` for every row whose entry's
+/// `(systemId, mediaPath)` matches `key`. Cheap walk of the current
+/// `entries` vec — recents pages top out at a few hundred rows after
+/// look-ahead, and the bridge runs only when the cover-cache fetch
+/// driver delivers a result.
+///
+/// Also drains `pending_first_paint_keys`: each cover landing during
+/// the gate's hold ticks the set down, and emptying the set releases
+/// the gate so the screen-flip overlay clears.
+fn notify_cover_update(mut model: Pin<&mut ffi::RecentsModel>, key: &MediaKey) {
+    let rows: Vec<i32> = model
+        .entries
+        .iter()
+        .enumerate()
+        .filter(|(_, e)| e.media_path == *key.path && e.system_id == *key.system_id)
+        .filter_map(|(i, _)| i32::try_from(i).ok())
+        .collect();
+    if !rows.is_empty() {
+        let mut roles = QList::<i32>::default();
+        roles.append(COVER_KEY_ROLE);
+        let parent = QModelIndex::default();
+        for row in rows {
+            let idx = model.index(row, 0, &parent);
+            model.as_mut().data_changed(&idx, &idx, &roles);
+        }
+    }
+    // Tick the gate's pending set down. `remove` returns false if the
+    // key wasn't gated (broadcast events fire for every cache update,
+    // including miss-recovery enqueues from `cover_key_for`); we only
+    // try to release when a gated key was actually drained.
+    let was_pending = model
+        .as_mut()
+        .rust_mut()
+        .pending_first_paint_keys
+        .remove(key);
+    if was_pending && model.pending_first_paint_keys.is_empty() && model.loading {
+        if let Some(handle) = model.as_mut().rust_mut().cover_gate_timer.take() {
+            handle.abort();
+        }
+        // Bytes are cached, but QML's `MediaImageProvider` still has to
+        // decode them. The hidden cover pre-warmer in
+        // `RecentsScreen.qml` dispatches all N requests at once and the
+        // provider's 4-worker pool decodes them in ~75–150 ms; without
+        // this settle window the gate flips `loading=false` before the
+        // last few decodes complete and the grid materialises with
+        // those tiles still showing the procedural fallback. Mirrors
+        // the same hand-off in `games.rs::notify_cover_update`. Same
+        // seq-ticket guard as the safety timer so a model reset
+        // cancels the pending release.
+        info!("recents: cover gate bytes settled — entering decode-settle window");
+        let seq = model.rust().cover_gate_seq.clone();
+        let ticket = seq.fetch_add(1, Ordering::SeqCst) + 1;
+        let qt_thread = model.qt_thread();
+        let handle = global_runtime().spawn(async move {
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            let _ = qt_thread.queue(move |mut model: Pin<&mut ffi::RecentsModel>| {
+                if seq.load(Ordering::SeqCst) != ticket {
+                    return;
+                }
+                model.as_mut().rust_mut().cover_gate_timer = None;
+                if model.loading {
+                    info!("recents: cover gate released after decode-settle window");
+                    model.as_mut().set_loading(false);
+                }
+            });
+        });
+        model.as_mut().rust_mut().cover_gate_timer = Some(handle);
+    }
+}
+
+/// Compute the set of media keys on the current page whose covers we
+/// must wait on before releasing the cover gate. Rows without enough
+/// info to key on, already-cached keys, and negatively-memoised keys
+/// are all excluded. Pure helper so the gate's binning logic is unit-
+/// testable without spinning up the global cache + tokio runtime.
+fn compute_unresolved_keys<F, G>(
+    entries: &[MediaHistoryEntry],
+    is_cached: F,
+    is_negative: G,
+) -> HashSet<MediaKey>
+where
+    F: Fn(&MediaKey) -> bool,
+    G: Fn(&MediaKey) -> bool,
+{
+    entries
+        .iter()
+        .filter_map(media_key_for)
+        .filter(|k| !is_cached(k) && !is_negative(k))
+        .collect()
+}
+
+/// Decide whether to hold `loading=true` until the page's covers are
+/// cached, or release immediately. Called once per Ready `apply_state`.
+///
+/// - If every history row's cover is already cached or negatively-
+///   memoised, set loading=false right now — the screen-flip overlay
+///   clears.
+/// - Otherwise, store the unresolved set on the model, arm a 3 s
+///   safety timer, and leave loading=true. `notify_cover_update` will
+///   drain the set as covers land; whichever happens first (set
+///   empties or timer fires) releases the gate.
+fn arm_cover_gate(mut model: Pin<&mut ffi::RecentsModel>) {
+    if let Some(handle) = model.as_mut().rust_mut().cover_gate_timer.take() {
+        handle.abort();
+    }
+    let cache = global_media_image_cache();
+    let unresolved = compute_unresolved_keys(
+        &model.entries,
+        |k| cache.is_cached(k),
+        |k| cache.is_negative(k),
+    );
+    if unresolved.is_empty() {
+        model.as_mut().rust_mut().pending_first_paint_keys.clear();
+        if model.loading {
+            model.as_mut().set_loading(false);
+        }
+        return;
+    }
+    info!(
+        pending = unresolved.len(),
+        "recents: arm cover gate (holding loading until covers cached)"
+    );
+    model.as_mut().rust_mut().pending_first_paint_keys = unresolved;
+    let seq = model.rust().cover_gate_seq.clone();
+    let ticket = seq.fetch_add(1, Ordering::SeqCst) + 1;
+    let qt_thread = model.qt_thread();
+    let handle = global_runtime().spawn(async move {
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        let _ = qt_thread.queue(move |model| {
+            if seq.load(Ordering::SeqCst) != ticket {
+                return;
+            }
+            release_cover_gate_after_timeout(model);
+        });
+    });
+    model.as_mut().rust_mut().cover_gate_timer = Some(handle);
+}
+
+/// Tear down any active cover gate. Used by Pending/Errored apply paths
+/// to invalidate an in-flight timer's queued callback (via the seq
+/// bump) before the next Ready installs a fresh one.
+fn disarm_cover_gate(mut model: Pin<&mut ffi::RecentsModel>) {
+    if let Some(handle) = model.as_mut().rust_mut().cover_gate_timer.take() {
+        handle.abort();
+    }
+    model.as_mut().rust_mut().pending_first_paint_keys.clear();
+    model.rust().cover_gate_seq.fetch_add(1, Ordering::SeqCst);
+}
+
+/// Force-release the cover gate from the safety timer. Called only via
+/// the timer's queued callback after a seq-match check; the
+/// notify-driven release path lives inline in `notify_cover_update`.
+fn release_cover_gate_after_timeout(mut model: Pin<&mut ffi::RecentsModel>) {
+    let pending = model.pending_first_paint_keys.len();
+    info!(pending, "recents: cover gate timed out, releasing");
+    model.as_mut().rust_mut().pending_first_paint_keys.clear();
+    model.as_mut().rust_mut().cover_gate_timer = None;
+    if model.loading {
+        model.as_mut().set_loading(false);
+    }
 }
 
 /// Build the `text` payload sent to Core's `run` for a history entry.
@@ -384,6 +697,7 @@ fn apply_append_page(
             let has_next_page = result.has_next_page();
             let next_cursor = result.next_cursor();
             let new_count = i32::try_from(result.entries.len()).unwrap_or(i32::MAX - model.count);
+            enqueue_recents_covers(&result.entries);
             if new_count > 0 {
                 let first = model.count;
                 let last = first.saturating_add(new_count).saturating_sub(1);
@@ -417,7 +731,12 @@ mod tests {
         reason = "tests should fail-fast on unexpected errors"
     )]
 
-    use super::{cover_key_for, launch_text_for, position_of_path, project};
+    use super::{
+        compute_unresolved_keys, cover_key_for_with, launch_text_for, media_key_for,
+        position_of_path, project,
+    };
+    use crate::media_image_cache::{MediaImageCache, MediaKey};
+    use std::collections::HashSet;
     use zaparoo_core::media_types::{MediaHistoryEntry, MediaHistoryResult, Pagination};
     use zaparoo_core::remote_resource::ResourceStatus;
 
@@ -432,15 +751,37 @@ mod tests {
     }
 
     #[test]
-    fn cover_key_uses_system_folder_for_known_system() {
+    fn cover_key_uses_system_logo_when_uncached() {
         let e = entry("smb", "/p/smb", "NES", "NES");
-        assert_eq!(cover_key_for(&e), "systems/NES");
+        let key = media_key_for(&e).expect("media has key");
+        assert_eq!(cover_key_for_with(&e, Some(&key), false), "systems/NES",);
+    }
+
+    #[test]
+    fn cover_key_returns_media_image_key_when_cached() {
+        let e = entry("smb", "/p/smb", "NES", "NES");
+        let key = media_key_for(&e).expect("media has key");
+        let expected = MediaImageCache::image_key_for(&key);
+        assert_eq!(cover_key_for_with(&e, Some(&key), true), expected);
+        assert!(expected.starts_with("media-image/"));
     }
 
     #[test]
     fn cover_key_falls_back_to_file_glyph_when_system_missing() {
         let e = entry("orphan", "/p/orphan", "", "");
-        assert_eq!(cover_key_for(&e), "icons/File");
+        assert_eq!(cover_key_for_with(&e, None, false), "icons/File");
+    }
+
+    #[test]
+    fn media_key_for_skips_rows_without_path_or_system() {
+        let pathless = entry("ghost", "", "NES", "NES");
+        assert!(media_key_for(&pathless).is_none());
+        let unattributed = entry("ghost", "/p", "", "");
+        assert!(media_key_for(&unattributed).is_none());
+        let key =
+            media_key_for(&entry("smb", "/p/smb", "NES", "NES")).expect("complete entry has key");
+        assert_eq!(key.system_id.as_ref(), "NES");
+        assert_eq!(key.path.as_ref(), "/p/smb");
     }
 
     #[test]
@@ -541,5 +882,61 @@ mod tests {
         });
         assert!(page.is_none());
         assert_eq!(err, "rpc kaboom");
+    }
+
+    #[test]
+    fn compute_unresolved_keys_empty_entries_returns_empty() {
+        let unresolved = compute_unresolved_keys(&[], |_| false, |_| false);
+        assert!(unresolved.is_empty());
+    }
+
+    #[test]
+    fn compute_unresolved_keys_all_cached_returns_empty() {
+        let entries = vec![
+            entry("smb", "/p/smb", "NES", "NES"),
+            entry("zelda", "/p/zelda", "NES", "NES"),
+        ];
+        let unresolved = compute_unresolved_keys(&entries, |_| true, |_| false);
+        assert!(unresolved.is_empty());
+    }
+
+    #[test]
+    fn compute_unresolved_keys_mixed_returns_only_uncached() {
+        let cached_path = "/p/smb";
+        let entries = vec![
+            entry("smb", cached_path, "NES", "NES"),
+            entry("zelda", "/p/zelda", "NES", "NES"),
+        ];
+        let unresolved =
+            compute_unresolved_keys(&entries, |k| k.path.as_ref() == cached_path, |_| false);
+        let expected: HashSet<MediaKey> = [MediaKey::new("NES", "/p/zelda")].into_iter().collect();
+        assert_eq!(unresolved, expected);
+    }
+
+    #[test]
+    fn compute_unresolved_keys_excludes_negative_memo() {
+        let negative_path = "/p/no-image";
+        let entries = vec![
+            entry("smb", "/p/smb", "NES", "NES"),
+            entry("orphan", negative_path, "NES", "NES"),
+        ];
+        let unresolved =
+            compute_unresolved_keys(&entries, |_| false, |k| k.path.as_ref() == negative_path);
+        let expected: HashSet<MediaKey> = [MediaKey::new("NES", "/p/smb")].into_iter().collect();
+        assert_eq!(unresolved, expected);
+    }
+
+    #[test]
+    fn compute_unresolved_keys_skips_unattributed_rows() {
+        // Rows without a system id or path never key into the cache —
+        // gate must not wait on them.
+        let entries = vec![
+            entry("smb", "/p/smb", "NES", "NES"),
+            entry("orphan", "", "NES", "NES"),
+            entry("ghost", "/p/ghost", "", ""),
+        ];
+        let unresolved = compute_unresolved_keys(&entries, |_| false, |_| false);
+        let expected: HashSet<MediaKey> = [MediaKey::new("NES", "/p/smb")].into_iter().collect();
+        assert_eq!(unresolved, expected);
     }
 }

--- a/rust/zaparoo-core/src/client.rs
+++ b/rust/zaparoo-core/src/client.rs
@@ -15,10 +15,10 @@
 
 use crate::media_types::{
     MediaBrowseParams, MediaBrowseResult, MediaHistoryParams, MediaHistoryResult,
-    MediaHistoryTopParams, MediaHistoryTopResult, MediaImageParams, MediaImageResult,
-    MediaLookupParams, MediaLookupResult, MediaMetaParams, MediaMetaResult, MediaSearchParams,
-    MediaSearchResult, MediaTagsParams, MediaTagsResult, ReadersResult, ReadersWriteParams,
-    RunParams, SystemsParams, SystemsResult, VersionResult,
+    MediaHistoryTopParams, MediaHistoryTopResult, MediaImageBulkParams, MediaImageBulkResult,
+    MediaImageParams, MediaImageResult, MediaLookupParams, MediaLookupResult, MediaMetaParams,
+    MediaMetaResult, MediaSearchParams, MediaSearchResult, MediaTagsParams, MediaTagsResult,
+    ReadersResult, ReadersWriteParams, RunParams, SystemsParams, SystemsResult, VersionResult,
 };
 use futures_util::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
@@ -464,6 +464,22 @@ impl Client {
         &self,
         params: MediaImageParams,
     ) -> Result<MediaImageResult, ClientError> {
+        let val = self.call("media.image", &params).await?;
+        serde_json::from_value(val).map_err(|e| ClientError {
+            message: e.to_string(),
+        })
+    }
+
+    /// Batched `media.image`: resolves up to `MEDIA_IMAGE_BATCH_MAX`
+    /// (50) covers in a single JSON-RPC call. Core dispatches by
+    /// request shape, so the wire method name is the same as the
+    /// single-shot wrapper. Per-item failures (system not found, no
+    /// image) come back inside the response as an `error` string —
+    /// the call itself only fails on transport / RPC-level errors.
+    pub async fn media_image_bulk(
+        &self,
+        params: MediaImageBulkParams,
+    ) -> Result<MediaImageBulkResult, ClientError> {
         let val = self.call("media.image", &params).await?;
         serde_json::from_value(val).map_err(|e| ClientError {
             message: e.to_string(),

--- a/rust/zaparoo-core/src/media_types.rs
+++ b/rust/zaparoo-core/src/media_types.rs
@@ -56,6 +56,12 @@ pub struct TagInfo {
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MediaItem {
+    /// Opaque media database row ID. Treat as ephemeral — valid only
+    /// for the current Core session and only meaningful when used as a
+    /// shorthand for `(system, path)` on follow-up
+    /// `media.image`/`media.meta` requests in the same session.
+    #[serde(default)]
+    pub media_id: Option<i64>,
     pub name: String,
     pub path: String,
     #[serde(default)]
@@ -175,6 +181,10 @@ pub struct MediaBrowseParams {
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BrowseEntry {
+    /// Opaque media database row ID. Present on `media` entries only.
+    /// Treat as ephemeral — valid only for the current Core session.
+    #[serde(default)]
+    pub media_id: Option<i64>,
     pub name: String,
     pub path: String,
     #[serde(rename = "type", default)]
@@ -254,6 +264,11 @@ pub struct MediaHistoryParams {
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MediaHistoryEntry {
+    /// Opaque media database row ID. Omitted when the history path
+    /// cannot be resolved in the current media database. Treat as
+    /// ephemeral — valid only for the current Core session.
+    #[serde(default)]
+    pub media_id: Option<i64>,
     #[serde(default)]
     pub system_id: String,
     #[serde(default)]
@@ -337,6 +352,77 @@ pub struct MediaImageResult {
     pub data: String,
     #[serde(default)]
     pub type_tag: String,
+}
+
+/// Maximum number of items Core accepts in a single batched
+/// `media.image` request. Documented in `methods.md`; enforced server
+/// side, so callers must split larger fetches across multiple batches.
+pub const MEDIA_IMAGE_BATCH_MAX: usize = 50;
+
+/// Batch parameters for `media.image`. Core dispatches by request
+/// shape — the JSON-RPC method name stays `media.image`. Items address
+/// a media row by `media_id` **or** `(system, path)` (never both on
+/// the same item). A top-level `image_types` preference list applies
+/// to every item unless an item supplies its own override.
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MediaImageBulkParams {
+    pub items: Vec<MediaImageBulkItem>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub image_types: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MediaImageBulkItem {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub media_id: Option<i64>,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub system: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub path: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub image_types: Vec<String>,
+}
+
+impl MediaImageBulkItem {
+    pub fn for_media(system: impl Into<String>, path: impl Into<String>) -> Self {
+        Self {
+            media_id: None,
+            system: system.into(),
+            path: path.into(),
+            image_types: Vec::new(),
+        }
+    }
+
+    pub fn for_media_id(media_id: i64) -> Self {
+        Self {
+            media_id: Some(media_id),
+            system: String::new(),
+            path: String::new(),
+            image_types: Vec::new(),
+        }
+    }
+}
+
+/// Batch result from `media.image`. `items` is matched by index to the
+/// request items. Each entry contains either `image` (success) **or**
+/// `error` (per-item failure) — partial failure is allowed and does
+/// not fail the batch.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MediaImageBulkResult {
+    #[serde(default)]
+    pub items: Vec<MediaImageBulkItemResult>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MediaImageBulkItemResult {
+    #[serde(default)]
+    pub image: Option<MediaImageResult>,
+    #[serde(default)]
+    pub error: Option<String>,
 }
 
 /// Parameters for `media.meta`. Identifies the media row by `(system,
@@ -624,10 +710,10 @@ mod tests {
 
     use super::{
         BrowseEntry, MediaBrowseParams, MediaBrowseResult, MediaHistoryParams, MediaHistoryResult,
-        MediaHistoryTopParams, MediaHistoryTopResult, MediaImageParams, MediaImageResult,
-        MediaLookupParams, MediaLookupResult, MediaMetaParams, MediaMetaResult, MediaSearchParams,
-        MediaSearchResult, MediaTagsParams, MediaTagsResult, ReaderInfo, ReadersResult,
-        SystemsResult, VersionResult,
+        MediaHistoryTopParams, MediaHistoryTopResult, MediaImageBulkResult, MediaImageParams,
+        MediaImageResult, MediaLookupParams, MediaLookupResult, MediaMetaParams, MediaMetaResult,
+        MediaSearchParams, MediaSearchResult, MediaTagsParams, MediaTagsResult, ReaderInfo,
+        ReadersResult, SystemsResult, VersionResult,
     };
 
     #[test]
@@ -1326,5 +1412,44 @@ mod tests {
         let result: VersionResult = serde_json::from_str("{}").expect("parse");
         assert_eq!(result.version, "");
         assert_eq!(result.platform, "");
+    }
+
+    #[test]
+    fn media_image_bulk_result_decodes_partial_failure_in_request_order() {
+        // Index N of `items` aligns with request item N — Core docs
+        // call out that response order matches request order, and a
+        // per-item `error` is a partial failure (HTTP 200, batch ok).
+        let json = r#"{
+            "items": [
+                {
+                    "image": {
+                        "contentType": "image/png",
+                        "extension": "png",
+                        "data": "iVBORw0KG",
+                        "typeTag": "boxart"
+                    }
+                },
+                { "error": "media not found" }
+            ]
+        }"#;
+        let result: MediaImageBulkResult = serde_json::from_str(json).expect("parse");
+        assert_eq!(result.items.len(), 2);
+        let first = result.items[0]
+            .image
+            .as_ref()
+            .expect("first item carries image");
+        assert!(result.items[0].error.is_none());
+        assert_eq!(first.content_type, "image/png");
+        assert_eq!(first.extension.as_deref(), Some("png"));
+        assert_eq!(first.data, "iVBORw0KG");
+        assert_eq!(first.type_tag, "boxart");
+        assert!(result.items[1].image.is_none());
+        assert_eq!(result.items[1].error.as_deref(), Some("media not found"));
+    }
+
+    #[test]
+    fn media_image_bulk_result_defaults_to_empty_items() {
+        let result: MediaImageBulkResult = serde_json::from_str("{}").expect("parse");
+        assert!(result.items.is_empty());
     }
 }

--- a/src/app/media_image_provider.cpp
+++ b/src/app/media_image_provider.cpp
@@ -7,11 +7,15 @@
 #include <QByteArray>
 #include <QImage>
 #include <QImageReader>
+#include <QLatin1Char>
 #include <QList>
+#include <QQuickTextureFactory>
 #include <QString>
 #include <QStringList>
 #include <cstddef>
 #include <cstdint>
+#include <sys/resource.h>
+#include <utility>
 
 extern "C" void zaparoo_media_image_bytes_for(
     const char* encoded, std::size_t encoded_len,
@@ -65,13 +69,54 @@ QImage scaleForRequestedSize(const QImage& image, const QSize& requestedSize)
 }
 } // namespace
 
-MediaImageProvider::MediaImageProvider() : QQuickImageProvider(QQuickImageProvider::Image) {}
-
-QImage MediaImageProvider::requestImage(const QString& id, QSize* size, const QSize& requestedSize)
+MediaImageResponse::MediaImageResponse(QString id, QSize requestedSize)
+    : m_id(std::move(id)), m_requestedSize(requestedSize)
 {
+    // QThreadPool would `delete` the runnable after `run()` returns,
+    // but `QQuickAsyncImageProvider` expects the response to live until
+    // the QML engine has consumed `textureFactory()`. Disabling
+    // auto-delete hands ownership to Qt's QObject lifecycle, which
+    // calls `deleteLater()` once the engine is done with it.
+    setAutoDelete(false);
+}
+
+QQuickTextureFactory* MediaImageResponse::textureFactory() const
+{
+    // Hand off the worker-built factory to QtQuick (it takes ownership
+    // and will destroy it when the response is consumed). On the
+    // unexpected path where `run()` didn't populate `m_factory` (decode
+    // failed and m_image is null), fall back to the per-call
+    // construction the base contract expects so QtQuick still gets a
+    // non-null factory and the response unwinds cleanly.
+    if (m_factory)
+    {
+        return m_factory.release();
+    }
+    return QQuickTextureFactory::textureFactoryForImage(m_image);
+}
+
+void MediaImageResponse::run()
+{
+    // De-prioritize the decoder thread on first use so the QML render
+    // thread (default niceness on the GUI thread) always preempts it.
+    // setpriority(PRIO_PROCESS, 0, …) on Linux is per-thread (NPTL nice),
+    // and bumping nice UP doesn't require CAP_SYS_NICE — any user can
+    // drop their own thread's priority. The +10 niceness puts decoders
+    // at the bottom of the OS scheduler's preference list without going
+    // full IDLE, so they still make progress when the GUI is paused.
+    // Persists for the lifetime of the QThreadPool's worker thread, so
+    // the thread_local guard skips the syscall on subsequent runs that
+    // land on the same worker.
+    static thread_local bool s_decoderNiced = false;
+    if (!s_decoderNiced)
+    {
+        setpriority(PRIO_PROCESS, 0, 10);
+        s_decoderNiced = true;
+    }
+
     // QtQuick strips the `image://media-image/` prefix before calling
-    // us, so `id` is the raw encoded key (base64url-no-pad).
-    const QByteArray idUtf8 = id.toUtf8();
+    // the provider, so `m_id` is the raw encoded key (base64url-no-pad).
+    const QByteArray idUtf8 = m_id.toUtf8();
     QByteArray bytes;
     zaparoo_media_image_bytes_for(idUtf8.constData(), static_cast<std::size_t>(idUtf8.size()),
                                   &appendBytesCallback, &bytes);
@@ -81,11 +126,8 @@ QImage MediaImageProvider::requestImage(const QString& id, QSize* size, const QS
     {
         qWarning("media-image provider: 0 bytes for id=%s (cache miss or empty payload)",
                  idUtf8.constData());
-        if (size != nullptr)
-        {
-            *size = QSize(0, 0);
-        }
-        return {};
+        emit finished();
+        return;
     }
     QImage image;
     if (!image.loadFromData(bytes))
@@ -119,15 +161,34 @@ QImage MediaImageProvider::requestImage(const QString& id, QSize* size, const QS
             "supportedFormats=[%s]",
             idUtf8.constData(), static_cast<long long>(bytes.size()), qUtf8Printable(prefixHex),
             qUtf8Printable(formatNames.join(QStringLiteral(", "))));
-        if (size != nullptr)
-        {
-            *size = QSize(0, 0);
-        }
-        return {};
+        emit finished();
+        return;
     }
-    if (size != nullptr)
-    {
-        *size = image.size();
-    }
-    return scaleForRequestedSize(image, requestedSize);
+    m_image = scaleForRequestedSize(image, m_requestedSize);
+    // Build the texture factory here so the GUI thread doesn't pay
+    // the allocation cost during paint. `textureFactoryForImage` is
+    // documented as safe to call on any thread; the resulting factory
+    // wraps `m_image` and is consumed once by QtQuick after `finished()`.
+    m_factory.reset(QQuickTextureFactory::textureFactoryForImage(m_image));
+    emit finished();
+}
+
+MediaImageProvider::MediaImageProvider()
+{
+    // Workers run at nice +10 (see MediaImageResponse::run), so they
+    // get CPU only when the GUI thread isn't asking for it. With that
+    // safety in place, parallelism here is "free" against renderer
+    // responsiveness and we want all of it: PagedGrid widens its
+    // cover-radius gate to ±2 pages, so a page advance can land 30
+    // covers in the queue at once, and a fatter pool drains them
+    // sooner so page N+2's decode finishes before the user gets there.
+    m_pool.setMaxThreadCount(4);
+}
+
+QQuickImageResponse* MediaImageProvider::requestImageResponse(const QString& id,
+                                                              const QSize& requestedSize)
+{
+    auto* response = new MediaImageResponse(id, requestedSize);
+    m_pool.start(response);
+    return response;
 }

--- a/src/app/media_image_provider.h
+++ b/src/app/media_image_provider.h
@@ -2,27 +2,71 @@
 // Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 //
-// QQuickImageProvider that serves media image bytes (boxart, screenshot,
-// wheel, titleshot, map, marquee, fanart, generic image — anything Core
-// returns from `media.image`) from the Rust-side in-memory cache
-// (`media_image_cache.rs`). QML loads `image://media-image/<key>` URLs;
-// QtQuick calls `requestImage` with `<key>` (the bit after the scheme +
-// host); we hand the encoded key to the Rust C ABI which looks the
-// bytes up in the LRU cache and copies them into a QByteArray. Empty
-// bytes → null QImage, and Tile.qml's fallback text stays visible.
+// QQuickAsyncImageProvider that serves media image bytes (boxart,
+// screenshot, wheel, titleshot, map, marquee, fanart, generic image —
+// anything Core returns from `media.image`) from the Rust-side in-memory
+// cache (`media_image_cache.rs`). QML loads `image://media-image/<key>`
+// URLs; QtQuick calls `requestImageResponse` with `<key>` (the bit after
+// the scheme + host); we hand the encoded key to the Rust C ABI which
+// looks the bytes up in the LRU cache and copies them into a QByteArray.
+// Empty bytes → null QImage, and Tile.qml's fallback text stays visible.
+//
+// Async because the synchronous predecessor blocked the Qt thread on
+// every `requestImage` call: a freshly-loaded folder of 10 covers
+// produced ~5 s of serial decode (~250–700 ms each) during which the
+// page rendered with placeholders and tiles popped in one at a time as
+// each lookup finally returned. Moving the FFI lookup, `loadFromData`,
+// and scaling onto a `QThreadPool` parallelises decode (4 workers) and
+// keeps the Qt thread free to layout and paint while images settle.
 
 #pragma once
 
 #include <QImage>
-#include <QQuickImageProvider>
+#include <QQuickAsyncImageProvider>
+#include <QQuickImageResponse>
+#include <QQuickTextureFactory>
+#include <QRunnable>
 #include <QSize>
 #include <QString>
+#include <QThreadPool>
+#include <memory>
 
-class MediaImageProvider : public QQuickImageProvider
+class MediaImageResponse : public QQuickImageResponse, public QRunnable
+{
+  public:
+    MediaImageResponse(QString id, QSize requestedSize);
+    ~MediaImageResponse() override = default;
+
+    [[nodiscard]] QQuickTextureFactory* textureFactory() const override;
+    void run() override;
+
+  private:
+    QString m_id;
+    QSize m_requestedSize;
+    QImage m_image;
+    // Built on the worker thread once decode completes so the GUI
+    // thread doesn't pay the QQuickTextureFactory allocation cost
+    // when QtQuick consumes the response. `mutable` because the
+    // base-class signature `textureFactory() const` transfers the
+    // pointer to QtQuick (which will own and destroy it), so the
+    // const method needs to release ownership of the cached unique_ptr.
+    mutable std::unique_ptr<QQuickTextureFactory> m_factory;
+};
+
+class MediaImageProvider : public QQuickAsyncImageProvider
 {
   public:
     MediaImageProvider();
     ~MediaImageProvider() override = default;
 
-    QImage requestImage(const QString& id, QSize* size, const QSize& requestedSize) override;
+    QQuickImageResponse* requestImageResponse(const QString& id,
+                                              const QSize& requestedSize) override;
+
+  private:
+    // Bounded so a fast-scrolling user enqueueing 30+ tiles doesn't
+    // spawn dozens of decode threads on MiSTer's two ARM cores. Four
+    // workers is the same cap `MediaImageCache`'s fetch driver uses;
+    // beyond that, context-switch cost outweighs parallel decode on
+    // the software-rendered build.
+    QThreadPool m_pool;
 };

--- a/src/ui/app/MainLayout.qml
+++ b/src/ui/app/MainLayout.qml
@@ -226,6 +226,7 @@ ApplicationWindow {
             id: gamesScreen
             anchors.fill: parent
             visible: root.activeScreen === root.screenGames
+            transitioning: root.pendingTransition !== ""
         }
 
         RecentsScreen {

--- a/src/ui/components/PagedGrid.qml
+++ b/src/ui/components/PagedGrid.qml
@@ -358,6 +358,57 @@ Item {
                 readonly property int cellCol: cellLocal % root.columns
                 readonly property bool isSelected: index === root.currentIndex
 
+                // Cover-load gate. PagedGrid's Repeater materialises every
+                // model row at construction, so without a gate every loaded
+                // cell would fire its image-provider request immediately
+                // and saturate the async pool — visible-page covers then
+                // can't finish decoding before the cover gate releases,
+                // which produces the per-tile pop-in we tried to fix in
+                // v1.
+                //
+                // Two-tier gate:
+                //   - request range (±2 pages): cells inside this radius
+                //     fire image-provider requests. Bounds the initial
+                //     fanout to a fixed ~50 covers while still
+                //     pre-decoding pages N+1 and N+2 so a forward PgDn
+                //     lands on already-cached pixmaps.
+                //   - retention range (±5 pages): cells already requested
+                //     keep their TileLoader coverKey set so Tile's Image
+                //     keeps the decoded texture *referenced*. That
+                //     prevents QQuickPixmapCache from evicting it when
+                //     the user pages on, so a back-nav within the
+                //     retention window doesn't pay re-decode. Cells that
+                //     are in retention range but were never requested
+                //     stay gated to "" — retention doesn't get to trigger
+                //     new requests, only to keep already-loaded ones
+                //     alive.
+                //
+                // Off-radius cells (outside both ranges, or in retention
+                // range without ever having been requested) set their
+                // coverKey to "" so Tile's Image collapses to source: ""
+                // and the texture reference drops; Qt may evict.
+                //
+                // Memory ceiling: ±5 around currentPage = up to 11 pages
+                // × pageSize covers ≈ 110 covers ≈ 40 MB decoded — OK on
+                // MiSTer's shared 512 MB. The decoders run at nice +10
+                // (see media_image_provider.cpp), so a re-decode after
+                // crossing past the retention edge is invisible to the
+                // renderer.
+                readonly property bool _coverInRange:
+                    Math.abs(cellPage - root.currentPage) <= 2
+                readonly property bool _coverInRetentionRange:
+                    Math.abs(cellPage - root.currentPage) <= 5
+                property bool _coverEverRequested: false
+                Binding on _coverEverRequested {
+                    when: cellItem._coverInRange
+                    value: true
+                    restoreMode: Binding.RestoreNone
+                }
+                readonly property string _gatedCoverKey:
+                    (_coverInRange
+                     || (_coverEverRequested && _coverInRetentionRange))
+                        ? coverKey : ""
+
                 width: root.cellWidth
                 height: root.cellHeight
                 x: root.leftInset
@@ -375,7 +426,7 @@ Item {
                     isSelected: cellItem.isSelected
                     isFocused: root.focused
                     name: cellItem.name
-                    coverKey: cellItem.coverKey
+                    coverKey: cellItem._gatedCoverKey
                 }
 
                 MouseArea {

--- a/src/ui/components/Tile.qml
+++ b/src/ui/components/Tile.qml
@@ -43,6 +43,17 @@ Item {
 
     anchors.fill: parent
 
+    // Do NOT add `layer.enabled` here. On Qt's software adaptation
+    // it allocates a per-item QImage backing store, blits it into
+    // the parent on every paint (extra memcpy, not the cached-blit
+    // win the docs imply for hardware rendering), and its
+    // compositing path with translucent siblings/parents differs
+    // from the direct-paint path — visible as flicker on focus
+    // moves and lost transparency around the focus ring.
+    // `layer.enabled` is documented for scene graph (GPU) rendering;
+    // on the MiSTer software target it is a regression, not an
+    // optimization.
+
     // qmllint disable missing-property compiler
     readonly property bool delegateIsSelected: parent.isSelected
     readonly property bool delegateIsFocused: parent.isFocused
@@ -90,22 +101,15 @@ Item {
         Resources.coverUrl(root.delegateCoverKey)
     readonly property bool _hasCover: cover.status === Image.Ready
 
-    // Selected tile bumps up a hair so the user can see at a glance
-    // which one is current. PagedGrid bumps cellItem.z for the
-    // selected slot, so the scaled tile draws on top of its
-    // right/bottom neighbours. Gated on `_focusedSelection` so a tile
-    // in an unfocused section doesn't compete for the eye with the
-    // focused section's selection cue.
-    //
-    // No `Behavior on scale`: under software rendering, animating
-    // two tiles' scale across 120 ms forces a bilinear resample of
-    // each decoded cover PNG every frame, on both the outgoing and
-    // incoming tile. The focus outline ring is the primary focus
-    // cue; the scale bump is supplementary and looks fine snapping
-    // instantly. See `docs/qml-gotchas.md` → "Software-renderer
-    // animation costs".
-    transformOrigin: Item.Center
-    scale: root._focusedSelection ? 1.06 : 1.0
+    // No focus scale bump. The earlier 1.06 scale on the focused tile
+    // forced a bilinear resample of the cover pixmap on every focus
+    // move and overflowed the cell by ~3% on each side, dirtying
+    // strips of up to four neighbours per press — under software
+    // rendering on MiSTer that read as choppy d-pad navigation on
+    // covered grids. The focus outline ring + caption + active-label
+    // already mark the selection clearly, so the size cue isn't worth
+    // the per-press repaint cost. See `docs/qml-gotchas.md` →
+    // "Software-renderer animation costs".
 
     // Tile body. Solid card so the white icon has a high-contrast
     // surface. Always visible — no opacity gating — which is the
@@ -246,9 +250,10 @@ Item {
     }
 
     // Bottom caption strip (caption mode only). Single line, ellipsised
-    // when long. Same focus-tinted colouring as the non-caption
-    // fallback so the focused tile's caption brightens with the rest
-    // of the focus cue.
+    // when long. Tints to `textPrimary` on the focused tile so the
+    // selection reads at a glance even when the focus outline ring is
+    // outside the eye's centre — matches the procedural fallback's
+    // focus tint above.
     Text {
         id: caption
         anchors {

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -22,6 +22,16 @@ Item {
 
     property alias gamesGrid: gamesGrid
 
+    // True while the cover gate in `GamesModel` is holding `loading`.
+    // Mirrors the `transitioning` contract in `SystemsScreen.qml` /
+    // `RecentsScreen.qml`: the screen body hides while transitioning so
+    // the centred `ScreenStateOverlay` paints alone on a cleared band,
+    // rather than reading as pasted on top of a populated grid. The
+    // cover gate already scopes `loading` to the initial-page path
+    // (pagination uses a separate `loading_more` flag), so PgDn doesn't
+    // trip this hide.
+    readonly property bool transitioning: Browse.GamesModel.loading
+
     // Emitted when the user presses Escape — Main.qml flips the
     // active screen back to SystemsScreen (one peer up the back-stack;
     // a second Escape from there pops to Hub).
@@ -175,6 +185,7 @@ Item {
     // entry count for the path.
     TopStatusStrip {
         id: topStrip
+        visible: !games.transitioning
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: parent.top
@@ -203,6 +214,7 @@ Item {
     PagedGrid {
         id: gamesGrid
 
+        visible: !games.transitioning
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: topStrip.bottom
@@ -235,6 +247,7 @@ Item {
     // tile selection).
     ActiveLabel {
         id: activeLabel
+        visible: !games.transitioning
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: gamesGrid.bottom

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -22,15 +22,19 @@ Item {
 
     property alias gamesGrid: gamesGrid
 
-    // True while the cover gate in `GamesModel` is holding `loading`.
-    // Mirrors the `transitioning` contract in `SystemsScreen.qml` /
-    // `RecentsScreen.qml`: the screen body hides while transitioning so
-    // the centred `ScreenStateOverlay` paints alone on a cleared band,
-    // rather than reading as pasted on top of a populated grid. The
-    // cover gate already scopes `loading` to the initial-page path
-    // (pagination uses a separate `loading_more` flag), so PgDn doesn't
-    // trip this hide.
-    readonly property bool transitioning: Browse.GamesModel.loading
+    // Router-driven flag: `MainLayout.qml` writes this to
+    // `root.pendingTransition !== ""` for every peer screen, including
+    // this one. The screen body hides while it's true so the global
+    // "Loading…" cue paints alone on a cleared band rather than over
+    // a populated grid.
+    property bool transitioning: false
+
+    // Cover-gate flag: true while `GamesModel` is holding `loading`
+    // for the initial-page paint. Pagination uses a separate
+    // `loading_more` flag, so PgDn doesn't trip this. The body hides
+    // on either flag (see `visible:` bindings below) so the centred
+    // `ScreenStateOverlay` paints alone in both cases.
+    readonly property bool coverGateLoading: Browse.GamesModel.loading
 
     // Emitted when the user presses Escape — Main.qml flips the
     // active screen back to SystemsScreen (one peer up the back-stack;
@@ -185,7 +189,7 @@ Item {
     // entry count for the path.
     TopStatusStrip {
         id: topStrip
-        visible: !games.transitioning
+        visible: !games.transitioning && !games.coverGateLoading
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: parent.top
@@ -214,7 +218,7 @@ Item {
     PagedGrid {
         id: gamesGrid
 
-        visible: !games.transitioning
+        visible: !games.transitioning && !games.coverGateLoading
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: topStrip.bottom
@@ -247,7 +251,7 @@ Item {
     // tile selection).
     ActiveLabel {
         id: activeLabel
-        visible: !games.transitioning
+        visible: !games.transitioning && !games.coverGateLoading
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: gamesGrid.bottom

--- a/src/ui/screens/RecentsScreen.qml
+++ b/src/ui/screens/RecentsScreen.qml
@@ -34,6 +34,15 @@ Item {
     // a Recents-as-source path.
     property bool transitioning: false
 
+    // True while either the cross-screen router is mid-flip
+    // (`transitioning`) or the in-screen cover gate is holding
+    // `RecentsModel.loading`. The grid + active-label hide on this so
+    // the centred `ScreenStateOverlay` paints alone on a cleared band
+    // during cold-launch / model-reset, matching `GamesScreen.qml`.
+    // Pagination uses a separate `loading_more` flag and is unaffected.
+    readonly property bool _gateHide:
+        recents.transitioning || Browse.RecentsModel.loading
+
     signal requestHubScreen()
 
     // Restore the previously focused entry when the model is Ready.
@@ -125,6 +134,7 @@ Item {
     // server-side total. Good enough until Core surfaces a total.
     TopStatusStrip {
         id: topStrip
+        visible: !recents._gateHide
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: parent.top
@@ -142,6 +152,7 @@ Item {
     PagedGrid {
         id: recentsGrid
 
+        visible: !recents._gateHide
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: topStrip.bottom
@@ -164,6 +175,7 @@ Item {
 
     ActiveLabel {
         id: activeLabel
+        visible: !recents._gateHide
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: recentsGrid.bottom


### PR DESCRIPTION
## Summary

- **Bulk `media.image` RPC**: covers fetch in batches of up to 50 per round-trip (`BrowseEntry`/`MediaItem`/`MediaHistoryEntry` now carry `media_id` so the cheap row-id form is preferred). A 200-entry folder open drops from N serial RPCs to ⌈N/50⌉.
- **Async image provider**: `MediaImageProvider` is now a `QQuickAsyncImageProvider` with a bounded `QThreadPool` (4 workers). Decode + scale + texture-factory construction runs off the GUI thread; workers self-nice to +10 so the QML renderer always preempts.
- **Two-tier cover gate** in `PagedGrid`: request range (±2 pages) bounds initial fanout to ~50 covers and prefetches PgDn; retention range (±5 pages) keeps already-decoded covers *referenced* so `QQuickPixmapCache` doesn't evict pages the user is likely to back-nav into.
- **`Tile` cleanup**: removed the 1.06 focus-scale bump (per-frame bilinear resample under software rendering). Tombstone comment on the root Item warning against `layer.enabled` — documented for scene-graph rendering only; on QPainter-based software adaptation it allocates a backing QImage, blits via `CompositionMode`, and breaks alpha (tested, regressed, reverted).
- **Recents wiring**: `RecentsModel` added; `RecentsScreen` and `GamesScreen` connect to the new pipeline.

## Test plan

- [x] `just lint` clean (clang-tidy, qmllint, cargo clippy, cargo deny)
- [x] `just test` clean (275 passing)
- [ ] MiSTer smoke: open a fresh folder >1 page (e.g. Genesis "1 US — A-F", 219 entries). Loading hold ~2 s while bulk RPC + first decodes complete. Page paints with covers visible, no per-tile pop-in.
- [ ] PgDn through several pages — each paints from the prefetch radius without re-decode hold.
- [ ] Back-nav (PgUp) within ±5 pages — hits the retention cache, no re-decode.
- [ ] Recently Played screen loads, focus is restored on revisit, launch fires Core's `run`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Asynchronous image decoding in background workers for smoother UI responsiveness
  * Intelligent cover preloading (±2-page) with ±5-page retention to reduce memory use
  * Cover-gate loading/transition states that keep a single overlay visible until covers settle, reducing flicker and partial renders
  * More robust handling of missing covers to avoid repeated failed loads

* **Bug Fixes**
  * Removed focused-tile scale animation that caused rendering artifacts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->