### PR TITLE
feat(status): core status pill, boot overlay, first-run index modal

### DIFF
--- a/rust/launcher/build.rs
+++ b/rust/launcher/build.rs
@@ -34,6 +34,7 @@ fn main() {
         "src/models/systems_state.rs",
         "src/models/games_state.rs",
         "src/models/input.rs",
+        "src/models/media_status.rs",
         "src/models/platform.rs",
         "src/models/qr_code.rs",
         "src/models/recents.rs",

--- a/rust/launcher/src/models/app_status.rs
+++ b/rust/launcher/src/models/app_status.rs
@@ -3,20 +3,39 @@
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 //
 // `Browse.AppStatus` — ephemeral connection / catalog health, exposed
-// to QML so the UI can render a status strip when Core is unreachable
-// or the initial catalog fetch failed. State is not persisted: it is
-// derived from a single `ResourceStatus<CatalogData>` watch which
-// already merges the link state and the fetch state (see
-// `RemoteResource` for the dispatch table).
+// to QML so the UI can render a status surface (status pill, boot
+// overlay) when Core is unreachable or the initial catalog fetch
+// failed. State is not persisted: it is derived from two channels —
 //
-// `connection_state` constants:
+//   * `CatalogEndpoint`'s `ResourceStatus<CatalogData>` — collapses the
+//     link state and the catalog fetch into the four banner states the
+//     UI used to drive the pre-pill connection strip. Kept on
+//     `connection_state` so existing callers still observe the
+//     "everything together" view.
+//
+//   * The raw `Client::connection` watch (`ConnectionState`) — the
+//     unmerged link lifecycle. Surfaced as `link_state` so the new
+//     `CoreStatusPill` can distinguish "first-ever connect attempt"
+//     from "lost a live link, retrying" without watching the catalog
+//     resource separately.
+//
+// `connection_state` constants (legacy banner view):
 //   0 DISCONNECTED — resource Idle (link not attempted yet)
 //   1 CONNECTING   — resource Loading (handshake or RPC in flight)
 //   2 READY        — resource Ready (catalog loaded)
 //   3 ERROR        — resource Errored (link unreachable or RPC failed)
+//
+// `link_state` constants (raw `ConnectionState`):
+//   0 DISCONNECTED — initial value before the connect loop's first attempt
+//   1 CONNECTING   — first-ever `connect_async` in flight
+//   2 CONNECTED    — ws link up
+//   3 RECONNECTING — lost a previously-live link, retrying
+//   4 UNREACHABLE  — `RETRY_ERROR_THRESHOLD` consecutive failures hit
 
+use cxx_qt::{Initialize, Threading};
 use cxx_qt_lib::QString;
 use std::pin::Pin;
+use zaparoo_core::client::ConnectionState;
 use zaparoo_core::endpoints::catalog::CatalogEndpoint;
 use zaparoo_core::remote_resource::ResourceStatus;
 use zaparoo_core::systems_catalog::CatalogData;
@@ -26,9 +45,16 @@ pub const CONNECTING: i32 = 1;
 pub const READY: i32 = 2;
 pub const ERROR: i32 = 3;
 
+pub const LINK_DISCONNECTED: i32 = 0;
+pub const LINK_CONNECTING: i32 = 1;
+pub const LINK_CONNECTED: i32 = 2;
+pub const LINK_RECONNECTING: i32 = 3;
+pub const LINK_UNREACHABLE: i32 = 4;
+
 pub struct AppStatusRust {
     connection_state: i32,
     last_error: QString,
+    link_state: i32,
 }
 
 impl Default for AppStatusRust {
@@ -36,6 +62,7 @@ impl Default for AppStatusRust {
         Self {
             connection_state: DISCONNECTED,
             last_error: QString::default(),
+            link_state: LINK_DISCONNECTED,
         }
     }
 }
@@ -54,6 +81,7 @@ pub mod ffi {
         #[qml_singleton]
         #[qproperty(i32, connection_state)]
         #[qproperty(QString, last_error)]
+        #[qproperty(i32, link_state)]
         type AppStatus = super::AppStatusRust;
     }
 
@@ -61,19 +89,58 @@ pub mod ffi {
     impl cxx_qt::Initialize for AppStatus {}
 }
 
-crate::bind_to_endpoint! {
-    for ffi::AppStatus,
-    endpoint = CatalogEndpoint,
-    args = (),
-    select = project,
-    apply = apply_state,
+impl Initialize for ffi::AppStatus {
+    fn initialize(mut self: Pin<&mut Self>) {
+        bind_catalog_status(self.as_mut());
+        bind_link_state(self);
+    }
+}
+
+/// Subscribe to the catalog resource status and drive the legacy
+/// `connection_state` / `last_error` properties. Same shape as the
+/// previous `bind_to_endpoint!` invocation; hand-rolled so it can sit
+/// alongside the second binding below.
+fn bind_catalog_status(mut model: Pin<&mut ffi::AppStatus>) {
+    let mut rx = crate::models::global_store()
+        .subscribe::<CatalogEndpoint>(())
+        .subscribe();
+    let projected = project_catalog(&rx.borrow_and_update());
+    apply_catalog_state(model.as_mut(), projected);
+
+    let qt_thread = model.qt_thread();
+    crate::models::global_runtime().spawn(async move {
+        while rx.changed().await.is_ok() {
+            let projected = project_catalog(&rx.borrow_and_update());
+            let _ = qt_thread.queue(move |m| apply_catalog_state(m, projected));
+        }
+    });
+}
+
+/// Subscribe to the raw `Client::connection` watch and drive the new
+/// `link_state` property. The seed reads the current value through
+/// `borrow_and_update` so the first QML frame reflects whatever
+/// transition Core has already produced — usually `Connecting` by the
+/// time the QML engine boots.
+fn bind_link_state(mut model: Pin<&mut ffi::AppStatus>) {
+    let client = crate::models::global_store().client();
+    let mut rx = client.connection.subscribe();
+    let projected = project_link(&rx.borrow_and_update());
+    apply_link_state(model.as_mut(), projected);
+
+    let qt_thread = model.qt_thread();
+    crate::models::global_runtime().spawn(async move {
+        while rx.changed().await.is_ok() {
+            let projected = project_link(&rx.borrow_and_update());
+            let _ = qt_thread.queue(move |m| apply_link_state(m, projected));
+        }
+    });
 }
 
 /// Map `ResourceStatus<CatalogData>` onto the four banner states the QML
 /// side knows about. The error message is whatever the resource layer
 /// surfaced — link error (`Unreachable`) or RPC error (`Errored` while
 /// the link is still up). The UI treats them the same.
-fn project(status: &ResourceStatus<CatalogData>) -> (i32, String) {
+fn project_catalog(status: &ResourceStatus<CatalogData>) -> (i32, String) {
     match status {
         ResourceStatus::Idle => (DISCONNECTED, String::new()),
         ResourceStatus::Loading => (CONNECTING, String::new()),
@@ -82,16 +149,37 @@ fn project(status: &ResourceStatus<CatalogData>) -> (i32, String) {
     }
 }
 
+/// Map a raw `ConnectionState` onto the five-state `link_state`. The
+/// `Unreachable(msg)` payload is intentionally not surfaced here —
+/// `last_error` already carries the error string from the catalog
+/// projection, and exposing the same message twice would let the two
+/// drift.
+fn project_link(state: &ConnectionState) -> i32 {
+    match state {
+        ConnectionState::Disconnected => LINK_DISCONNECTED,
+        ConnectionState::Connecting => LINK_CONNECTING,
+        ConnectionState::Connected => LINK_CONNECTED,
+        ConnectionState::Reconnecting => LINK_RECONNECTING,
+        ConnectionState::Unreachable(_) => LINK_UNREACHABLE,
+    }
+}
+
 /// Apply a freshly-derived `(state, err)` to the model, suppressing
 /// `QProperty` setters whose value hasn't changed so QML doesn't see
 /// spurious `Changed` signals on every reconnect.
-fn apply_state(mut model: Pin<&mut ffi::AppStatus>, (state, err): (i32, String)) {
+fn apply_catalog_state(mut model: Pin<&mut ffi::AppStatus>, (state, err): (i32, String)) {
     if model.connection_state != state {
         model.as_mut().set_connection_state(state);
     }
     let qerr = QString::from(err.as_str());
     if model.last_error != qerr {
         model.as_mut().set_last_error(qerr);
+    }
+}
+
+fn apply_link_state(mut model: Pin<&mut ffi::AppStatus>, state: i32) {
+    if model.link_state != state {
+        model.as_mut().set_link_state(state);
     }
 }
 
@@ -108,28 +196,28 @@ mod tests {
 
     #[test]
     fn idle_maps_to_disconnected() {
-        let (state, err) = project(&ResourceStatus::Idle);
+        let (state, err) = project_catalog(&ResourceStatus::Idle);
         assert_eq!(state, DISCONNECTED);
         assert_eq!(err, "");
     }
 
     #[test]
     fn loading_maps_to_connecting() {
-        let (state, err) = project(&ResourceStatus::Loading);
+        let (state, err) = project_catalog(&ResourceStatus::Loading);
         assert_eq!(state, CONNECTING);
         assert_eq!(err, "");
     }
 
     #[test]
     fn ready_maps_to_ready_with_no_error() {
-        let (state, err) = project(&ResourceStatus::Ready(empty_catalog()));
+        let (state, err) = project_catalog(&ResourceStatus::Ready(empty_catalog()));
         assert_eq!(state, READY);
         assert_eq!(err, "");
     }
 
     #[test]
     fn errored_with_retrying_surfaces_message() {
-        let (state, err) = project(&ResourceStatus::Errored {
+        let (state, err) = project_catalog(&ResourceStatus::Errored {
             message: "rpc kaboom".into(),
             retrying: true,
         });
@@ -139,11 +227,29 @@ mod tests {
 
     #[test]
     fn errored_without_retrying_surfaces_message() {
-        let (state, err) = project(&ResourceStatus::Errored {
+        let (state, err) = project_catalog(&ResourceStatus::Errored {
             message: "connection refused".into(),
             retrying: false,
         });
         assert_eq!(state, ERROR);
         assert_eq!(err, "connection refused");
+    }
+
+    #[test]
+    fn link_state_covers_every_connection_variant() {
+        assert_eq!(
+            project_link(&ConnectionState::Disconnected),
+            LINK_DISCONNECTED
+        );
+        assert_eq!(project_link(&ConnectionState::Connecting), LINK_CONNECTING);
+        assert_eq!(project_link(&ConnectionState::Connected), LINK_CONNECTED);
+        assert_eq!(
+            project_link(&ConnectionState::Reconnecting),
+            LINK_RECONNECTING
+        );
+        assert_eq!(
+            project_link(&ConnectionState::Unreachable("boom".into())),
+            LINK_UNREACHABLE
+        );
     }
 }

--- a/rust/launcher/src/models/media_status.rs
+++ b/rust/launcher/src/models/media_status.rs
@@ -1,0 +1,387 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+//
+// `Browse.MediaStatus` — QML-facing view of Core's media-database build
+// state and scraper progress. Subscribes to the
+// `MediaStatusResource` watch channel set up by the store, and exposes
+// every field the launcher renders as a Q_PROPERTY plus the four action
+// methods (`start_index`, `cancel_index`, `start_scrape`, `cancel_scrape`)
+// as `qinvokable`s.
+//
+// Why this isn't `bind_to_endpoint!`: the resource is a plain
+// `tokio::sync::watch::Sender<MediaStatusState>` rather than an
+// `Endpoint`, because the underlying state is half-pull / half-push —
+// see `rust/zaparoo-core/src/store/media_status.rs` for the rationale.
+// The wiring is shaped exactly like `app_status.rs::bind_link_state`:
+// seed via `borrow_and_update`, then loop on `changed().await`, queueing
+// each projected snapshot back onto the QObject's Qt thread.
+//
+// Action methods (`start_index` / `cancel_index` / `start_scrape` /
+// `cancel_scrape`) spawn fire-and-forget tasks on the global runtime —
+// the resulting state changes flow back through Core's notification
+// stream, which the resource folds into the same watch channel. Caller
+// errors are logged but not surfaced as a Q_PROPERTY because the
+// notification stream is the source of truth for what the UI renders.
+
+use cxx_qt::{Initialize, Threading};
+use cxx_qt_lib::QString;
+use std::pin::Pin;
+use tracing::warn;
+use zaparoo_core::media_types::{MediaIndexParams, MediaScrapeParams};
+use zaparoo_core::store::MediaStatusState;
+
+#[allow(
+    clippy::struct_excessive_bools,
+    reason = "wire-faithful flags; one bool per Core status field exposed to QML"
+)]
+#[derive(Default)]
+pub struct MediaStatusRust {
+    seeded: bool,
+
+    exists: bool,
+    indexing: bool,
+    optimizing: bool,
+    paused: bool,
+    current_step: i32,
+    total_steps: i32,
+    current_step_display: QString,
+    total_files: i32,
+    total_media: i32,
+
+    scraping: bool,
+    scrape_done: bool,
+    scrape_paused: bool,
+    scrape_processed: i32,
+    scrape_total: i32,
+    scrape_matched: i32,
+    scrape_skipped: i32,
+    scrape_total_scraped: i32,
+    scrape_system_id: QString,
+    scrape_scraper_id: QString,
+}
+
+#[cxx_qt::bridge]
+pub mod ffi {
+    unsafe extern "C++" {
+        include!("model_includes.h");
+
+        type QString = cxx_qt_lib::QString;
+    }
+
+    unsafe extern "RustQt" {
+        #[qobject]
+        #[qml_element]
+        #[qml_singleton]
+        #[qproperty(bool, seeded)]
+        #[qproperty(bool, exists)]
+        #[qproperty(bool, indexing)]
+        #[qproperty(bool, optimizing)]
+        #[qproperty(bool, paused)]
+        #[qproperty(i32, current_step)]
+        #[qproperty(i32, total_steps)]
+        #[qproperty(QString, current_step_display)]
+        #[qproperty(i32, total_files)]
+        #[qproperty(i32, total_media)]
+        #[qproperty(bool, scraping)]
+        #[qproperty(bool, scrape_done)]
+        #[qproperty(bool, scrape_paused)]
+        #[qproperty(i32, scrape_processed)]
+        #[qproperty(i32, scrape_total)]
+        #[qproperty(i32, scrape_matched)]
+        #[qproperty(i32, scrape_skipped)]
+        #[qproperty(i32, scrape_total_scraped)]
+        #[qproperty(QString, scrape_system_id)]
+        #[qproperty(QString, scrape_scraper_id)]
+        type MediaStatus = super::MediaStatusRust;
+
+        #[qinvokable]
+        fn start_index(self: Pin<&mut MediaStatus>);
+
+        #[qinvokable]
+        fn cancel_index(self: Pin<&mut MediaStatus>);
+
+        #[qinvokable]
+        fn start_scrape(self: Pin<&mut MediaStatus>);
+
+        #[qinvokable]
+        fn cancel_scrape(self: Pin<&mut MediaStatus>);
+    }
+
+    impl cxx_qt::Threading for MediaStatus {}
+    impl cxx_qt::Initialize for MediaStatus {}
+}
+
+/// Mirror of `MediaStatusState` shaped for the closure-queue contract:
+/// owned `String`s become `QString`s ahead of the Qt-thread hop so the
+/// apply path doesn't need to allocate while holding the model pin.
+#[allow(
+    clippy::struct_excessive_bools,
+    reason = "wire-faithful flags; mirrors the QML singleton's bool surface"
+)]
+struct Snapshot {
+    seeded: bool,
+
+    exists: bool,
+    indexing: bool,
+    optimizing: bool,
+    paused: bool,
+    current_step: i32,
+    total_steps: i32,
+    current_step_display: QString,
+    total_files: i32,
+    total_media: i32,
+
+    scraping: bool,
+    scrape_done: bool,
+    scrape_paused: bool,
+    scrape_processed: i32,
+    scrape_total: i32,
+    scrape_matched: i32,
+    scrape_skipped: i32,
+    scrape_total_scraped: i32,
+    scrape_system_id: QString,
+    scrape_scraper_id: QString,
+}
+
+fn project(state: &MediaStatusState) -> Snapshot {
+    Snapshot {
+        seeded: state.seeded,
+        exists: state.exists,
+        indexing: state.indexing,
+        optimizing: state.optimizing,
+        paused: state.paused,
+        current_step: state.current_step,
+        total_steps: state.total_steps,
+        current_step_display: QString::from(state.current_step_display.as_str()),
+        total_files: state.total_files,
+        total_media: state.total_media,
+        scraping: state.scraping,
+        scrape_done: state.scrape_done,
+        scrape_paused: state.scrape_paused,
+        scrape_processed: state.scrape_processed,
+        scrape_total: state.scrape_total,
+        scrape_matched: state.scrape_matched,
+        scrape_skipped: state.scrape_skipped,
+        scrape_total_scraped: state.scrape_total_scraped,
+        scrape_system_id: QString::from(state.scrape_system_id.as_str()),
+        scrape_scraper_id: QString::from(state.scrape_scraper_id.as_str()),
+    }
+}
+
+impl Initialize for ffi::MediaStatus {
+    fn initialize(mut self: Pin<&mut Self>) {
+        let resource = crate::models::global_store().media_status();
+        let mut rx = resource.subscribe();
+        apply(self.as_mut(), project(&rx.borrow_and_update()));
+
+        let qt_thread = self.qt_thread();
+        crate::models::global_runtime().spawn(async move {
+            while rx.changed().await.is_ok() {
+                let snapshot = project(&rx.borrow_and_update());
+                let _ = qt_thread.queue(move |m| apply(m, snapshot));
+            }
+        });
+    }
+}
+
+impl ffi::MediaStatus {
+    fn start_index(self: Pin<&mut Self>) {
+        let resource = crate::models::global_store().media_status();
+        crate::models::global_runtime().spawn(async move {
+            if let Err(e) = resource.start_index(MediaIndexParams::default()).await {
+                warn!("media_status: start_index failed: {}", e.message);
+            }
+        });
+    }
+
+    fn cancel_index(self: Pin<&mut Self>) {
+        let resource = crate::models::global_store().media_status();
+        crate::models::global_runtime().spawn(async move {
+            if let Err(e) = resource.cancel_index().await {
+                warn!("media_status: cancel_index failed: {}", e.message);
+            }
+        });
+    }
+
+    fn start_scrape(self: Pin<&mut Self>) {
+        let resource = crate::models::global_store().media_status();
+        crate::models::global_runtime().spawn(async move {
+            // Default scraper, all indexed systems, no force. Resolving
+            // a specific `scraper_id` is the QML caller's job once a
+            // chooser exists; the first cut just kicks the configured
+            // default. Core's `media.scrape` validates `scraperId` as
+            // `min=1`, so we send the conventional sentinel that Core
+            // resolves to its configured default.
+            let params = MediaScrapeParams {
+                scraper_id: "default".into(),
+                systems: Vec::new(),
+                force: false,
+            };
+            if let Err(e) = resource.start_scrape(params).await {
+                warn!("media_status: start_scrape failed: {}", e.message);
+            }
+        });
+    }
+
+    fn cancel_scrape(self: Pin<&mut Self>) {
+        let resource = crate::models::global_store().media_status();
+        crate::models::global_runtime().spawn(async move {
+            if let Err(e) = resource.cancel_scrape().await {
+                warn!("media_status: cancel_scrape failed: {}", e.message);
+            }
+        });
+    }
+}
+
+#[allow(
+    clippy::cognitive_complexity,
+    reason = "21 fields × diff-and-set is mechanical; folding it loses the per-field NOTIFY suppression"
+)]
+fn apply(mut model: Pin<&mut ffi::MediaStatus>, s: Snapshot) {
+    if model.seeded != s.seeded {
+        model.as_mut().set_seeded(s.seeded);
+    }
+    if model.exists != s.exists {
+        model.as_mut().set_exists(s.exists);
+    }
+    if model.indexing != s.indexing {
+        model.as_mut().set_indexing(s.indexing);
+    }
+    if model.optimizing != s.optimizing {
+        model.as_mut().set_optimizing(s.optimizing);
+    }
+    if model.paused != s.paused {
+        model.as_mut().set_paused(s.paused);
+    }
+    if model.current_step != s.current_step {
+        model.as_mut().set_current_step(s.current_step);
+    }
+    if model.total_steps != s.total_steps {
+        model.as_mut().set_total_steps(s.total_steps);
+    }
+    if model.current_step_display != s.current_step_display {
+        model
+            .as_mut()
+            .set_current_step_display(s.current_step_display);
+    }
+    if model.total_files != s.total_files {
+        model.as_mut().set_total_files(s.total_files);
+    }
+    if model.total_media != s.total_media {
+        model.as_mut().set_total_media(s.total_media);
+    }
+    if model.scraping != s.scraping {
+        model.as_mut().set_scraping(s.scraping);
+    }
+    if model.scrape_done != s.scrape_done {
+        model.as_mut().set_scrape_done(s.scrape_done);
+    }
+    if model.scrape_paused != s.scrape_paused {
+        model.as_mut().set_scrape_paused(s.scrape_paused);
+    }
+    if model.scrape_processed != s.scrape_processed {
+        model.as_mut().set_scrape_processed(s.scrape_processed);
+    }
+    if model.scrape_total != s.scrape_total {
+        model.as_mut().set_scrape_total(s.scrape_total);
+    }
+    if model.scrape_matched != s.scrape_matched {
+        model.as_mut().set_scrape_matched(s.scrape_matched);
+    }
+    if model.scrape_skipped != s.scrape_skipped {
+        model.as_mut().set_scrape_skipped(s.scrape_skipped);
+    }
+    if model.scrape_total_scraped != s.scrape_total_scraped {
+        model
+            .as_mut()
+            .set_scrape_total_scraped(s.scrape_total_scraped);
+    }
+    if model.scrape_system_id != s.scrape_system_id {
+        model.as_mut().set_scrape_system_id(s.scrape_system_id);
+    }
+    if model.scrape_scraper_id != s.scrape_scraper_id {
+        model.as_mut().set_scrape_scraper_id(s.scrape_scraper_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::project;
+    use cxx_qt_lib::QString;
+    use zaparoo_core::store::MediaStatusState;
+
+    #[test]
+    fn project_copies_every_field() {
+        let state = MediaStatusState {
+            seeded: true,
+            exists: true,
+            indexing: true,
+            optimizing: false,
+            paused: false,
+            current_step: 3,
+            total_steps: 5,
+            current_step_display: "Indexing SNES".into(),
+            total_files: 1234,
+            total_media: 567,
+            scraping: false,
+            scrape_done: false,
+            scrape_paused: false,
+            scrape_processed: 0,
+            scrape_total: 0,
+            scrape_matched: 0,
+            scrape_skipped: 0,
+            scrape_total_scraped: 0,
+            scrape_system_id: String::new(),
+            scrape_scraper_id: String::new(),
+        };
+        let snapshot = project(&state);
+        assert!(snapshot.seeded);
+        assert!(snapshot.exists);
+        assert!(snapshot.indexing);
+        assert_eq!(snapshot.current_step, 3);
+        assert_eq!(snapshot.total_steps, 5);
+        assert_eq!(
+            snapshot.current_step_display,
+            QString::from("Indexing SNES"),
+        );
+        assert_eq!(snapshot.total_files, 1234);
+        assert_eq!(snapshot.total_media, 567);
+    }
+
+    #[test]
+    fn project_preserves_scraping_state() {
+        let state = MediaStatusState {
+            scraping: true,
+            scrape_processed: 12,
+            scrape_total: 200,
+            scrape_matched: 10,
+            scrape_skipped: 2,
+            scrape_total_scraped: 50,
+            scrape_system_id: "SNES".into(),
+            scrape_scraper_id: "screenscraper".into(),
+            ..MediaStatusState::default()
+        };
+        let snapshot = project(&state);
+        assert!(snapshot.scraping);
+        assert_eq!(snapshot.scrape_processed, 12);
+        assert_eq!(snapshot.scrape_total, 200);
+        assert_eq!(snapshot.scrape_matched, 10);
+        assert_eq!(snapshot.scrape_skipped, 2);
+        assert_eq!(snapshot.scrape_total_scraped, 50);
+        assert_eq!(snapshot.scrape_system_id, QString::from("SNES"));
+        assert_eq!(snapshot.scrape_scraper_id, QString::from("screenscraper"));
+    }
+
+    #[test]
+    fn project_default_state_is_quiet() {
+        let snapshot = project(&MediaStatusState::default());
+        assert!(!snapshot.seeded);
+        assert!(!snapshot.exists);
+        assert!(!snapshot.indexing);
+        assert!(!snapshot.scraping);
+        assert_eq!(snapshot.current_step, 0);
+        assert_eq!(snapshot.total_steps, 0);
+        assert_eq!(snapshot.current_step_display, QString::default());
+    }
+}

--- a/rust/launcher/src/models/mod.rs
+++ b/rust/launcher/src/models/mod.rs
@@ -31,6 +31,7 @@ pub mod games;
 pub mod games_state;
 pub mod hub_state;
 pub mod input;
+pub mod media_status;
 pub mod platform;
 pub mod qr_code;
 pub mod recents;

--- a/rust/zaparoo-core/src/client.rs
+++ b/rust/zaparoo-core/src/client.rs
@@ -16,9 +16,10 @@
 use crate::media_types::{
     MediaBrowseParams, MediaBrowseResult, MediaHistoryParams, MediaHistoryResult,
     MediaHistoryTopParams, MediaHistoryTopResult, MediaImageBulkParams, MediaImageBulkResult,
-    MediaImageParams, MediaImageResult, MediaLookupParams, MediaLookupResult, MediaMetaParams,
-    MediaMetaResult, MediaSearchParams, MediaSearchResult, MediaTagsParams, MediaTagsResult,
-    ReadersResult, ReadersWriteParams, RunParams, SystemsParams, SystemsResult, VersionResult,
+    MediaImageParams, MediaImageResult, MediaIndexParams, MediaLookupParams, MediaLookupResult,
+    MediaMetaParams, MediaMetaResult, MediaResult, MediaScrapeParams, MediaSearchParams,
+    MediaSearchResult, MediaTagsParams, MediaTagsResult, ReadersResult, ReadersWriteParams,
+    RunParams, ScrapersResult, SystemsParams, SystemsResult, VersionResult,
 };
 use futures_util::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
@@ -557,6 +558,65 @@ impl Client {
         params: MediaTagsParams,
     ) -> Result<MediaTagsResult, ClientError> {
         let val = self.call("media.tags", &params).await?;
+        serde_json::from_value(val).map_err(|e| ClientError {
+            message: e.to_string(),
+        })
+    }
+
+    /// Snapshot of Core's media state — database build status plus the
+    /// active-media list. The launcher uses the `database` block to seed
+    /// the status pill / first-run gate; later notifications
+    /// (`media.indexing`) supersede the seed.
+    pub async fn media(&self) -> Result<MediaResult, ClientError> {
+        #[derive(Serialize)]
+        struct P {}
+        let val = self.call("media", &P {}).await?;
+        serde_json::from_value(val).map_err(|e| ClientError {
+            message: e.to_string(),
+        })
+    }
+
+    /// Triggers a (re)build of Core's media database. With an empty
+    /// `params`, the build runs across every configured system. Core
+    /// emits `media.indexing` notifications during the run.
+    pub async fn media_generate(&self, params: MediaIndexParams) -> Result<(), ClientError> {
+        self.call("media.generate", &params).await?;
+        Ok(())
+    }
+
+    /// Cancels an in-flight `media.generate`. Core's response is null on
+    /// success and an error if no build is running, which surfaces
+    /// through `ClientError`.
+    pub async fn media_generate_cancel(&self) -> Result<(), ClientError> {
+        #[derive(Serialize)]
+        struct P {}
+        self.call("media.generate.cancel", &P {}).await?;
+        Ok(())
+    }
+
+    /// Runs a scraper across (a subset of) Core's media database.
+    /// `scraper_id` is required server-side — pick one from `scrapers()`.
+    /// Core emits `media.scraping` notifications during the run.
+    pub async fn media_scrape(&self, params: MediaScrapeParams) -> Result<(), ClientError> {
+        self.call("media.scrape", &params).await?;
+        Ok(())
+    }
+
+    /// Cancels an in-flight `media.scrape`. As with the indexer, Core
+    /// returns an error when no scraper is running.
+    pub async fn media_scrape_cancel(&self) -> Result<(), ClientError> {
+        #[derive(Serialize)]
+        struct P {}
+        self.call("media.scrape.cancel", &P {}).await?;
+        Ok(())
+    }
+
+    /// Lists the scrapers Core knows how to run. Used to resolve a
+    /// default `scraperId` for the "Run scraper" Settings action.
+    pub async fn scrapers(&self) -> Result<ScrapersResult, ClientError> {
+        #[derive(Serialize)]
+        struct P {}
+        let val = self.call("scrapers", &P {}).await?;
         serde_json::from_value(val).map_err(|e| ClientError {
             message: e.to_string(),
         })

--- a/rust/zaparoo-core/src/media_types.rs
+++ b/rust/zaparoo-core/src/media_types.rs
@@ -629,6 +629,162 @@ pub struct MediaTagsResult {
     pub tags: Vec<TagInfo>,
 }
 
+/// Parameters for `media.generate` — triggers a (re)build of Core's media
+/// database. `systems` optionally narrows the scope; `None` indexes every
+/// configured system. `fuzzySystem` is intentionally omitted: it exists
+/// in Core for LLM clients that may misspell ids, and the launcher
+/// composes ids from canonical Core data so a mismatch would be a bug
+/// to fix rather than paper over.
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MediaIndexParams {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub systems: Option<Vec<String>>,
+}
+
+/// Parameters for `media.scrape` — runs the named scraper across the
+/// indexed media database. `scraper_id` is required server-side
+/// (validated as `min=1`); the launcher resolves it from the `scrapers`
+/// RPC. `systems` optionally narrows the run; `force` re-scrapes media
+/// already attached to a title slug.
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MediaScrapeParams {
+    pub scraper_id: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub systems: Vec<String>,
+    #[serde(default)]
+    pub force: bool,
+}
+
+/// Snapshot of Core's media database build state. Mirrors the upstream
+/// `IndexingStatusResponse` shape verbatim — every numeric field is
+/// optional because Core only populates them while a build is actually
+/// in progress (or reports `total_media`/`total_files` after the build
+/// settles).
+///
+/// Used for both the `media.indexing` notification body and the
+/// `database` block of the `media` query response, so we keep it in
+/// one place.
+#[allow(
+    clippy::struct_excessive_bools,
+    reason = "wire-faithful mirror of Core's IndexingStatusResponse"
+)]
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IndexingStatusResponse {
+    #[serde(default)]
+    pub total_steps: Option<i32>,
+    #[serde(default)]
+    pub current_step: Option<i32>,
+    #[serde(default)]
+    pub current_step_display: Option<String>,
+    #[serde(default)]
+    pub total_files: Option<i32>,
+    #[serde(default)]
+    pub total_media: Option<i32>,
+    #[serde(default)]
+    pub exists: bool,
+    #[serde(default)]
+    pub indexing: bool,
+    #[serde(default)]
+    pub optimizing: bool,
+    #[serde(default)]
+    pub paused: bool,
+}
+
+/// Snapshot of Core's scraper progress. Mirrors `ScrapingStatusResponse`
+/// from upstream. `scraper_id` and `system_id` carry the in-flight job's
+/// identifiers; the counters are cumulative for the run.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScrapingStatusResponse {
+    #[serde(default)]
+    pub scraper_id: String,
+    #[serde(default)]
+    pub system_id: String,
+    #[serde(default)]
+    pub processed: i32,
+    #[serde(default)]
+    pub total: i32,
+    #[serde(default)]
+    pub matched: i32,
+    #[serde(default)]
+    pub skipped: i32,
+    #[serde(default)]
+    pub total_scraped: i32,
+    #[serde(default)]
+    pub scraping: bool,
+    #[serde(default)]
+    pub done: bool,
+    #[serde(default)]
+    pub paused: bool,
+}
+
+/// Currently-active media as reported by `media`. The launcher does not
+/// surface this surface yet, but the field is part of the documented
+/// `media` envelope so we deserialise it for forward-compatibility —
+/// trimming it would mean the next consumer has to re-extend the wire
+/// type before they can use it.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ActiveMediaInfo {
+    #[serde(default)]
+    pub started: String,
+    #[serde(default)]
+    pub launcher_id: String,
+    #[serde(default)]
+    pub system_id: String,
+    #[serde(default)]
+    pub system_name: String,
+    #[serde(default)]
+    pub media_path: String,
+    #[serde(default)]
+    pub media_name: String,
+    #[serde(default)]
+    pub launcher_controls: Vec<String>,
+    #[serde(default)]
+    pub media_id: Option<i64>,
+    #[serde(default)]
+    pub relative_path: Option<String>,
+    #[serde(default)]
+    pub zap_script: String,
+}
+
+/// Response envelope for the `media` query. Carries both the database
+/// build state (used for the first-run gate / status pill) and the
+/// active-media list (carried for completeness — see
+/// `ActiveMediaInfo`).
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MediaResult {
+    #[serde(default)]
+    pub database: IndexingStatusResponse,
+    #[serde(default)]
+    pub active: Vec<ActiveMediaInfo>,
+}
+
+/// One scraper Core knows how to run. `id` is the value to pass to
+/// `media.scrape.scraperId`; `name` is a human label; `supported_systems`
+/// is the system-id allow-list — empty means "supports every indexed
+/// system."
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScraperInfo {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub supported_systems: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct ScrapersResult {
+    #[serde(default)]
+    pub scrapers: Vec<ScraperInfo>,
+}
+
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct RunParams {
     pub text: String,
@@ -709,11 +865,13 @@ mod tests {
     )]
 
     use super::{
-        BrowseEntry, MediaBrowseParams, MediaBrowseResult, MediaHistoryParams, MediaHistoryResult,
-        MediaHistoryTopParams, MediaHistoryTopResult, MediaImageBulkResult, MediaImageParams,
-        MediaImageResult, MediaLookupParams, MediaLookupResult, MediaMetaParams, MediaMetaResult,
-        MediaSearchParams, MediaSearchResult, MediaTagsParams, MediaTagsResult, ReaderInfo,
-        ReadersResult, SystemsResult, VersionResult,
+        BrowseEntry, IndexingStatusResponse, MediaBrowseParams, MediaBrowseResult,
+        MediaHistoryParams, MediaHistoryResult, MediaHistoryTopParams, MediaHistoryTopResult,
+        MediaImageBulkResult, MediaImageParams, MediaImageResult, MediaIndexParams,
+        MediaLookupParams, MediaLookupResult, MediaMetaParams, MediaMetaResult, MediaResult,
+        MediaScrapeParams, MediaSearchParams, MediaSearchResult, MediaTagsParams, MediaTagsResult,
+        ReaderInfo, ReadersResult, ScrapersResult, ScrapingStatusResponse, SystemsResult,
+        VersionResult,
     };
 
     #[test]
@@ -1451,5 +1609,181 @@ mod tests {
     fn media_image_bulk_result_defaults_to_empty_items() {
         let result: MediaImageBulkResult = serde_json::from_str("{}").expect("parse");
         assert!(result.items.is_empty());
+    }
+
+    #[test]
+    fn media_index_params_defaults_to_empty_object() {
+        let params = MediaIndexParams::default();
+        let json = serde_json::to_value(&params).expect("serialise");
+        let object = json.as_object().expect("object");
+        assert!(object.is_empty());
+        assert!(!object.contains_key("fuzzySystem"));
+    }
+
+    #[test]
+    fn media_index_params_serialises_systems_when_set() {
+        let params = MediaIndexParams {
+            systems: Some(vec!["SNES".into(), "NES".into()]),
+        };
+        let json = serde_json::to_value(&params).expect("serialise");
+        let object = json.as_object().expect("object");
+        assert_eq!(
+            object
+                .get("systems")
+                .and_then(|v| v.as_array())
+                .map(Vec::len),
+            Some(2)
+        );
+        assert!(!object.contains_key("fuzzySystem"));
+    }
+
+    #[test]
+    fn media_scrape_params_serialises_required_scraper_id() {
+        let params = MediaScrapeParams {
+            scraper_id: "screenscraper".into(),
+            ..MediaScrapeParams::default()
+        };
+        let json = serde_json::to_value(&params).expect("serialise");
+        let object = json.as_object().expect("object");
+        assert_eq!(
+            object.get("scraperId").and_then(|v| v.as_str()),
+            Some("screenscraper")
+        );
+        // `force` is not skipped; default is `false`.
+        assert_eq!(
+            object.get("force").and_then(serde_json::Value::as_bool),
+            Some(false)
+        );
+        // `systems` is skipped when empty.
+        assert!(!object.contains_key("systems"));
+    }
+
+    #[test]
+    fn media_scrape_params_serialises_systems_and_force() {
+        let params = MediaScrapeParams {
+            scraper_id: "screenscraper".into(),
+            systems: vec!["SNES".into()],
+            force: true,
+        };
+        let json = serde_json::to_value(&params).expect("serialise");
+        let object = json.as_object().expect("object");
+        assert_eq!(
+            object.get("force").and_then(serde_json::Value::as_bool),
+            Some(true)
+        );
+        assert_eq!(
+            object
+                .get("systems")
+                .and_then(|v| v.as_array())
+                .map(Vec::len),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn indexing_status_response_parses_running_payload() {
+        let json = r#"{
+            "totalSteps": 4,
+            "currentStep": 2,
+            "currentStepDisplay": "Indexing SNES",
+            "totalFiles": 1234,
+            "totalMedia": 567,
+            "exists": true,
+            "indexing": true,
+            "optimizing": false,
+            "paused": false
+        }"#;
+        let result: IndexingStatusResponse = serde_json::from_str(json).expect("parse");
+        assert_eq!(result.total_steps, Some(4));
+        assert_eq!(result.current_step, Some(2));
+        assert_eq!(
+            result.current_step_display.as_deref(),
+            Some("Indexing SNES")
+        );
+        assert_eq!(result.total_files, Some(1234));
+        assert_eq!(result.total_media, Some(567));
+        assert!(result.exists);
+        assert!(result.indexing);
+        assert!(!result.optimizing);
+        assert!(!result.paused);
+    }
+
+    #[test]
+    fn indexing_status_response_handles_idle_payload() {
+        // Core sends `*int omitempty` for the counters; an idle Core
+        // (no build in flight) reports only the booleans.
+        let json = r#"{"exists": true, "indexing": false, "optimizing": false, "paused": false}"#;
+        let result: IndexingStatusResponse = serde_json::from_str(json).expect("parse");
+        assert!(result.total_steps.is_none());
+        assert!(result.current_step.is_none());
+        assert!(result.current_step_display.is_none());
+        assert!(result.total_files.is_none());
+        assert!(result.total_media.is_none());
+        assert!(result.exists);
+    }
+
+    #[test]
+    fn scraping_status_response_parses_running_payload() {
+        let json = r#"{
+            "scraperId": "screenscraper",
+            "systemId": "SNES",
+            "processed": 12,
+            "total": 200,
+            "matched": 10,
+            "skipped": 2,
+            "totalScraped": 50,
+            "scraping": true,
+            "done": false,
+            "paused": false
+        }"#;
+        let result: ScrapingStatusResponse = serde_json::from_str(json).expect("parse");
+        assert_eq!(result.scraper_id, "screenscraper");
+        assert_eq!(result.system_id, "SNES");
+        assert_eq!(result.processed, 12);
+        assert_eq!(result.total, 200);
+        assert_eq!(result.matched, 10);
+        assert_eq!(result.skipped, 2);
+        assert_eq!(result.total_scraped, 50);
+        assert!(result.scraping);
+        assert!(!result.done);
+    }
+
+    #[test]
+    fn media_result_parses_envelope_with_database_and_active() {
+        let json = r#"{
+            "database": {"exists": true, "indexing": false, "optimizing": false, "paused": false, "totalMedia": 42},
+            "active": [
+                {
+                    "started": "2026-05-03T12:00:00Z",
+                    "launcherId": "SNES",
+                    "systemId": "SNES",
+                    "systemName": "Super Nintendo",
+                    "mediaPath": "/p",
+                    "mediaName": "X",
+                    "zapScript": "@SNES/X"
+                }
+            ]
+        }"#;
+        let result: MediaResult = serde_json::from_str(json).expect("parse");
+        assert!(result.database.exists);
+        assert_eq!(result.database.total_media, Some(42));
+        assert_eq!(result.active.len(), 1);
+        assert_eq!(result.active[0].system_id, "SNES");
+        assert_eq!(result.active[0].zap_script, "@SNES/X");
+    }
+
+    #[test]
+    fn scrapers_result_parses_payload() {
+        let json = r#"{
+            "scrapers": [
+                {"id":"screenscraper","name":"ScreenScraper","supportedSystems":["SNES","NES"]},
+                {"id":"local","name":"Local"}
+            ]
+        }"#;
+        let result: ScrapersResult = serde_json::from_str(json).expect("parse");
+        assert_eq!(result.scrapers.len(), 2);
+        assert_eq!(result.scrapers[0].id, "screenscraper");
+        assert_eq!(result.scrapers[0].supported_systems, vec!["SNES", "NES"]);
+        assert!(result.scrapers[1].supported_systems.is_empty());
     }
 }

--- a/rust/zaparoo-core/src/store/media_status.rs
+++ b/rust/zaparoo-core/src/store/media_status.rs
@@ -1,0 +1,407 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+//
+// `MediaStatusResource` — the live snapshot of Core's media-database
+// build state and scraper state, surfaced as a single
+// `tokio::sync::watch` channel.
+//
+// Why this isn't an `Endpoint`: endpoints are pull-only — Core decides
+// the value, the resource fetches and caches it. Media status is
+// half-pull/half-push: the initial value comes from a `media` query, but
+// every subsequent change is pushed through the
+// `media.indexing`/`media.scraping` notification streams. Folding those
+// notifications into the same shape and republishing keeps the QML
+// singleton's binding cost flat — one `watch::Receiver` and a single
+// projection function.
+//
+// `watch` (not `broadcast`) so a freshly-mounted modal sees the current
+// state, not just the next edge — see `feedback_broadcast_vs_watch` in
+// the project memory.
+
+use crate::client::{Client, ClientError, ConnectionState, Notification};
+use crate::media_types::{
+    IndexingStatusResponse, MediaIndexParams, MediaScrapeParams, ScrapingStatusResponse,
+};
+use std::sync::Arc;
+use tokio::runtime::Runtime;
+use tokio::sync::{broadcast, watch};
+use tokio::time::{sleep, Duration};
+use tracing::{debug, warn};
+
+/// Snapshot of every field the launcher renders from `media`,
+/// `media.indexing`, and `media.scraping`. Cloned out of the watch
+/// channel by the QML projection function — keep field counts modest
+/// and types cheap to clone (no nested `Vec`s of large payloads).
+///
+/// `seeded` flips true after the first successful `media` query so the
+/// UI can distinguish "we don't know yet" from "we know there's no
+/// database." Without it, the empty-DB first-run gate would trip on the
+/// initial `Default::default()` value before the seed lands.
+#[allow(
+    clippy::struct_excessive_bools,
+    reason = "wire-faithful flags; one bool per Core status field"
+)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct MediaStatusState {
+    pub seeded: bool,
+
+    // From `media.database` and `media.indexing`.
+    pub exists: bool,
+    pub indexing: bool,
+    pub optimizing: bool,
+    pub paused: bool,
+    pub current_step: i32,
+    pub total_steps: i32,
+    pub current_step_display: String,
+    pub total_files: i32,
+    pub total_media: i32,
+
+    // From `media.scraping`.
+    pub scraping: bool,
+    pub scrape_done: bool,
+    pub scrape_paused: bool,
+    pub scrape_processed: i32,
+    pub scrape_total: i32,
+    pub scrape_matched: i32,
+    pub scrape_skipped: i32,
+    pub scrape_total_scraped: i32,
+    pub scrape_system_id: String,
+    pub scrape_scraper_id: String,
+}
+
+impl MediaStatusState {
+    fn apply_indexing(&mut self, status: &IndexingStatusResponse) {
+        self.exists = status.exists;
+        self.indexing = status.indexing;
+        self.optimizing = status.optimizing;
+        self.paused = status.paused;
+        self.current_step = status.current_step.unwrap_or(0);
+        self.total_steps = status.total_steps.unwrap_or(0);
+        status
+            .current_step_display
+            .as_deref()
+            .unwrap_or_default()
+            .clone_into(&mut self.current_step_display);
+        self.total_files = status.total_files.unwrap_or(0);
+        self.total_media = status.total_media.unwrap_or(0);
+    }
+
+    fn apply_scraping(&mut self, status: &ScrapingStatusResponse) {
+        self.scraping = status.scraping;
+        self.scrape_done = status.done;
+        self.scrape_paused = status.paused;
+        self.scrape_processed = status.processed;
+        self.scrape_total = status.total;
+        self.scrape_matched = status.matched;
+        self.scrape_skipped = status.skipped;
+        self.scrape_total_scraped = status.total_scraped;
+        self.scrape_system_id.clone_from(&status.system_id);
+        self.scrape_scraper_id.clone_from(&status.scraper_id);
+    }
+}
+
+/// Live media-status publisher. One per `Store`; subscribers go through
+/// `subscribe()` to receive a `watch::Receiver` whose initial value is
+/// whatever the publisher last set (always either the `Default` sentinel
+/// or a real seeded value).
+pub struct MediaStatusResource {
+    state: Arc<watch::Sender<MediaStatusState>>,
+    client: Arc<Client>,
+}
+
+impl std::fmt::Debug for MediaStatusResource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MediaStatusResource")
+            .finish_non_exhaustive()
+    }
+}
+
+impl MediaStatusResource {
+    pub fn new(client: &Arc<Client>, runtime: &Arc<Runtime>) -> Arc<Self> {
+        let (state_tx, _) = watch::channel(MediaStatusState::default());
+        let state_arc = Arc::new(state_tx);
+
+        let resource = Arc::new(Self {
+            state: state_arc.clone(),
+            client: client.clone(),
+        });
+
+        // Drive the seed on connect and fold notifications into the
+        // shared state. The task lives for the lifetime of the runtime;
+        // it exits when the connection watch is closed (i.e. the
+        // `Client` is dropped).
+        let connection_rx = client.connection.subscribe();
+        let notifications_rx = client.subscribe_notifications();
+        let client_for_task = client.clone();
+        let state_for_task = state_arc;
+        runtime.spawn(async move {
+            run_task(
+                client_for_task,
+                connection_rx,
+                notifications_rx,
+                state_for_task,
+            )
+            .await;
+        });
+
+        resource
+    }
+
+    pub fn subscribe(&self) -> watch::Receiver<MediaStatusState> {
+        self.state.subscribe()
+    }
+
+    /// Trigger `media.generate`. The Core notification stream — not
+    /// this call's return value — drives the resulting state changes;
+    /// the caller only sees whether the request reached Core.
+    pub async fn start_index(&self, params: MediaIndexParams) -> Result<(), ClientError> {
+        self.client.media_generate(params).await
+    }
+
+    pub async fn cancel_index(&self) -> Result<(), ClientError> {
+        self.client.media_generate_cancel().await
+    }
+
+    pub async fn start_scrape(&self, params: MediaScrapeParams) -> Result<(), ClientError> {
+        self.client.media_scrape(params).await
+    }
+
+    pub async fn cancel_scrape(&self) -> Result<(), ClientError> {
+        self.client.media_scrape_cancel().await
+    }
+}
+
+/// Re-seed delay after a failed `media` query while the connection is
+/// still up. Keeps a flapping Core from hammering the RPC layer; long
+/// enough that a real recovery (Core finishing its own startup) fits
+/// inside one cycle.
+const SEED_RETRY_DELAY: Duration = Duration::from_secs(2);
+
+async fn run_task(
+    client: Arc<Client>,
+    mut connection_rx: watch::Receiver<ConnectionState>,
+    mut notifications_rx: broadcast::Receiver<Notification>,
+    state: Arc<watch::Sender<MediaStatusState>>,
+) {
+    // Connection-driven outer loop. On every `Connected` transition,
+    // re-seed via `media`; while connected, fold notifications into
+    // the watch state. A drop / reconnect cycle exits the inner loop
+    // and re-seeds — Core's view of the DB may have changed during the
+    // outage.
+    loop {
+        let current = connection_rx.borrow_and_update().clone();
+        if matches!(current, ConnectionState::Connected) {
+            seed_now(&client, &state).await;
+
+            // Inner notification-fold loop. Exits on connection-state
+            // change (caught by the outer `changed().await` below).
+            loop {
+                tokio::select! {
+                    notification = notifications_rx.recv() => {
+                        match notification {
+                            Ok(n) => fold_notification(&n, &state),
+                            Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                                // Lossy broadcast caught up — re-seed
+                                // so we don't drift from Core.
+                                warn!(skipped, "media_status: notifications lagged; re-seeding");
+                                seed_now(&client, &state).await;
+                            }
+                            Err(broadcast::error::RecvError::Closed) => return,
+                        }
+                    }
+                    changed = connection_rx.changed() => {
+                        if changed.is_err() {
+                            return;
+                        }
+                        // Re-evaluate outer loop on every connection
+                        // transition, including spurious reconnects.
+                        break;
+                    }
+                }
+            }
+        } else if connection_rx.changed().await.is_err() {
+            return;
+        }
+    }
+}
+
+async fn seed_now(client: &Arc<Client>, state: &Arc<watch::Sender<MediaStatusState>>) {
+    match client.media().await {
+        Ok(media) => {
+            state.send_modify(|s| {
+                s.apply_indexing(&media.database);
+                s.seeded = true;
+            });
+            debug!("media_status: seeded from media query");
+        }
+        Err(e) => {
+            // Don't hammer the RPC layer — wait a beat and let the
+            // outer connection loop re-trigger the seed on the next
+            // change. If the link is still up after the delay, the
+            // notification stream will drive any state change; if it
+            // dropped, the outer loop catches the disconnect.
+            warn!("media_status: media seed failed: {e}");
+            sleep(SEED_RETRY_DELAY).await;
+        }
+    }
+}
+
+fn fold_notification(notification: &Notification, state: &Arc<watch::Sender<MediaStatusState>>) {
+    match notification.method.as_str() {
+        "media.indexing" => {
+            match serde_json::from_value::<IndexingStatusResponse>(notification.params.clone()) {
+                Ok(status) => state.send_modify(|s| {
+                    s.apply_indexing(&status);
+                    s.seeded = true;
+                }),
+                Err(e) => warn!("media_status: media.indexing decode failed: {e}"),
+            }
+        }
+        "media.scraping" => {
+            match serde_json::from_value::<ScrapingStatusResponse>(notification.params.clone()) {
+                Ok(status) => state.send_modify(|s| s.apply_scraping(&status)),
+                Err(e) => warn!("media_status: media.scraping decode failed: {e}"),
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    reason = "tests should fail-fast on unexpected errors"
+)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn apply_indexing_unwraps_optional_counters() {
+        let mut state = MediaStatusState::default();
+        let status = IndexingStatusResponse {
+            total_steps: Some(4),
+            current_step: Some(2),
+            current_step_display: Some("Indexing SNES".into()),
+            total_files: Some(1234),
+            total_media: Some(567),
+            exists: true,
+            indexing: true,
+            optimizing: false,
+            paused: false,
+        };
+        state.apply_indexing(&status);
+        assert!(state.exists);
+        assert!(state.indexing);
+        assert_eq!(state.current_step, 2);
+        assert_eq!(state.total_steps, 4);
+        assert_eq!(state.current_step_display, "Indexing SNES");
+        assert_eq!(state.total_files, 1234);
+        assert_eq!(state.total_media, 567);
+    }
+
+    #[test]
+    fn apply_indexing_treats_missing_counters_as_zero() {
+        // Idle Core sends `*int omitempty` with the counters absent —
+        // the wire-level `None` lands as a numeric zero, not as a
+        // sentinel that breaks the QML bindings.
+        let mut state = MediaStatusState::default();
+        state.apply_indexing(&IndexingStatusResponse {
+            exists: true,
+            ..IndexingStatusResponse::default()
+        });
+        assert!(state.exists);
+        assert_eq!(state.current_step, 0);
+        assert_eq!(state.total_steps, 0);
+        assert_eq!(state.current_step_display, "");
+    }
+
+    #[test]
+    fn fold_notification_routes_indexing_into_state() {
+        let (tx, rx) = watch::channel(MediaStatusState::default());
+        let tx = Arc::new(tx);
+        let payload = json!({
+            "totalSteps": 3, "currentStep": 1, "currentStepDisplay": "Discovering files",
+            "totalFiles": 100, "totalMedia": 50,
+            "exists": true, "indexing": true, "optimizing": false, "paused": false
+        });
+        fold_notification(
+            &Notification {
+                method: "media.indexing".into(),
+                params: payload,
+            },
+            &tx,
+        );
+        let snapshot = rx.borrow().clone();
+        assert!(snapshot.indexing);
+        assert!(snapshot.seeded);
+        assert_eq!(snapshot.current_step, 1);
+        assert_eq!(snapshot.current_step_display, "Discovering files");
+    }
+
+    #[test]
+    fn fold_notification_routes_scraping_into_state() {
+        let (tx, rx) = watch::channel(MediaStatusState::default());
+        let tx = Arc::new(tx);
+        let payload = json!({
+            "scraperId": "screenscraper", "systemId": "SNES",
+            "processed": 12, "total": 200, "matched": 10, "skipped": 2,
+            "totalScraped": 50, "scraping": true, "done": false, "paused": false
+        });
+        fold_notification(
+            &Notification {
+                method: "media.scraping".into(),
+                params: payload,
+            },
+            &tx,
+        );
+        let snapshot = rx.borrow().clone();
+        assert!(snapshot.scraping);
+        assert_eq!(snapshot.scrape_processed, 12);
+        assert_eq!(snapshot.scrape_total, 200);
+        assert_eq!(snapshot.scrape_system_id, "SNES");
+        // `scraped`-side notifications must not flip the indexing
+        // `seeded` flag — that's the `media` query's job.
+        assert!(!snapshot.seeded);
+    }
+
+    #[test]
+    fn fold_notification_ignores_unrelated_methods() {
+        let (tx, rx) = watch::channel(MediaStatusState::default());
+        let tx = Arc::new(tx);
+        let before = rx.borrow().clone();
+        fold_notification(
+            &Notification {
+                method: "tokens.added".into(),
+                params: json!({}),
+            },
+            &tx,
+        );
+        let after = rx.borrow().clone();
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn fold_notification_swallows_decode_errors() {
+        // A malformed `media.indexing` payload must not panic; the
+        // existing state stays put and a warning is logged.
+        let (tx, rx) = watch::channel(MediaStatusState {
+            exists: true,
+            indexing: false,
+            ..MediaStatusState::default()
+        });
+        let tx = Arc::new(tx);
+        let before = rx.borrow().clone();
+        fold_notification(
+            &Notification {
+                method: "media.indexing".into(),
+                params: json!("not an object"),
+            },
+            &tx,
+        );
+        let after = rx.borrow().clone();
+        assert_eq!(before, after);
+    }
+}

--- a/rust/zaparoo-core/src/store/mod.rs
+++ b/rust/zaparoo-core/src/store/mod.rs
@@ -14,10 +14,12 @@
 // intersects a successful mutation's `invalidates` list.
 
 mod endpoint;
+mod media_status;
 mod mutation;
 mod tag;
 
 pub use endpoint::Endpoint;
+pub use media_status::{MediaStatusResource, MediaStatusState};
 pub use mutation::Mutation;
 pub use tag::Tag;
 
@@ -76,6 +78,10 @@ pub struct Store {
     client: Arc<Client>,
     runtime: Arc<Runtime>,
     inner: Arc<Mutex<Inner>>,
+    /// Singleton media-status publisher. Eagerly constructed on
+    /// `Store::new` so the seeding task starts as soon as the launcher
+    /// has a `Client`, even if no QML side has subscribed yet.
+    media_status: Arc<MediaStatusResource>,
 }
 
 impl std::fmt::Debug for Store {
@@ -86,15 +92,24 @@ impl std::fmt::Debug for Store {
 
 impl Store {
     pub fn new(client: Arc<Client>, runtime: Arc<Runtime>) -> Arc<Self> {
+        let media_status = MediaStatusResource::new(&client, &runtime);
         Arc::new(Self {
             client,
             runtime,
             inner: Arc::new(Mutex::new(Inner::default())),
+            media_status,
         })
     }
 
     pub fn subscribe_notifications(&self) -> broadcast::Receiver<Notification> {
         self.client.subscribe_notifications()
+    }
+
+    /// Shared `MediaStatusResource`. Singleton — every QML caller uses
+    /// the same publisher, so subscribing late still observes the
+    /// current state through the underlying watch channel.
+    pub fn media_status(&self) -> Arc<MediaStatusResource> {
+        self.media_status.clone()
     }
 
     /// Direct access to the underlying `Client` for callers that need

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -31,6 +31,11 @@ MainLayout {
     readonly property string modalCardWrite: "card_write"
     readonly property string modalContextMenu: "context_menu"
     readonly property string modalQrCode: "qr_code"
+    readonly property string modalFirstRunIndex: "first_run_index"
+    // One-shot session flag: the first-run modal is shown at most
+    // once per launcher process, even if the WS link drops and the
+    // mediadb-empty condition would otherwise be satisfied again.
+    property bool _firstRunIndexShown: false
     property string cardWriteOwner: ""
     property string contextMenuOwner: ""
     property int contextMenuIndex: -1
@@ -100,6 +105,11 @@ MainLayout {
                 root.recentsScreen.restoreSelection()
             }
         }
+        // Kick the first-run check in case both READY and a seeded
+        // empty-mediadb snapshot landed before our Connections wired up
+        // (e.g. an unusually fast warm-cache reconnect).
+        root._maybeCompleteBoot()
+        root._maybeOpenFirstRunIndex()
     }
 
     // Seed row/grid indices from persisted state when models deliver new
@@ -564,6 +574,65 @@ MainLayout {
             ScreenManager.popModal()
     }
 
+    // First-run modal lifecycle. Push exactly once per session, the
+    // moment we see an authoritative MediaStatus snapshot (`seeded ===
+    // true`) reporting an empty mediadb (`exists === false`) on a
+    // ready Core link. The `seeded` gate is critical: the singleton's
+    // initial Default state has `exists: false`, so without it we'd
+    // fire the modal on cold launch before the watch channel has
+    // received a single notification.
+    function _maybeOpenFirstRunIndex(): void {
+        if (root._firstRunIndexShown)
+            return
+        if (Browse.AppStatus.connection_state !== 2 /* READY */)
+            return
+        if (!Browse.MediaStatus.seeded)
+            return
+        if (Browse.MediaStatus.exists)
+            return
+        root._firstRunIndexShown = true
+        root.firstRunIndexModalVisible = true
+        if (ScreenManager.topModal !== root.modalFirstRunIndex)
+            ScreenManager.pushModal(root.modalFirstRunIndex)
+    }
+
+    function closeFirstRunIndexModal(): void {
+        root.firstRunIndexModalVisible = false
+        if (ScreenManager.topModal === root.modalFirstRunIndex)
+            ScreenManager.popModal()
+    }
+
+    Connections {
+        target: Browse.AppStatus
+        function onConnection_stateChanged(): void {
+            root._maybeOpenFirstRunIndex()
+            root._maybeCompleteBoot()
+        }
+    }
+
+    // One-shot dismiss for the cold-launch curtain. The first time the
+    // catalog reports READY we flip `bootComplete` and never reset it
+    // — a later disconnect surfaces only via the status pill so the
+    // user keeps their cached catalog.
+    function _maybeCompleteBoot(): void {
+        if (root.bootComplete)
+            return
+        if (Browse.AppStatus.connection_state === 2 /* READY */)
+            root.bootComplete = true
+    }
+
+    Connections {
+        target: Browse.MediaStatus
+        function onSeededChanged(): void {
+            root._maybeOpenFirstRunIndex()
+        }
+        function onExistsChanged(): void {
+            root._maybeOpenFirstRunIndex()
+        }
+    }
+
+    onCloseFirstRunIndexRequested: root.closeFirstRunIndexModal()
+
     function beginCardWrite(owner: string): void {
         if (owner === "systems")
             Browse.SystemsModel.cancel_card_write()
@@ -639,6 +708,8 @@ MainLayout {
                 root.closeQrCodeModal()
             } else if (ScreenManager.topModal === root.modalContextMenu) {
                 root.contextMenu.handleAction(action)
+            } else if (ScreenManager.topModal === root.modalFirstRunIndex) {
+                root.firstRunIndexModal.handleAction(action)
             }
             // While a modal owns input, swallow everything not handled
             // above rather than leak it to the root screen.

--- a/src/ui/app/MainLayout.qml
+++ b/src/ui/app/MainLayout.qml
@@ -64,10 +64,12 @@ ApplicationWindow {
     property alias recentsScreen: recentsScreen
     property alias settingsScreen: settingsScreen
     property alias contextMenu: contextMenu
+    property alias firstRunIndexModal: firstRunIndexModal
 
     property bool cardWriteModalVisible: false
     property bool cardWriteFailed: false
     property bool qrCodeModalVisible: false
+    property bool firstRunIndexModalVisible: false
     property bool contextMenuVisible: false
     property rect contextMenuAnchor: Qt.rect(0, 0, 0, 0)
     readonly property var contextMenuEntries: [
@@ -86,6 +88,16 @@ ApplicationWindow {
     // content-hiding bindings (row/grid `visible`) resolve statically
     // in qmllint.
     property string pendingTransition: ""
+
+    // Cold-launch curtain. False until the catalog has loaded for the
+    // first time this session; while false the host screens are
+    // hidden and `BootOverlay` paints alone over the global
+    // background. Flipped exactly once by Main.qml's connection-state
+    // watcher when `connection_state` first reaches READY. After that,
+    // the Loader unmounts the overlay and a subsequent disconnect
+    // surfaces only via the top-right status pill — the user keeps
+    // their cached catalog and just sees the link state change.
+    property bool bootComplete: false
 
     // Per-screen state derivation. Shape mirrors ScreenStateOverlay's
     // `state` ternary so the help bar and the in-screen overlay agree
@@ -114,6 +126,7 @@ ApplicationWindow {
 
     signal cancelCardWriteRequested()
     signal closeQrCodeRequested()
+    signal closeFirstRunIndexRequested()
 
     // Two-way sync between root.activeScreen and ScreenManager.activeScreen.
     // Binding-breaking assignments (tests setting root.activeScreen = "games")
@@ -207,6 +220,10 @@ ApplicationWindow {
         id: stackedScreens
 
         anchors.fill: parent
+        // Screens stay hidden until the catalog has loaded for the
+        // first time. BootOverlay holds the window in the meantime;
+        // see the `bootComplete` property declaration above.
+        visible: root.bootComplete
 
         HubScreen {
             id: hubScreen
@@ -244,6 +261,21 @@ ApplicationWindow {
         }
     }
 
+    // ── Boot overlay ─────────────────────────────────────────────────────────
+    //
+    // Painted between the screens and the modal layer; unmounts itself
+    // the first time `bootComplete` flips true. Loader (rather than
+    // `visible: false`) so the overlay leaves the scene graph after
+    // dismissal — a subsequent disconnect must not bring it back over
+    // the user's cached catalog.
+
+    Loader {
+        anchors.fill: parent
+        active: !root.bootComplete
+        z: 50
+        sourceComponent: BootOverlay { }
+    }
+
     // ── Card writer modal ────────────────────────────────────────────────────
 
     Modal {
@@ -273,6 +305,18 @@ ApplicationWindow {
 
         anchors.fill: parent
         open: root.qrCodeModalVisible
+    }
+
+    // First-run mediadb index modal. Pushed by Main.qml the first time
+    // we connect to a Core whose mediadb is empty. Blocks the screens
+    // beneath until the initial scan completes (or the user cancels and
+    // tries again).
+    FirstRunIndexModal {
+        id: firstRunIndexModal
+
+        anchors.fill: parent
+        open: root.firstRunIndexModalVisible
+        onCloseRequested: root.closeFirstRunIndexRequested()
     }
 
     // ── Top-right HUD ─────────────────────────────────────────────────────────
@@ -362,51 +406,16 @@ ApplicationWindow {
         }
     }
 
-    // ── Connection status strip ───────────────────────────────────────────────
-    //
-    // Shown only when Core is unreachable or the catalog failed to load;
-    // otherwise the strip is hidden and takes no space. Connection state
-    // constants mirror rust/launcher/src/models/app_status.rs:
-    //   0 DISCONNECTED · 1 CONNECTING · 2 READY · 3 ERROR.
-
-    Rectangle {
-        id: statusStrip
-
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.bottom: instructionsBar.top
-        height: visible ? Sizing.pctH(4) : 0
-        visible: Browse.AppStatus.connection_state !== 2
-        color: Theme.bgBar
-        border.width: 1
-        // White border on ERROR draws the eye to the strip; the muted
-        // border on CONNECTING/DISCONNECTED keeps it informational.
-        border.color: Browse.AppStatus.connection_state === 3
-                      ? Theme.textPrimary
-                      : Theme.borderSubtle
-        z: 150
-
-        Text {
-            anchors.centerIn: parent
-            // `%1` placeholder keeps translators in charge of word order —
-            // some languages won't lead with "Core error". `last_error`
-            // is untranslated (it's the Rust-side error string) on purpose.
-            text: {
-                const state = Browse.AppStatus.connection_state;
-                if (state === 3) {
-                    const msg = Browse.AppStatus.last_error ?? "";
-                    return msg !== ""
-                        ? qsTr("Core error: %1").arg(msg)
-                        : qsTr("Core error");
-                }
-                if (state === 1) return qsTr("Connecting to Zaparoo Core…");
-                return qsTr("Disconnected from Zaparoo Core");
-            }
-            font.family: Theme.fontUi
-            font.pixelSize: Sizing.fontSize(2.5)
-            color: Theme.textPrimary
-            renderType: Text.NativeRendering
-        }
+    // Mutually-exclusive Core/indexing/scraper status surface. Sits on
+    // its own line directly under `topHud`, right-aligned to the same
+    // edge as the clock. When the pill is idle (no connection issue,
+    // no indexing, no scraping) it collapses to zero size and the
+    // second line takes no visual space.
+    CoreStatusPill {
+        anchors.top: topHud.bottom
+        anchors.right: topHud.right
+        anchors.topMargin: Sizing.pctH(0.8)
+        z: 200
     }
 
     // ── Instructions bar ──────────────────────────────────────────────────────
@@ -458,6 +467,16 @@ ApplicationWindow {
                 return [{ button: "ButtonB", label: qsTr("Cancel") }];
             if (root.qrCodeModalVisible)
                 return [{ button: "ButtonB", label: qsTr("Close") }];
+            if (!root.bootComplete)
+                return [];
+            if (root.firstRunIndexModalVisible) {
+                const phase = root.firstRunIndexModal.phase;
+                if (phase === "running")
+                    return [{ button: "ButtonB", label: qsTr("Cancel") }];
+                if (phase === "completed")
+                    return [];
+                return [{ button: "ButtonA", label: qsTr("Start") }];
+            }
             if (root.pendingTransition !== "")
                 return [];
             if (root.activeScreen === root.screenHub) {
@@ -525,8 +544,10 @@ ApplicationWindow {
                     });
                 }
                 // Left/Right cycles the focused field's value. Skip
-                // the cue when there are no fields.
-                if (root.settingsScreen.fieldCount > 0) {
+                // the cue when the focused field is an action row
+                // (no left/right binding) or there are no fields.
+                if (root.settingsScreen.fieldCount > 0
+                    && !root.settingsScreen.focusedFieldIsAction) {
                     row.push({
                         buttons: ["DpadLeft", "DpadRight"],
                         label: qsTr("Change")
@@ -534,6 +555,12 @@ ApplicationWindow {
                 }
                 if (root.settingsScreen.focusedFieldIsMouse)
                     row.push({ button: "ButtonA", label: qsTr("Toggle") });
+                else if (root.settingsScreen.focusedFieldIsAction)
+                    row.push({
+                        button: "ButtonA",
+                        label: root.settingsScreen.focusedActionBusy
+                               ? qsTr("Cancel") : qsTr("Start")
+                    });
                 row.push({ button: "ButtonB", label: qsTr("Back") });
                 return row;
             }

--- a/src/ui/app/MainLayout.qml
+++ b/src/ui/app/MainLayout.qml
@@ -555,7 +555,8 @@ ApplicationWindow {
                 }
                 if (root.settingsScreen.focusedFieldIsMouse)
                     row.push({ button: "ButtonA", label: qsTr("Toggle") });
-                else if (root.settingsScreen.focusedFieldIsAction)
+                else if (root.settingsScreen.focusedFieldIsAction
+                         && !root.settingsScreen.focusedActionDisabled)
                     row.push({
                         button: "ButtonA",
                         label: root.settingsScreen.focusedActionBusy

--- a/src/ui/components/BootOverlay.qml
+++ b/src/ui/components/BootOverlay.qml
@@ -1,0 +1,86 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+import QtQuick
+import Zaparoo.Browse as Browse
+
+// cxx-qt 0.8 patches `isFinal: true` on singleton properties but the
+// qmltypes schema has no `isFinal` slot, so every read trips qmllint's
+// "Member can be shadowed" check. Until the schema grows the slot,
+// suppress the compiler category file-wide.
+// qmllint disable compiler
+
+// Cold-launch curtain. The launcher process starts before Core finishes
+// listening, and the very first frames of the Hub paint with a still-
+// loading catalog (categories empty, status icons stale). Rather than
+// expose that mid-construction frame to the user we keep the screens
+// hidden until the catalog is Ready and let this component own the
+// window: the global background (`bgDeep` + circuit-trace tile) that
+// `MainLayout` already paints provides the surface, and the overlay
+// simply adds a single centred `LoadingIndicator` on top — same icon,
+// font, and baseline as every other loading cue in the app.
+//
+// Per `feedback_never_paint_background`, the overlay does **not** add a
+// new full-screen fill. The existing `MainLayout` background paints
+// through. Only the host screens are hidden (their `visible` flips off
+// via `root.bootComplete`).
+//
+// Dismissal is one-shot — `MainLayout` removes the overlay from the
+// scene graph the moment `connection_state` first reaches READY, so a
+// subsequent disconnect surfaces only via the status pill and never
+// re-asserts itself over the user's now-loaded catalog.
+Item {
+    id: overlay
+
+    // Link-state constants mirror rust/launcher/src/models/app_status.rs:
+    //   0 DISCONNECTED · 1 CONNECTING · 2 CONNECTED · 3 RECONNECTING · 4 UNREACHABLE.
+    readonly property int _linkDisconnected: 0
+    readonly property int _linkConnecting: 1
+    readonly property int _linkConnected: 2
+    readonly property int _linkReconnecting: 3
+    readonly property int _linkUnreachable: 4
+
+    // Tracks elapsed time on UNREACHABLE so the message escalates after
+    // a few seconds instead of immediately. A flicker on first connect
+    // — TCP open then a transient probe failure — wouldn't otherwise be
+    // worth scaring the user about.
+    property bool _unreachableLong: false
+
+    Connections {
+        target: Browse.AppStatus
+        function onLink_stateChanged(): void {
+            if (Browse.AppStatus.link_state === overlay._linkUnreachable) {
+                unreachableEscalateTimer.restart()
+            } else {
+                unreachableEscalateTimer.stop()
+                overlay._unreachableLong = false
+            }
+        }
+    }
+
+    Timer {
+        id: unreachableEscalateTimer
+        interval: 5000
+        repeat: false
+        onTriggered: overlay._unreachableLong = true
+    }
+
+    LoadingIndicator {
+        anchors.centerIn: parent
+        text: {
+            const link = Browse.AppStatus.link_state ?? overlay._linkDisconnected
+            if (link === overlay._linkUnreachable && overlay._unreachableLong)
+                return qsTr("Can't reach Zaparoo Core. Check your connection.")
+            if (link === overlay._linkReconnecting)
+                return qsTr("Reconnecting…")
+            if (link === overlay._linkConnected)
+                return qsTr("Loading library…")
+            // DISCONNECTED, CONNECTING, and the first few seconds of
+            // UNREACHABLE all read the same — the user pressed launch,
+            // we're trying to reach Core. Don't blame the network until
+            // we're sure.
+            return qsTr("Connecting to Zaparoo Core…")
+        }
+    }
+}

--- a/src/ui/components/CMakeLists.txt
+++ b/src/ui/components/CMakeLists.txt
@@ -10,7 +10,10 @@ qt_add_qml_module(
     VERSION 1.0
     QML_FILES
         ActiveLabel.qml
+        BootOverlay.qml
         ContextMenu.qml
+        CoreStatusPill.qml
+        FirstRunIndexModal.qml
         LoadingIndicator.qml
         Modal.qml
         PagedGrid.qml

--- a/src/ui/components/ContextMenu.qml
+++ b/src/ui/components/ContextMenu.qml
@@ -111,7 +111,7 @@ Item {
                         anchors.leftMargin: menu.horizontalPadding
                         anchors.rightMargin: menu.horizontalPadding
                         text: row.modelData
-                        color: index === menu.currentIndex ? Theme.textPrimary : Theme.textLabel
+                        color: row.index === menu.currentIndex ? Theme.textPrimary : Theme.textLabel
                         font.family: Theme.fontUi
                         font.pixelSize: Sizing.fontSize(2.4)
                         elide: Text.ElideRight

--- a/src/ui/components/CoreStatusPill.qml
+++ b/src/ui/components/CoreStatusPill.qml
@@ -1,0 +1,116 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+import QtQuick
+import Zaparoo.Theme
+import Zaparoo.Browse as Browse
+
+// cxx-qt 0.8 patches `isFinal: true` on singleton properties but the
+// qmltypes schema has no `isFinal` slot, so every read trips qmllint's
+// "Member can be shadowed" check. Until the schema grows the slot,
+// suppress the compiler category file-wide.
+// qmllint disable compiler
+
+// Single mutually-exclusive status pill anchored in the top-right HUD.
+// Surfaces — in priority order, only one ever paints — Core link state
+// (disconnected / connecting / error), media-database build progress
+// (indexing / optimizing / paused), and scraper progress.
+//
+// When no condition is interesting the pill is `visible: false` and
+// `width: 0`, so the surrounding Row collapses around it and the rest
+// of the HUD slides flush to the right edge.
+//
+// Software-renderer safe: a single Rectangle with two Text children,
+// no animations, no shaders. Counter and step text update via plain
+// property bindings so the dirty rect is bounded to the pill.
+Item {
+    id: pill
+
+    // Link-state constants mirror rust/launcher/src/models/app_status.rs:
+    //   0 DISCONNECTED · 1 CONNECTING · 2 CONNECTED · 3 RECONNECTING · 4 UNREACHABLE.
+    // Catalog connection_state constants:
+    //   0 DISCONNECTED · 1 CONNECTING · 2 READY · 3 ERROR.
+    readonly property int _linkDisconnected: 0
+    readonly property int _linkConnecting: 1
+    readonly property int _linkConnected: 2
+    readonly property int _linkReconnecting: 3
+    readonly property int _linkUnreachable: 4
+
+    readonly property int _connError: 3
+
+    // Resolved (priority, label) for the current state. Empty `text`
+    // means "nothing interesting is happening" and the pill hides.
+    readonly property string _label: {
+        const link = Browse.AppStatus.link_state ?? pill._linkDisconnected;
+        const conn = Browse.AppStatus.connection_state ?? pill._linkDisconnected;
+        // Priority 1 — Core link state.
+        if (link === pill._linkUnreachable) return qsTr("Disconnected");
+        if (link === pill._linkReconnecting) return qsTr("Reconnecting…");
+        if (link === pill._linkDisconnected) return qsTr("Disconnected");
+        if (link === pill._linkConnecting) return qsTr("Connecting…");
+        if (conn === pill._connError) return qsTr("Core error");
+        // Priority 2 — media database.
+        if (Browse.MediaStatus.optimizing) return qsTr("Optimizing database");
+        if (Browse.MediaStatus.indexing) {
+            const cur = Browse.MediaStatus.current_step;
+            const tot = Browse.MediaStatus.total_steps;
+            const display = Browse.MediaStatus.current_step_display;
+            if (Browse.MediaStatus.paused)
+                return qsTr("Indexing paused");
+            if (tot > 0 && display !== "")
+                return qsTr("Indexing %1/%2 — %3").arg(cur).arg(tot).arg(display);
+            if (tot > 0)
+                return qsTr("Indexing %1/%2").arg(cur).arg(tot);
+            return qsTr("Indexing…");
+        }
+        // Priority 3 — scraper.
+        if (Browse.MediaStatus.scraping) {
+            const proc = Browse.MediaStatus.scrape_processed;
+            const total = Browse.MediaStatus.scrape_total;
+            const sys = Browse.MediaStatus.scrape_system_id;
+            if (Browse.MediaStatus.scrape_paused)
+                return qsTr("Scrape paused");
+            if (total > 0 && sys !== "")
+                return qsTr("Scraping %1/%2 — %3").arg(proc).arg(total).arg(sys);
+            if (total > 0)
+                return qsTr("Scraping %1/%2").arg(proc).arg(total);
+            return qsTr("Scraping…");
+        }
+        return "";
+    }
+
+    // Border colour leans on the same convention as the old connection
+    // strip: warmer accent for error-class link states, muted otherwise.
+    readonly property bool _isError:
+        Browse.AppStatus.link_state === pill._linkUnreachable
+        || Browse.AppStatus.connection_state === pill._connError
+
+    visible: pill._label !== ""
+    height: pill.visible ? Sizing.fontSize(3.4) : 0
+    width: pill.visible ? labelText.implicitWidth + Sizing.pctW(2.4) : 0
+
+    Rectangle {
+        anchors.fill: parent
+        color: Theme.surfaceCard
+        radius: pill.height / 2
+        border.width: 1
+        border.color: pill._isError ? Theme.accent : Theme.borderMid
+
+        Text {
+            id: labelText
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.left: parent.left
+            anchors.leftMargin: Sizing.pctW(1.2)
+            anchors.right: parent.right
+            anchors.rightMargin: Sizing.pctW(1.2)
+            elide: Text.ElideRight
+            horizontalAlignment: Text.AlignHCenter
+            text: pill._label
+            font.family: Theme.fontUi
+            font.pixelSize: Sizing.fontSize(2.2)
+            color: Theme.textPrimary
+            renderType: Text.NativeRendering
+        }
+    }
+}

--- a/src/ui/components/FirstRunIndexModal.qml
+++ b/src/ui/components/FirstRunIndexModal.qml
@@ -1,0 +1,320 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+import QtQuick
+import Zaparoo.Theme
+import Zaparoo.Browse as Browse
+
+// cxx-qt 0.8 patches `isFinal: true` on singleton properties but the
+// qmltypes schema has no `isFinal` slot, so every read trips qmllint's
+// "Member can be shadowed" check. Until the schema grows the slot,
+// suppress the compiler category file-wide.
+// qmllint disable compiler
+
+// Blocking first-run modal. Shown once per session when the launcher
+// first connects to a Core whose media database doesn't exist yet.
+// The launcher refuses to drill into Systems / Games until an initial
+// scan has run, so this modal owns input and only releases when the
+// scan completes (auto-dismiss after a short "Done" beat) or — after
+// a cancel — when the user presses Start again and lets it finish.
+//
+// Three visual phases:
+//   "idle"      — explanatory body + a single "Start scan" button.
+//   "running"   — progress bar driven by `current_step / total_steps`,
+//                 the current step display below, and a Cancel button.
+//                 During the vacuum phase the bar is replaced with an
+//                 "Optimizing database — almost done" line (no animation
+//                 — software-renderer constraint).
+//   "completed" — "Done. N files indexed." for ~1.5 s, then auto-pop.
+//
+// The component is purely presentational; routing and the modal stack
+// are owned by `Main.qml`. We emit `closeRequested` and trust the
+// router to actually pop. `handleAction(accept|cancel)` is the input
+// hook called from `Main.qml`'s modal-dispatch branch.
+Item {
+    id: modal
+
+    property bool open: false
+
+    // "idle" → user must press Start.
+    // "running" → indexing in flight (or optimizing).
+    // "completed" → finished, completionTimer ticking down to dismiss.
+    property string phase: "idle"
+
+    signal closeRequested()
+
+    visible: modal.open
+    anchors.fill: parent
+    z: 300
+
+    onOpenChanged: {
+        if (modal.open) {
+            modal.phase = Browse.MediaStatus.indexing ? "running" : "idle"
+        } else {
+            modal.phase = "idle"
+            completionTimer.stop()
+        }
+    }
+
+    // Track Core's indexing flag. Pressing Start optimistically flips
+    // phase to "running" before the first notification arrives (so the
+    // "Preparing…" body paints immediately); the Connections below
+    // simply confirms or unwinds when the notification stream catches
+    // up.
+    Connections {
+        target: Browse.MediaStatus
+        function onIndexingChanged(): void {
+            if (!modal.open)
+                return
+            if (Browse.MediaStatus.indexing) {
+                modal.phase = "running"
+                completionTimer.stop()
+                return
+            }
+            if (modal.phase === "running") {
+                if (Browse.MediaStatus.total_files > 0) {
+                    modal.phase = "completed"
+                    completionTimer.restart()
+                } else {
+                    // Cancel landed before any files were counted, or
+                    // Core never started. Drop back to idle so the user
+                    // can retry.
+                    modal.phase = "idle"
+                }
+            }
+        }
+
+        // If Core acquires a populated mediadb out of band — restart,
+        // manual TUI-driven index in another session, etc. — the
+        // first-run gate has nothing left to defend, so we close.
+        function onExistsChanged(): void {
+            if (modal.open
+                && Browse.MediaStatus.exists
+                && modal.phase !== "completed") {
+                modal.closeRequested()
+            }
+        }
+    }
+
+    function handleAction(action: string): void {
+        if (action === "accept") {
+            if (modal.phase === "idle") {
+                Browse.MediaStatus.start_index()
+                modal.phase = "running"
+            }
+        } else if (action === "cancel") {
+            if (modal.phase === "running")
+                Browse.MediaStatus.cancel_index()
+        }
+    }
+
+    // Scrim. Eats clicks so they don't reach the screen tree underneath.
+    Rectangle {
+        anchors.fill: parent
+        color: "#cc000000"
+
+        MouseArea {
+            anchors.fill: parent
+        }
+    }
+
+    Rectangle {
+        id: panel
+
+        anchors.centerIn: parent
+        width: Math.min(parent.width * 0.78, Sizing.pctH(90))
+        height: Sizing.pctH(46)
+        color: Theme.bgPanel
+        border.width: 2
+        border.color: Theme.textPrimary
+        radius: Sizing.cornerRadius
+
+        Text {
+            id: titleText
+
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.top: parent.top
+            anchors.topMargin: Sizing.pctH(6)
+            anchors.leftMargin: Sizing.pctW(5)
+            anchors.rightMargin: Sizing.pctW(5)
+            text: qsTr("First-time setup")
+            font.family: Theme.fontUi
+            font.pixelSize: Sizing.fontSize(3.2)
+            color: Theme.textPrimary
+            wrapMode: Text.WordWrap
+            horizontalAlignment: Text.AlignHCenter
+            renderType: Text.NativeRendering
+        }
+
+        Text {
+            id: bodyIdle
+
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.top: titleText.bottom
+            anchors.topMargin: Sizing.pctH(2)
+            anchors.leftMargin: Sizing.pctW(6)
+            anchors.rightMargin: Sizing.pctW(6)
+            visible: modal.phase === "idle"
+            text: qsTr("Zaparoo needs to scan your games before you can use the launcher. This usually takes a few minutes.")
+            font.family: Theme.fontUi
+            font.pixelSize: Sizing.fontSize(2.5)
+            color: Theme.textPrimary
+            wrapMode: Text.WordWrap
+            horizontalAlignment: Text.AlignHCenter
+            renderType: Text.NativeRendering
+        }
+
+        Item {
+            id: runningView
+
+            anchors.top: titleText.bottom
+            anchors.topMargin: Sizing.pctH(4)
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.leftMargin: Sizing.pctW(7)
+            anchors.rightMargin: Sizing.pctW(7)
+            height: Sizing.pctH(14)
+            visible: modal.phase === "running"
+
+            // Vacuum phase fallback. Mirrors the mobile app's "Optimizing
+            // database" copy without the pulsing animation (software
+            // renderer pays per-frame for translucent overlays).
+            Text {
+                anchors.fill: parent
+                visible: Browse.MediaStatus.optimizing
+                text: qsTr("Optimizing database — almost done")
+                font.family: Theme.fontUi
+                font.pixelSize: Sizing.fontSize(2.6)
+                color: Theme.textPrimary
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                wrapMode: Text.WordWrap
+                renderType: Text.NativeRendering
+            }
+
+            Item {
+                anchors.fill: parent
+                visible: !Browse.MediaStatus.optimizing
+
+                Rectangle {
+                    id: progressTrack
+
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.top: parent.top
+                    anchors.topMargin: Sizing.pctH(1)
+                    height: Sizing.pctH(1.4)
+                    color: Theme.borderSubtle
+                    radius: height / 2
+
+                    Rectangle {
+                        readonly property real _ratio: {
+                            const tot = Browse.MediaStatus.total_steps
+                            if (tot <= 0)
+                                return 0
+                            const cur = Browse.MediaStatus.current_step
+                            return Math.max(0, Math.min(1, cur / tot))
+                        }
+
+                        anchors.left: parent.left
+                        anchors.top: parent.top
+                        anchors.bottom: parent.bottom
+                        width: progressTrack.width * _ratio
+                        color: Theme.accent
+                        radius: parent.radius
+                    }
+                }
+
+                Text {
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.top: progressTrack.bottom
+                    anchors.topMargin: Sizing.pctH(2.4)
+                    text: {
+                        const display = Browse.MediaStatus.current_step_display
+                        const cur = Browse.MediaStatus.current_step
+                        const tot = Browse.MediaStatus.total_steps
+                        if (Browse.MediaStatus.paused)
+                            return qsTr("Indexing paused")
+                        if (tot > 0 && display !== "")
+                            return qsTr("Step %1 of %2 — %3").arg(cur).arg(tot).arg(display)
+                        if (tot > 0)
+                            return qsTr("Step %1 of %2").arg(cur).arg(tot)
+                        return qsTr("Preparing…")
+                    }
+                    font.family: Theme.fontUi
+                    font.pixelSize: Sizing.fontSize(2.3)
+                    color: Theme.textLabel
+                    wrapMode: Text.WordWrap
+                    horizontalAlignment: Text.AlignHCenter
+                    renderType: Text.NativeRendering
+                    elide: Text.ElideRight
+                    maximumLineCount: 2
+                }
+            }
+        }
+
+        Text {
+            id: completionMessage
+
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.top: titleText.bottom
+            anchors.topMargin: Sizing.pctH(4)
+            anchors.leftMargin: Sizing.pctW(6)
+            anchors.rightMargin: Sizing.pctW(6)
+            visible: modal.phase === "completed"
+            text: qsTr("Done. %1 files indexed.").arg(Browse.MediaStatus.total_files)
+            font.family: Theme.fontUi
+            font.pixelSize: Sizing.fontSize(2.6)
+            color: Theme.textPrimary
+            horizontalAlignment: Text.AlignHCenter
+            wrapMode: Text.WordWrap
+            renderType: Text.NativeRendering
+        }
+
+        Rectangle {
+            id: actionButton
+
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.bottom: parent.bottom
+            anchors.bottomMargin: Sizing.pctH(5)
+            width: Sizing.pctW(28)
+            height: Sizing.pctH(7)
+            color: Theme.bgBar
+            border.width: 1
+            border.color: Theme.borderMid
+            radius: Sizing.cornerRadius
+            visible: modal.phase !== "completed"
+
+            Text {
+                anchors.centerIn: parent
+                text: modal.phase === "running"
+                      ? qsTr("Cancel")
+                      : qsTr("Start scan")
+                font.family: Theme.fontUi
+                font.pixelSize: Sizing.fontSize(2.5)
+                color: Theme.textPrimary
+                renderType: Text.NativeRendering
+            }
+
+            MouseArea {
+                anchors.fill: parent
+                acceptedButtons: Qt.LeftButton
+                onClicked: modal.handleAction(modal.phase === "running"
+                                              ? "cancel" : "accept")
+            }
+        }
+    }
+
+    Timer {
+        id: completionTimer
+
+        interval: 1500
+        repeat: false
+        onTriggered: modal.closeRequested()
+    }
+}

--- a/src/ui/components/SettingsField.qml
+++ b/src/ui/components/SettingsField.qml
@@ -30,9 +30,17 @@ Item {
     // nothing at the ends of a list.
     property bool canCyclePrev: true
     property bool canCycleNext: true
+    // For `control: "action"` — short live-state string painted on the
+    // right ("In progress", "Paused", or "" when idle). The screen
+    // owns the binding; the field treats it as a plain caption.
+    property string actionStatus: ""
 
     signal hovered()
     signal clicked()
+    // Emitted when the action-control row receives an accept press.
+    // The screen wires this to the matching invokable (start/cancel
+    // index, start/cancel scrape) and gates by `actionStatus`.
+    signal accepted()
 
     implicitHeight: Sizing.pctH(8)
 
@@ -127,12 +135,32 @@ Item {
         }
     }
 
+    // Right-side caption for `control: "action"`. No `< >` arrows, no
+    // toggle pill — just a single muted-when-idle string showing the
+    // current operation state. Empty `actionStatus` collapses to no
+    // text, matching the visual quietness of an idle row.
+    Text {
+        visible: root.control === "action"
+        anchors.right: parent.right
+        anchors.rightMargin: Sizing.pctW(3)
+        anchors.verticalCenter: parent.verticalCenter
+        text: root.actionStatus
+        color: Theme.textPrimary
+        font.family: Theme.fontUi
+        font.pixelSize: Sizing.fontSize(2.4)
+        renderType: Text.NativeRendering
+    }
+
     MouseArea {
         anchors.fill: parent
         hoverEnabled: true
         acceptedButtons: Qt.LeftButton
 
         onEntered: root.hovered()
-        onClicked: root.clicked()
+        onClicked: {
+            root.clicked();
+            if (root.control === "action")
+                root.accepted();
+        }
     }
 }

--- a/src/ui/components/SettingsField.qml
+++ b/src/ui/components/SettingsField.qml
@@ -42,6 +42,12 @@ Item {
     // index, start/cancel scrape) and gates by `actionStatus`.
     signal accepted()
 
+    // Item.enabled (built-in) gates the MouseArea below; the dimmed
+    // opacity here gives a matching visual cue. Setting `enabled: false`
+    // on the row makes Accept a no-op (the index/scrape pair use this
+    // when one of the two is in flight — Core serialises them).
+    opacity: enabled ? 1.0 : 0.4
+
     implicitHeight: Sizing.pctH(8)
 
     Rectangle {
@@ -157,10 +163,16 @@ Item {
         acceptedButtons: Qt.LeftButton
 
         onEntered: root.hovered()
+        // Action rows fire `accepted()` (the screen runs start/cancel
+        // there); every other control fires `clicked()` (the screen
+        // moves focus and toggles a value). Emitting both for action
+        // rows used to make `onClicked` and `onAccepted` race over
+        // the same press.
         onClicked: {
-            root.clicked();
             if (root.control === "action")
                 root.accepted();
+            else
+                root.clicked();
         }
     }
 }

--- a/src/ui/screens/SettingsScreen.qml
+++ b/src/ui/screens/SettingsScreen.qml
@@ -140,6 +140,20 @@ Item {
             return settings._scrapeBusy
         return false
     }
+    // True when the focused action can't run right now because the
+    // *other* media operation has the bus. Drives the dimmed-row
+    // visual and lets the help bar drop the Accept hint instead of
+    // promising a press that will silently no-op.
+    readonly property bool focusedActionDisabled: {
+        if (settings.fieldCount === 0)
+            return false
+        const id = settings.fields[settings.currentIndex].id
+        if (id === "updateMediaDb")
+            return settings._scrapeBusy
+        if (id === "runScraper")
+            return settings._indexBusy
+        return false
+    }
 
     property int currentIndex: 0
 
@@ -334,6 +348,15 @@ Item {
 
                 width: form.width
                 isFocused: index === settings.currentIndex
+                // Index and scrape can't run together; while one
+                // operation is in flight the other row dims and its
+                // MouseArea stops responding. Keyboard Accept is
+                // separately gated in `_triggerIndex`/`_triggerScrape`.
+                enabled: modelData.id === "updateMediaDb"
+                         ? !settings._scrapeBusy
+                         : modelData.id === "runScraper"
+                         ? !settings._indexBusy
+                         : true
                 label: modelData.label
                 value: modelData.id === "resolution"
                        ? settings._resolutionDisplay(Browse.Settings.current_resolution)
@@ -376,7 +399,12 @@ Item {
                     if (modelData.id === "mouseEnabled")
                         settings._toggleMouseEnabled()
                 }
+                // Action rows route through `onAccepted` only (see
+                // `SettingsField.qml`'s MouseArea), so the focus
+                // commit lives here too — clicking an action row
+                // moves focus before firing the action.
                 onAccepted: {
+                    settings.currentIndex = index
                     if (modelData.id === "updateMediaDb")
                         settings._triggerIndex()
                     else if (modelData.id === "runScraper")

--- a/src/ui/screens/SettingsScreen.qml
+++ b/src/ui/screens/SettingsScreen.qml
@@ -63,12 +63,83 @@ Item {
             id: "mouseEnabled",
             label: qsTr("Mouse support")
         })
+        out.push({
+            id: "updateMediaDb",
+            label: qsTr("Update media database")
+        })
+        out.push({
+            id: "runScraper",
+            label: qsTr("Run scraper")
+        })
         return out
+    }
+
+    // Live-state caption helpers for the action rows. Empty string when
+    // the row's operation is idle, so the field renders as quietly as
+    // the cycler rows above. Pause/cancel paths use the same vocabulary
+    // as the Core TUI so the launcher looks like a third surface for
+    // the same flow.
+    function _indexActionStatus(): string {
+        if (Browse.MediaStatus.optimizing)
+            return qsTr("Optimizing")
+        if (Browse.MediaStatus.indexing)
+            return Browse.MediaStatus.paused ? qsTr("Paused") : qsTr("In progress")
+        return ""
+    }
+
+    function _scrapeActionStatus(): string {
+        if (Browse.MediaStatus.scraping)
+            return Browse.MediaStatus.scrape_paused ? qsTr("Paused") : qsTr("In progress")
+        return ""
+    }
+
+    // Index and scrape can't run concurrently — Core serialises them.
+    // While one is in flight the *other* row is non-actionable so we
+    // don't queue a request that Core will reject.
+    readonly property bool _indexBusy:
+        Browse.MediaStatus.indexing || Browse.MediaStatus.optimizing
+    readonly property bool _scrapeBusy: Browse.MediaStatus.scraping
+
+    function _triggerIndex(): void {
+        if (settings._scrapeBusy)
+            return
+        if (settings._indexBusy)
+            Browse.MediaStatus.cancel_index()
+        else
+            Browse.MediaStatus.start_index()
+    }
+
+    function _triggerScrape(): void {
+        if (settings._indexBusy)
+            return
+        if (settings._scrapeBusy)
+            Browse.MediaStatus.cancel_scrape()
+        else
+            Browse.MediaStatus.start_scrape()
     }
 
     readonly property int fieldCount: settings.fields.length
     readonly property bool focusedFieldIsMouse:
         settings.fieldCount > 0 && settings.fields[settings.currentIndex].id === "mouseEnabled"
+    // True when the focused field is an action button (updateMediaDb,
+    // runScraper). Drives the help-bar Accept hint.
+    readonly property bool focusedFieldIsAction:
+        settings.fieldCount > 0
+        && (settings.fields[settings.currentIndex].id === "updateMediaDb"
+            || settings.fields[settings.currentIndex].id === "runScraper")
+    // True when the focused action's matching operation is currently
+    // running, so the help bar can label Accept as "Cancel" rather
+    // than "Start".
+    readonly property bool focusedActionBusy: {
+        if (settings.fieldCount === 0)
+            return false
+        const id = settings.fields[settings.currentIndex].id
+        if (id === "updateMediaDb")
+            return settings._indexBusy
+        if (id === "runScraper")
+            return settings._scrapeBusy
+        return false
+    }
 
     property int currentIndex: 0
 
@@ -196,6 +267,7 @@ Item {
             settings._cycleButtonLayout(direction)
         else if (id === "mouseEnabled")
             settings._setMouseEnabled(direction)
+        // Action fields ignore left/right — they only respond to accept.
     }
 
     function handleAction(action: string): void {
@@ -210,9 +282,15 @@ Item {
         } else if (action === "right") {
             settings._cycleFocused(1)
         } else if (action === "accept") {
-            if (settings.fieldCount > 0
-                && settings.fields[settings.currentIndex].id === "mouseEnabled")
+            if (settings.fieldCount === 0)
+                return
+            const id = settings.fields[settings.currentIndex].id
+            if (id === "mouseEnabled")
                 settings._toggleMouseEnabled()
+            else if (id === "updateMediaDb")
+                settings._triggerIndex()
+            else if (id === "runScraper")
+                settings._triggerScrape()
         } else if (action === "cancel") {
             settings.requestHubScreen()
         }
@@ -264,8 +342,16 @@ Item {
                        : modelData.id === "buttonLayout"
                        ? settings._buttonLayoutDisplay(Browse.Settings.current_button_layout)
                        : ""
-                control: modelData.id === "mouseEnabled" ? "toggle" : "value"
+                control: modelData.id === "mouseEnabled" ? "toggle"
+                         : (modelData.id === "updateMediaDb"
+                            || modelData.id === "runScraper") ? "action"
+                         : "value"
                 checked: Browse.Settings.current_mouse_enabled
+                actionStatus: modelData.id === "updateMediaDb"
+                              ? settings._indexActionStatus()
+                              : modelData.id === "runScraper"
+                              ? settings._scrapeActionStatus()
+                              : ""
                 // Pickers wrap modulo, so both arrows apply when the
                 // focused field has a populated option list.
                 canCyclePrev: (modelData.id === "resolution"
@@ -289,6 +375,12 @@ Item {
                     settings.currentIndex = index
                     if (modelData.id === "mouseEnabled")
                         settings._toggleMouseEnabled()
+                }
+                onAccepted: {
+                    if (modelData.id === "updateMediaDb")
+                        settings._triggerIndex()
+                    else if (modelData.id === "runScraper")
+                        settings._triggerScrape()
                 }
             }
         }

--- a/tests/ui/tst_navigation.qml
+++ b/tests/ui/tst_navigation.qml
@@ -23,6 +23,11 @@ TestCase {
     }
 
     function init(): void {
+        // The cold-launch BootOverlay normally hides every screen until
+        // Core's catalog reaches READY. Tests don't run a real Core, so
+        // we mark the boot complete up-front; otherwise every visibility
+        // assertion below would fail against the boot curtain.
+        main.bootComplete = true
         main.activeScreen = main.screenHub
         // Hub focus is two rows now (categories + actions); reset both
         // axes so a prior test's row-jump doesn't leak into the next.

--- a/tests/ui/tst_persistence.qml
+++ b/tests/ui/tst_persistence.qml
@@ -33,6 +33,11 @@ TestCase {
     }
 
     function init(): void {
+        // The cold-launch BootOverlay normally hides every screen until
+        // Core's catalog reaches READY. Tests don't run a real Core, so
+        // mark the boot complete up-front; otherwise visibility-driven
+        // assertions would fail against the boot curtain.
+        main.bootComplete = true
         main.activeScreen = main.screenHub
     }
 


### PR DESCRIPTION
## Summary
- Adds `Browse.MediaStatus` watch on Core's `media` snapshot + `media.indexing`/`media.scraping` notifications, with the supporting Core RPC methods (`media`, `media.generate(.cancel)`, `media.scrape(.cancel)`, `scrapers`).
- Surfaces it in the UI as `CoreStatusPill` (live state), `BootOverlay` (covers the screen until the link is up), and `FirstRunIndexModal` (empty-database flow + index/scrape triggers).
- `AppStatus` now exposes raw `link_state` alongside the existing merged `connection_state` so the pill can distinguish a first connect attempt from a reconnect after the link drops.
- Settings screen gains entry points to trigger an index/scrape from the UI.

Stacked on top of #56 — base is `cover-art-async-pipeline`, not `main`.

## Test plan
- [ ] `just lint`
- [ ] `just test`
- [ ] Cold launch with Core down → BootOverlay paints, pill reflects link state
- [ ] Cold launch with Core up but empty media DB → FirstRunIndexModal appears, index triggers, progress reflected via `media.indexing`
- [ ] Mid-session Core restart → pill flips to RECONNECTING, not first-connect
- [ ] Settings → Run scraper triggers `media.scrape`, completion observed via `media.scraping`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * First-run indexing modal to guide initial media database setup
  * Boot overlay with enhanced connection/link-state feedback and escalation messaging
  * Core status pill showing prioritized connection/indexing/scraping status
  * Live media status indicators and actions: Start/Cancel index, Start/Cancel scrape, Run scraper
  * Settings screen adds action-backed fields and live action status

* **Tests**
  * UI tests updated to bypass boot overlay for deterministic runs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->