### PR TITLE
feat(settings): log upload, debug toggle; root dedup + QML guards

### DIFF
--- a/rust/launcher/build.rs
+++ b/rust/launcher/build.rs
@@ -34,6 +34,7 @@ fn main() {
         "src/models/systems_state.rs",
         "src/models/games_state.rs",
         "src/models/input.rs",
+        "src/models/log_upload.rs",
         "src/models/media_status.rs",
         "src/models/platform.rs",
         "src/models/qr_code.rs",

--- a/rust/launcher/src/models/categories.rs
+++ b/rust/launcher/src/models/categories.rs
@@ -5,6 +5,7 @@
 use cxx_qt::CxxQtType;
 use cxx_qt_lib::{QByteArray, QHash, QHashPair_i32_QByteArray, QModelIndex, QString, QVariant};
 use std::pin::Pin;
+use tracing::debug;
 use zaparoo_core::endpoints::catalog::CatalogEndpoint;
 use zaparoo_core::remote_resource::ResourceStatus;
 use zaparoo_core::systems_catalog::CatalogData;
@@ -144,6 +145,11 @@ fn apply_state(
 ) {
     if let Some(categories) = categories {
         let count = categories.len() as i32;
+        debug!(
+            count,
+            categories = ?categories,
+            "categories: apply_state filled list",
+        );
         model.as_mut().begin_reset_model();
         model.as_mut().rust_mut().categories = categories;
         model.as_mut().rust_mut().count = count;

--- a/rust/launcher/src/models/games.rs
+++ b/rust/launcher/src/models/games.rs
@@ -43,7 +43,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::broadcast::error::RecvError;
 use tokio::task::JoinHandle;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 use zaparoo_core::client::ClientError;
 use zaparoo_core::endpoints::media_browse::{BrowseArgs, MediaBrowseEndpoint};
 use zaparoo_core::endpoints::readers_write::ReadersWriteMutation;
@@ -568,6 +568,7 @@ impl ffi::GamesModel {
             ?path,
             ?systems,
             eligible_for_auto_nav,
+            page_size = self.page_size,
             "games: start_initial_browse",
         );
         self.as_mut().ensure_cover_subscription();
@@ -1031,6 +1032,45 @@ fn leading_dir_count(entries: &[BrowseEntry]) -> i32 {
     i32::try_from(n).unwrap_or(i32::MAX)
 }
 
+/// Drop any root-type entry whose path is a strict ancestor of another
+/// root entry's path. Defends against Core occasionally surfacing the
+/// shared parent dir (e.g. `/media/fat/games`) as a system root alongside
+/// the actual per-system roots beneath it; the parent appears as a
+/// phantom option in the launcher's roots screen, and selecting it
+/// browses into a directory that contains every other system.
+///
+/// Only `root`-type entries participate. `directory` and `media` entries
+/// pass through unchanged — a normal directory listing where a folder
+/// and its subfolder appear as siblings is legitimate.
+fn dedup_roots_drop_ancestors(entries: Vec<BrowseEntry>) -> Vec<BrowseEntry> {
+    let root_paths: Vec<String> = entries
+        .iter()
+        .filter(|e| e.entry_type == "root" && !e.path.is_empty())
+        .map(|e| e.path.trim_end_matches('/').to_string())
+        .collect();
+    entries
+        .into_iter()
+        .filter(|e| {
+            if e.entry_type != "root" || e.path.is_empty() {
+                return true;
+            }
+            let candidate = e.path.trim_end_matches('/');
+            !root_paths
+                .iter()
+                .any(|other| is_strict_ancestor_path(candidate, other.as_str()))
+        })
+        .collect()
+}
+
+fn is_strict_ancestor_path(parent: &str, child: &str) -> bool {
+    if parent.is_empty() || child.is_empty() || parent == child {
+        return false;
+    }
+    child
+        .strip_prefix(parent)
+        .is_some_and(|rest| rest.starts_with('/'))
+}
+
 fn apply_status(mut model: Pin<&mut ffi::GamesModel>, status: ResourceStatus<MediaBrowseResult>) {
     match project_status(status) {
         Projection::Pending => {
@@ -1050,7 +1090,7 @@ fn apply_status(mut model: Pin<&mut ffi::GamesModel>, status: ResourceStatus<Med
                 model.as_mut().set_has_next_page(false);
             }
         }
-        Projection::Ready(result) => {
+        Projection::Ready(mut result) => {
             let eligible = model.rust().auto_nav_eligible;
             // Eligibility is consumed by the first Ready that follows
             // an eligible load. A subsequent refetch (mutation
@@ -1061,6 +1101,7 @@ fn apply_status(mut model: Pin<&mut ffi::GamesModel>, status: ResourceStatus<Med
             model.as_mut().rust_mut().auto_nav_eligible = false;
             let platform = platform::current();
             let current_path = model.current_path.to_string();
+            let current_system_id = model.current_system_id.to_string();
             info!(
                 entries_len = result.entries.len(),
                 total_files = result.total_files,
@@ -1068,6 +1109,43 @@ fn apply_status(mut model: Pin<&mut ffi::GamesModel>, status: ResourceStatus<Med
                 ?current_path,
                 "media.browse Ready",
             );
+            if result.entries.is_empty() {
+                warn!(
+                    ?current_path,
+                    ?current_system_id,
+                    total_files = result.total_files,
+                    "media.browse returned 0 entries",
+                );
+            } else {
+                let mut type_counts: std::collections::BTreeMap<&str, usize> =
+                    std::collections::BTreeMap::new();
+                for e in &result.entries {
+                    *type_counts.entry(e.entry_type.as_str()).or_insert(0) += 1;
+                }
+                let sample: Vec<_> = result
+                    .entries
+                    .iter()
+                    .take(3)
+                    .map(|e| {
+                        format!(
+                            "{}|sid={}|sids={:?}|type={}|path={}",
+                            e.name, e.system_id, e.system_ids, e.entry_type, e.path
+                        )
+                    })
+                    .collect();
+                debug!(?type_counts, ?sample, "media.browse Ready entry shape",);
+            }
+            let pre_dedup = result.entries.len();
+            result.entries = dedup_roots_drop_ancestors(result.entries);
+            let removed = pre_dedup.saturating_sub(result.entries.len());
+            if removed > 0 {
+                warn!(
+                    removed,
+                    ?current_path,
+                    ?current_system_id,
+                    "media.browse: dropped ancestor-of-sibling root entries",
+                );
+            }
             match decide_initial(&result, eligible, platform.as_ref(), &current_path) {
                 InitialAction::AutoNavigate { path } => {
                     info!(?path, "media.browse: auto-navigating into single folder");
@@ -1240,9 +1318,9 @@ mod tests {
     )]
 
     use super::{
-        compute_unresolved_keys, cover_key_for_with, decide_initial, display_name, entry_system_id,
-        leading_dir_count, media_key_for, position_of_game_path, project_status, transform_entries,
-        InitialAction, Projection,
+        compute_unresolved_keys, cover_key_for_with, decide_initial, dedup_roots_drop_ancestors,
+        display_name, entry_system_id, is_strict_ancestor_path, leading_dir_count, media_key_for,
+        position_of_game_path, project_status, transform_entries, InitialAction, Projection,
     };
     use crate::media_image_cache::{MediaImageCache, MediaKey};
     use std::collections::HashSet;
@@ -1524,6 +1602,98 @@ mod tests {
     #[test]
     fn leading_dir_count_zero_on_empty() {
         assert_eq!(leading_dir_count(&[]), 0);
+    }
+
+    #[test]
+    fn is_strict_ancestor_path_matches_parent_of_child() {
+        assert!(is_strict_ancestor_path(
+            "/media/fat/games",
+            "/media/fat/games/Genesis",
+        ));
+        assert!(is_strict_ancestor_path(
+            "/media/fat/games",
+            "/media/fat/games/MegaDrive",
+        ));
+    }
+
+    #[test]
+    fn is_strict_ancestor_path_rejects_equal_paths() {
+        assert!(!is_strict_ancestor_path("/a/b", "/a/b"));
+    }
+
+    #[test]
+    fn is_strict_ancestor_path_rejects_unrelated_paths() {
+        assert!(!is_strict_ancestor_path("/a/b", "/a/bc"));
+        assert!(!is_strict_ancestor_path("/a/b", "/x/b/c"));
+    }
+
+    #[test]
+    fn is_strict_ancestor_path_rejects_empty_inputs() {
+        assert!(!is_strict_ancestor_path("", "/a"));
+        assert!(!is_strict_ancestor_path("/a", ""));
+    }
+
+    #[test]
+    fn dedup_roots_drops_ancestor_root_when_sibling_is_descendant() {
+        // The Genesis 3-root payload Core surfaced on a real MiSTer:
+        // /media/fat/games appears alongside the per-system roots beneath
+        // it. The shared parent dir must not reach the launcher's roots
+        // screen as a third option.
+        let entries = vec![
+            root("MegaDrive", "/media/fat/games/MegaDrive", "Genesis"),
+            root("Genesis", "/media/fat/games/Genesis", "Genesis"),
+            root("games", "/media/fat/games", "Genesis"),
+        ];
+        let kept = dedup_roots_drop_ancestors(entries);
+        assert_eq!(kept.len(), 2);
+        assert!(kept.iter().any(|e| e.path == "/media/fat/games/MegaDrive"));
+        assert!(kept.iter().any(|e| e.path == "/media/fat/games/Genesis"));
+        assert!(!kept.iter().any(|e| e.path == "/media/fat/games"));
+    }
+
+    #[test]
+    fn dedup_roots_passes_through_unrelated_roots() {
+        let entries = vec![
+            root("primary", "/roms/A", "NES"),
+            root("backup", "/roms/B", "NES"),
+        ];
+        let kept = dedup_roots_drop_ancestors(entries);
+        assert_eq!(kept.len(), 2);
+    }
+
+    #[test]
+    fn dedup_roots_ignores_non_root_entries() {
+        // A directory listing that contains a folder and its subfolder is
+        // legitimate (e.g. inside a system browse). The filter only
+        // applies to root-typed entries.
+        let entries = vec![
+            folder("parent", "/x"),
+            folder("child", "/x/sub"),
+            media("smb", "/x/sub/smb.nes", "NES"),
+        ];
+        let kept = dedup_roots_drop_ancestors(entries);
+        assert_eq!(kept.len(), 3);
+    }
+
+    #[test]
+    fn dedup_roots_keeps_root_with_blank_path() {
+        // Blank-path roots cannot be navigated into (handled separately
+        // by decide_initial). They never participate as ancestors and
+        // never get dropped as descendants.
+        let entries = vec![root("ghost", "", "NES"), root("real", "/roms/NES", "NES")];
+        let kept = dedup_roots_drop_ancestors(entries);
+        assert_eq!(kept.len(), 2);
+    }
+
+    #[test]
+    fn dedup_roots_handles_trailing_slash_on_either_side() {
+        let entries = vec![
+            root("parent", "/media/fat/games/", "Genesis"),
+            root("child", "/media/fat/games/Genesis", "Genesis"),
+        ];
+        let kept = dedup_roots_drop_ancestors(entries);
+        assert_eq!(kept.len(), 1);
+        assert_eq!(kept[0].path, "/media/fat/games/Genesis");
     }
 
     #[test]

--- a/rust/launcher/src/models/log_upload.rs
+++ b/rust/launcher/src/models/log_upload.rs
@@ -1,0 +1,192 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+//
+// `Browse.LogUpload` — drives the "Upload log" affordance in Settings.
+//
+// The user kicks the flow with `upload()`; the singleton spawns a worker
+// thread that POSTs `launcher.log` as multipart/form-data to
+// `https://logs.zaparoo.org/` (mirroring Core's TUI exportlog flow), then
+// queues the result back onto the Qt thread.
+//
+// HTTP via shelled-out curl: the launcher otherwise has no HTTPS client
+// (tokio-tungstenite is built without TLS to keep the MiSTer ARM32 binary
+// small) and curl is a hard requirement of Core's installer, so it's
+// reliably present everywhere this launcher runs.
+//
+// The QML side observes `state` (idle / uploading / success / error) and
+// renders one of three views in `LogUploadModal.qml`. On success the URL
+// is plain text plus a QR code generated through `Browse.QrCode`.
+
+use cxx_qt::Threading;
+use cxx_qt_lib::QString;
+use std::pin::Pin;
+use std::process::{Command, Stdio};
+use std::thread;
+use tracing::{error, info, warn};
+use zaparoo_core::platform_paths::log_file_path;
+
+/// Public endpoint used by Core's TUI for the same flow. Hardcoded
+/// because it is the only place this launcher uploads anything and the
+/// destination is part of the user contract.
+const UPLOAD_URL: &str = "https://logs.zaparoo.org/";
+
+/// curl wall-clock cap. Matches Core's TUI (`30 * time.Second`); the
+/// log file is small but the upload service occasionally stalls and we
+/// don't want to block the modal forever.
+const UPLOAD_TIMEOUT_SECS: u32 = 30;
+
+/// State machine values exposed to QML. Kept as integers because
+/// cxx-qt 0.8 does not surface Rust enums to QML cleanly; the QML side
+/// has matching readonly properties on the modal.
+const STATE_IDLE: i32 = 0;
+const STATE_UPLOADING: i32 = 1;
+const STATE_SUCCESS: i32 = 2;
+const STATE_ERROR: i32 = 3;
+
+#[derive(Default)]
+pub struct LogUploadRust {
+    state: i32,
+    url: QString,
+    error_message: QString,
+}
+
+#[cxx_qt::bridge]
+pub mod ffi {
+    unsafe extern "C++" {
+        include!("model_includes.h");
+
+        type QString = cxx_qt_lib::QString;
+    }
+
+    unsafe extern "RustQt" {
+        #[qobject]
+        #[qml_element]
+        #[qml_singleton]
+        #[qproperty(i32, state)]
+        #[qproperty(QString, url)]
+        #[qproperty(QString, error_message)]
+        type LogUpload = super::LogUploadRust;
+
+        #[qinvokable]
+        fn upload(self: Pin<&mut LogUpload>);
+
+        #[qinvokable]
+        fn reset(self: Pin<&mut LogUpload>);
+    }
+
+    impl cxx_qt::Threading for LogUpload {}
+}
+
+impl ffi::LogUpload {
+    fn upload(mut self: Pin<&mut Self>) {
+        if self.state == STATE_UPLOADING {
+            // Already in flight — debounce repeated Accept presses while
+            // the modal is still painting "Uploading…".
+            return;
+        }
+        self.as_mut().set_state(STATE_UPLOADING);
+        self.as_mut().set_url(QString::default());
+        self.as_mut().set_error_message(QString::default());
+
+        let qt_thread = self.qt_thread();
+        if let Err(e) = thread::Builder::new()
+            .name("zaparoo-log-upload".into())
+            .spawn(move || {
+                let outcome = run_upload();
+                let _ = qt_thread.queue(move |model| apply_outcome(model, outcome));
+            })
+        {
+            error!("failed to spawn log upload thread: {e}");
+            self.as_mut()
+                .set_error_message(QString::from("Could not start upload."));
+            self.as_mut().set_state(STATE_ERROR);
+        }
+    }
+
+    fn reset(mut self: Pin<&mut Self>) {
+        self.as_mut().set_state(STATE_IDLE);
+        self.as_mut().set_url(QString::default());
+        self.as_mut().set_error_message(QString::default());
+    }
+}
+
+#[derive(Debug)]
+enum UploadOutcome {
+    Success(String),
+    Error(String),
+}
+
+fn apply_outcome(mut model: Pin<&mut ffi::LogUpload>, outcome: UploadOutcome) {
+    match outcome {
+        UploadOutcome::Success(url) => {
+            info!("log upload succeeded: {url}");
+            model.as_mut().set_url(QString::from(url.as_str()));
+            model.as_mut().set_state(STATE_SUCCESS);
+        }
+        UploadOutcome::Error(message) => {
+            warn!("log upload failed: {message}");
+            model
+                .as_mut()
+                .set_error_message(QString::from(message.as_str()));
+            model.as_mut().set_state(STATE_ERROR);
+        }
+    }
+}
+
+fn run_upload() -> UploadOutcome {
+    let log_path = log_file_path();
+    if !log_path.exists() {
+        return UploadOutcome::Error(format!("Log file not found at {}", log_path.display()));
+    }
+
+    let log_arg = format!("file=@{}", log_path.display());
+    let timeout_arg = UPLOAD_TIMEOUT_SECS.to_string();
+    // `--insecure` skips TLS verification. MiSTer ships with an outdated
+    // CA bundle and a clock that's wrong until NTP syncs minutes after
+    // boot, both of which make standard verification fail. The launcher
+    // is uploading a log to a known endpoint owned by the project — the
+    // payload is not sensitive and the destination is hard-coded — so
+    // accepting any cert is the right trade-off.
+    let output = match Command::new("curl")
+        .args([
+            "--silent",
+            "--show-error",
+            "--fail-with-body",
+            "--insecure",
+            "--max-time",
+            timeout_arg.as_str(),
+            "-F",
+            log_arg.as_str(),
+            UPLOAD_URL,
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+    {
+        Ok(out) => out,
+        Err(e) => {
+            return UploadOutcome::Error(format!("curl failed to start: {e}"));
+        }
+    };
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let message = if stderr.is_empty() {
+            format!("curl exited with status {}", output.status)
+        } else {
+            stderr
+        };
+        return UploadOutcome::Error(message);
+    }
+
+    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if url.is_empty() {
+        return UploadOutcome::Error("Upload service returned an empty response.".into());
+    }
+    if !url.starts_with("http://") && !url.starts_with("https://") {
+        return UploadOutcome::Error(format!("Unexpected upload response: {url}"));
+    }
+    UploadOutcome::Success(url)
+}

--- a/rust/launcher/src/models/mod.rs
+++ b/rust/launcher/src/models/mod.rs
@@ -31,6 +31,7 @@ pub mod games;
 pub mod games_state;
 pub mod hub_state;
 pub mod input;
+pub mod log_upload;
 pub mod media_status;
 pub mod platform;
 pub mod qr_code;

--- a/rust/launcher/src/models/settings.rs
+++ b/rust/launcher/src/models/settings.rs
@@ -36,6 +36,10 @@
 //     selection across the rename.
 //   * `current_mouse_enabled` — READ + NOTIFY, persisted. Defaults to true
 //     so existing installs keep the visible cursor and mouse hit targets.
+//   * `current_debug_logging` — READ + NOTIFY, persisted. Defaults to false.
+//     Toggling it writes `[logging] debug = …` into launcher.toml; the
+//     tracing subscriber is built once at startup so the change only takes
+//     effect on the next launch (mirrors how `language` works).
 //
 // Launcher-owned durable settings are mirrored into both `state.toml`
 // and `launcher.toml`. `state.toml` keeps the in-process snapshot
@@ -82,6 +86,7 @@ pub struct SettingsRust {
     available_button_layouts: QStringList,
     current_button_layout: QString,
     current_mouse_enabled: bool,
+    current_debug_logging: bool,
 }
 
 #[cxx_qt::bridge]
@@ -105,6 +110,7 @@ pub mod ffi {
         #[qproperty(QStringList, available_button_layouts, READ, CONSTANT)]
         #[qproperty(QString, current_button_layout, READ, WRITE = set_button_layout, NOTIFY)]
         #[qproperty(bool, current_mouse_enabled, READ, WRITE = set_mouse_enabled, NOTIFY)]
+        #[qproperty(bool, current_debug_logging, READ, WRITE = set_debug_logging, NOTIFY)]
         type Settings = super::SettingsRust;
 
         #[qinvokable]
@@ -118,6 +124,9 @@ pub mod ffi {
 
         #[qinvokable]
         fn set_mouse_enabled(self: Pin<&mut Settings>, value: bool);
+
+        #[qinvokable]
+        fn set_debug_logging(self: Pin<&mut Settings>, value: bool);
     }
 
     impl cxx_qt::Initialize for Settings {}
@@ -145,6 +154,7 @@ impl Initialize for ffi::Settings {
         self.as_mut().rust_mut().current_button_layout =
             QString::from(merged.button_layout.as_str());
         self.as_mut().rust_mut().current_mouse_enabled = merged.mouse_enabled;
+        self.as_mut().rust_mut().current_debug_logging = merged.debug_logging;
     }
 }
 
@@ -209,6 +219,16 @@ impl ffi::Settings {
         self.as_mut().rust_mut().current_mouse_enabled = value;
         self.as_mut().current_mouse_enabled_changed();
     }
+
+    fn set_debug_logging(mut self: Pin<&mut Self>, value: bool) {
+        if self.current_debug_logging == value {
+            return;
+        }
+        let snapshot = persist_settings(|s| s.debug_logging = value);
+        mirror_settings_to_config(&config_file_path(), &snapshot.settings);
+        self.as_mut().rust_mut().current_debug_logging = value;
+        self.as_mut().current_debug_logging_changed();
+    }
 }
 
 fn persist_settings<F: FnOnce(&mut SettingsState)>(mutator: F) -> persist::PersistedState {
@@ -237,6 +257,7 @@ fn mirror_settings_to_config(config_path: &std::path::Path, settings: &SettingsS
         settings.language.as_str(),
         settings.button_layout.as_str(),
         settings.mouse_enabled,
+        settings.debug_logging,
     ) {
         warn!(
             "could not save settings mirror to {}: {e}",
@@ -261,6 +282,9 @@ fn merge_settings(snapshot: &SettingsState, config: &Config) -> SettingsState {
             .settings
             .mouse_enabled
             .unwrap_or(snapshot.mouse_enabled),
+        // Config wins so launcher.toml is the durable source of truth on
+        // MiSTer (state.toml lives on tmpfs).
+        debug_logging: config.debug_logging,
     }
 }
 

--- a/rust/launcher/src/models/systems.rs
+++ b/rust/launcher/src/models/systems.rs
@@ -9,7 +9,7 @@ use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::task::JoinHandle;
-use tracing::{trace, warn};
+use tracing::{debug, trace, warn};
 use zaparoo_core::endpoints::catalog::CatalogEndpoint;
 use zaparoo_core::endpoints::readers_write::ReadersWriteMutation;
 use zaparoo_core::endpoints::run::RunMutation;
@@ -204,6 +204,13 @@ fn apply_state(mut model: Pin<&mut ffi::SystemsModel>, (data, err): (Option<Cata
             model.rust().seq.fetch_add(1, Ordering::SeqCst);
             let rows = rows_for_category(Some(&data), &cat);
             let count = rows.len() as i32;
+            let ids: Vec<&str> = rows.iter().map(|s| s.id.as_str()).collect();
+            debug!(
+                category = %cat,
+                count,
+                ?ids,
+                "systems: apply_state filled rows for category",
+            );
             model.as_mut().begin_reset_model();
             model.as_mut().rust_mut().systems = rows;
             model.as_mut().rust_mut().count = count;
@@ -339,6 +346,7 @@ impl ffi::SystemsModel {
             let rows = rows_for_category(catalog.as_ref(), &cat);
             let count = rows.len() as i32;
             let cat_for_log = cat.clone();
+            let ids_for_log: Vec<String> = rows.iter().map(|s| s.id.clone()).collect();
             let _ = qt_thread.queue(move |mut model| {
                 let current = seq.load(Ordering::SeqCst);
                 if current != ticket {
@@ -350,6 +358,12 @@ impl ffi::SystemsModel {
                     );
                     return;
                 }
+                debug!(
+                    category = %cat_for_log,
+                    count,
+                    ids = ?ids_for_log,
+                    "systems: set_category worker filled rows",
+                );
                 model.as_mut().begin_reset_model();
                 model.as_mut().rust_mut().systems = rows;
                 model.as_mut().rust_mut().count = count;

--- a/rust/zaparoo-core/src/client.rs
+++ b/rust/zaparoo-core/src/client.rs
@@ -449,7 +449,22 @@ impl Client {
         &self,
         params: MediaBrowseParams,
     ) -> Result<MediaBrowseResult, ClientError> {
+        debug!(
+            path = %params.path,
+            systems = ?params.systems,
+            max_results = ?params.max_results,
+            cursor_set = params.cursor.is_some(),
+            letter = ?params.letter,
+            sort = ?params.sort,
+            "media.browse request",
+        );
         let val = self.call("media.browse", &params).await?;
+        let entries_len = val
+            .get("entries")
+            .and_then(Value::as_array)
+            .map_or(0, Vec::len);
+        let total_files = val.get("totalFiles").and_then(Value::as_u64).unwrap_or(0);
+        debug!(entries_len, total_files, "media.browse response");
         serde_json::from_value(val).map_err(|e| ClientError {
             message: e.to_string(),
         })

--- a/rust/zaparoo-core/src/config.rs
+++ b/rust/zaparoo-core/src/config.rs
@@ -163,6 +163,7 @@ pub fn save_settings_mirror(
     language: &str,
     button_layout: &str,
     mouse_enabled: bool,
+    debug_logging: bool,
 ) -> Result<(), String> {
     let mut table = if path.exists() {
         let src = std::fs::read_to_string(path)
@@ -201,6 +202,17 @@ pub fn save_settings_mirror(
         toml::Value::String(button_layout.trim().to_string()),
     );
     settings.insert("mouse_enabled".into(), toml::Value::Boolean(mouse_enabled));
+
+    let logging_value = table
+        .entry("logging")
+        .or_insert_with(|| toml::Value::Table(toml::Table::new()));
+    let Some(logging) = logging_value.as_table_mut() else {
+        return Err(format!(
+            "config key [logging] in {} is not a table",
+            path.display()
+        ));
+    };
+    logging.insert("debug".into(), toml::Value::Boolean(debug_logging));
 
     let serialized =
         toml::to_string(&table).map_err(|e| format!("config serialisation failed: {e}"))?;
@@ -392,11 +404,12 @@ mod tests {
     fn save_settings_mirror_creates_sections() {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("launcher.toml");
-        save_settings_mirror(&path, "it_IT", "b", false).expect("save");
+        save_settings_mirror(&path, "it_IT", "b", false, true).expect("save");
         let cfg = load_config(&path);
         assert_eq!(cfg.language, "it_IT");
         assert_eq!(cfg.settings.button_layout.as_deref(), Some("b"));
         assert_eq!(cfg.settings.mouse_enabled, Some(false));
+        assert!(cfg.debug_logging);
     }
 
     #[test]
@@ -404,7 +417,7 @@ mod tests {
         let f = write_tmp(
             "[core]\nendpoint = \"ws://example.com/api\"\n[video]\nwidth = 1280\nheight = 720\n",
         );
-        save_settings_mirror(f.path(), "en", "a", true).expect("save");
+        save_settings_mirror(f.path(), "en", "a", true, false).expect("save");
         let cfg = load_config(f.path());
         assert_eq!(cfg.language, "en");
         assert_eq!(cfg.core_endpoint, "ws://example.com/api");
@@ -412,20 +425,23 @@ mod tests {
         assert_eq!(cfg.video_height, 720);
         assert_eq!(cfg.settings.button_layout.as_deref(), Some("a"));
         assert_eq!(cfg.settings.mouse_enabled, Some(true));
+        assert!(!cfg.debug_logging);
     }
 
     #[test]
     fn save_settings_mirror_normalizes_auto() {
         let f = write_tmp("");
-        save_settings_mirror(f.path(), "", "c", false).expect("save");
+        save_settings_mirror(f.path(), "", "c", false, true).expect("save");
         let written = std::fs::read_to_string(f.path()).expect("read");
         assert!(written.contains("language = \"auto\""));
         assert!(written.contains("button_layout = \"c\""));
         assert!(written.contains("mouse_enabled = false"));
+        assert!(written.contains("debug = true"));
         let cfg = load_config(f.path());
         assert_eq!(cfg.language, "");
         assert_eq!(cfg.settings.button_layout.as_deref(), Some("c"));
         assert_eq!(cfg.settings.mouse_enabled, Some(false));
+        assert!(cfg.debug_logging);
     }
 
     // Single test because std::env is process-global; splitting into

--- a/rust/zaparoo-core/src/persist.rs
+++ b/rust/zaparoo-core/src/persist.rs
@@ -92,6 +92,8 @@ pub struct SettingsState {
     pub button_layout: String,
     #[serde(default = "default_mouse_enabled")]
     pub mouse_enabled: bool,
+    #[serde(default)]
+    pub debug_logging: bool,
 }
 
 impl Default for SettingsState {
@@ -101,6 +103,7 @@ impl Default for SettingsState {
             language: String::new(),
             button_layout: default_button_layout(),
             mouse_enabled: default_mouse_enabled(),
+            debug_logging: false,
         }
     }
 }
@@ -240,6 +243,7 @@ mod tests {
                 language: "it_IT".into(),
                 button_layout: "b".into(),
                 mouse_enabled: false,
+                debug_logging: true,
             },
         };
         save_to(&path, &original);
@@ -331,6 +335,7 @@ mod tests {
         assert_eq!(state.settings.language, "");
         assert_eq!(state.settings.button_layout, "a");
         assert!(state.settings.mouse_enabled);
+        assert!(!state.settings.debug_logging);
     }
 
     #[test]

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -32,6 +32,7 @@ MainLayout {
     readonly property string modalContextMenu: "context_menu"
     readonly property string modalQrCode: "qr_code"
     readonly property string modalFirstRunIndex: "first_run_index"
+    readonly property string modalLogUpload: "log_upload"
     // One-shot session flag: the first-run modal is shown at most
     // once per launcher process, even if the WS link drops and the
     // mediadb-empty condition would otherwise be satisfied again.
@@ -452,6 +453,7 @@ MainLayout {
     Connections {
         target: root.settingsScreen
         function onRequestHubScreen(): void { root._goto(root.screenHub) }
+        function onRequestLogUploadModal(): void { root.openLogUploadModal() }
     }
     Connections {
         target: root.systemsScreen
@@ -540,12 +542,14 @@ MainLayout {
     // Pure helper — owner/entryType/hasNfc → list of `{id,label}` entries.
     // Empty list = no menu (caller bails out of openContextMenu).
     //
-    // No `list<var>` return annotation: MiSTer's AOT-compiled static QML
-    // build coerces the JS array through that type and the caller saw
-    // `entries.length === 0` despite the function pushing 3 items in.
-    // Plain JS arrays round-trip cleanly through an unannotated return.
+    // Annotated as `: var` (not `list<var>`): MiSTer's AOT-compiled
+    // static QML build coerces the JS array through `list<var>` and the
+    // caller saw `entries.length === 0` despite the function pushing 3
+    // items in. Plain `var` round-trips cleanly and silences the
+    // qmllint "insufficiently annotated" coercion warning at the call
+    // site.
     function buildContextMenuEntries(
-            owner: string, entryType: string, hasNfc: bool) {
+            owner: string, entryType: string, hasNfc: bool): var {
         if (owner === "systems") {
             return [{ id: "launch_system", label: qsTr("Launch core") }]
         }
@@ -677,6 +681,28 @@ MainLayout {
             ScreenManager.popModal()
     }
 
+    // Log-upload modal lifecycle. Triggered from the Settings "Upload
+    // log" action; the modal kicks off `Browse.LogUpload.upload()` on
+    // its own when `open` flips true. The modal owns its three-phase
+    // view; the router only owns push/pop and stack bookkeeping.
+    function openLogUploadModal(): void {
+        // Reset before showing so a previous success/error from earlier
+        // in the session doesn't paint stale state behind the new
+        // upload's "Uploading…" copy.
+        Browse.LogUpload.reset()
+        root.logUploadModalVisible = true
+        if (ScreenManager.topModal !== root.modalLogUpload)
+            ScreenManager.pushModal(root.modalLogUpload)
+    }
+
+    function closeLogUploadModal(): void {
+        root.logUploadModalVisible = false
+        if (ScreenManager.topModal === root.modalLogUpload)
+            ScreenManager.popModal()
+    }
+
+    onCloseLogUploadRequested: root.closeLogUploadModal()
+
     Connections {
         target: Browse.AppStatus
         function onConnection_stateChanged(): void {
@@ -785,6 +811,8 @@ MainLayout {
                 root.contextMenu.handleAction(action)
             } else if (ScreenManager.topModal === root.modalFirstRunIndex) {
                 root.firstRunIndexModal.handleAction(action)
+            } else if (ScreenManager.topModal === root.modalLogUpload) {
+                root.logUploadModal.handleAction(action)
             }
             // While a modal owns input, swallow everything not handled
             // above rather than leak it to the root screen.

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -453,7 +453,10 @@ MainLayout {
     Connections {
         target: root.settingsScreen
         function onRequestHubScreen(): void { root._goto(root.screenHub) }
-        function onRequestLogUploadModal(): void { root.openLogUploadModal() }
+        function onRequestAccept(actionId: string): void {
+            if (actionId === "uploadLog")
+                root.openLogUploadModal()
+        }
     }
     Connections {
         target: root.systemsScreen

--- a/src/ui/app/MainLayout.qml
+++ b/src/ui/app/MainLayout.qml
@@ -65,11 +65,13 @@ ApplicationWindow {
     property alias settingsScreen: settingsScreen
     property alias contextMenu: contextMenu
     property alias firstRunIndexModal: firstRunIndexModal
+    property alias logUploadModal: logUploadModal
 
     property bool cardWriteModalVisible: false
     property bool cardWriteFailed: false
     property bool qrCodeModalVisible: false
     property bool firstRunIndexModalVisible: false
+    property bool logUploadModalVisible: false
     property bool contextMenuVisible: false
     property rect contextMenuAnchor: Qt.rect(0, 0, 0, 0)
     // Owner-aware. Written by Main.qml at openContextMenu time; each entry
@@ -130,6 +132,7 @@ ApplicationWindow {
     signal cancelCardWriteRequested()
     signal closeQrCodeRequested()
     signal closeFirstRunIndexRequested()
+    signal closeLogUploadRequested()
 
     // Two-way sync between root.activeScreen and ScreenManager.activeScreen.
     // Binding-breaking assignments (tests setting root.activeScreen = "games")
@@ -322,6 +325,17 @@ ApplicationWindow {
         onCloseRequested: root.closeFirstRunIndexRequested()
     }
 
+    // Log-upload modal. Pushed by Main.qml when the user triggers the
+    // "Upload log" action in Settings. Owns its own three-phase view
+    // (uploading / success / error) — the router only sees open / close.
+    LogUploadModal {
+        id: logUploadModal
+
+        anchors.fill: parent
+        open: root.logUploadModalVisible
+        onCloseRequested: root.closeLogUploadRequested()
+    }
+
     // ── Top-right HUD ─────────────────────────────────────────────────────────
     //
     // Host status icons plus clock. The Row is right-anchored so icons
@@ -470,6 +484,21 @@ ApplicationWindow {
                 return [{ button: "ButtonB", label: qsTr("Cancel") }];
             if (root.qrCodeModalVisible)
                 return [{ button: "ButtonB", label: qsTr("Close") }];
+            if (root.logUploadModalVisible) {
+                const phase = root.logUploadModal.phase;
+                if (phase === root.logUploadModal._stateSuccess)
+                    return [
+                        { button: "ButtonA", label: qsTr("Done") },
+                        { button: "ButtonB", label: qsTr("Close") }
+                    ];
+                if (phase === root.logUploadModal._stateError)
+                    return [
+                        { button: "ButtonA", label: qsTr("Retry") },
+                        { button: "ButtonB", label: qsTr("Close") }
+                    ];
+                // Idle / uploading: only Cancel.
+                return [{ button: "ButtonB", label: qsTr("Cancel") }];
+            }
             if (!root.bootComplete)
                 return [];
             if (root.firstRunIndexModalVisible) {
@@ -558,7 +587,7 @@ ApplicationWindow {
                         label: qsTr("Change")
                     });
                 }
-                if (root.settingsScreen.focusedFieldIsMouse)
+                if (root.settingsScreen.focusedFieldIsToggle)
                     row.push({ button: "ButtonA", label: qsTr("Toggle") });
                 else if (root.settingsScreen.focusedFieldIsAction
                          && !root.settingsScreen.focusedActionDisabled)

--- a/src/ui/components/CMakeLists.txt
+++ b/src/ui/components/CMakeLists.txt
@@ -15,6 +15,7 @@ qt_add_qml_module(
         CoreStatusPill.qml
         FirstRunIndexModal.qml
         LoadingIndicator.qml
+        LogUploadModal.qml
         Modal.qml
         PagedGrid.qml
         QrCodeModal.qml

--- a/src/ui/components/CoreStatusPill.qml
+++ b/src/ui/components/CoreStatusPill.qml
@@ -59,7 +59,7 @@ Item {
             if (Browse.MediaStatus.paused)
                 return qsTr("Indexing paused");
             if (tot > 0 && display !== "")
-                return qsTr("Indexing %1/%2 — %3").arg(cur).arg(tot).arg(display);
+                return qsTr("Indexing %1/%2 - %3").arg(cur).arg(tot).arg(display);
             if (tot > 0)
                 return qsTr("Indexing %1/%2").arg(cur).arg(tot);
             return qsTr("Indexing…");
@@ -72,7 +72,7 @@ Item {
             if (Browse.MediaStatus.scrape_paused)
                 return qsTr("Scrape paused");
             if (total > 0 && sys !== "")
-                return qsTr("Scraping %1/%2 — %3").arg(proc).arg(total).arg(sys);
+                return qsTr("Scraping %1/%2 - %3").arg(proc).arg(total).arg(sys);
             if (total > 0)
                 return qsTr("Scraping %1/%2").arg(proc).arg(total);
             return qsTr("Scraping…");

--- a/src/ui/components/FirstRunIndexModal.qml
+++ b/src/ui/components/FirstRunIndexModal.qml
@@ -129,188 +129,189 @@ Item {
 
         anchors.centerIn: parent
         width: Math.min(parent.width * 0.78, Sizing.pctH(90))
-        height: Sizing.pctH(46)
+        // Fit current contents. Column drops invisible children from
+        // its layout, so the panel shrinks for the short idle body and
+        // grows for the running progress block.
+        height: contentColumn.height + Sizing.pctH(12)
         color: Theme.bgPanel
         border.width: 2
         border.color: Theme.textPrimary
         radius: Sizing.cornerRadius
 
-        Text {
-            id: titleText
+        Column {
+            id: contentColumn
 
             anchors.left: parent.left
             anchors.right: parent.right
             anchors.top: parent.top
             anchors.topMargin: Sizing.pctH(6)
-            anchors.leftMargin: Sizing.pctW(5)
-            anchors.rightMargin: Sizing.pctW(5)
-            text: qsTr("First-time setup")
-            font.family: Theme.fontUi
-            font.pixelSize: Sizing.fontSize(3.2)
-            color: Theme.textPrimary
-            wrapMode: Text.WordWrap
-            horizontalAlignment: Text.AlignHCenter
-            renderType: Text.NativeRendering
-        }
-
-        Text {
-            id: bodyIdle
-
-            anchors.left: parent.left
-            anchors.right: parent.right
-            anchors.top: titleText.bottom
-            anchors.topMargin: Sizing.pctH(2)
             anchors.leftMargin: Sizing.pctW(6)
             anchors.rightMargin: Sizing.pctW(6)
-            visible: modal.phase === "idle"
-            text: qsTr("Zaparoo needs to scan your games before you can use the launcher. This usually takes a few minutes.")
-            font.family: Theme.fontUi
-            font.pixelSize: Sizing.fontSize(2.5)
-            color: Theme.textPrimary
-            wrapMode: Text.WordWrap
-            horizontalAlignment: Text.AlignHCenter
-            renderType: Text.NativeRendering
-        }
+            spacing: Sizing.pctH(3)
 
-        Item {
-            id: runningView
-
-            anchors.top: titleText.bottom
-            anchors.topMargin: Sizing.pctH(4)
-            anchors.left: parent.left
-            anchors.right: parent.right
-            anchors.leftMargin: Sizing.pctW(7)
-            anchors.rightMargin: Sizing.pctW(7)
-            height: Sizing.pctH(14)
-            visible: modal.phase === "running"
-
-            // Vacuum phase fallback. Mirrors the mobile app's "Optimizing
-            // database" copy without the pulsing animation (software
-            // renderer pays per-frame for translucent overlays).
             Text {
-                anchors.fill: parent
-                visible: Browse.MediaStatus.optimizing
-                text: qsTr("Optimizing database — almost done")
+                id: titleText
+
+                width: parent.width
+                text: qsTr("First-time setup")
+                font.family: Theme.fontUi
+                font.pixelSize: Sizing.fontSize(3.2)
+                color: Theme.textPrimary
+                wrapMode: Text.WordWrap
+                horizontalAlignment: Text.AlignHCenter
+                renderType: Text.NativeRendering
+            }
+
+            Text {
+                id: bodyIdle
+
+                width: parent.width
+                visible: modal.phase === "idle"
+                text: qsTr("Zaparoo needs to scan your games before you can use the launcher. This usually takes a few minutes.")
+                font.family: Theme.fontUi
+                font.pixelSize: Sizing.fontSize(2.5)
+                color: Theme.textPrimary
+                wrapMode: Text.WordWrap
+                horizontalAlignment: Text.AlignHCenter
+                renderType: Text.NativeRendering
+            }
+
+            Item {
+                id: runningView
+
+                width: parent.width
+                height: Sizing.pctH(14)
+                visible: modal.phase === "running"
+
+                // Vacuum phase fallback. Mirrors the mobile app's "Optimizing
+                // database" copy without the pulsing animation (software
+                // renderer pays per-frame for translucent overlays).
+                Text {
+                    anchors.fill: parent
+                    visible: Browse.MediaStatus.optimizing
+                    text: qsTr("Optimizing database - almost done")
+                    font.family: Theme.fontUi
+                    font.pixelSize: Sizing.fontSize(2.6)
+                    color: Theme.textPrimary
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
+                    wrapMode: Text.WordWrap
+                    renderType: Text.NativeRendering
+                }
+
+                Item {
+                    anchors.fill: parent
+                    visible: !Browse.MediaStatus.optimizing
+
+                    Rectangle {
+                        id: progressTrack
+
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.top: parent.top
+                        anchors.topMargin: Sizing.pctH(1)
+                        height: Sizing.pctH(1.4)
+                        color: Theme.borderSubtle
+                        radius: height / 2
+
+                        Rectangle {
+                            readonly property real _ratio: {
+                                const tot = Browse.MediaStatus.total_steps
+                                if (tot <= 0)
+                                    return 0
+                                const cur = Browse.MediaStatus.current_step
+                                return Math.max(0, Math.min(1, cur / tot))
+                            }
+
+                            anchors.left: parent.left
+                            anchors.top: parent.top
+                            anchors.bottom: parent.bottom
+                            width: progressTrack.width * _ratio
+                            color: Theme.accent
+                            radius: parent.radius
+                        }
+                    }
+
+                    Text {
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.top: progressTrack.bottom
+                        anchors.topMargin: Sizing.pctH(2.4)
+                        text: {
+                            const display = Browse.MediaStatus.current_step_display
+                            const cur = Browse.MediaStatus.current_step
+                            const tot = Browse.MediaStatus.total_steps
+                            if (Browse.MediaStatus.paused)
+                                return qsTr("Indexing paused")
+                            if (tot > 0 && display !== "")
+                                return qsTr("Step %1 of %2 - %3").arg(cur).arg(tot).arg(display)
+                            if (tot > 0)
+                                return qsTr("Step %1 of %2").arg(cur).arg(tot)
+                            return qsTr("Preparing…")
+                        }
+                        font.family: Theme.fontUi
+                        font.pixelSize: Sizing.fontSize(2.3)
+                        color: Theme.textLabel
+                        wrapMode: Text.WordWrap
+                        horizontalAlignment: Text.AlignHCenter
+                        renderType: Text.NativeRendering
+                        elide: Text.ElideRight
+                        maximumLineCount: 2
+                    }
+                }
+            }
+
+            Text {
+                id: completionMessage
+
+                width: parent.width
+                visible: modal.phase === "completed"
+                text: qsTr("Done. %1 files indexed.").arg(Browse.MediaStatus.total_files)
                 font.family: Theme.fontUi
                 font.pixelSize: Sizing.fontSize(2.6)
                 color: Theme.textPrimary
                 horizontalAlignment: Text.AlignHCenter
-                verticalAlignment: Text.AlignVCenter
                 wrapMode: Text.WordWrap
                 renderType: Text.NativeRendering
             }
 
             Item {
-                anchors.fill: parent
-                visible: !Browse.MediaStatus.optimizing
+                id: actionButtonSlot
+
+                width: parent.width
+                height: Sizing.pctH(7)
+                visible: modal.phase !== "completed"
 
                 Rectangle {
-                    id: progressTrack
+                    id: actionButton
 
-                    anchors.left: parent.left
-                    anchors.right: parent.right
-                    anchors.top: parent.top
-                    anchors.topMargin: Sizing.pctH(1)
-                    height: Sizing.pctH(1.4)
-                    color: Theme.borderSubtle
-                    radius: height / 2
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    anchors.verticalCenter: parent.verticalCenter
+                    width: Sizing.pctW(28)
+                    height: parent.height
+                    color: Theme.bgBar
+                    border.width: 1
+                    border.color: Theme.borderMid
+                    radius: Sizing.cornerRadius
 
-                    Rectangle {
-                        readonly property real _ratio: {
-                            const tot = Browse.MediaStatus.total_steps
-                            if (tot <= 0)
-                                return 0
-                            const cur = Browse.MediaStatus.current_step
-                            return Math.max(0, Math.min(1, cur / tot))
-                        }
+                    Text {
+                        anchors.centerIn: parent
+                        text: modal.phase === "running"
+                              ? qsTr("Cancel")
+                              : qsTr("Start scan")
+                        font.family: Theme.fontUi
+                        font.pixelSize: Sizing.fontSize(2.5)
+                        color: Theme.textPrimary
+                        renderType: Text.NativeRendering
+                    }
 
-                        anchors.left: parent.left
-                        anchors.top: parent.top
-                        anchors.bottom: parent.bottom
-                        width: progressTrack.width * _ratio
-                        color: Theme.accent
-                        radius: parent.radius
+                    MouseArea {
+                        anchors.fill: parent
+                        acceptedButtons: Qt.LeftButton
+                        onClicked: modal.handleAction(modal.phase === "running"
+                                                      ? "cancel" : "accept")
                     }
                 }
-
-                Text {
-                    anchors.left: parent.left
-                    anchors.right: parent.right
-                    anchors.top: progressTrack.bottom
-                    anchors.topMargin: Sizing.pctH(2.4)
-                    text: {
-                        const display = Browse.MediaStatus.current_step_display
-                        const cur = Browse.MediaStatus.current_step
-                        const tot = Browse.MediaStatus.total_steps
-                        if (Browse.MediaStatus.paused)
-                            return qsTr("Indexing paused")
-                        if (tot > 0 && display !== "")
-                            return qsTr("Step %1 of %2 — %3").arg(cur).arg(tot).arg(display)
-                        if (tot > 0)
-                            return qsTr("Step %1 of %2").arg(cur).arg(tot)
-                        return qsTr("Preparing…")
-                    }
-                    font.family: Theme.fontUi
-                    font.pixelSize: Sizing.fontSize(2.3)
-                    color: Theme.textLabel
-                    wrapMode: Text.WordWrap
-                    horizontalAlignment: Text.AlignHCenter
-                    renderType: Text.NativeRendering
-                    elide: Text.ElideRight
-                    maximumLineCount: 2
-                }
-            }
-        }
-
-        Text {
-            id: completionMessage
-
-            anchors.left: parent.left
-            anchors.right: parent.right
-            anchors.top: titleText.bottom
-            anchors.topMargin: Sizing.pctH(4)
-            anchors.leftMargin: Sizing.pctW(6)
-            anchors.rightMargin: Sizing.pctW(6)
-            visible: modal.phase === "completed"
-            text: qsTr("Done. %1 files indexed.").arg(Browse.MediaStatus.total_files)
-            font.family: Theme.fontUi
-            font.pixelSize: Sizing.fontSize(2.6)
-            color: Theme.textPrimary
-            horizontalAlignment: Text.AlignHCenter
-            wrapMode: Text.WordWrap
-            renderType: Text.NativeRendering
-        }
-
-        Rectangle {
-            id: actionButton
-
-            anchors.horizontalCenter: parent.horizontalCenter
-            anchors.bottom: parent.bottom
-            anchors.bottomMargin: Sizing.pctH(5)
-            width: Sizing.pctW(28)
-            height: Sizing.pctH(7)
-            color: Theme.bgBar
-            border.width: 1
-            border.color: Theme.borderMid
-            radius: Sizing.cornerRadius
-            visible: modal.phase !== "completed"
-
-            Text {
-                anchors.centerIn: parent
-                text: modal.phase === "running"
-                      ? qsTr("Cancel")
-                      : qsTr("Start scan")
-                font.family: Theme.fontUi
-                font.pixelSize: Sizing.fontSize(2.5)
-                color: Theme.textPrimary
-                renderType: Text.NativeRendering
-            }
-
-            MouseArea {
-                anchors.fill: parent
-                acceptedButtons: Qt.LeftButton
-                onClicked: modal.handleAction(modal.phase === "running"
-                                              ? "cancel" : "accept")
             }
         }
     }

--- a/src/ui/components/LogUploadModal.qml
+++ b/src/ui/components/LogUploadModal.qml
@@ -1,0 +1,281 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+import QtQuick
+import Zaparoo.Theme
+import Zaparoo.Browse as Browse
+
+// cxx-qt 0.8 patches `isFinal: true` on singleton properties but the
+// qmltypes schema has no `isFinal` slot, so every read trips qmllint's
+// "Member can be shadowed" check. Until the schema grows the slot,
+// suppress the compiler category file-wide.
+// qmllint disable compiler
+
+// Modal shown when the user triggers "Upload log" from Settings. Three
+// visual phases driven by `Browse.LogUpload.state`:
+//
+//   uploading (1) — single line of body copy, no buttons. Cancel via
+//                   Escape (router pops the modal; the upload finishes
+//                   in the background but the user can no longer see
+//                   the result).
+//   success   (2) — QR of the URL on top, the URL as plain text below,
+//                   and a "Done" button that closes the modal.
+//   error     (3) — error message + a "Retry" button that re-fires
+//                   `Browse.LogUpload.upload()`.
+//
+// Routing and the modal stack are owned by `Main.qml`. We emit
+// `closeRequested` and trust the router to pop. `handleAction` is the
+// input hook called from `Main.qml`'s modal-dispatch branch.
+Item {
+    id: modal
+
+    property bool open: false
+
+    signal closeRequested()
+
+    readonly property int _stateIdle: 0
+    readonly property int _stateUploading: 1
+    readonly property int _stateSuccess: 2
+    readonly property int _stateError: 3
+
+    readonly property int phase: Browse.LogUpload.state
+
+    visible: modal.open
+    anchors.fill: parent
+    z: 300
+
+    onOpenChanged: {
+        if (!modal.open)
+            return
+        if (modal.phase === modal._stateIdle)
+            Browse.LogUpload.upload()
+    }
+
+    // Generate the QR matrix as soon as we have a URL. `Browse.QrCode`
+    // is shared across the launcher; the next consumer (a future flow)
+    // will overwrite it with their own content, so generate eagerly
+    // rather than relying on a previously cached matrix.
+    Connections {
+        target: Browse.LogUpload
+        function onStateChanged(): void {
+            if (Browse.LogUpload.state === modal._stateSuccess)
+                Browse.QrCode.generate(Browse.LogUpload.url)
+        }
+    }
+
+    function handleAction(action: string): void {
+        if (action === "accept") {
+            if (modal.phase === modal._stateSuccess) {
+                modal.closeRequested()
+            } else if (modal.phase === modal._stateError) {
+                Browse.LogUpload.upload()
+            }
+        } else if (action === "cancel") {
+            modal.closeRequested()
+        }
+    }
+
+    // Scrim. Eats clicks so they don't reach the screen tree underneath.
+    Rectangle {
+        anchors.fill: parent
+        color: "#cc000000"
+
+        MouseArea {
+            anchors.fill: parent
+        }
+    }
+
+    Rectangle {
+        id: panel
+
+        anchors.centerIn: parent
+        width: Math.min(parent.width * 0.78, Sizing.pctH(110))
+        height: contentColumn.height + Sizing.pctH(12)
+        color: Theme.bgPanel
+        border.width: 2
+        border.color: Theme.textPrimary
+        radius: Sizing.cornerRadius
+
+        Column {
+            id: contentColumn
+
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.top: parent.top
+            anchors.topMargin: Sizing.pctH(6)
+            anchors.leftMargin: Sizing.pctW(6)
+            anchors.rightMargin: Sizing.pctW(6)
+            spacing: Sizing.pctH(3)
+
+            Text {
+                width: parent.width
+                text: qsTr("Upload log file")
+                font.family: Theme.fontUi
+                font.pixelSize: Sizing.fontSize(3.2)
+                color: Theme.textPrimary
+                wrapMode: Text.WordWrap
+                horizontalAlignment: Text.AlignHCenter
+                renderType: Text.NativeRendering
+            }
+
+            Text {
+                width: parent.width
+                visible: modal.phase === modal._stateUploading
+                         || modal.phase === modal._stateIdle
+                text: qsTr("Uploading log file - this may take a moment.")
+                font.family: Theme.fontUi
+                font.pixelSize: Sizing.fontSize(2.6)
+                color: Theme.textPrimary
+                horizontalAlignment: Text.AlignHCenter
+                wrapMode: Text.WordWrap
+                renderType: Text.NativeRendering
+            }
+
+            // Success block — QR matrix above, URL plain-text below.
+            // The QR is a fixed pixel size derived from the matrix size
+            // so the modal's panel height stays stable across phases.
+            Item {
+                id: successBlock
+
+                width: parent.width
+                visible: modal.phase === modal._stateSuccess
+                height: visible ? qrHolder.height + urlText.height + Sizing.pctH(2) : 0
+
+                readonly property int matrixSize: Browse.QrCode.size
+                readonly property int quietZone: 4
+                readonly property real maxQrPixels:
+                    Math.min(Sizing.pctW(38), Sizing.pctH(54))
+                readonly property real moduleSize: matrixSize > 0
+                    ? Math.max(1,
+                        Math.floor(maxQrPixels / (matrixSize + quietZone * 2)))
+                    : 1
+                readonly property real qrPixels:
+                    moduleSize * (matrixSize + quietZone * 2)
+
+                Rectangle {
+                    id: qrHolder
+
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    anchors.top: parent.top
+                    width: successBlock.qrPixels
+                    height: successBlock.qrPixels
+                    color: "white"
+                    border.width: Math.max(1,
+                                           Math.round(successBlock.moduleSize * 0.18))
+                    border.color: Theme.borderSubtle
+
+                    Item {
+                        id: matrix
+
+                        anchors.centerIn: parent
+                        width: successBlock.moduleSize * successBlock.matrixSize
+                        height: successBlock.moduleSize * successBlock.matrixSize
+                        visible: successBlock.matrixSize > 0
+
+                        Repeater {
+                            model: successBlock.matrixSize
+
+                            delegate: Item {
+                                id: rowDelegate
+
+                                required property int index
+
+                                readonly property int row: index
+                                readonly property string bits:
+                                    Browse.QrCode.row_at(row)
+
+                                x: 0
+                                y: row * successBlock.moduleSize
+                                width: matrix.width
+                                height: successBlock.moduleSize
+
+                                Repeater {
+                                    model: successBlock.matrixSize
+
+                                    delegate: Rectangle {
+                                        required property int index
+
+                                        x: index * successBlock.moduleSize
+                                        y: 0
+                                        width: successBlock.moduleSize
+                                        height: successBlock.moduleSize
+                                        color: "black"
+                                        visible: rowDelegate.bits.charAt(index) === "1"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Text {
+                    id: urlText
+
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    anchors.top: qrHolder.bottom
+                    anchors.topMargin: Sizing.pctH(2)
+                    width: parent.width
+                    text: Browse.LogUpload.url
+                    font.family: Theme.fontUi
+                    font.pixelSize: Sizing.fontSize(2.2)
+                    color: Theme.textPrimary
+                    horizontalAlignment: Text.AlignHCenter
+                    wrapMode: Text.WrapAnywhere
+                    renderType: Text.NativeRendering
+                }
+            }
+
+            Text {
+                width: parent.width
+                visible: modal.phase === modal._stateError
+                text: Browse.LogUpload.error_message !== ""
+                      ? qsTr("Upload failed: %1").arg(Browse.LogUpload.error_message)
+                      : qsTr("Upload failed.")
+                font.family: Theme.fontUi
+                font.pixelSize: Sizing.fontSize(2.4)
+                color: Theme.textPrimary
+                horizontalAlignment: Text.AlignHCenter
+                wrapMode: Text.WordWrap
+                renderType: Text.NativeRendering
+            }
+
+            Item {
+                width: parent.width
+                height: Sizing.pctH(7)
+                visible: modal.phase === modal._stateSuccess
+                         || modal.phase === modal._stateError
+
+                Rectangle {
+                    id: actionButton
+
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    anchors.verticalCenter: parent.verticalCenter
+                    width: Sizing.pctW(28)
+                    height: parent.height
+                    color: Theme.bgBar
+                    border.width: 1
+                    border.color: Theme.borderMid
+                    radius: Sizing.cornerRadius
+
+                    Text {
+                        anchors.centerIn: parent
+                        text: modal.phase === modal._stateError
+                              ? qsTr("Retry")
+                              : qsTr("Done")
+                        font.family: Theme.fontUi
+                        font.pixelSize: Sizing.fontSize(2.5)
+                        color: Theme.textPrimary
+                        renderType: Text.NativeRendering
+                    }
+
+                    MouseArea {
+                        anchors.fill: parent
+                        acceptedButtons: Qt.LeftButton
+                        onClicked: modal.handleAction("accept")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/ui/screens/HubScreen.qml
+++ b/src/ui/screens/HubScreen.qml
@@ -475,8 +475,14 @@ Item {
         anchors.right: parent.right
         height: Sizing.pctH(7)
         text: {
-            if (hub.currentRow === 1)
-                return hub.actionEntries[hub.currentIndex].text
+            if (hub.currentRow === 1) {
+                // currentIndex can briefly outrun actionEntries.length
+                // during cold launch, before HubState is clamped to the
+                // row. Guard the lookup so an undefined access doesn't
+                // surface as a TypeError in the log.
+                const entry = hub.actionEntries[hub.currentIndex]
+                return entry ? entry.text : ""
+            }
             if (Browse.CategoriesModel.count > 0)
                 return Browse.CategoriesModel.category_at(hub.currentIndex)
             return ""

--- a/src/ui/screens/SettingsScreen.qml
+++ b/src/ui/screens/SettingsScreen.qml
@@ -35,6 +35,10 @@ Item {
     property bool transitioning: false
 
     signal requestHubScreen()
+    // Asks the router to push the log-upload modal. Emitted when the
+    // upload-log action row is accepted; the modal owns its own state
+    // machine from there.
+    signal requestLogUploadModal()
 
     // Field registry. Each entry's `id` is read by handleAction to
     // route the cycle to the right model setter. Keeping this as data
@@ -76,6 +80,14 @@ Item {
         out.push({
             id: "runScraper",
             label: qsTr("Scrape metadata")
+        })
+        out.push({
+            id: "debugLogging",
+            label: qsTr("Debug logging")
+        })
+        out.push({
+            id: "uploadLog",
+            label: qsTr("Upload log file")
         })
         return out
     }
@@ -125,14 +137,22 @@ Item {
     }
 
     readonly property int fieldCount: settings.fields.length
-    readonly property bool focusedFieldIsMouse:
-        settings.fieldCount > 0 && settings.fields[settings.currentIndex].id === "mouseEnabled"
+    readonly property bool focusedFieldIsToggle: {
+        if (settings.fieldCount === 0)
+            return false
+        const id = settings.fields[settings.currentIndex].id
+        return id === "mouseEnabled" || id === "debugLogging"
+    }
     // True when the focused field is an action button (updateMediaDb,
-    // runScraper). Drives the help-bar Accept hint.
-    readonly property bool focusedFieldIsAction:
-        settings.fieldCount > 0
-        && (settings.fields[settings.currentIndex].id === "updateMediaDb"
-            || settings.fields[settings.currentIndex].id === "runScraper")
+    // runScraper, uploadLog). Drives the help-bar Accept hint.
+    readonly property bool focusedFieldIsAction: {
+        if (settings.fieldCount === 0)
+            return false
+        const id = settings.fields[settings.currentIndex].id
+        return id === "updateMediaDb"
+               || id === "runScraper"
+               || id === "uploadLog"
+    }
     // True when the focused action's matching operation is currently
     // running, so the help bar can label Accept as "Cancel" rather
     // than "Start".
@@ -275,6 +295,14 @@ Item {
         Browse.Settings.set_mouse_enabled(!Browse.Settings.current_mouse_enabled)
     }
 
+    function _setDebugLogging(direction: int): void {
+        Browse.Settings.set_debug_logging(direction > 0)
+    }
+
+    function _toggleDebugLogging(): void {
+        Browse.Settings.set_debug_logging(!Browse.Settings.current_debug_logging)
+    }
+
     function _cycleFocused(direction: int): void {
         if (settings.fieldCount === 0)
             return
@@ -287,6 +315,8 @@ Item {
             settings._cycleButtonLayout(direction)
         else if (id === "mouseEnabled")
             settings._setMouseEnabled(direction)
+        else if (id === "debugLogging")
+            settings._setDebugLogging(direction)
         // Action fields ignore left/right — they only respond to accept.
     }
 
@@ -307,10 +337,14 @@ Item {
             const id = settings.fields[settings.currentIndex].id
             if (id === "mouseEnabled")
                 settings._toggleMouseEnabled()
+            else if (id === "debugLogging")
+                settings._toggleDebugLogging()
             else if (id === "updateMediaDb")
                 settings._triggerIndex()
             else if (id === "runScraper")
                 settings._triggerScrape()
+            else if (id === "uploadLog")
+                settings.requestLogUploadModal()
         } else if (action === "cancel") {
             settings.requestHubScreen()
         }
@@ -371,11 +405,15 @@ Item {
                        : modelData.id === "buttonLayout"
                        ? settings._buttonLayoutDisplay(Browse.Settings.current_button_layout)
                        : ""
-                control: modelData.id === "mouseEnabled" ? "toggle"
+                control: modelData.id === "mouseEnabled" || modelData.id === "debugLogging"
+                         ? "toggle"
                          : (modelData.id === "updateMediaDb"
-                            || modelData.id === "runScraper") ? "action"
+                            || modelData.id === "runScraper"
+                            || modelData.id === "uploadLog") ? "action"
                          : "value"
-                checked: Browse.Settings.current_mouse_enabled
+                checked: modelData.id === "debugLogging"
+                         ? Browse.Settings.current_debug_logging
+                         : Browse.Settings.current_mouse_enabled
                 actionStatus: modelData.id === "updateMediaDb"
                               ? settings._indexActionStatus()
                               : modelData.id === "runScraper"
@@ -391,6 +429,8 @@ Item {
                                   && settings._buttonLayoutList().length > 1)
                               || (modelData.id === "mouseEnabled"
                                   && Browse.Settings.current_mouse_enabled)
+                              || (modelData.id === "debugLogging"
+                                  && Browse.Settings.current_debug_logging)
                 canCycleNext: (modelData.id === "resolution"
                                && settings._resolutionList().length > 0)
                               || (modelData.id === "language"
@@ -399,11 +439,15 @@ Item {
                                   && settings._buttonLayoutList().length > 1)
                               || (modelData.id === "mouseEnabled"
                                   && !Browse.Settings.current_mouse_enabled)
+                              || (modelData.id === "debugLogging"
+                                  && !Browse.Settings.current_debug_logging)
                 onHovered: settings.currentIndex = index
                 onClicked: {
                     settings.currentIndex = index
                     if (modelData.id === "mouseEnabled")
                         settings._toggleMouseEnabled()
+                    else if (modelData.id === "debugLogging")
+                        settings._toggleDebugLogging()
                 }
                 // Action rows route through `onAccepted` only (see
                 // `SettingsField.qml`'s MouseArea), so the focus
@@ -415,6 +459,8 @@ Item {
                         settings._triggerIndex()
                     else if (modelData.id === "runScraper")
                         settings._triggerScrape()
+                    else if (modelData.id === "uploadLog")
+                        settings.requestLogUploadModal()
                 }
             }
         }

--- a/src/ui/screens/SettingsScreen.qml
+++ b/src/ui/screens/SettingsScreen.qml
@@ -35,10 +35,10 @@ Item {
     property bool transitioning: false
 
     signal requestHubScreen()
-    // Asks the router to push the log-upload modal. Emitted when the
-    // upload-log action row is accepted; the modal owns its own state
-    // machine from there.
-    signal requestLogUploadModal()
+    // Forward signal carrying the focused action row's id. The router
+    // decides what the payload means — currently only "uploadLog" is
+    // wired, which opens the log-upload modal.
+    signal requestAccept(actionId: string)
 
     // Field registry. Each entry's `id` is read by handleAction to
     // route the cycle to the right model setter. Keeping this as data
@@ -344,7 +344,7 @@ Item {
             else if (id === "runScraper")
                 settings._triggerScrape()
             else if (id === "uploadLog")
-                settings.requestLogUploadModal()
+                settings.requestAccept("uploadLog")
         } else if (action === "cancel") {
             settings.requestHubScreen()
         }
@@ -460,7 +460,7 @@ Item {
                     else if (modelData.id === "runScraper")
                         settings._triggerScrape()
                     else if (modelData.id === "uploadLog")
-                        settings.requestLogUploadModal()
+                        settings.requestAccept("uploadLog")
                 }
             }
         }


### PR DESCRIPTION
## Summary

- **Settings: Upload log file** — new action that POSTs `launcher.log` to `logs.zaparoo.org` (mirrors Core's TUI exportlog flow). New `Browse.LogUpload` model + `LogUploadModal` QML component handle the four-state machine and display the URL plus a QR code on success.
- **Settings: Debug logging toggle** — persists into `state.toml` and the `[logging] debug` key in `launcher.toml`. Takes effect on the next launch (mirrors how `language` works).
- **Defensive root dedup** — `dedup_roots_drop_ancestors` in `games.rs` filters any root-typed entry whose path is a strict ancestor of another root's path. Catches the case where Core surfaces `/media/fat/games` as a Genesis root alongside `MegaDrive` / `Genesis`.
- **QML guards** — `: var` return annotation on `buildContextMenuEntries` (silences qmllint coercion warning), and a guard around `hub.actionEntries[hub.currentIndex].text` for the cold-launch window where `currentIndex` outruns `actionEntries.length`.
- **Diagnostic logging** — `media.browse` request/response debug lines in `client.rs` plus structured debug emissions in `categories.rs` / `systems.rs` / `games.rs` apply paths, to speed up on-device triage.
- **CoreStatusPill** — two em-dashes → hyphens in indexing/scraping status strings so the MiSTer font renders cleanly.

## Test plan

- [ ] `just lint` clean
- [ ] `just test` clean (Rust: 8 new dedup tests + updated config mirror tests with `debug_logging`)
- [ ] Settings: focus "Upload log file" → Accept → modal cycles uploading → success (URL + QR) → Close
- [ ] Settings: focus "Debug logging" → Accept toggles, persists to `launcher.toml`, restart picks it up
- [ ] On a Genesis-rooted MiSTer where Core returns `/media/fat/games` as a phantom root, confirm only the legitimate roots reach the roots screen
- [ ] HubScreen no longer logs `TypeError: Cannot read property 'text' of undefined` on cold launch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Log upload flow in Settings with a modal UI, QR code display and retry/close controls
  * New "Upload log" action and a debug-logging toggle exposed in Settings

* **Bug Fixes**
  * Prevented a potential runtime error when navigating action menus with changing entries

* **Style**
  * Normalized progress label separators from em dash to hyphen for consistency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->