### PR TITLE
Desktop shell polish: header bar, About, favorites, modal unification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ output/
 CLAUDE.md
 .claude/
 .opencode/
+docs/plans/
 
 # Cargo build cache
 rust/target/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,9 +21,14 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 option(BUILD_SHARED_LIBS "Build shared libraries (required for LGPL desktop builds)" ON)
 option(ZAPAROO_BUILD_TESTS "Build unit/smoke tests" ON)
 option(ZAPAROO_DEV "Development mode: windowed window and dev core endpoint" OFF)
+option(ZAPAROO_EMBEDDED "Embedded device build (MiSTer): default fullscreen, no window chrome" OFF)
 
 if(ZAPAROO_DEV)
     add_compile_definitions(ZAPAROO_DEV_BUILD)
+endif()
+
+if(ZAPAROO_EMBEDDED)
+    add_compile_definitions(ZAPAROO_EMBEDDED_BUILD)
 endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")

--- a/Dockerfile.arm32
+++ b/Dockerfile.arm32
@@ -21,6 +21,11 @@
 ARG TOOLCHAIN_IMAGE=zaparoo/qt6-arm32-mister:unset
 FROM ${TOOLCHAIN_IMAGE} AS app-build
 
+# Forwarded by scripts/build-arm32.sh when invoked through `just release`.
+# Empty by default so dev builds report channel = "dev". The build.rs check is
+# presence-only, so we only export the env var when the ARG is non-empty.
+ARG ZAPAROO_OFFICIAL_BUILD=
+
 # cxx-qt's build script resolves Qt paths via qmake, which returns
 # sysroot-prefixed paths (e.g. {sysroot}/opt/qt6-arm32/...). Symlink Qt
 # into the sysroot so those paths resolve on the build host.
@@ -37,6 +42,9 @@ COPY resources/ resources/
 COPY rust/ rust/
 
 RUN mkdir build && cd build && \
+    if [ -n "${ZAPAROO_OFFICIAL_BUILD}" ]; then \
+        export ZAPAROO_OFFICIAL_BUILD="${ZAPAROO_OFFICIAL_BUILD}"; \
+    fi && \
     /opt/qt6-arm32/bin/qt-cmake .. \
         -G Ninja \
         -DCMAKE_BUILD_TYPE=Release \

--- a/Dockerfile.arm32
+++ b/Dockerfile.arm32
@@ -42,6 +42,7 @@ RUN mkdir build && cd build && \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=OFF \
         -DZAPAROO_BUILD_TESTS=OFF \
+        -DZAPAROO_EMBEDDED=ON \
         -DQt6LinguistTools_DIR=/opt/qt6-host/lib/cmake/Qt6LinguistTools \
     && ninja
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -88,9 +88,9 @@ In a second terminal:
 just run-dev
 ```
 
-`run-dev` is windowed and points at the mock. `just run` is the
-production-style runner: it respects `~/.config/zaparoo/launcher.toml` and
-starts fullscreen.
+`run-dev` points at the mock through `ZAPAROO_CORE_ENDPOINT`. `just run` is
+the production-style runner: it reads `~/.config/zaparoo/launcher.toml`
+instead.
 
 ## 5. Check the result
 
@@ -105,10 +105,10 @@ starts fullscreen.
 - Pressing Enter on a system opens the **paged games grid** (five
   entries per system).
 - Pressing Enter on a game sends a `run` RPC to the mock. The mock logs the
-  selected game's zap script, but the launcher keeps running because nothing is
+  selected game's ZapScript, but the launcher keeps running because nothing is
   actually launched.
 - Pressing Tab on a system or game sends a `readers.write` RPC with the
-  selected entry's zap script. The launcher shows a card-write modal while the
+  selected entry's ZapScript. The launcher shows a card-write modal while the
   request is pending; the mock logs the write request.
 - Escape backs out; Escape on the top level quits.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -110,7 +110,8 @@ instead.
 - Pressing Tab on a system or game sends a `readers.write` RPC with the
   selected entry's ZapScript. The launcher shows a card-write modal while the
   request is pending; the mock logs the write request.
-- Escape backs out; Escape on the top level quits.
+- Escape backs out; Escape on the top level opens a quit-confirm modal —
+  confirm to exit.
 
 The FPS counter in the corner should stay green (≥ 55). Red means the UI fell
 below 30 FPS and needs investigation.

--- a/docs/style.md
+++ b/docs/style.md
@@ -28,11 +28,35 @@ Toggle controls (`SettingsField.qml` track + thumb) use `height/2` and
 shape for binary on/off controls (same convention as iOS toggles). They do
 not use `Sizing.cornerRadius` and shouldn't be made to.
 
-## Sharp corners
+## Modal chrome
 
-`Modal.qml` is intentionally sharp. Modals are attention-demanding and the
-visual contrast against rounded surfaces is part of the design. Don't add
-radius unless the design changes.
+Every modal panel and the context menu use `Sizing.cornerRadius`. They join
+the rounded-square family with tile cards, settings rows, and focus rings —
+one shape, one radius across the app. `Modal.qml` is the canonical shell;
+the first-run, commercial-notice, and log-upload modals all wrap it via
+`kind: "shell"` rather than hand-rolling their own panel.
+
+| Surface | Token |
+|---|---|
+| Background | `Theme.bgPanel` |
+| Border | `2px`, `Theme.textPrimary` |
+| Corner radius | `Sizing.cornerRadius` |
+| Scrim | `#cc000000` |
+| Column top margin | `Sizing.pctH(6)` |
+| Column side margins | `Sizing.pctW(6)` |
+| Column spacing | `Sizing.pctH(3)` |
+| Title | `Sizing.fontSize(3.2)`, `Theme.textPrimary` |
+| Body | `Sizing.fontSize(2.5)`, `Theme.textPrimary` |
+| Button slot height | `Sizing.pctH(7)` |
+| Button width | `Sizing.pctW(28)` |
+| Button background | `Theme.bgBar` |
+| Button border | `1px`, `Theme.borderMid` (focus: `2px`, `Theme.accent`) |
+| Button radius | `Sizing.cornerRadius` |
+| Button text | `Sizing.fontSize(2.5)`, `Theme.textPrimary` |
+
+When adding a new modal, prefer extending `Modal.qml` (a new `kind`, or the
+shell content slot) over a bespoke panel — the chrome should never need to
+be hand-rolled twice.
 
 ## Tile aspect
 

--- a/justfile
+++ b/justfile
@@ -20,6 +20,15 @@ build-release:
     cmake --preset desktop-release
     cmake --build --preset desktop-release
 
+# Release build with provenance markers baked in. Sets
+# ZAPAROO_OFFICIAL_BUILD=1 so the launcher reports
+# `channel = "official"` in About / License and the startup log,
+# distinguishing distributed packages from local dev builds. Use this
+# (not `build-release`) when producing a binary you intend to ship.
+release:
+    ZAPAROO_OFFICIAL_BUILD=1 cmake --preset desktop-release
+    ZAPAROO_OFFICIAL_BUILD=1 cmake --build --preset desktop-release
+
 build-dev:
     cmake --preset desktop-dev
     cmake --build --preset desktop-dev

--- a/justfile
+++ b/justfile
@@ -24,10 +24,13 @@ build-release:
 # ZAPAROO_OFFICIAL_BUILD=1 so the launcher reports
 # `channel = "official"` in About / License and the startup log,
 # distinguishing distributed packages from local dev builds. Use this
-# (not `build-release`) when producing a binary you intend to ship.
+# (not `build-release`) when producing binaries you intend to ship.
+# Produces both shippable artifacts: desktop release in build-release/bin
+# and the MiSTer ARM32 binary in output/launcher.
 release:
     ZAPAROO_OFFICIAL_BUILD=1 cmake --preset desktop-release
     ZAPAROO_OFFICIAL_BUILD=1 cmake --build --preset desktop-release
+    ZAPAROO_OFFICIAL_BUILD=1 ./scripts/build-arm32.sh
 
 build-dev:
     cmake --preset desktop-dev

--- a/justfile
+++ b/justfile
@@ -45,7 +45,7 @@ run: build
     ./build/bin/launcher
 
 run-dev: build-dev
-    ./build-dev/bin/launcher
+    ZAPAROO_CORE_ENDPOINT=ws://127.0.0.1:27497/api/v0.1 ./build-dev/bin/launcher
 
 # Run a local mock Zaparoo Core (ws://127.0.0.1:27497/api/v0.1).
 # Deliberately offset from the real Core's 7497 so dev never collides

--- a/rust/launcher/build.rs
+++ b/rust/launcher/build.rs
@@ -64,6 +64,15 @@ fn main() {
     println!("cargo:rerun-if-env-changed=ZAPAROO_DEV_BUILD");
     println!("cargo:rerun-if-env-changed=ZAPAROO_OFFICIAL_BUILD");
 
+    // Rerun when HEAD or any branch ref moves so ZAPAROO_BUILD_COMMIT /
+    // ZAPAROO_BUILD_DATE refresh after rebases, branch switches, and
+    // commits that don't otherwise touch this crate. Emitting any
+    // rerun-if-* directive disables Cargo's "rerun on any package
+    // file change" default, which is why these are needed alongside
+    // the env-changed lines above.
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
+    println!("cargo:rerun-if-changed=../../.git/refs/heads");
+
     println!("cargo:rustc-check-cfg=cfg(zaparoo_runtime, values(\"mister\"))");
     println!("cargo:rustc-check-cfg=cfg(dev_build)");
     if let Ok(rt) = std::env::var("ZAPAROO_RUNTIME") {

--- a/rust/launcher/build.rs
+++ b/rust/launcher/build.rs
@@ -30,6 +30,7 @@ fn main() {
         "src/models/favorites.rs",
         "src/models/browse.rs",
         "src/models/app_state.rs",
+        "src/models/build_info.rs",
         "src/models/app_status.rs",
         "src/models/hub_state.rs",
         "src/models/systems_state.rs",
@@ -38,6 +39,7 @@ fn main() {
         "src/models/input.rs",
         "src/models/log_upload.rs",
         "src/models/media_status.rs",
+        "src/models/notice.rs",
         "src/models/platform.rs",
         "src/models/qr_code.rs",
         "src/models/recents.rs",
@@ -60,6 +62,7 @@ fn main() {
 
     println!("cargo:rerun-if-env-changed=ZAPAROO_RUNTIME");
     println!("cargo:rerun-if-env-changed=ZAPAROO_DEV_BUILD");
+    println!("cargo:rerun-if-env-changed=ZAPAROO_OFFICIAL_BUILD");
 
     println!("cargo:rustc-check-cfg=cfg(zaparoo_runtime, values(\"mister\"))");
     println!("cargo:rustc-check-cfg=cfg(dev_build)");
@@ -75,4 +78,38 @@ fn main() {
     if std::env::var("ZAPAROO_DEV_BUILD").is_ok() {
         println!("cargo:rustc-cfg=dev_build");
     }
+
+    // Build provenance — baked into the binary and surfaced through the
+    // `Browse.BuildInfo` singleton plus the startup log. Goal is
+    // "this binary is from this source tree at this date, and it is /
+    // is not an official package", not DRM. Failures fall back to
+    // "unknown" / "dev"; the build still succeeds.
+    let commit = std::process::Command::new("git")
+        .args(["rev-parse", "--short=7", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=ZAPAROO_BUILD_COMMIT={commit}");
+
+    let build_date = std::process::Command::new("date")
+        .args(["-u", "+%Y-%m-%d"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=ZAPAROO_BUILD_DATE={build_date}");
+
+    let channel = if std::env::var("ZAPAROO_OFFICIAL_BUILD").is_ok() {
+        "official"
+    } else {
+        "dev"
+    };
+    println!("cargo:rustc-env=ZAPAROO_BUILD_CHANNEL={channel}");
 }

--- a/rust/launcher/src/lib.rs
+++ b/rust/launcher/src/lib.rs
@@ -284,6 +284,10 @@ pub extern "C" fn zaparoo_rust_init() -> c_int {
     install_crash_signal_handler();
 
     tracing::info!("Zaparoo Launcher starting");
+    tracing::info!(
+        "build {}",
+        models::build_info::provenance_string(env!("CARGO_PKG_VERSION"))
+    );
 
     let runtime = match tokio::runtime::Builder::new_multi_thread()
         .enable_all()

--- a/rust/launcher/src/models/build_info.rs
+++ b/rust/launcher/src/models/build_info.rs
@@ -1,0 +1,69 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+//
+// `Browse.BuildInfo` — provenance baked in at build time. Surfaces the
+// short git commit, the UTC build date, and the build channel
+// ("official" for binaries produced via `just release`, "dev"
+// otherwise). Read-only constants seeded from `cargo:rustc-env`
+// values emitted by `build.rs`.
+//
+// Goal is provenance, not enforcement. A fork can rebuild without
+// `ZAPAROO_OFFICIAL_BUILD` and the channel falls back to "dev"; that
+// is the desired behavior — it makes unofficial builds visibly
+// unofficial without sabotaging anyone.
+
+use cxx_qt::CxxQtType;
+use cxx_qt::Initialize;
+use cxx_qt_lib::QString;
+use std::pin::Pin;
+
+const BUILD_COMMIT: &str = env!("ZAPAROO_BUILD_COMMIT");
+const BUILD_DATE: &str = env!("ZAPAROO_BUILD_DATE");
+const BUILD_CHANNEL: &str = env!("ZAPAROO_BUILD_CHANNEL");
+
+#[derive(Default)]
+pub struct BuildInfoRust {
+    commit: QString,
+    build_date: QString,
+    channel: QString,
+}
+
+#[cxx_qt::bridge]
+pub mod ffi {
+    unsafe extern "C++" {
+        include!("model_includes.h");
+
+        type QString = cxx_qt_lib::QString;
+    }
+
+    unsafe extern "RustQt" {
+        #[qobject]
+        #[qml_element]
+        #[qml_singleton]
+        // READ + CONSTANT + FINAL — values are baked at compile time
+        // from build.rs env vars and never change after Initialize.
+        // Same shape as `Browse.Runtime`.
+        #[qproperty(QString, commit, READ, CONSTANT, FINAL)]
+        #[qproperty(QString, build_date, READ, CONSTANT, FINAL)]
+        #[qproperty(QString, channel, READ, CONSTANT, FINAL)]
+        type BuildInfo = super::BuildInfoRust;
+    }
+
+    impl cxx_qt::Initialize for BuildInfo {}
+}
+
+impl Initialize for ffi::BuildInfo {
+    fn initialize(mut self: Pin<&mut Self>) {
+        let mut rust = self.as_mut().rust_mut();
+        rust.commit = QString::from(BUILD_COMMIT);
+        rust.build_date = QString::from(BUILD_DATE);
+        rust.channel = QString::from(BUILD_CHANNEL);
+    }
+}
+
+/// Plain-Rust accessor for the startup log. Avoids constructing the
+/// `QObject` just to read the constants.
+pub fn provenance_string(version: &str) -> String {
+    format!("version={version} commit={BUILD_COMMIT} date={BUILD_DATE} channel={BUILD_CHANNEL}")
+}

--- a/rust/launcher/src/models/games.rs
+++ b/rust/launcher/src/models/games.rs
@@ -123,6 +123,15 @@ pub struct GamesModelRust {
     // intermediate state, so the flag is consumed by the apply
     // function and reset once the decision has been made.
     auto_nav_eligible: bool,
+    // Set once `apply_initial_page` has installed a result for the
+    // current browse target; cleared on every `start_initial_browse`.
+    // Subsequent Ready transitions on the same target (cache
+    // invalidation refetches, e.g. after `MediaTagsUpdateMutation`)
+    // skip the full reset so the user's pagination position and
+    // appended pages aren't clobbered. Local mutations
+    // (`apply_favorite_tags`) keep the visible model in sync without
+    // needing the refetch.
+    is_seeded: bool,
     // Invalidates stale card-write completions after the user cancels
     // or starts another write before the previous RPC returns.
     card_write_seq: Arc<AtomicU64>,
@@ -169,6 +178,7 @@ impl Default for GamesModelRust {
             watcher: None,
             seq: Arc::new(AtomicU64::new(0)),
             auto_nav_eligible: false,
+            is_seeded: false,
             card_write_seq: Arc::new(AtomicU64::new(0)),
             cover_subscription: None,
             pending_first_paint_keys: HashSet::new(),
@@ -636,6 +646,12 @@ impl ffi::GamesModel {
         self.as_mut().set_has_next_page(false);
         self.as_mut().set_loading_more(false);
         self.as_mut().rust_mut().auto_nav_eligible = eligible_for_auto_nav;
+        // Cleared on every browse target swap: a new path needs the
+        // full `apply_initial_page` reset to install fresh entries.
+        // The flag is set back to true at the end of that function
+        // so subsequent refetches (cache invalidations) skip the
+        // reset and preserve appended pages + selection.
+        self.as_mut().rust_mut().is_seeded = false;
         self.as_mut().rust_mut().next_cursor = None;
         if !self.entries.is_empty() {
             self.as_mut().begin_reset_model();
@@ -1303,6 +1319,15 @@ fn apply_status(mut model: Pin<&mut ffi::GamesModel>, status: ResourceStatus<Med
 }
 
 fn apply_initial_page(mut model: Pin<&mut ffi::GamesModel>, result: MediaBrowseResult) {
+    // Already seeded: this Ready is a cache invalidation refetch on
+    // the same browse target (e.g. `MediaTagsUpdateMutation`'s
+    // `MediaBrowseEndpoint` invalidation after a favorite toggle).
+    // The full reset below would clobber any pages the user
+    // paginated to and reset the grid to row 0; the local mutation
+    // paths (`apply_favorite_tags`) keep the visible model in sync.
+    if model.is_seeded {
+        return;
+    }
     let has_next_page = result.has_next_page();
     let next_cursor = result.next_cursor();
     let total = i32::try_from(result.total_files).unwrap_or(i32::MAX);
@@ -1355,6 +1380,10 @@ fn apply_initial_page(mut model: Pin<&mut ffi::GamesModel>, result: MediaBrowseR
     if has_next_page && !model.loading_more {
         model.as_mut().fetch_more();
     }
+    // Mark seeded last so any early-return from this function leaves
+    // the flag in its previous state. Subsequent Ready transitions
+    // on the same browse target now skip the reset above.
+    model.as_mut().rust_mut().is_seeded = true;
 }
 
 fn apply_append_page(

--- a/rust/launcher/src/models/games.rs
+++ b/rust/launcher/src/models/games.rs
@@ -1218,7 +1218,13 @@ fn apply_status(mut model: Pin<&mut ffi::GamesModel>, status: ResourceStatus<Med
             if !model.error_message.is_empty() {
                 model.as_mut().set_error_message(QString::default());
             }
-            if model.has_next_page {
+            // Pagination state is only stale on a fresh browse target;
+            // a transient Pending (connection blip, post-error retry)
+            // on a seeded model must preserve `has_next_page` so the
+            // user's paginated view stays usable once Ready arrives —
+            // the early-return in `apply_initial_page` won't restore
+            // it.
+            if !model.is_seeded && model.has_next_page {
                 model.as_mut().set_has_next_page(false);
             }
         }
@@ -1321,11 +1327,18 @@ fn apply_status(mut model: Pin<&mut ffi::GamesModel>, status: ResourceStatus<Med
 fn apply_initial_page(mut model: Pin<&mut ffi::GamesModel>, result: MediaBrowseResult) {
     // Already seeded: this Ready is a cache invalidation refetch on
     // the same browse target (e.g. `MediaTagsUpdateMutation`'s
-    // `MediaBrowseEndpoint` invalidation after a favorite toggle).
-    // The full reset below would clobber any pages the user
+    // `MediaBrowseEndpoint` invalidation after a favorite toggle, or
+    // a Loading→Ready cycle from a connection blip / post-error
+    // retry). The full reset below would clobber any pages the user
     // paginated to and reset the grid to row 0; the local mutation
     // paths (`apply_favorite_tags`) keep the visible model in sync.
+    // Loading was set true by the preceding Pending — clear it so a
+    // transient blip doesn't leave the spinner stuck on after the
+    // refetch lands.
     if model.is_seeded {
+        if model.loading {
+            model.as_mut().set_loading(false);
+        }
         return;
     }
     let has_next_page = result.has_next_page();

--- a/rust/launcher/src/models/mod.rs
+++ b/rust/launcher/src/models/mod.rs
@@ -26,6 +26,7 @@
 pub mod app_state;
 pub mod app_status;
 pub mod browse;
+pub mod build_info;
 pub mod categories;
 pub mod favorites;
 pub mod favorites_state;
@@ -35,6 +36,7 @@ pub mod hub_state;
 pub mod input;
 pub mod log_upload;
 pub mod media_status;
+pub mod notice;
 pub mod platform;
 pub mod qr_code;
 pub mod recents;

--- a/rust/launcher/src/models/notice.rs
+++ b/rust/launcher/src/models/notice.rs
@@ -1,0 +1,81 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+//
+// `Browse.Notice` — first-run notices the user has acknowledged.
+//
+// Persisted in `launcher.toml` (under `[notice]`), not `state.toml`,
+// because `MiSTer`'s `/tmp` state is wiped on every reboot — using
+// state would re-show the notice on every cold boot, which is exactly
+// the "nag legitimate users" failure mode the plan calls out.
+//
+// Currently exposes a single `commercial_ack` flag for the
+// non-commercial-use notice. The flag is read once at construction
+// from disk, so the modal can decide on first paint whether to show.
+// The QML side calls `acknowledge_commercial()` from the modal's
+// "I understand" button; that flips the flag and writes it back
+// atomically.
+
+use cxx_qt::{CxxQtType, Initialize};
+use std::pin::Pin;
+use tracing::warn;
+use zaparoo_core::config::{load_config, save_notice_ack};
+use zaparoo_core::platform_paths::config_file_path;
+
+#[derive(Default)]
+pub struct NoticeRust {
+    commercial_ack: bool,
+}
+
+#[cxx_qt::bridge]
+pub mod ffi {
+    unsafe extern "C++" {
+        include!("model_includes.h");
+    }
+
+    unsafe extern "RustQt" {
+        #[qobject]
+        #[qml_element]
+        #[qml_singleton]
+        // READ + NOTIFY — flips exactly once per install (the user
+        // pressing "I understand" on the first-run notice). The QML
+        // modal binds its `open` gate on this so it self-closes the
+        // moment the slot persists.
+        #[qproperty(bool, commercial_ack, READ, NOTIFY)]
+        type Notice = super::NoticeRust;
+
+        #[qinvokable]
+        fn acknowledge_commercial(self: Pin<&mut Notice>);
+    }
+
+    impl cxx_qt::Initialize for Notice {}
+}
+
+impl Initialize for ffi::Notice {
+    fn initialize(mut self: Pin<&mut Self>) {
+        let cfg = load_config(&config_file_path());
+        self.as_mut().rust_mut().commercial_ack = cfg.notice.commercial_ack;
+    }
+}
+
+impl ffi::Notice {
+    fn acknowledge_commercial(mut self: Pin<&mut Self>) {
+        if self.commercial_ack {
+            return;
+        }
+        let path = config_file_path();
+        if let Err(e) = save_notice_ack(&path, true) {
+            // Log and surface the in-memory flip anyway: the user
+            // pressed "I understand" once and shouldn't be re-prompted
+            // for the rest of this session even if the disk write
+            // failed (read-only FS, full tmpfs, etc.). The next launch
+            // will re-show the notice, which is the right fallback.
+            warn!(
+                "could not persist commercial notice ack to {}: {e}",
+                path.display()
+            );
+        }
+        self.as_mut().rust_mut().commercial_ack = true;
+        self.as_mut().commercial_ack_changed();
+    }
+}

--- a/rust/launcher/src/models/recents.rs
+++ b/rust/launcher/src/models/recents.rs
@@ -660,20 +660,26 @@ fn release_cover_gate_after_timeout(mut model: Pin<&mut ffi::RecentsModel>) {
 
 /// Build the `text` payload sent to Core's `run` for a history entry.
 /// History entries don't carry a synthesised `zap_script` (Core surfaces
-/// only the raw fields), so compose `**launch:<path>` from the row's
+/// only the raw fields), so compose `**launch:"<path>"` from the row's
 /// `mediaPath`, with `?launcher=<id>` appended when `launcherId` is known
 /// so Core picks the same launcher the entry originally ran under. An
 /// empty path yields an empty string, suppressing the run entirely —
 /// `**launch.system:<id>` would just boot the core without a game.
+///
+/// The path is always wrapped in double quotes so spaces and shell
+/// metacharacters (parens, commas) survive Core's argument parsing —
+/// real-world paths like
+/// `/media/fat/cifs/games/Genesis/1 US - A-F/B.O.B. (USA,Europe) (Rev A).md`
+/// fail to launch unquoted.
 fn launch_text_for(entry: &MediaHistoryEntry) -> String {
     if entry.media_path.is_empty() {
         return String::new();
     }
     if entry.launcher_id.is_empty() {
-        format!("**launch:{}", entry.media_path)
+        format!("**launch:\"{}\"", entry.media_path)
     } else {
         format!(
-            "**launch:{}?launcher={}",
+            "**launch:\"{}\"?launcher={}",
             entry.media_path, entry.launcher_id
         )
     }
@@ -795,13 +801,30 @@ mod tests {
     #[test]
     fn launch_text_uses_launch_with_launcher_override_when_known() {
         let e = entry("smb", "/p/smb.nes", "NES", "NES");
-        assert_eq!(launch_text_for(&e), "**launch:/p/smb.nes?launcher=NES");
+        assert_eq!(launch_text_for(&e), "**launch:\"/p/smb.nes\"?launcher=NES");
     }
 
     #[test]
     fn launch_text_falls_back_to_bare_launch_when_launcher_missing() {
         let e = entry("smb", "/p/smb.nes", "NES", "");
-        assert_eq!(launch_text_for(&e), "**launch:/p/smb.nes");
+        assert_eq!(launch_text_for(&e), "**launch:\"/p/smb.nes\"");
+    }
+
+    #[test]
+    fn launch_text_quotes_path_with_spaces_and_metacharacters() {
+        // Real-world path that fails to launch unquoted because of
+        // spaces, parens, and commas — exactly the regression the
+        // user reported when running from Recently Played.
+        let e = entry(
+            "bob",
+            "/media/fat/cifs/games/Genesis/1 US - A-F/B.O.B. (USA,Europe) (Rev A).md",
+            "Genesis",
+            "Genesis",
+        );
+        assert_eq!(
+            launch_text_for(&e),
+            "**launch:\"/media/fat/cifs/games/Genesis/1 US - A-F/B.O.B. (USA,Europe) (Rev A).md\"?launcher=Genesis"
+        );
     }
 
     #[test]

--- a/rust/launcher/src/models/recents.rs
+++ b/rust/launcher/src/models/recents.rs
@@ -670,18 +670,20 @@ fn release_cover_gate_after_timeout(mut model: Pin<&mut ffi::RecentsModel>) {
 /// metacharacters (parens, commas) survive Core's argument parsing —
 /// real-world paths like
 /// `/media/fat/cifs/games/Genesis/1 US - A-F/B.O.B. (USA,Europe) (Rev A).md`
-/// fail to launch unquoted.
+/// fail to launch unquoted. Embedded backslashes and double quotes are
+/// escaped per `ZapScript`'s `parseQuotedArg` rules (backslash first so
+/// the quote-escape's leading `\` doesn't get re-escaped) — Windows-host
+/// paths and the rare filename containing a literal `"` would otherwise
+/// produce a malformed token.
 fn launch_text_for(entry: &MediaHistoryEntry) -> String {
     if entry.media_path.is_empty() {
         return String::new();
     }
+    let escaped = entry.media_path.replace('\\', "\\\\").replace('"', "\\\"");
     if entry.launcher_id.is_empty() {
-        format!("**launch:\"{}\"", entry.media_path)
+        format!("**launch:\"{escaped}\"")
     } else {
-        format!(
-            "**launch:\"{}\"?launcher={}",
-            entry.media_path, entry.launcher_id
-        )
+        format!("**launch:\"{escaped}\"?launcher={}", entry.launcher_id)
     }
 }
 
@@ -824,6 +826,19 @@ mod tests {
         assert_eq!(
             launch_text_for(&e),
             "**launch:\"/media/fat/cifs/games/Genesis/1 US - A-F/B.O.B. (USA,Europe) (Rev A).md\"?launcher=Genesis"
+        );
+    }
+
+    #[test]
+    fn launch_text_escapes_backslashes_and_quotes_in_path() {
+        // Windows-host paths reach Core with backslash separators, and
+        // a stray `"` in a filename would otherwise close the quoted
+        // arg early. Both must be ZapScript-escaped so
+        // `parseQuotedArg` decodes them back to the original path.
+        let e = entry("weird", r#"C:\Games\say "hi".rom"#, "DOS", "DOS");
+        assert_eq!(
+            launch_text_for(&e),
+            r#"**launch:"C:\\Games\\say \"hi\".rom"?launcher=DOS"#
         );
     }
 

--- a/rust/zaparoo-core/src/config.rs
+++ b/rust/zaparoo-core/src/config.rs
@@ -28,12 +28,22 @@ pub struct Config {
     /// Durable mirror of launcher-owned settings. These stay in
     /// `launcher.toml` so they survive `MiSTer`'s `/tmp` lifecycle.
     pub settings: SettingsConfig,
+    /// First-run notices the user has acknowledged. Stored in
+    /// `launcher.toml` (not `state.toml`) because `MiSTer`'s `/tmp`
+    /// state is wiped on reboot — using state would re-show the notice
+    /// every cold boot.
+    pub notice: NoticeConfig,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct SettingsConfig {
     pub button_layout: Option<String>,
     pub mouse_enabled: Option<bool>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct NoticeConfig {
+    pub commercial_ack: bool,
 }
 
 impl Default for Config {
@@ -46,6 +56,7 @@ impl Default for Config {
             language: String::new(),
             key_to_action: input_actions::invert(&input_actions::default_bindings()),
             settings: SettingsConfig::default(),
+            notice: NoticeConfig::default(),
         }
     }
 }
@@ -64,6 +75,8 @@ struct RawConfig {
     input: RawInput,
     #[serde(default)]
     settings: RawSettings,
+    #[serde(default)]
+    notice: RawNotice,
 }
 
 #[derive(Deserialize, Default)]
@@ -99,17 +112,29 @@ struct RawSettings {
     mouse_enabled: Option<bool>,
 }
 
+#[derive(Deserialize, Default)]
+struct RawNotice {
+    commercial_ack: Option<bool>,
+}
+
 pub fn load_config(path: &Path) -> Config {
     let mut cfg = Config::default();
-    let Ok(src) = std::fs::read_to_string(path) else {
-        return cfg;
-    };
-    let raw: RawConfig = match toml::from_str(&src) {
-        Ok(r) => r,
-        Err(e) => {
-            warn!("config parse error in {}: {e}", path.display());
-            return cfg;
-        }
+    let raw: RawConfig = match std::fs::read_to_string(path) {
+        Ok(src) => match toml::from_str(&src) {
+            Ok(r) => r,
+            Err(e) => {
+                warn!("config parse error in {}: {e}", path.display());
+                // Fall through with defaults so the env-var override
+                // below still applies on a malformed file.
+                RawConfig::default()
+            }
+        },
+        // Missing file is the first-run case. Don't early-return — the
+        // env-var override below must still apply, otherwise an invocation
+        // like `ZAPAROO_CORE_ENDPOINT=… just run` with no launcher.toml
+        // silently falls back to the localhost default and the launcher
+        // sits in CONNECTING forever.
+        Err(_) => RawConfig::default(),
     };
     if let Some(lang) = raw.general.language {
         // "auto" is the documented opt-in to system-locale detection; treat
@@ -154,6 +179,9 @@ pub fn load_config(path: &Path) -> Config {
             .button_layout
             .map(|value| value.trim().to_string()),
         mouse_enabled: raw.settings.mouse_enabled,
+    };
+    cfg.notice = NoticeConfig {
+        commercial_ack: raw.notice.commercial_ack.unwrap_or(false),
     };
     cfg
 }
@@ -220,6 +248,40 @@ pub fn save_settings_mirror(
         .map_err(|e| format!("could not write {}: {e}", path.display()))
 }
 
+/// Persist a first-run notice acknowledgement into `launcher.toml`.
+/// Mirrors `save_settings_mirror`'s atomic-write + section-preserving
+/// pattern so unrelated keys in the file (core endpoint, video, input
+/// bindings) survive untouched.
+pub fn save_notice_ack(path: &Path, commercial_ack: bool) -> Result<(), String> {
+    let mut table = if path.exists() {
+        let src = std::fs::read_to_string(path)
+            .map_err(|e| format!("could not read {}: {e}", path.display()))?;
+        toml::from_str::<toml::Table>(&src)
+            .map_err(|e| format!("config parse error in {}: {e}", path.display()))?
+    } else {
+        toml::Table::new()
+    };
+
+    let notice_value = table
+        .entry("notice")
+        .or_insert_with(|| toml::Value::Table(toml::Table::new()));
+    let Some(notice) = notice_value.as_table_mut() else {
+        return Err(format!(
+            "config key [notice] in {} is not a table",
+            path.display()
+        ));
+    };
+    notice.insert(
+        "commercial_ack".into(),
+        toml::Value::Boolean(commercial_ack),
+    );
+
+    let serialized =
+        toml::to_string(&table).map_err(|e| format!("config serialisation failed: {e}"))?;
+    write_atomic(path, serialized.as_bytes())
+        .map_err(|e| format!("could not write {}: {e}", path.display()))
+}
+
 fn normalize_language_override(value: &str) -> String {
     let trimmed = value.trim();
     if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("auto") {
@@ -269,7 +331,7 @@ mod tests {
         reason = "tests should fail-fast on unexpected errors"
     )]
 
-    use super::{load_config, save_settings_mirror, Config};
+    use super::{load_config, save_notice_ack, save_settings_mirror, Config};
     use std::io::Write;
 
     fn write_tmp(contents: &str) -> tempfile::NamedTempFile {
@@ -288,8 +350,36 @@ mod tests {
         assert_eq!(cfg.language, "");
         assert_eq!(cfg.settings.button_layout, None);
         assert_eq!(cfg.settings.mouse_enabled, None);
+        assert!(!cfg.notice.commercial_ack);
         // Default keyboard bindings populate the map.
         assert!(!cfg.key_to_action.is_empty());
+    }
+
+    #[test]
+    fn notice_commercial_ack_round_trips() {
+        let f = write_tmp("[notice]\ncommercial_ack = true\n");
+        let cfg = load_config(f.path());
+        assert!(cfg.notice.commercial_ack);
+    }
+
+    #[test]
+    fn save_notice_ack_creates_section_and_preserves_others() {
+        let f = write_tmp(
+            "[core]\nendpoint = \"ws://example.com/api\"\n[settings]\nbutton_layout = \"b\"\n",
+        );
+        save_notice_ack(f.path(), true).expect("save");
+        let cfg = load_config(f.path());
+        assert!(cfg.notice.commercial_ack);
+        assert_eq!(cfg.core_endpoint, "ws://example.com/api");
+        assert_eq!(cfg.settings.button_layout.as_deref(), Some("b"));
+    }
+
+    #[test]
+    fn save_notice_ack_can_unset() {
+        let f = write_tmp("[notice]\ncommercial_ack = true\n");
+        save_notice_ack(f.path(), false).expect("save");
+        let cfg = load_config(f.path());
+        assert!(!cfg.notice.commercial_ack);
     }
 
     #[test]
@@ -463,6 +553,24 @@ mod tests {
         // out the user's launcher.toml.
         std::env::set_var(KEY, "");
         assert_eq!(load_config(f.path()).core_endpoint, "ws://example.com/api");
+
+        // Regression: missing file used to early-return defaults before
+        // the env-var override applied, so a first-run invocation like
+        // `ZAPAROO_CORE_ENDPOINT=… just run` silently fell back to the
+        // localhost default and the launcher sat in CONNECTING forever.
+        std::env::set_var(KEY, "ws://10.0.0.115:7497/api/v0.1");
+        assert_eq!(
+            load_config(std::path::Path::new("/definitely/does/not/exist.toml")).core_endpoint,
+            "ws://10.0.0.115:7497/api/v0.1"
+        );
+
+        // Same regression on a malformed file — fall through to the env
+        // override rather than freezing on the localhost default.
+        let bad = write_tmp("this is not = valid toml [[[");
+        assert_eq!(
+            load_config(bad.path()).core_endpoint,
+            "ws://10.0.0.115:7497/api/v0.1"
+        );
 
         match prior {
             Some(v) => std::env::set_var(KEY, v),

--- a/scripts/build-arm32.sh
+++ b/scripts/build-arm32.sh
@@ -83,6 +83,7 @@ docker buildx build \
     --platform "${DOCKER_PLATFORM}" \
     -f "${PROJECT_ROOT}/Dockerfile.arm32" \
     --build-arg "TOOLCHAIN_IMAGE=${TOOLCHAIN_IMAGE}" \
+    --build-arg "ZAPAROO_OFFICIAL_BUILD=${ZAPAROO_OFFICIAL_BUILD:-}" \
     --output "type=local,dest=${OUTPUT_DIR}" \
     --target export \
     "${PROJECT_ROOT}"

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -154,7 +154,7 @@ int main(int argc, char* argv[])
     qInfo("QImageReader supportedImageFormats: %s",
           qUtf8Printable(formatNames.join(QStringLiteral(", "))));
 
-#ifndef ZAPAROO_DEV_BUILD
+#ifdef ZAPAROO_EMBEDDED_BUILD
     engine.setInitialProperties({{"fullScreen", true}});
 #endif
 

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -221,7 +221,58 @@ MainLayout {
             const sels = Browse.GamesState.selected_at_level
             const savedPath = sels.length > 0 ? sels[sels.length - 1] : ""
             const idx = savedPath === "" ? -1 : Browse.GamesModel.index_for_game_path(savedPath)
-            root.gamesScreen.gamesGrid.setCurrentIndexImmediate(idx >= 0 ? idx : 0)
+            if (idx >= 0) {
+                root.gamesScreen.gamesGrid.setCurrentIndexImmediate(idx)
+                root._pendingGameRestorePath = ""
+                return
+            }
+            // Saved entry isn't on page 1. If there are more pages,
+            // keep paginating until it shows up or we exhaust the
+            // folder; the count-watcher below drives the loop.
+            // Otherwise (entry truly gone, or single-page folder)
+            // fall back to row 0.
+            if (savedPath !== "" && Browse.GamesModel.has_next_page) {
+                root._pendingGameRestorePath = savedPath
+                root.gamesScreen.gamesGrid.setCurrentIndexImmediate(0)
+                Browse.GamesModel.fetch_more()
+                return
+            }
+            root._pendingGameRestorePath = ""
+            root.gamesScreen.gamesGrid.setCurrentIndexImmediate(0)
+        }
+        // Pages 2+ append rows via begin_insert_rows / end_insert_rows
+        // (no model reset), so we can't piggy-back on onModelReset to
+        // retry the lookup. `count` bumps on every append, giving us a
+        // stable per-page edge to resume the deep-page restore on.
+        function onCountChanged(): void {
+            const path = root._pendingGameRestorePath
+            if (path === "")
+                return
+            // User input updates `selected_at_level` on every move,
+            // so a divergence between the pending path and the top
+            // of stack means the user navigated during the restore
+            // — drop the auto-restore and let them stay where they
+            // landed.
+            const sels = Browse.GamesState.selected_at_level
+            const currentTop = sels.length > 0 ? sels[sels.length - 1] : ""
+            if (currentTop !== path) {
+                root._pendingGameRestorePath = ""
+                return
+            }
+            const idx = Browse.GamesModel.index_for_game_path(path)
+            if (idx >= 0) {
+                root.gamesScreen.gamesGrid.setCurrentIndexImmediate(idx)
+                root._pendingGameRestorePath = ""
+                return
+            }
+            if (Browse.GamesModel.has_next_page) {
+                // fetch_more is itself debounced by `loading_more` and
+                // `has_next_page`, so a redundant call here is a cheap
+                // no-op rather than a duplicate request.
+                Browse.GamesModel.fetch_more()
+                return
+            }
+            root._pendingGameRestorePath = ""
         }
     }
 
@@ -249,6 +300,13 @@ MainLayout {
     property var _systemReadyCallback: null
     property var _favoritesReadyCallback: null
     property var _recentsReadyCallback: null
+    // Saved games-screen entry path that wasn't on the freshly seeded
+    // page 1 of MediaBrowse. The GamesModel.onCountChanged watcher
+    // below paginates forward via fetch_more until the path is found
+    // or `has_next_page` goes false. Cleared on resolution and on
+    // any navigation that starts a new browse target so a stale
+    // restore can't keep paginating after the user moves on.
+    property string _pendingGameRestorePath: ""
 
     // Listen for SystemsModel fills owned by an in-flight transition.
     // `loading` flips true at the start of set_category and false when

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -25,8 +25,12 @@ import Zaparoo.Browse as Browse
 MainLayout {
     id: root
 
-    width: Screen.width
-    height: Screen.height
+    // Fullscreen builds (MiSTer) fill the screen; desktop windowed
+    // builds inherit MainLayout's 1280x720 design defaults so the user
+    // can resize freely. The fullscreen override is a one-shot in
+    // Component.onCompleted (below) rather than a binding — a binding
+    // here would re-assert 1280 after any user resize, fighting the
+    // OS resize gesture.
 
     readonly property string modalCardWrite: "card_write"
     readonly property string modalContextMenu: "context_menu"
@@ -71,6 +75,13 @@ MainLayout {
         Sizing.screenWidth = width
     }
     Component.onCompleted: {
+        // One-shot fullscreen sizing for embedded builds. Done as an
+        // imperative write rather than a binding so a user resize on
+        // a windowed build can never be undone by a re-evaluation.
+        if (root.fullScreen) {
+            root.width = Screen.width
+            root.height = Screen.height
+        }
         Sizing.screenWidth = width
         Sizing.screenHeight = height
         Browse.GamesModel.page_size = root._gamesPageSize

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -38,6 +38,7 @@ MainLayout {
     readonly property string modalCommercialNotice: "commercial_notice"
     readonly property string modalFirstRunIndex: "first_run_index"
     readonly property string modalLogUpload: "log_upload"
+    readonly property string modalQuitConfirm: "quit_confirm"
     // One-shot session flag: the first-run modal is shown at most
     // once per launcher process, even if the WS link drops and the
     // mediadb-empty condition would otherwise be satisfied again.
@@ -503,7 +504,7 @@ MainLayout {
         function onRequestAccept(category: string): void {
             root._navigateFromHub(category)
         }
-        function onRequestQuit(): void { Qt.quit() }
+        function onRequestQuit(): void { root.openQuitConfirmModal() }
         function onRequestFavoritesScreen(): void { root._navigateToFavorites() }
         function onRequestRecentsScreen(): void { root._navigateToRecents() }
         function onRequestSettingsScreen(): void { root._navigateToSettings() }
@@ -841,6 +842,24 @@ MainLayout {
 
     onCloseLogUploadRequested: root.closeLogUploadModal()
 
+    // Quit-confirm lifecycle. Hub's cancel signal lands on
+    // `openQuitConfirmModal` instead of `Qt.quit()` so a stray B / Esc
+    // can't kill the launcher; the modal owns the actual decision.
+    function openQuitConfirmModal(): void {
+        root.quitConfirmModalVisible = true
+        if (ScreenManager.topModal !== root.modalQuitConfirm)
+            ScreenManager.pushModal(root.modalQuitConfirm)
+    }
+
+    function closeQuitConfirmModal(): void {
+        root.quitConfirmModalVisible = false
+        if (ScreenManager.topModal === root.modalQuitConfirm)
+            ScreenManager.popModal()
+    }
+
+    onCloseQuitConfirmRequested: root.closeQuitConfirmModal()
+    onQuitConfirmAccepted: Qt.quit()
+
     Connections {
         target: Browse.AppStatus
         function onConnection_stateChanged(): void {
@@ -963,6 +982,8 @@ MainLayout {
                 root.commercialNoticeModal.handleAction(action)
             } else if (ScreenManager.topModal === root.modalLogUpload) {
                 root.logUploadModal.handleAction(action)
+            } else if (ScreenManager.topModal === root.modalQuitConfirm) {
+                root.quitConfirmModal.handleAction(action)
             }
             // While a modal owns input, swallow everything not handled
             // above rather than leak it to the root screen.

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -248,6 +248,14 @@ MainLayout {
             const path = root._pendingGameRestorePath
             if (path === "")
                 return
+            // User backed out to Hub/Systems before pagination caught
+            // up — selected_at_level isn't touched by a peer-screen
+            // exit, so without this gate the loop would keep hammering
+            // fetch_more in the background until the folder exhausts.
+            if (root.activeScreen !== root.screenGames) {
+                root._pendingGameRestorePath = ""
+                return
+            }
             // User input updates `selected_at_level` on every move,
             // so a divergence between the pending path and the top
             // of stack means the user navigated during the restore

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -35,6 +35,7 @@ MainLayout {
     readonly property string modalCardWrite: "card_write"
     readonly property string modalContextMenu: "context_menu"
     readonly property string modalQrCode: "qr_code"
+    readonly property string modalCommercialNotice: "commercial_notice"
     readonly property string modalFirstRunIndex: "first_run_index"
     readonly property string modalLogUpload: "log_upload"
     // One-shot session flag: the first-run modal is shown at most
@@ -96,7 +97,8 @@ MainLayout {
             || savedScreen === root.screenHub
             || savedScreen === root.screenFavorites
             || savedScreen === root.screenRecents
-            || savedScreen === root.screenSettings)
+            || savedScreen === root.screenSettings
+            || savedScreen === root.screenAbout)
             root.activeScreen = savedScreen
         // If the catalog is already ready, fire the restore here so
         // the cascade (set_category → SystemsModel reset → seed
@@ -127,6 +129,12 @@ MainLayout {
                 root.recentsScreen.restoreSelection()
             }
         }
+        // Open the commercial-use notice on first paint of an unacked
+        // install. Sits in front of the media-DB first-run modal in the
+        // routing order — `_maybeOpenFirstRunIndex` early-returns until
+        // `Browse.Notice.commercial_ack` flips true, at which point the
+        // notice's close handler retriggers the media-DB check.
+        root._maybeOpenCommercialNotice()
         // Kick the first-run check in case both READY and a seeded
         // empty-mediadb snapshot landed before our Connections wired up
         // (e.g. an unusually fast warm-cache reconnect).
@@ -422,6 +430,12 @@ MainLayout {
         root._goto(root.screenSettings)
     }
 
+    // Settings → About transition. Static info screen, no async data,
+    // so the flip is instant — same shape as _navigateToSettings above.
+    function _navigateToAbout(): void {
+        root._goto(root.screenAbout)
+    }
+
     // Systems Accept routing. Pin destination to Games, fill the
     // chosen system, then flip. The Games→back routing decision is
     // re-evaluated live from current state at B-press time (see
@@ -511,7 +525,13 @@ MainLayout {
         function onRequestAccept(actionId: string): void {
             if (actionId === "uploadLog")
                 root.openLogUploadModal()
+            else if (actionId === "aboutLicense")
+                root._navigateToAbout()
         }
+    }
+    Connections {
+        target: root.aboutScreen
+        function onRequestSettingsScreen(): void { root._goto(root.screenSettings) }
     }
     Connections {
         target: root.systemsScreen
@@ -604,8 +624,7 @@ MainLayout {
     // static QML build coerces the JS array through `list<var>` and the
     // caller saw `entries.length === 0` despite the function pushing 3
     // items in. Plain `var` round-trips cleanly and silences the
-    // qmllint "insufficiently annotated" coercion warning at the call
-    // site.
+    // "insufficiently annotated" coercion warning at the call site.
     function buildContextMenuEntries(
             owner: string, entryType: string, hasNfc: bool, isFavorite: bool) {
         if (owner === "systems") {
@@ -743,6 +762,11 @@ MainLayout {
     function _maybeOpenFirstRunIndex(): void {
         if (root._firstRunIndexShown)
             return
+        // Defer to the commercial-use notice. The notice's close handler
+        // calls back into here once acked, so chaining is automatic and
+        // we avoid stacking two modals at the same time.
+        if (!Browse.Notice.commercial_ack)
+            return
         if (Browse.AppStatus.connection_state !== 2 /* READY */)
             return
         if (!Browse.CategoriesModel.loaded)
@@ -759,6 +783,40 @@ MainLayout {
         root.firstRunIndexModalVisible = false
         if (ScreenManager.topModal === root.modalFirstRunIndex)
             ScreenManager.popModal()
+    }
+
+    // Commercial-use first-run notice. Persisted ack lives in
+    // `launcher.toml` (not state.toml — MiSTer's tmpfs would re-show
+    // the notice on every reboot). The router opens the modal on first
+    // paint when the flag is false, and the modal's close handler is
+    // what advances to the next first-run gate (mediadb index).
+    function _maybeOpenCommercialNotice(): void {
+        if (Browse.Notice.commercial_ack)
+            return
+        if (root.commercialNoticeModalVisible)
+            return
+        // Defer until the cold-launch curtain has lifted. Otherwise
+        // the modal paints over the BootOverlay's "Connecting…" cue,
+        // and the user perceives the launcher as stuck — they can't
+        // tell whether dismissing the notice will reveal a working
+        // app or an actual connection failure. Waiting for boot means
+        // every "I understand" press lands on a hub that's already
+        // ready to use.
+        if (!root.bootComplete)
+            return
+        root.commercialNoticeModalVisible = true
+        if (ScreenManager.topModal !== root.modalCommercialNotice)
+            ScreenManager.pushModal(root.modalCommercialNotice)
+    }
+
+    function closeCommercialNoticeModal(): void {
+        root.commercialNoticeModalVisible = false
+        if (ScreenManager.topModal === root.modalCommercialNotice)
+            ScreenManager.popModal()
+        // Now that the notice is dismissed, re-check the media-DB gate
+        // — if the catalog had already settled empty behind the notice,
+        // this opens that modal as the next step in the chain.
+        root._maybeOpenFirstRunIndex()
     }
 
     // Log-upload modal lifecycle. Triggered from the Settings "Upload
@@ -798,8 +856,13 @@ MainLayout {
     function _maybeCompleteBoot(): void {
         if (root.bootComplete)
             return
-        if (Browse.AppStatus.connection_state === 2 /* READY */)
+        if (Browse.AppStatus.connection_state === 2 /* READY */) {
             root.bootComplete = true
+            // Curtain just lifted — fire the notice gate now that the
+            // hub is paintable. _maybeOpenCommercialNotice early-returns
+            // until bootComplete is true, so this is the natural edge.
+            root._maybeOpenCommercialNotice()
+        }
     }
 
     Connections {
@@ -813,6 +876,7 @@ MainLayout {
     }
 
     onCloseFirstRunIndexRequested: root.closeFirstRunIndexModal()
+    onCloseCommercialNoticeRequested: root.closeCommercialNoticeModal()
 
     function beginCardWrite(owner: string): void {
         if (owner === "systems")
@@ -895,6 +959,8 @@ MainLayout {
                 root.contextMenu.handleAction(action)
             } else if (ScreenManager.topModal === root.modalFirstRunIndex) {
                 root.firstRunIndexModal.handleAction(action)
+            } else if (ScreenManager.topModal === root.modalCommercialNotice) {
+                root.commercialNoticeModal.handleAction(action)
             } else if (ScreenManager.topModal === root.modalLogUpload) {
                 root.logUploadModal.handleAction(action)
             }
@@ -912,6 +978,8 @@ MainLayout {
             root.recentsScreen.handleAction(action)
         } else if (root.activeScreen === root.screenSettings) {
             root.settingsScreen.handleAction(action)
+        } else if (root.activeScreen === root.screenAbout) {
+            root.aboutScreen.handleAction(action)
         } else {
             root.hubScreen.handleAction(action)
         }

--- a/src/ui/app/MainLayout.qml
+++ b/src/ui/app/MainLayout.qml
@@ -45,6 +45,8 @@ ApplicationWindow {
     // Screen.height, so the live launcher still fills the screen.
     width: 1280
     height: 720
+    minimumWidth: 426
+    minimumHeight: 240
     visible: true
     visibility: root.fullScreen ? Window.FullScreen : Window.Windowed
     title: qsTr("Zaparoo Launcher")
@@ -187,16 +189,20 @@ ApplicationWindow {
         asynchronous: false
     }
 
-    // ── Logo ──────────────────────────────────────────────────────────────────
+    // ── Top header (logo + status row + status pill) ───────────────────────────
 
-    Image {
+    // Single component owning the brand mark, host status icons +
+    // clock, and Core status pill. Height is fixed (Sizing.headerHeight)
+    // so the pill's slot stays reserved when idle and the logo always
+    // matches the stacked rows. Screens clear `Sizing.headerBottom`.
+    HeaderBar {
+        id: headerBar
+
         anchors.left: parent.left
+        anchors.right: parent.right
         anchors.top: parent.top
-        anchors.leftMargin: Sizing.pctW(2)
-        anchors.topMargin: Sizing.pctH(2)
-        height: Sizing.pctH(7)
-        fillMode: Image.PreserveAspectFit
-        source: "qrc:/qt/qml/Zaparoo/App/resources/images/logo.png"
+        anchors.topMargin: Sizing.headerTopMargin
+        z: 200
     }
 
     // ── Screen containers ─────────────────────────────────────────────────────
@@ -348,105 +354,6 @@ ApplicationWindow {
         anchors.fill: parent
         open: root.logUploadModalVisible
         onCloseRequested: root.closeLogUploadRequested()
-    }
-
-    // ── Top-right HUD ─────────────────────────────────────────────────────────
-    //
-    // Host status icons plus clock. The Row is right-anchored so icons
-    // can appear/disappear without moving the clock away from the edge.
-
-    Row {
-        id: topHud
-
-        anchors.top: parent.top
-        anchors.right: parent.right
-        anchors.topMargin: Sizing.pctH(2)
-        anchors.rightMargin: Sizing.pctW(2)
-        spacing: Sizing.pctW(1)
-        z: 200
-        // Explicit row height matches StatusIcon's square size so every
-        // child can verticalCenter against the row and the icons + clock
-        // sit on a single line. Without this Row height tracks the
-        // tallest child, which is the Text element (font ascender +
-        // descender) — that pushes icons up and out of alignment.
-        // Clock pixelSize runs larger than the icon box because a font's
-        // cap-height is ~0.7× pixelSize, so matching pixelSize to icon
-        // height makes glyphs look small next to the square SVGs; bumping
-        // the clock font to ~1.4× the icon size lands their visual weight
-        // on par. Row height takes the max so neither child clips.
-        readonly property real _iconSize: Sizing.fontSize(2.4)
-        readonly property real _clockFontSize: Sizing.fontSize(3.4)
-        height: Math.max(topHud._iconSize, topHud._clockFontSize)
-
-        StatusIcon {
-            anchors.verticalCenter: parent.verticalCenter
-            visible: Browse.SystemStatus.has_nfc
-            source: Resources.statusIconUrl("NFC")
-            name: "NFC"
-        }
-
-        StatusIcon {
-            anchors.verticalCenter: parent.verticalCenter
-            visible: Browse.SystemStatus.has_wifi_internet
-            source: Resources.statusIconUrl("WiFi")
-            name: "Wi-Fi"
-        }
-
-        StatusIcon {
-            anchors.verticalCenter: parent.verticalCenter
-            visible: Browse.SystemStatus.has_lan_internet
-            source: Resources.statusIconUrl("WiredNetwork")
-            name: "LAN"
-        }
-
-        StatusIcon {
-            anchors.verticalCenter: parent.verticalCenter
-            visible: Browse.SystemStatus.has_bluetooth
-            source: Resources.statusIconUrl("Bluetooth")
-            name: "Bluetooth"
-        }
-
-        Text {
-            id: clockLabel
-
-            // 30s tick keeps the displayed minute fresh without per-second
-            // wakeups; minutes-only display means we never need finer.
-            // Fixed width avoids reflow on the minute boundary because
-            // proportional digits make "11:11" narrower than "10:00".
-            property string currentTime: Qt.formatDateTime(new Date(), "HH:mm")
-
-            anchors.verticalCenter: parent.verticalCenter
-            height: parent.height
-            width: topHud._clockFontSize * 3
-            verticalAlignment: Text.AlignVCenter
-            horizontalAlignment: Text.AlignRight
-            text: clockLabel.currentTime
-            font.family: Theme.fontUi
-            font.pixelSize: topHud._clockFontSize
-            color: Theme.textPrimary
-            renderType: Text.NativeRendering
-
-            Timer {
-                interval: 30000
-                running: true
-                repeat: true
-                triggeredOnStart: true
-                onTriggered: clockLabel.currentTime =
-                    Qt.formatDateTime(new Date(), "HH:mm")
-            }
-        }
-    }
-
-    // Mutually-exclusive Core/indexing/scraper status surface. Sits on
-    // its own line directly under `topHud`, right-aligned to the same
-    // edge as the clock. When the pill is idle (no connection issue,
-    // no indexing, no scraping) it collapses to zero size and the
-    // second line takes no visual space.
-    CoreStatusPill {
-        anchors.top: topHud.bottom
-        anchors.right: topHud.right
-        anchors.topMargin: Sizing.pctH(0.8)
-        z: 200
     }
 
     // ── Instructions bar ──────────────────────────────────────────────────────

--- a/src/ui/app/MainLayout.qml
+++ b/src/ui/app/MainLayout.qml
@@ -73,6 +73,7 @@ ApplicationWindow {
     property alias commercialNoticeModal: commercialNoticeModal
     property alias firstRunIndexModal: firstRunIndexModal
     property alias logUploadModal: logUploadModal
+    property alias quitConfirmModal: quitConfirmModal
 
     property bool cardWriteModalVisible: false
     property bool cardWriteFailed: false
@@ -80,6 +81,7 @@ ApplicationWindow {
     property bool commercialNoticeModalVisible: false
     property bool firstRunIndexModalVisible: false
     property bool logUploadModalVisible: false
+    property bool quitConfirmModalVisible: false
     property bool contextMenuVisible: false
     property rect contextMenuAnchor: Qt.rect(0, 0, 0, 0)
     // Owner-aware. Written by Main.qml at openContextMenu time; each entry
@@ -147,6 +149,8 @@ ApplicationWindow {
     signal closeCommercialNoticeRequested()
     signal closeFirstRunIndexRequested()
     signal closeLogUploadRequested()
+    signal closeQuitConfirmRequested()
+    signal quitConfirmAccepted()
 
     // Two-way sync between root.activeScreen and ScreenManager.activeScreen.
     // Binding-breaking assignments (tests setting root.activeScreen = "games")
@@ -380,6 +384,21 @@ ApplicationWindow {
         onCloseRequested: root.closeLogUploadRequested()
     }
 
+    // Quit-confirm modal. Pushed by Main.qml when the user presses
+    // cancel on Hub. Default focus is "No" so an accidental press
+    // can't quit; "Yes" routes through `quitConfirmAccepted` and the
+    // router calls Qt.quit().
+    Modal {
+        id: quitConfirmModal
+
+        open: root.quitConfirmModalVisible
+        kind: "confirm"
+        title: qsTr("Quit Zaparoo Launcher?")
+        body: qsTr("Are you sure you want to exit?")
+        onConfirmed: root.quitConfirmAccepted()
+        onCancelRequested: root.closeQuitConfirmRequested()
+    }
+
     // ── Instructions bar ──────────────────────────────────────────────────────
 
     Rectangle {
@@ -454,6 +473,12 @@ ApplicationWindow {
             }
             if (root.commercialNoticeModalVisible)
                 return [{ button: "ButtonA", label: qsTr("I understand") }];
+            if (root.quitConfirmModalVisible)
+                return [
+                    { button: "Dpad", label: qsTr("Move") },
+                    { button: "ButtonA", label: qsTr("Select") },
+                    { button: "ButtonB", label: qsTr("Cancel") }
+                ];
             if (!root.bootComplete)
                 return [];
             if (root.firstRunIndexModalVisible) {

--- a/src/ui/app/MainLayout.qml
+++ b/src/ui/app/MainLayout.qml
@@ -33,6 +33,7 @@ ApplicationWindow {
     readonly property string screenFavorites: ScreenManager.screenFavorites
     readonly property string screenRecents: ScreenManager.screenRecents
     readonly property string screenSettings: ScreenManager.screenSettings
+    readonly property string screenAbout: ScreenManager.screenAbout
 
     // Runtime state. `activeScreen` mirrors ScreenManager's property
     // (two-way synced below so direct assignment from tests still
@@ -67,13 +68,16 @@ ApplicationWindow {
     property alias favoritesScreen: favoritesScreen
     property alias recentsScreen: recentsScreen
     property alias settingsScreen: settingsScreen
+    property alias aboutScreen: aboutScreen
     property alias contextMenu: contextMenu
+    property alias commercialNoticeModal: commercialNoticeModal
     property alias firstRunIndexModal: firstRunIndexModal
     property alias logUploadModal: logUploadModal
 
     property bool cardWriteModalVisible: false
     property bool cardWriteFailed: false
     property bool qrCodeModalVisible: false
+    property bool commercialNoticeModalVisible: false
     property bool firstRunIndexModalVisible: false
     property bool logUploadModalVisible: false
     property bool contextMenuVisible: false
@@ -140,6 +144,7 @@ ApplicationWindow {
 
     signal cancelCardWriteRequested()
     signal closeQrCodeRequested()
+    signal closeCommercialNoticeRequested()
     signal closeFirstRunIndexRequested()
     signal closeLogUploadRequested()
 
@@ -285,6 +290,13 @@ ApplicationWindow {
             visible: root.activeScreen === root.screenSettings
             transitioning: root.pendingTransition !== ""
         }
+
+        AboutScreen {
+            id: aboutScreen
+            anchors.fill: parent
+            visible: root.activeScreen === root.screenAbout
+            transitioning: root.pendingTransition !== ""
+        }
     }
 
     // ── Boot overlay ─────────────────────────────────────────────────────────
@@ -345,6 +357,18 @@ ApplicationWindow {
         onCloseRequested: root.closeFirstRunIndexRequested()
     }
 
+    // Commercial-use notice. Sits above every other modal (z: 310) so
+    // it always paints first on a fresh install. Once the user acks,
+    // `Browse.Notice.commercial_ack` flips to true on disk and the
+    // modal stays closed for the rest of this install.
+    CommercialNoticeModal {
+        id: commercialNoticeModal
+
+        anchors.fill: parent
+        open: root.commercialNoticeModalVisible
+        onCloseRequested: root.closeCommercialNoticeRequested()
+    }
+
     // Log-upload modal. Pushed by Main.qml when the user triggers the
     // "Upload log" action in Settings. Owns its own three-phase view
     // (uploading / success / error) — the router only sees open / close.
@@ -365,6 +389,12 @@ ApplicationWindow {
         anchors.right: parent.right
         anchors.bottom: parent.bottom
         height: Sizing.pctH(6)
+        // Sits above every modal scrim (modals max out at z: 310 — see
+        // CommercialNoticeModal) so the help cue stays readable while a
+        // dialog is open. The bar's content is already modal-aware
+        // (helpEntries above branches per topModal), so the cue under
+        // the modal is the right one.
+        z: 400
         color: Theme.bgBar
         border.width: 1
         border.color: Theme.borderSubtle
@@ -422,6 +452,8 @@ ApplicationWindow {
                 // Idle / uploading: only Cancel.
                 return [{ button: "ButtonB", label: qsTr("Cancel") }];
             }
+            if (root.commercialNoticeModalVisible)
+                return [{ button: "ButtonA", label: qsTr("I understand") }];
             if (!root.bootComplete)
                 return [];
             if (root.firstRunIndexModalVisible) {
@@ -526,8 +558,20 @@ ApplicationWindow {
                          && !root.settingsScreen.focusedActionDisabled)
                     row.push({
                         button: "ButtonA",
-                        label: root.settingsScreen.focusedActionBusy
-                               ? qsTr("Cancel") : qsTr("Start")
+                        label: root.settingsScreen.focusedActionLabel
+                    });
+                row.push({ button: "ButtonB", label: qsTr("Back") });
+                return row;
+            }
+            if (root.activeScreen === root.screenAbout) {
+                let row = [];
+                // Up/Down only meaningful when the body actually
+                // overflows the viewport (per the minimal help-bar
+                // policy — never advertise a press that no-ops).
+                if (root.aboutScreen.contentOverflows)
+                    row.push({
+                        buttons: ["DpadUp", "DpadDown"],
+                        label: qsTr("Scroll")
                     });
                 row.push({ button: "ButtonB", label: qsTr("Back") });
                 return row;

--- a/src/ui/components/CMakeLists.txt
+++ b/src/ui/components/CMakeLists.txt
@@ -14,6 +14,7 @@ qt_add_qml_module(
         ContextMenu.qml
         CoreStatusPill.qml
         FirstRunIndexModal.qml
+        HeaderBar.qml
         LoadingIndicator.qml
         LogUploadModal.qml
         Modal.qml
@@ -21,6 +22,7 @@ qt_add_qml_module(
         QrCodeModal.qml
         ScreenStateOverlay.qml
         SettingsField.qml
+        SettingsSectionHeader.qml
         StatusIcon.qml
         Tile.qml
         TileLoader.qml

--- a/src/ui/components/CMakeLists.txt
+++ b/src/ui/components/CMakeLists.txt
@@ -11,6 +11,7 @@ qt_add_qml_module(
     QML_FILES
         ActiveLabel.qml
         BootOverlay.qml
+        CommercialNoticeModal.qml
         ContextMenu.qml
         CoreStatusPill.qml
         FirstRunIndexModal.qml

--- a/src/ui/components/CommercialNoticeModal.qml
+++ b/src/ui/components/CommercialNoticeModal.qml
@@ -21,7 +21,9 @@ import Zaparoo.Browse as Browse
 // Pure presentation: input is dispatched by `Main.qml`, the only
 // interactive surface is the "I understand" action, and dismiss runs
 // through the `closeRequested` signal so the router owns the modal
-// stack.
+// stack. Chrome (scrim, panel, border, radius, title) comes from the
+// shared `Modal` shell so every dialog in the app reads as the same
+// surface.
 Item {
     id: modal
 
@@ -49,48 +51,17 @@ Item {
         // launcher becomes interactive.
     }
 
-    // Scrim. Eats clicks so they don't reach the screen tree underneath.
-    Rectangle {
-        anchors.fill: parent
-        color: "#cc000000"
+    Modal {
+        id: shell
 
-        MouseArea {
-            anchors.fill: parent
-        }
-    }
-
-    Rectangle {
-        id: panel
-
-        anchors.centerIn: parent
-        width: Math.min(parent.width * 0.78, Sizing.pctH(110))
-        height: contentColumn.height + Sizing.pctH(12)
-        color: Theme.bgPanel
-        border.width: 2
-        border.color: Theme.textPrimary
-        radius: Sizing.cornerRadius
+        open: modal.open
+        kind: "shell"
+        title: qsTr("Welcome to Zaparoo Launcher")
+        panelMaxWidth: Sizing.pctH(110)
 
         Column {
-            id: contentColumn
-
-            anchors.left: parent.left
-            anchors.right: parent.right
-            anchors.top: parent.top
-            anchors.topMargin: Sizing.pctH(6)
-            anchors.leftMargin: Sizing.pctW(6)
-            anchors.rightMargin: Sizing.pctW(6)
+            width: parent.width
             spacing: Sizing.pctH(3)
-
-            Text {
-                width: parent.width
-                text: qsTr("Welcome to Zaparoo Launcher")
-                font.family: Theme.fontUi
-                font.pixelSize: Sizing.fontSize(3.2)
-                color: Theme.textPrimary
-                wrapMode: Text.WordWrap
-                horizontalAlignment: Text.AlignHCenter
-                renderType: Text.NativeRendering
-            }
 
             Text {
                 width: parent.width
@@ -172,8 +143,6 @@ Item {
                 height: Sizing.pctH(7)
 
                 Rectangle {
-                    id: actionButton
-
                     anchors.horizontalCenter: parent.horizontalCenter
                     anchors.verticalCenter: parent.verticalCenter
                     width: Sizing.pctW(28)

--- a/src/ui/components/CommercialNoticeModal.qml
+++ b/src/ui/components/CommercialNoticeModal.qml
@@ -139,13 +139,14 @@ Item {
             }
 
             Item {
+                id: understandSlot
                 width: parent.width
                 height: Sizing.pctH(7)
 
                 Rectangle {
                     anchors.horizontalCenter: parent.horizontalCenter
                     anchors.verticalCenter: parent.verticalCenter
-                    width: Sizing.pctW(28)
+                    width: Math.min(Sizing.pctW(28), understandSlot.width)
                     height: parent.height
                     color: Theme.bgBar
                     border.width: 1

--- a/src/ui/components/CommercialNoticeModal.qml
+++ b/src/ui/components/CommercialNoticeModal.qml
@@ -1,0 +1,204 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+import QtQuick
+import Zaparoo.Theme
+import Zaparoo.Browse as Browse
+
+// cxx-qt 0.8 patches `isFinal: true` on singleton properties but the
+// qmltypes schema has no `isFinal` slot, so every read trips qmllint's
+// "Member can be shadowed" check. Until the schema grows the slot,
+// suppress the compiler category file-wide.
+// qmllint disable compiler
+
+// Blocking first-run notice. Shown once per install before the launcher
+// becomes usable, then never again — `Browse.Notice.commercial_ack`
+// persists in `launcher.toml` (not `state.toml`, which is tmpfs on
+// MiSTer). Routed in front of the media-DB first-run modal so the user
+// sees this prose first, then the indexing prompt.
+//
+// Pure presentation: input is dispatched by `Main.qml`, the only
+// interactive surface is the "I understand" action, and dismiss runs
+// through the `closeRequested` signal so the router owns the modal
+// stack.
+Item {
+    id: modal
+
+    property bool open: false
+
+    signal closeRequested()
+
+    visible: modal.open
+    anchors.fill: parent
+    z: 310
+
+    function handleAction(action: string): void {
+        if (action === "accept") {
+            // Persist before signalling close so the next Component
+            // construction (warm-restart on MiSTer) sees the ack flag
+            // already written. The Rust slot is synchronous on the Qt
+            // thread; if the disk write fails it logs and still flips
+            // the in-memory flag for this session.
+            Browse.Notice.acknowledge_commercial()
+            modal.closeRequested()
+        }
+        // No cancel path. The notice is informational, not a license
+        // condition — but it must be acknowledged once so the user has
+        // demonstrably seen the non-commercial-use message before the
+        // launcher becomes interactive.
+    }
+
+    // Scrim. Eats clicks so they don't reach the screen tree underneath.
+    Rectangle {
+        anchors.fill: parent
+        color: "#cc000000"
+
+        MouseArea {
+            anchors.fill: parent
+        }
+    }
+
+    Rectangle {
+        id: panel
+
+        anchors.centerIn: parent
+        width: Math.min(parent.width * 0.78, Sizing.pctH(110))
+        height: contentColumn.height + Sizing.pctH(12)
+        color: Theme.bgPanel
+        border.width: 2
+        border.color: Theme.textPrimary
+        radius: Sizing.cornerRadius
+
+        Column {
+            id: contentColumn
+
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.top: parent.top
+            anchors.topMargin: Sizing.pctH(6)
+            anchors.leftMargin: Sizing.pctW(6)
+            anchors.rightMargin: Sizing.pctW(6)
+            spacing: Sizing.pctH(3)
+
+            Text {
+                width: parent.width
+                text: qsTr("Welcome to Zaparoo Launcher")
+                font.family: Theme.fontUi
+                font.pixelSize: Sizing.fontSize(3.2)
+                color: Theme.textPrimary
+                wrapMode: Text.WordWrap
+                horizontalAlignment: Text.AlignHCenter
+                renderType: Text.NativeRendering
+            }
+
+            Text {
+                width: parent.width
+                text: qsTr("Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.")
+                font.family: Theme.fontUi
+                font.pixelSize: Sizing.fontSize(2.5)
+                color: Theme.textPrimary
+                wrapMode: Text.WordWrap
+                horizontalAlignment: Text.AlignHCenter
+                renderType: Text.NativeRendering
+            }
+
+            Text {
+                width: parent.width
+                text: qsTr("This free source-available build is for personal and non-commercial use only. Commercial use or redistribution requires a license.")
+                font.family: Theme.fontUi
+                font.pixelSize: Sizing.fontSize(2.5)
+                color: Theme.textPrimary
+                wrapMode: Text.WordWrap
+                horizontalAlignment: Text.AlignHCenter
+                renderType: Text.NativeRendering
+            }
+
+            Text {
+                width: parent.width
+                text: qsTr("Contact: legal@zaparoo.org")
+                font.family: Theme.fontUi
+                font.pixelSize: Sizing.fontSize(2.5)
+                color: Theme.textLabel
+                wrapMode: Text.WordWrap
+                horizontalAlignment: Text.AlignHCenter
+                renderType: Text.NativeRendering
+            }
+
+            Text {
+                width: parent.width
+                text: qsTr("Full details available any time under Settings → About / License.")
+                font.family: Theme.fontUi
+                font.pixelSize: Sizing.fontSize(2.3)
+                color: Theme.textLabel
+                wrapMode: Text.WordWrap
+                horizontalAlignment: Text.AlignHCenter
+                renderType: Text.NativeRendering
+            }
+
+            // Tight inner Column so the "Created by" caption sits
+            // directly above the names without inheriting the outer
+            // Column's paragraph spacing.
+            Column {
+                width: parent.width
+                spacing: Sizing.pctH(0.4)
+
+                Text {
+                    width: parent.width
+                    text: qsTr("Created by")
+                    font.family: Theme.fontUi
+                    font.pixelSize: Sizing.fontSize(2.3)
+                    color: Theme.textLabel
+                    horizontalAlignment: Text.AlignHCenter
+                    renderType: Text.NativeRendering
+                }
+
+                // Contributor names are not translated — they're
+                // proper names.
+                Text {
+                    width: parent.width
+                    text: "Andrea Bogazzi, BossRighteous, Tim Wilsie, Wizzo"
+                    font.family: Theme.fontUi
+                    font.pixelSize: Sizing.fontSize(2.5)
+                    color: Theme.textPrimary
+                    wrapMode: Text.WordWrap
+                    horizontalAlignment: Text.AlignHCenter
+                    renderType: Text.NativeRendering
+                }
+            }
+
+            Item {
+                width: parent.width
+                height: Sizing.pctH(7)
+
+                Rectangle {
+                    id: actionButton
+
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    anchors.verticalCenter: parent.verticalCenter
+                    width: Sizing.pctW(28)
+                    height: parent.height
+                    color: Theme.bgBar
+                    border.width: 1
+                    border.color: Theme.borderMid
+                    radius: Sizing.cornerRadius
+
+                    Text {
+                        anchors.centerIn: parent
+                        text: qsTr("I understand")
+                        font.family: Theme.fontUi
+                        font.pixelSize: Sizing.fontSize(2.5)
+                        color: Theme.textPrimary
+                        renderType: Text.NativeRendering
+                    }
+
+                    MouseArea {
+                        anchors.fill: parent
+                        acceptedButtons: Qt.LeftButton
+                        onClicked: modal.handleAction("accept")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/ui/components/CommercialNoticeModal.qml
+++ b/src/ui/components/CommercialNoticeModal.qml
@@ -98,7 +98,7 @@ Item {
 
             Text {
                 width: parent.width
-                text: qsTr("Full details available any time under Settings → About / License.")
+                text: qsTr("Full details available any time under Settings > About / License.")
                 font.family: Theme.fontUi
                 font.pixelSize: Sizing.fontSize(2.3)
                 color: Theme.textLabel

--- a/src/ui/components/ContextMenu.qml
+++ b/src/ui/components/ContextMenu.qml
@@ -37,8 +37,13 @@ Item {
     readonly property int panelWidth:
         Math.min(Math.max(Sizing.pctW(26), Sizing.pctH(44)),
                  Math.max(0, width - 2 * margin))
+    // Top/bottom margins inside the panel are sized to the panel
+    // radius so a focused row's square background never intersects
+    // the rounded corners — see the panel `Rectangle` below.
+    readonly property int panelRadius: Sizing.cornerRadius / 2
     readonly property int panelHeight:
-        Math.min(entries.length * rowHeight + 2, Math.max(0, height - 2 * margin))
+        Math.min(entries.length * rowHeight + 2 * panelRadius,
+                 Math.max(0, height - 2 * margin))
     readonly property bool preferRight:
         anchorRect.x + anchorRect.width + gap + panelWidth <= width - margin
     readonly property int preferredX:
@@ -97,16 +102,14 @@ Item {
         color: Theme.bgPanel
         border.width: 2
         border.color: Theme.textPrimary
-        radius: Sizing.cornerRadius
-        // Rows fill the full width and the focused row paints a square
-        // background, so without clipping the row colors would bleed
-        // past the rounded corner curvature at the top and bottom of
-        // the panel.
-        clip: true
+        radius: menu.panelRadius
 
         Column {
             anchors.fill: parent
-            anchors.margins: 1
+            anchors.topMargin: menu.panelRadius
+            anchors.bottomMargin: menu.panelRadius
+            anchors.leftMargin: 1
+            anchors.rightMargin: 1
 
             Repeater {
                 model: menu.entries

--- a/src/ui/components/ContextMenu.qml
+++ b/src/ui/components/ContextMenu.qml
@@ -97,6 +97,12 @@ Item {
         color: Theme.bgPanel
         border.width: 2
         border.color: Theme.textPrimary
+        radius: Sizing.cornerRadius
+        // Rows fill the full width and the focused row paints a square
+        // background, so without clipping the row colors would bleed
+        // past the rounded corner curvature at the top and bottom of
+        // the panel.
+        clip: true
 
         Column {
             anchors.fill: parent

--- a/src/ui/components/ContextMenu.qml
+++ b/src/ui/components/ContextMenu.qml
@@ -1,9 +1,16 @@
 // Zaparoo Launcher
 // Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+pragma ComponentBehavior: Bound
 
 import QtQuick
 import Zaparoo.Theme
+
+// `entries` is a `var` array of plain JS objects (`{ id, label }`). The
+// AOT compiler can't infer the shape of `var`, so every binding that
+// reads `entries.length` or `modelData.label` falls back to the JS
+// interpreter and trips the compiler category. Suppress file-wide.
+// qmllint disable compiler
 
 // Software-rendering safe contextual menu. It positions itself next to an
 // anchor rectangle and clamps to the window bounds so edge tiles never push

--- a/src/ui/components/FirstRunIndexModal.qml
+++ b/src/ui/components/FirstRunIndexModal.qml
@@ -31,7 +31,9 @@ import Zaparoo.Browse as Browse
 // The component is purely presentational; routing and the modal stack
 // are owned by `Main.qml`. We emit `closeRequested` and trust the
 // router to actually pop. `handleAction(accept|cancel)` is the input
-// hook called from `Main.qml`'s modal-dispatch branch.
+// hook called from `Main.qml`'s modal-dispatch branch. Chrome (scrim,
+// panel, border, radius, title) comes from the shared `Modal` shell so
+// every dialog in the app reads as the same surface.
 Item {
     id: modal
 
@@ -114,57 +116,18 @@ Item {
         }
     }
 
-    // Scrim. Eats clicks so they don't reach the screen tree underneath.
-    Rectangle {
-        anchors.fill: parent
-        color: "#cc000000"
+    Modal {
+        id: shell
 
-        MouseArea {
-            anchors.fill: parent
-        }
-    }
-
-    Rectangle {
-        id: panel
-
-        anchors.centerIn: parent
-        width: Math.min(parent.width * 0.78, Sizing.pctH(90))
-        // Fit current contents. Column drops invisible children from
-        // its layout, so the panel shrinks for the short idle body and
-        // grows for the running progress block.
-        height: contentColumn.height + Sizing.pctH(12)
-        color: Theme.bgPanel
-        border.width: 2
-        border.color: Theme.textPrimary
-        radius: Sizing.cornerRadius
+        open: modal.open
+        kind: "shell"
+        title: qsTr("First-time setup")
 
         Column {
-            id: contentColumn
-
-            anchors.left: parent.left
-            anchors.right: parent.right
-            anchors.top: parent.top
-            anchors.topMargin: Sizing.pctH(6)
-            anchors.leftMargin: Sizing.pctW(6)
-            anchors.rightMargin: Sizing.pctW(6)
+            width: parent.width
             spacing: Sizing.pctH(3)
 
             Text {
-                id: titleText
-
-                width: parent.width
-                text: qsTr("First-time setup")
-                font.family: Theme.fontUi
-                font.pixelSize: Sizing.fontSize(3.2)
-                color: Theme.textPrimary
-                wrapMode: Text.WordWrap
-                horizontalAlignment: Text.AlignHCenter
-                renderType: Text.NativeRendering
-            }
-
-            Text {
-                id: bodyIdle
-
                 width: parent.width
                 visible: modal.phase === "idle"
                 text: qsTr("Zaparoo needs to scan your games before you can use the launcher. This usually takes a few minutes.")
@@ -262,8 +225,6 @@ Item {
             }
 
             Text {
-                id: completionMessage
-
                 width: parent.width
                 visible: modal.phase === "completed"
                 text: qsTr("Done. %1 files indexed.").arg(Browse.MediaStatus.total_files)
@@ -276,15 +237,11 @@ Item {
             }
 
             Item {
-                id: actionButtonSlot
-
                 width: parent.width
                 height: Sizing.pctH(7)
                 visible: modal.phase !== "completed"
 
                 Rectangle {
-                    id: actionButton
-
                     anchors.horizontalCenter: parent.horizontalCenter
                     anchors.verticalCenter: parent.verticalCenter
                     width: Sizing.pctW(28)

--- a/src/ui/components/HeaderBar.qml
+++ b/src/ui/components/HeaderBar.qml
@@ -1,0 +1,127 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+import QtQuick
+import Zaparoo.Theme
+import Zaparoo.Browse as Browse
+
+// cxx-qt 0.8 patches `isFinal: true` on singleton properties but the
+// qmltypes schema has no `isFinal` slot, so every read of a Browse
+// singleton trips qmllint's "Member can be shadowed" check. Suppress
+// the compiler category file-wide until the schema grows the slot.
+// qmllint disable compiler
+
+// Top header bar — Zaparoo logo on the left, host status row + Core
+// status pill stacked on the right. Height is fixed at
+// `Sizing.headerHeight` so the pill's slot is reserved even when the
+// pill is idle and the logo can match the two stacked rows exactly.
+//
+// Software-renderer safe: only Image, Row, Item, Text, and the
+// existing CoreStatusPill subtree. No transforms, no shaders.
+Item {
+    id: header
+
+    height: Sizing.headerHeight
+
+    Image {
+        id: logo
+
+        anchors.left: parent.left
+        anchors.leftMargin: Sizing.headerSideMargin
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        // PreserveAspectFit caps width by the logo's intrinsic aspect,
+        // so the brand mark never stretches even though the Image
+        // element fills the full header height.
+        fillMode: Image.PreserveAspectFit
+        horizontalAlignment: Image.AlignLeft
+        source: "qrc:/qt/qml/Zaparoo/App/resources/images/logo.png"
+    }
+
+    // Host status row — NFC / Wi-Fi / LAN / Bluetooth icons plus the
+    // wall clock, right-anchored so badges can appear and disappear
+    // without nudging the clock away from the edge.
+    Row {
+        id: topHud
+
+        anchors.top: parent.top
+        anchors.right: parent.right
+        anchors.rightMargin: Sizing.headerSideMargin
+        spacing: Sizing.pctW(1)
+        // Explicit row height keeps every child on a single line. Without
+        // this the Row would track the tallest child (clock Text — font
+        // ascender + descender), which pushes icons up and out of
+        // alignment with the clock baseline.
+        height: Sizing.headerRowHeight
+
+        StatusIcon {
+            anchors.verticalCenter: parent.verticalCenter
+            visible: Browse.SystemStatus.has_nfc
+            source: Resources.statusIconUrl("NFC")
+            name: "NFC"
+        }
+
+        StatusIcon {
+            anchors.verticalCenter: parent.verticalCenter
+            visible: Browse.SystemStatus.has_wifi_internet
+            source: Resources.statusIconUrl("WiFi")
+            name: "Wi-Fi"
+        }
+
+        StatusIcon {
+            anchors.verticalCenter: parent.verticalCenter
+            visible: Browse.SystemStatus.has_lan_internet
+            source: Resources.statusIconUrl("WiredNetwork")
+            name: "LAN"
+        }
+
+        StatusIcon {
+            anchors.verticalCenter: parent.verticalCenter
+            visible: Browse.SystemStatus.has_bluetooth
+            source: Resources.statusIconUrl("Bluetooth")
+            name: "Bluetooth"
+        }
+
+        Text {
+            id: clockLabel
+
+            // 30s tick keeps the displayed minute fresh without per-second
+            // wakeups; minutes-only display means we never need finer.
+            // Fixed width avoids reflow on the minute boundary because
+            // proportional digits make "11:11" narrower than "10:00".
+            property string currentTime: Qt.formatDateTime(new Date(), "HH:mm")
+
+            anchors.verticalCenter: parent.verticalCenter
+            height: parent.height
+            width: Sizing.headerRowHeight * 3
+            verticalAlignment: Text.AlignVCenter
+            horizontalAlignment: Text.AlignRight
+            text: clockLabel.currentTime
+            font.family: Theme.fontUi
+            font.pixelSize: Sizing.headerRowHeight
+            color: Theme.textPrimary
+            renderType: Text.NativeRendering
+
+            Timer {
+                interval: 30000
+                running: true
+                repeat: true
+                triggeredOnStart: true
+                onTriggered: clockLabel.currentTime =
+                    Qt.formatDateTime(new Date(), "HH:mm")
+            }
+        }
+    }
+
+    // Mutually-exclusive Core / indexing / scraper status surface. Sits
+    // on its own line directly under `topHud`, right-aligned to the
+    // same edge as the clock. The pill collapses to zero size when
+    // idle, but its slot stays reserved by the header's fixed height
+    // so the logo and the surrounding layout don't shift.
+    CoreStatusPill {
+        anchors.top: topHud.bottom
+        anchors.right: topHud.right
+        anchors.topMargin: Sizing.headerStackGap
+    }
+}

--- a/src/ui/components/LogUploadModal.qml
+++ b/src/ui/components/LogUploadModal.qml
@@ -1,6 +1,7 @@
 // Zaparoo Launcher
 // Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+pragma ComponentBehavior: Bound
 
 import QtQuick
 import Zaparoo.Theme

--- a/src/ui/components/LogUploadModal.qml
+++ b/src/ui/components/LogUploadModal.qml
@@ -27,7 +27,9 @@ import Zaparoo.Browse as Browse
 //
 // Routing and the modal stack are owned by `Main.qml`. We emit
 // `closeRequested` and trust the router to pop. `handleAction` is the
-// input hook called from `Main.qml`'s modal-dispatch branch.
+// input hook called from `Main.qml`'s modal-dispatch branch. Chrome
+// (scrim, panel, border, radius, title) comes from the shared `Modal`
+// shell so every dialog in the app reads as the same surface.
 Item {
     id: modal
 
@@ -77,48 +79,17 @@ Item {
         }
     }
 
-    // Scrim. Eats clicks so they don't reach the screen tree underneath.
-    Rectangle {
-        anchors.fill: parent
-        color: "#cc000000"
+    Modal {
+        id: shell
 
-        MouseArea {
-            anchors.fill: parent
-        }
-    }
-
-    Rectangle {
-        id: panel
-
-        anchors.centerIn: parent
-        width: Math.min(parent.width * 0.78, Sizing.pctH(110))
-        height: contentColumn.height + Sizing.pctH(12)
-        color: Theme.bgPanel
-        border.width: 2
-        border.color: Theme.textPrimary
-        radius: Sizing.cornerRadius
+        open: modal.open
+        kind: "shell"
+        title: qsTr("Upload log file")
+        panelMaxWidth: Sizing.pctH(110)
 
         Column {
-            id: contentColumn
-
-            anchors.left: parent.left
-            anchors.right: parent.right
-            anchors.top: parent.top
-            anchors.topMargin: Sizing.pctH(6)
-            anchors.leftMargin: Sizing.pctW(6)
-            anchors.rightMargin: Sizing.pctW(6)
+            width: parent.width
             spacing: Sizing.pctH(3)
-
-            Text {
-                width: parent.width
-                text: qsTr("Upload log file")
-                font.family: Theme.fontUi
-                font.pixelSize: Sizing.fontSize(3.2)
-                color: Theme.textPrimary
-                wrapMode: Text.WordWrap
-                horizontalAlignment: Text.AlignHCenter
-                renderType: Text.NativeRendering
-            }
 
             Text {
                 width: parent.width
@@ -248,8 +219,6 @@ Item {
                          || modal.phase === modal._stateError
 
                 Rectangle {
-                    id: actionButton
-
                     anchors.horizontalCenter: parent.horizontalCenter
                     anchors.verticalCenter: parent.verticalCenter
                     width: Sizing.pctW(28)

--- a/src/ui/components/Modal.qml
+++ b/src/ui/components/Modal.qml
@@ -97,7 +97,7 @@ Item {
 
     Rectangle {
         anchors.fill: parent
-        color: "#cc000000"
+        color: Theme.scrim
 
         // Eat clicks on the scrim so they don't reach the screens
         // underneath.
@@ -164,6 +164,7 @@ Item {
                 // flips. Failure is a terminal display that auto-dismisses,
                 // not interactive.
                 Item {
+                    id: cancelSlot
                     width: parent.width
                     height: Sizing.pctH(7)
                     visible: modal.kind === "transient" && !modal.failed
@@ -171,7 +172,11 @@ Item {
                     Rectangle {
                         anchors.horizontalCenter: parent.horizontalCenter
                         anchors.verticalCenter: parent.verticalCenter
-                        width: Sizing.pctW(28)
+                        // Cap at pctW(28) for the typical case but never
+                        // exceed the slot width — the modal panel is
+                        // height-bound on widescreen, so a screen-width
+                        // pill can otherwise overflow the panel.
+                        width: Math.min(Sizing.pctW(28), cancelSlot.width)
                         height: parent.height
                         color: Theme.bgBar
                         border.width: 1
@@ -196,6 +201,7 @@ Item {
 
                 // Accept button — action_error flavor.
                 Item {
+                    id: acceptSlot
                     width: parent.width
                     height: Sizing.pctH(7)
                     visible: modal.kind === "action_error"
@@ -203,7 +209,7 @@ Item {
                     Rectangle {
                         anchors.horizontalCenter: parent.horizontalCenter
                         anchors.verticalCenter: parent.verticalCenter
-                        width: Sizing.pctW(28)
+                        width: Math.min(Sizing.pctW(28), acceptSlot.width)
                         height: parent.height
                         color: Theme.bgBar
                         border.width: 1
@@ -230,17 +236,29 @@ Item {
                 // accent border; mouse clicks bypass focus and dispatch
                 // straight to the matching signal.
                 Item {
+                    id: confirmSlot
+
                     width: parent.width
                     height: Sizing.pctH(7)
                     visible: modal.kind === "confirm"
 
+                    // Pill width caps at pctW(28) but shrinks to half
+                    // the slot (minus the gap) when the panel is too
+                    // narrow for two preferred pills. Computed off the
+                    // slot, not the Row, so the Row can stay implicitly
+                    // sized by its children and centered.
+                    readonly property int _gap: Sizing.pctW(2)
+                    readonly property int _pillWidth:
+                        Math.min(Sizing.pctW(28),
+                                 Math.max(0, (width - _gap) / 2))
+
                     Row {
                         anchors.horizontalCenter: parent.horizontalCenter
                         anchors.verticalCenter: parent.verticalCenter
-                        spacing: Sizing.pctW(2)
+                        spacing: confirmSlot._gap
 
                         Rectangle {
-                            width: Sizing.pctW(28)
+                            width: confirmSlot._pillWidth
                             height: Sizing.pctH(7)
                             color: Theme.bgBar
                             border.width: modal._focusYes ? 1 : 2
@@ -268,7 +286,7 @@ Item {
                         }
 
                         Rectangle {
-                            width: Sizing.pctW(28)
+                            width: confirmSlot._pillWidth
                             height: Sizing.pctH(7)
                             color: Theme.bgBar
                             border.width: modal._focusYes ? 2 : 1

--- a/src/ui/components/Modal.qml
+++ b/src/ui/components/Modal.qml
@@ -5,41 +5,99 @@
 import QtQuick
 import Zaparoo.Theme
 
-// Reusable modal panel. Two flavors selected by `kind`:
-//   "action_error" — title + one button. Caller wires `accepted` to
-//                    its dismiss handler. Border uses Theme.textPrimary.
-//   "transient"    — title + optional Cancel pill, no accept button.
-//                    Auto-dismisses via the caller's failure timer or
-//                    external signal. Border uses Theme.accent while
-//                    `failed === false`, Theme.textPrimary on failure.
+// Reusable modal panel. Four flavors selected by `kind`:
+//   "action_error" — title (+ optional body) + one OK button. Caller
+//                    wires `accepted` to its dismiss handler.
+//   "transient"    — title (+ optional body) + optional Cancel pill, no
+//                    accept button. Auto-dismisses via the caller's
+//                    failure timer or external signal. The Cancel pill
+//                    hides once `failed` flips so the failure flash is
+//                    non-interactive.
+//   "confirm"      — title + body + two pills (No / Yes). Default focus
+//                    is "No", so a stray accept can't trigger the
+//                    destructive path. The router calls `handleAction`
+//                    to toggle focus and dispatch confirm/cancel.
+//   "shell"        — title + caller-provided content slot, no built-in
+//                    body or buttons. Used by the first-run, commercial-
+//                    notice, and log-upload modals so they share this
+//                    chrome instead of hand-rolling their own scrim,
+//                    panel, and Column. The consumer places its content
+//                    (and any phase-specific buttons) in the default
+//                    property slot and owns its own `handleAction` and
+//                    dismissal.
 //
-// Pure presentation: input routing lives in Main.qml, persistence in
-// Browse.AppState. The component only renders, swallows clicks on its
-// scrim, and emits `cancelRequested` (transient Cancel pill) or
-// `accepted` (action_error button).
+// All four kinds share the same chrome — rounded corners
+// (`Sizing.cornerRadius`), 2px `Theme.textPrimary` border, `Theme.bgPanel`
+// fill, dark scrim — so every modal in the app reads as the same surface.
+// See `docs/style.md` → "Modal chrome".
 //
-// Software-rendering safe — only Item, Rectangle, Text, MouseArea.
-// No transforms, no shaders, no animations.
+// Pure presentation: input routing for the prebaked kinds lives in
+// Main.qml, persistence in Browse.AppState. The component renders,
+// swallows clicks on its scrim, and emits `cancelRequested` (transient
+// Cancel pill, confirm No / Back), `accepted` (action_error button), or
+// `confirmed` (confirm Yes).
+//
+// Software-rendering safe — only Item, Rectangle, Text, Column, Row,
+// MouseArea. No transforms, no shaders, no animations.
 Item {
     id: modal
 
     property bool open: false
-    property string kind: "action_error"     // or "transient"
+    property string kind: "action_error"
     property string title: ""
     property string body: ""                 // optional secondary line
     property string buttonLabel: qsTr("OK")  // action_error only
+    property string confirmYesLabel: qsTr("Yes")  // confirm only
+    property string confirmNoLabel: qsTr("No")    // confirm only
     property bool failed: false              // transient only
+    // Override the panel's max width on a per-callsite basis. The
+    // content-heavier shell modals (legal notice, log upload with QR)
+    // bump this up.
+    property int panelMaxWidth: Sizing.pctH(90)
+
+    // confirm-only focus. False = No focused (safe default), true = Yes
+    // focused. Reset on every open so a previous Yes-focus doesn't leak
+    // into the next prompt.
+    property bool _focusYes: false
+
+    // Shell-mode content slot. Children declared inside a Modal are
+    // routed here; only rendered when kind === "shell" so a stray child
+    // on a prebaked-kind modal can't leak into the panel.
+    default property alias contentData: contentSlot.data
 
     signal accepted()         // action_error: button click
-    signal cancelRequested()  // transient: Cancel pill click
+    signal cancelRequested()  // transient Cancel; confirm No / Back
+    signal confirmed()        // confirm: Yes selected
 
     visible: modal.open
     anchors.fill: parent
     z: 300
 
+    onOpenChanged: {
+        if (modal.open && modal.kind === "confirm")
+            modal._focusYes = false
+    }
+
+    // confirm-only input dispatch. Main.qml routes key/controller
+    // actions here while this modal is on top of the stack.
+    function handleAction(action: string): void {
+        if (modal.kind !== "confirm")
+            return
+        if (action === "left" || action === "right") {
+            modal._focusYes = !modal._focusYes
+        } else if (action === "accept") {
+            if (modal._focusYes)
+                modal.confirmed()
+            else
+                modal.cancelRequested()
+        } else if (action === "cancel") {
+            modal.cancelRequested()
+        }
+    }
+
     Rectangle {
         anchors.fill: parent
-        color: "#99000000"
+        color: "#cc000000"
 
         // Eat clicks on the scrim so they don't reach the screens
         // underneath.
@@ -49,104 +107,194 @@ Item {
 
         Rectangle {
             anchors.centerIn: parent
-            width: Math.min(parent.width * 0.78, Sizing.pctH(82))
-            height: Sizing.pctH(34)
+            width: Math.min(parent.width * 0.78, modal.panelMaxWidth)
+            height: contentColumn.height + Sizing.pctH(12)
             color: Theme.bgPanel
             border.width: 2
-            border.color: modal.failed
-                          ? Theme.textPrimary
-                          : (modal.kind === "action_error"
-                             ? Theme.textPrimary
-                             : Theme.accent)
+            border.color: Theme.textPrimary
+            radius: Sizing.cornerRadius
 
-            Text {
-                id: titleText
+            Column {
+                id: contentColumn
 
                 anchors.left: parent.left
                 anchors.right: parent.right
                 anchors.top: parent.top
-                anchors.topMargin: Sizing.pctH(7)
-                anchors.leftMargin: Sizing.pctW(5)
-                anchors.rightMargin: Sizing.pctW(5)
-                text: modal.title
-                font.family: Theme.fontUi
-                font.pixelSize: Sizing.fontSize(3)
-                color: Theme.textPrimary
-                wrapMode: Text.WordWrap
-                horizontalAlignment: Text.AlignHCenter
-                renderType: Text.NativeRendering
-            }
-
-            Text {
-                anchors.left: parent.left
-                anchors.right: parent.right
-                anchors.top: titleText.bottom
-                anchors.topMargin: Sizing.pctH(1.5)
-                anchors.leftMargin: Sizing.pctW(5)
-                anchors.rightMargin: Sizing.pctW(5)
-                visible: modal.body !== ""
-                text: modal.body
-                font.family: Theme.fontUi
-                font.pixelSize: Sizing.fontSize(2.4)
-                color: Theme.textPrimary
-                wrapMode: Text.WordWrap
-                horizontalAlignment: Text.AlignHCenter
-                renderType: Text.NativeRendering
-            }
-
-            // Cancel pill — transient flavor, hidden once `failed`
-            // flips. Failure is a terminal display that auto-dismisses,
-            // not interactive.
-            Rectangle {
-                anchors.horizontalCenter: parent.horizontalCenter
-                anchors.bottom: parent.bottom
-                anchors.bottomMargin: Sizing.pctH(5)
-                width: Sizing.pctW(22)
-                height: Sizing.pctH(7)
-                color: Theme.bgBar
-                border.width: 1
-                border.color: Theme.borderMid
-                visible: modal.kind === "transient" && !modal.failed
+                anchors.topMargin: Sizing.pctH(6)
+                anchors.leftMargin: Sizing.pctW(6)
+                anchors.rightMargin: Sizing.pctW(6)
+                spacing: Sizing.pctH(3)
 
                 Text {
-                    anchors.centerIn: parent
-                    text: qsTr("Cancel")
+                    width: parent.width
+                    visible: modal.title !== ""
+                    text: modal.title
                     font.family: Theme.fontUi
-                    font.pixelSize: Sizing.fontSize(2.4)
+                    font.pixelSize: Sizing.fontSize(3.2)
                     color: Theme.textPrimary
+                    wrapMode: Text.WordWrap
+                    horizontalAlignment: Text.AlignHCenter
                     renderType: Text.NativeRendering
                 }
 
-                MouseArea {
-                    anchors.fill: parent
-                    onClicked: modal.cancelRequested()
-                }
-            }
-
-            // Accept button — action_error flavor.
-            Rectangle {
-                anchors.horizontalCenter: parent.horizontalCenter
-                anchors.bottom: parent.bottom
-                anchors.bottomMargin: Sizing.pctH(5)
-                width: Sizing.pctW(22)
-                height: Sizing.pctH(7)
-                color: Theme.bgBar
-                border.width: 1
-                border.color: Theme.borderMid
-                visible: modal.kind === "action_error"
-
                 Text {
-                    anchors.centerIn: parent
-                    text: modal.buttonLabel
+                    width: parent.width
+                    visible: modal.body !== "" && modal.kind !== "shell"
+                    text: modal.body
                     font.family: Theme.fontUi
-                    font.pixelSize: Sizing.fontSize(2.4)
+                    font.pixelSize: Sizing.fontSize(2.5)
                     color: Theme.textPrimary
+                    wrapMode: Text.WordWrap
+                    horizontalAlignment: Text.AlignHCenter
                     renderType: Text.NativeRendering
                 }
 
-                MouseArea {
-                    anchors.fill: parent
-                    onClicked: modal.accepted()
+                // Caller content — only rendered in shell mode. Column
+                // skips invisible children, so the slot consumes no
+                // vertical space outside shell mode.
+                Item {
+                    id: contentSlot
+
+                    width: parent.width
+                    height: childrenRect.height
+                    visible: modal.kind === "shell"
+                }
+
+                // Cancel pill — transient flavor, hidden once `failed`
+                // flips. Failure is a terminal display that auto-dismisses,
+                // not interactive.
+                Item {
+                    width: parent.width
+                    height: Sizing.pctH(7)
+                    visible: modal.kind === "transient" && !modal.failed
+
+                    Rectangle {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        anchors.verticalCenter: parent.verticalCenter
+                        width: Sizing.pctW(28)
+                        height: parent.height
+                        color: Theme.bgBar
+                        border.width: 1
+                        border.color: Theme.borderMid
+                        radius: Sizing.cornerRadius
+
+                        Text {
+                            anchors.centerIn: parent
+                            text: qsTr("Cancel")
+                            font.family: Theme.fontUi
+                            font.pixelSize: Sizing.fontSize(2.5)
+                            color: Theme.textPrimary
+                            renderType: Text.NativeRendering
+                        }
+
+                        MouseArea {
+                            anchors.fill: parent
+                            onClicked: modal.cancelRequested()
+                        }
+                    }
+                }
+
+                // Accept button — action_error flavor.
+                Item {
+                    width: parent.width
+                    height: Sizing.pctH(7)
+                    visible: modal.kind === "action_error"
+
+                    Rectangle {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        anchors.verticalCenter: parent.verticalCenter
+                        width: Sizing.pctW(28)
+                        height: parent.height
+                        color: Theme.bgBar
+                        border.width: 1
+                        border.color: Theme.borderMid
+                        radius: Sizing.cornerRadius
+
+                        Text {
+                            anchors.centerIn: parent
+                            text: modal.buttonLabel
+                            font.family: Theme.fontUi
+                            font.pixelSize: Sizing.fontSize(2.5)
+                            color: Theme.textPrimary
+                            renderType: Text.NativeRendering
+                        }
+
+                        MouseArea {
+                            anchors.fill: parent
+                            onClicked: modal.accepted()
+                        }
+                    }
+                }
+
+                // No / Yes pair — confirm flavor. Focused pill draws an
+                // accent border; mouse clicks bypass focus and dispatch
+                // straight to the matching signal.
+                Item {
+                    width: parent.width
+                    height: Sizing.pctH(7)
+                    visible: modal.kind === "confirm"
+
+                    Row {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        anchors.verticalCenter: parent.verticalCenter
+                        spacing: Sizing.pctW(2)
+
+                        Rectangle {
+                            width: Sizing.pctW(28)
+                            height: Sizing.pctH(7)
+                            color: Theme.bgBar
+                            border.width: modal._focusYes ? 1 : 2
+                            border.color: modal._focusYes
+                                          ? Theme.borderMid
+                                          : Theme.accent
+                            radius: Sizing.cornerRadius
+
+                            Text {
+                                anchors.centerIn: parent
+                                text: modal.confirmNoLabel
+                                font.family: Theme.fontUi
+                                font.pixelSize: Sizing.fontSize(2.5)
+                                color: Theme.textPrimary
+                                renderType: Text.NativeRendering
+                            }
+
+                            MouseArea {
+                                anchors.fill: parent
+                                onClicked: {
+                                    modal._focusYes = false
+                                    modal.cancelRequested()
+                                }
+                            }
+                        }
+
+                        Rectangle {
+                            width: Sizing.pctW(28)
+                            height: Sizing.pctH(7)
+                            color: Theme.bgBar
+                            border.width: modal._focusYes ? 2 : 1
+                            border.color: modal._focusYes
+                                          ? Theme.accent
+                                          : Theme.borderMid
+                            radius: Sizing.cornerRadius
+
+                            Text {
+                                anchors.centerIn: parent
+                                text: modal.confirmYesLabel
+                                font.family: Theme.fontUi
+                                font.pixelSize: Sizing.fontSize(2.5)
+                                color: Theme.textPrimary
+                                renderType: Text.NativeRendering
+                            }
+
+                            MouseArea {
+                                anchors.fill: parent
+                                onClicked: {
+                                    modal._focusYes = true
+                                    modal.confirmed()
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/src/ui/components/Modal.qml
+++ b/src/ui/components/Modal.qml
@@ -83,8 +83,10 @@ Item {
     function handleAction(action: string): void {
         if (modal.kind !== "confirm")
             return
-        if (action === "left" || action === "right") {
-            modal._focusYes = !modal._focusYes
+        if (action === "left") {
+            modal._focusYes = false
+        } else if (action === "right") {
+            modal._focusYes = true
         } else if (action === "accept") {
             if (modal._focusYes)
                 modal.confirmed()

--- a/src/ui/components/QrCodeModal.qml
+++ b/src/ui/components/QrCodeModal.qml
@@ -1,10 +1,17 @@
 // Zaparoo Launcher
 // Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+pragma ComponentBehavior: Bound
 
 import QtQuick
 import Zaparoo.Theme
 import Zaparoo.Browse as Browse
+
+// cxx-qt 0.8 patches `isFinal: true` on singleton properties but the
+// qmltypes schema has no `isFinal` slot, so every read trips qmllint's
+// "Member can be shadowed" check. Until the schema grows the slot,
+// suppress the compiler category file-wide.
+// qmllint disable compiler
 
 Item {
     id: root

--- a/src/ui/components/SettingsField.qml
+++ b/src/ui/components/SettingsField.qml
@@ -145,20 +145,36 @@ Item {
         }
     }
 
-    // Right-side caption for `control: "action"`. No `< >` arrows, no
-    // toggle pill — just a single muted-when-idle string showing the
-    // current operation state. Empty `actionStatus` collapses to no
-    // text, matching the visual quietness of an idle row.
-    Text {
+    // Right-side cluster for `control: "action"`. The chevron is the
+    // affordance — it always paints so an idle action row reads as
+    // pressable. The status caption to its left only paints while the
+    // operation is in flight ("In progress" / "Paused" / "Optimizing");
+    // it's a status, not the label of the action.
+    Row {
         visible: root.control === "action"
         anchors.right: parent.right
         anchors.rightMargin: Sizing.pctW(3)
         anchors.verticalCenter: parent.verticalCenter
-        text: root.actionStatus
-        color: Theme.textPrimary
-        font.family: Theme.fontUi
-        font.pixelSize: Sizing.fontSize(2.4)
-        renderType: Text.NativeRendering
+        spacing: Sizing.pctW(1.5)
+
+        Text {
+            anchors.verticalCenter: parent.verticalCenter
+            visible: root.actionStatus !== ""
+            text: root.actionStatus
+            color: Theme.textLabel
+            font.family: Theme.fontUi
+            font.pixelSize: Sizing.fontSize(2.4)
+            renderType: Text.NativeRendering
+        }
+
+        Text {
+            anchors.verticalCenter: parent.verticalCenter
+            text: "›"
+            color: Theme.textPrimary
+            font.family: Theme.fontUi
+            font.pixelSize: Sizing.fontSize(3.0)
+            renderType: Text.NativeRendering
+        }
     }
 
     MouseArea {

--- a/src/ui/components/SettingsSectionHeader.qml
+++ b/src/ui/components/SettingsSectionHeader.qml
@@ -1,0 +1,44 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+import QtQuick
+import Zaparoo.Theme
+
+// Non-focusable group label for the Settings form. Splits the otherwise
+// flat list of `SettingsField` rows into bands (General / Library /
+// Advanced) so adjacent items are visibly related and rare entries
+// don't crowd the commonly-used ones.
+//
+// The screen's navigation logic skips entries whose `kind` is `"header"`,
+// so this row never receives focus, never paints a border, and has no
+// hover/accept handling — it's purely a divider.
+//
+// Software-renderer safe: a single Text in an Item, no shaders, no
+// transforms, no animations.
+Item {
+    id: root
+
+    required property string label
+
+    implicitHeight: Sizing.pctH(5.5)
+
+    Text {
+        anchors.left: parent.left
+        // Same left inset as `SettingsField` labels so headers and
+        // field labels share a vertical baseline.
+        anchors.leftMargin: Sizing.pctW(3)
+        anchors.bottom: parent.bottom
+        anchors.bottomMargin: Sizing.pctH(0.5)
+        // Sentence-case + DemiBold reads as a header without needing
+        // a separator rule. Sized one step above the field label
+        // (which is 2.6) and painted in `textPrimary` so the group
+        // break asserts itself across the form.
+        text: root.label
+        color: Theme.textPrimary
+        font.family: Theme.fontUi
+        font.pixelSize: Sizing.fontSize(2.9)
+        font.weight: Font.DemiBold
+        renderType: Text.NativeRendering
+    }
+}

--- a/src/ui/components/Tile.qml
+++ b/src/ui/components/Tile.qml
@@ -86,11 +86,17 @@ Item {
     // Recents) flip this on at the delegate template.
     property bool showCaption: false
 
-    readonly property int _padding: Sizing.pctH(3)
+    // Equal cover padding on top, left, and right — the bottom is
+    // owned by the caption strip in caption mode and matches `_padding`
+    // visually in non-caption mode. pctH(2) is enough to read as
+    // deliberate breathing room without giving back much cover area.
+    // Below the cover sits the caption flush against the card's
+    // bottom edge, separated from the cover by `_captionGap`.
+    readonly property int _padding: Sizing.pctH(2)
     readonly property int _outlineGap: Sizing.pctH(0.4)
     readonly property int _outlineWidth: Sizing.pctH(0.6)
-    readonly property int _captionHeight: Sizing.pctH(3.5)
-    readonly property int _captionGap: Sizing.pctH(0.8)
+    readonly property int _captionHeight: Sizing.pctH(5.5)
+    readonly property int _captionGap: Sizing.pctH(0.4)
 
     readonly property bool _focusedSelection:
         root.delegateIsSelected && root.delegateIsFocused
@@ -177,11 +183,13 @@ Item {
             top: parent.top
             topMargin: root._padding
             bottom: parent.bottom
-            // In caption mode the cover slot shrinks to leave a strip
-            // for the bottom caption; otherwise it fills body-padding.
+            // In caption mode the cover sits above the bottom caption
+            // strip with only `_captionGap` of breathing room. The
+            // caption is flush against the card's bottom edge, so the
+            // cover's lower bound is just (caption height + gap) —
+            // there is no second layer of card padding below.
             bottomMargin: root.showCaption
-                          ? root._padding + root._captionHeight
-                            + root._captionGap
+                          ? root._captionHeight + root._captionGap
                           : root._padding
             horizontalCenter: parent.horizontalCenter
         }
@@ -273,21 +281,32 @@ Item {
     // selection reads at a glance even when the focus outline ring is
     // outside the eye's centre — matches the procedural fallback's
     // focus tint above.
+    //
+    // The strip sits flush at the card's bottom edge so the title
+    // visually owns the bottom of the tile rather than hovering above
+    // a band of card padding. Horizontal margins clear `cornerRadius`
+    // so glyph descenders never enter the rounded-corner region (the
+    // card's surfaceCard fill curves away there, so a glyph past the
+    // inset would paint against whatever sits behind the tile).
+    // Vertically, the centred glyph lands well inside the focus
+    // ring's inner mask zone (which extends `_outlineGap +
+    // _outlineWidth` from the bottom edge), so the text background
+    // remains surfaceCard even on a focused tile.
     Text {
         id: caption
         anchors {
             left: parent.left
             right: parent.right
             bottom: parent.bottom
-            leftMargin: root._padding
-            rightMargin: root._padding
-            bottomMargin: root._padding
+            leftMargin: Sizing.cornerRadius
+            rightMargin: Sizing.cornerRadius
+            bottomMargin: 0
         }
         height: root._captionHeight
         visible: root.showCaption
         text: root.delegateName
         font.family: Theme.fontUi
-        font.pixelSize: Sizing.fontSize(1.7)
+        font.pixelSize: Sizing.fontSize(2.2)
         color: root._focusedSelection ? Theme.textPrimary : Theme.textLabel
         elide: Text.ElideRight
         horizontalAlignment: Text.AlignHCenter

--- a/src/ui/screens/AboutScreen.qml
+++ b/src/ui/screens/AboutScreen.qml
@@ -1,0 +1,227 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Zaparoo.Theme
+import Zaparoo.Ui
+import Zaparoo.Browse as Browse
+
+// cxx-qt 0.8 patches `isFinal: true` on singleton properties but the
+// qmltypes schema has no `isFinal` slot, so reads of `Browse.BuildInfo`
+// fields trip qmllint's "Member can be shadowed" check. Suppress just
+// the compiler category file-wide; matches the pattern used in
+// CommercialNoticeModal.qml.
+// qmllint disable compiler
+
+// About / License screen — static, scrollable info page reachable from
+// Settings → About / License. Pure input dispatcher: emits
+// `requestSettingsScreen()` on cancel; Up/Down scroll the Flickable.
+//
+// Build provenance (git commit, build channel, official-build marker)
+// will plug into the version line in a follow-up round; for now only
+// the hardcoded `Qt.application.version` is shown.
+Item {
+    id: about
+
+    // Bound by MainLayout to `root.pendingTransition !== ""`. About is
+    // a destination, never a source — kept for parity with the other
+    // screens.
+    property bool transitioning: false
+
+    signal requestSettingsScreen()
+
+    // True when the body Column overflows the Flickable viewport, so
+    // the help bar can show the Up/Down scroll cue only when it's
+    // actually meaningful. Per the minimal-help-bar policy, hints
+    // shouldn't promise a press that no-ops.
+    readonly property bool contentOverflows:
+        body.implicitHeight > flickable.height
+
+    function _scrollBy(delta: int): void {
+        const maxY = Math.max(0, flickable.contentHeight - flickable.height)
+        flickable.contentY = Math.max(0, Math.min(maxY, flickable.contentY + delta))
+    }
+
+    function handleAction(action: string): void {
+        if (action === "up")
+            about._scrollBy(-Sizing.pctH(8))
+        else if (action === "down")
+            about._scrollBy(Sizing.pctH(8))
+        else if (action === "cancel")
+            about.requestSettingsScreen()
+        // accept and left/right are no-ops on a static page.
+    }
+
+    // ── Visual tree ───────────────────────────────────────────────────────────
+
+    TopStatusStrip {
+        id: topStrip
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: parent.top
+        anchors.topMargin: Sizing.headerBottom
+        height: Sizing.pctH(7)
+        title: qsTr("About / License")
+        currentPage: 0
+        totalPages: 0
+        totalText: ""
+    }
+
+    // Body lives in a Flickable so the static content can grow past a
+    // single screen on MiSTer 240p without dropping off-frame. Width
+    // is capped tighter than Settings's pctW(70) — prose reads better
+    // at narrow line lengths, and the cap also keeps the logo from
+    // having to scale up past its 600px native width on widescreen.
+    // Bottom margin clears the help bar (pctH(6)) plus a small gap.
+    Flickable {
+        id: flickable
+
+        anchors.top: topStrip.bottom
+        anchors.topMargin: Sizing.pctH(2)
+        anchors.bottom: parent.bottom
+        anchors.bottomMargin: Sizing.pctH(8)
+        anchors.horizontalCenter: parent.horizontalCenter
+        width: Math.min(parent.width - Sizing.pctW(10), Sizing.pctW(50))
+        contentWidth: width
+        contentHeight: body.implicitHeight
+        clip: true
+        boundsBehavior: Flickable.StopAtBounds
+
+        Column {
+            id: body
+
+            width: parent.width
+            spacing: Sizing.pctH(2)
+
+            // Logo renders at half its 600x135 native size for a more
+            // restrained header; on narrower viewports it scales down
+            // further with PreserveAspectFit. sourceSize pinned to the
+            // native pixel dimensions stops Qt from upscaling then
+            // downsampling and keeps the lines crisp.
+            Image {
+                anchors.horizontalCenter: parent.horizontalCenter
+                source: "qrc:/qt/qml/Zaparoo/App/resources/images/logo.png"
+                fillMode: Image.PreserveAspectFit
+                sourceSize.width: 600
+                sourceSize.height: 135
+                width: Math.min(300, parent.width)
+                height: width * 135 / 600
+            }
+
+            Text {
+                anchors.horizontalCenter: parent.horizontalCenter
+                horizontalAlignment: Text.AlignHCenter
+                text: qsTr("Zaparoo Launcher")
+                color: Theme.textPrimary
+                font.family: Theme.fontUi
+                font.pixelSize: Sizing.fontSize(4)
+                font.weight: Font.Medium
+                renderType: Text.NativeRendering
+            }
+
+            Text {
+                anchors.horizontalCenter: parent.horizontalCenter
+                horizontalAlignment: Text.AlignHCenter
+                text: qsTr("Version %1 · %2 · %3")
+                    .arg(Qt.application.version)
+                    .arg(Browse.BuildInfo.commit)
+                    .arg(Browse.BuildInfo.channel)
+                color: Theme.textLabel
+                font.family: Theme.fontUi
+                font.pixelSize: Sizing.fontSize(2.4)
+                renderType: Text.NativeRendering
+            }
+
+            Text {
+                anchors.horizontalCenter: parent.horizontalCenter
+                horizontalAlignment: Text.AlignHCenter
+                text: qsTr("Built %1").arg(Browse.BuildInfo.build_date)
+                color: Theme.textLabel
+                font.family: Theme.fontUi
+                font.pixelSize: Sizing.fontSize(2.2)
+                renderType: Text.NativeRendering
+            }
+
+            Text {
+                width: parent.width
+                horizontalAlignment: Text.AlignHCenter
+                wrapMode: Text.Wrap
+                text: qsTr("Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.")
+                color: Theme.textPrimary
+                font.family: Theme.fontUi
+                font.pixelSize: Sizing.fontSize(2.6)
+                renderType: Text.NativeRendering
+            }
+
+            Text {
+                width: parent.width
+                horizontalAlignment: Text.AlignHCenter
+                wrapMode: Text.Wrap
+                text: qsTr("Source available under the PolyForm Noncommercial License 1.0.0. Free for personal, non-commercial use. Commercial use or redistribution requires a separate license.")
+                color: Theme.textPrimary
+                font.family: Theme.fontUi
+                font.pixelSize: Sizing.fontSize(2.6)
+                renderType: Text.NativeRendering
+            }
+
+            Text {
+                width: parent.width
+                horizontalAlignment: Text.AlignHCenter
+                wrapMode: Text.Wrap
+                text: qsTr("Commercial licensing: legal@zaparoo.org")
+                color: Theme.textPrimary
+                font.family: Theme.fontUi
+                font.pixelSize: Sizing.fontSize(2.6)
+                renderType: Text.NativeRendering
+            }
+
+            Text {
+                width: parent.width
+                horizontalAlignment: Text.AlignHCenter
+                wrapMode: Text.Wrap
+                text: qsTr("Project: https://zaparoo.org")
+                color: Theme.textPrimary
+                font.family: Theme.fontUi
+                font.pixelSize: Sizing.fontSize(2.6)
+                renderType: Text.NativeRendering
+            }
+
+            Text {
+                anchors.horizontalCenter: parent.horizontalCenter
+                horizontalAlignment: Text.AlignHCenter
+                text: qsTr("Created by")
+                color: Theme.textLabel
+                font.family: Theme.fontUi
+                font.pixelSize: Sizing.fontSize(2.4)
+                renderType: Text.NativeRendering
+            }
+
+            // Contributor names are not translated — they're proper
+            // names. Joined with newlines (not separate Text items)
+            // so the block reads as one credits paragraph and the
+            // Column spacing doesn't push them apart.
+            Text {
+                anchors.horizontalCenter: parent.horizontalCenter
+                horizontalAlignment: Text.AlignHCenter
+                text: "Andrea Bogazzi\nBossRighteous\nTim Wilsie\nWizzo"
+                color: Theme.textPrimary
+                font.family: Theme.fontUi
+                font.pixelSize: Sizing.fontSize(2.6)
+                renderType: Text.NativeRendering
+            }
+
+            Text {
+                width: parent.width
+                horizontalAlignment: Text.AlignHCenter
+                wrapMode: Text.Wrap
+                text: qsTr("Full license text in COPYING.")
+                color: Theme.textLabel
+                font.family: Theme.fontUi
+                font.pixelSize: Sizing.fontSize(2.4)
+                renderType: Text.NativeRendering
+            }
+        }
+    }
+}

--- a/src/ui/screens/AboutScreen.qml
+++ b/src/ui/screens/AboutScreen.qml
@@ -95,18 +95,19 @@ Item {
             width: parent.width
             spacing: Sizing.pctH(2)
 
-            // Logo renders at half its 600x135 native size for a more
-            // restrained header; on narrower viewports it scales down
-            // further with PreserveAspectFit. sourceSize pinned to the
-            // native pixel dimensions stops Qt from upscaling then
-            // downsampling and keeps the lines crisp.
+            // Logo width is capped at a screen-height-relative size so
+            // the brand mark stays a header element across 240p →
+            // 1080p without ballooning. sourceSize is pinned to the
+            // native pixel dimensions to stop Qt upscaling then
+            // downsampling and to keep the lines crisp; height is
+            // derived from width via the image's intrinsic aspect.
             Image {
                 anchors.horizontalCenter: parent.horizontalCenter
                 source: "qrc:/qt/qml/Zaparoo/App/resources/images/logo.png"
                 fillMode: Image.PreserveAspectFit
                 sourceSize.width: 600
                 sourceSize.height: 135
-                width: Math.min(300, parent.width)
+                width: Math.min(parent.width, Sizing.pctH(35))
                 height: width * 135 / 600
             }
 

--- a/src/ui/screens/CMakeLists.txt
+++ b/src/ui/screens/CMakeLists.txt
@@ -21,6 +21,7 @@ qt_add_qml_module(
         FavoritesScreen.qml
         RecentsScreen.qml
         SettingsScreen.qml
+        AboutScreen.qml
     IMPORTS
         Zaparoo.Ui
         Zaparoo.Theme

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -185,19 +185,18 @@ Item {
     // case where SystemsModel is empty; the user sees the id rather
     // than nothing.
     //
-    // The screen Item fills the whole window, so the strip has to
-    // clear the MainLayout logo (topMargin pctH(2) + height pctH(7) —
-    // bottom edge at pctH(9)) with a pctH(2) gap. Total is exact:
-    // Core's media.browse returns directories only on page 1 and
-    // always before files, so dir_count + total_files is the precise
-    // entry count for the path.
+    // The screen Item fills the whole window, so the strip clears the
+    // MainLayout HeaderBar (Sizing.headerBottom) with a small gap.
+    // Total is exact: Core's media.browse returns directories only on
+    // page 1 and always before files, so dir_count + total_files is
+    // the precise entry count for the path.
     TopStatusStrip {
         id: topStrip
         visible: !games.transitioning && !games.coverGateLoading
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: parent.top
-        anchors.topMargin: Sizing.pctH(11)
+        anchors.topMargin: Sizing.headerBottom + Sizing.pctH(1)
         height: Sizing.pctH(7)
         title: {
             const sid = Browse.GamesModel.current_system_id

--- a/src/ui/screens/HubScreen.qml
+++ b/src/ui/screens/HubScreen.qml
@@ -52,6 +52,15 @@ Item {
     property int currentRow: 0
     // Index within the active row.
     property int currentIndex: 0
+    // Source-row index from the most recent cross. Used to make a
+    // Down → Up (or Up → Down) round-trip return to the originating
+    // tile, which the centered visual-nearest mapping in `_mapCrossRow`
+    // can't deliver when `sourceCount !== destCount`. -1 means no
+    // round-trip is armed: either no cross has happened yet, or the
+    // user moved horizontally on the destination row since the last
+    // cross — at which point the saved index represents stale state
+    // and the next cross falls back to `_mapCrossRow`.
+    property int _crossSavedIndex: -1
 
     signal requestAccept(category: string)
     signal requestQuit()
@@ -102,6 +111,7 @@ Item {
     function resetFocus(): void {
         hub.currentRow = 0
         hub.currentIndex = 0
+        hub._crossSavedIndex = -1
     }
 
     // Restore the hub from the persisted `Browse.HubState`. Always
@@ -145,6 +155,11 @@ Item {
             hub.currentRow = 0
             hub.currentIndex = chosenCategoryIndex
         }
+        // A reseat from disk or from a category-list refresh makes any
+        // armed round-trip context meaningless (the user might be on a
+        // different row entirely now, and the saved source-index could
+        // point past the new category list).
+        hub._crossSavedIndex = -1
 
         if (Browse.SystemsModel.current_category === chosenCategory
             && Browse.SystemsModel.count > 0)
@@ -166,6 +181,10 @@ Item {
         if (next === hub.currentIndex)
             return false
         hub.currentIndex = next
+        // Horizontal motion on the destination row invalidates the
+        // round-trip context — the user's intent is now to navigate
+        // within this row, not bounce back to where they came from.
+        hub._crossSavedIndex = -1
         return true
     }
 
@@ -184,25 +203,47 @@ Item {
         return Math.max(0, Math.min(destCount - 1, target))
     }
 
-    // Cross-row jump. Up and Down both flip to the *other* row at the
-    // visually-nearest cell — there is no "off the top" or "off the
-    // bottom" since the two rows form a closed two-row loop. Returns
-    // false only when the destination row is empty (no categories
-    // loaded yet, etc.).
+    // Cross-row jump. Up and Down both flip to the *other* row — the
+    // two rows form a closed two-row loop, there is no "off the top"
+    // or "off the bottom".
+    //
+    // The destination index has two sources:
+    //
+    //   1. If `_crossSavedIndex` is armed (>= 0) and within the
+    //      destination row's bounds, restore it. This is the round-trip
+    //      path: the user pressed Down, then Up without horizontal
+    //      input in between, so the originating tile is the natural
+    //      target. With unequal row counts the centered visual mapping
+    //      can't return there on its own.
+    //
+    //   2. Otherwise fall back to `_mapCrossRow` (visually-nearest
+    //      cell in the centered row). This fires on the very first
+    //      cross of a session and after any horizontal input on the
+    //      destination row clears the armed index.
+    //
+    // Returns false only when the destination row is empty (no
+    // categories loaded yet, etc.).
     function _crossRow(): bool {
         const topCount = Browse.CategoriesModel.count
         const bottomCount = hub.actionEntries.length
-        if (hub.currentRow === 0) {
-            if (bottomCount <= 0)
-                return false
-            hub.currentRow = 1
-            hub.currentIndex = hub._mapCrossRow(hub.currentIndex, topCount, bottomCount)
-            return true
-        }
-        if (topCount <= 0)
+        const sourceCount = hub.currentRow === 0 ? topCount : bottomCount
+        const destCount = hub.currentRow === 0 ? bottomCount : topCount
+        if (destCount <= 0)
             return false
-        hub.currentRow = 0
-        hub.currentIndex = hub._mapCrossRow(hub.currentIndex, bottomCount, topCount)
+
+        const sourceIdx = hub.currentIndex
+        const restored = hub._crossSavedIndex >= 0
+                         && hub._crossSavedIndex < destCount
+        const destIdx = restored
+                        ? hub._crossSavedIndex
+                        : hub._mapCrossRow(sourceIdx, sourceCount, destCount)
+
+        // Save the source-row index BEFORE flipping so the next cross
+        // can return here. Reading `currentIndex` after the flip would
+        // capture the destination index instead.
+        hub._crossSavedIndex = sourceIdx
+        hub.currentRow = 1 - hub.currentRow
+        hub.currentIndex = destIdx
         return true
     }
 
@@ -237,6 +278,9 @@ Item {
             return
         hub.currentRow = 0
         hub.currentIndex = index
+        // Mouse focus is a deliberate landing on a specific tile — any
+        // armed cross-row round-trip is no longer what the user wants.
+        hub._crossSavedIndex = -1
         hub._commitCategorySelection()
     }
 
@@ -245,6 +289,7 @@ Item {
             return
         hub.currentRow = 1
         hub.currentIndex = index
+        hub._crossSavedIndex = -1
         hub._commitActionSelection()
     }
 

--- a/src/ui/screens/HubScreen.qml
+++ b/src/ui/screens/HubScreen.qml
@@ -60,12 +60,12 @@ Item {
     signal requestSettingsScreen()
 
     // Vertically center the (categories row + actions row + activeLabel)
-    // block in the band between the logo bottom (pctH(9)) and the help
-    // bar top (hub.height - pctH(6)). `_blockHeight` mirrors the
-    // anchor chain below: each row is `cellHeight + 2*verticalPadding`,
-    // the gap between them collapses the focus-bleed padding (see
-    // `actionsRow.anchors.topMargin`), and the label sits pctH(3) below
-    // the actions row at pctH(7) tall.
+    // block in the band between the HeaderBar bottom (Sizing.headerBottom)
+    // and the help bar top (hub.height - pctH(6)). `_blockHeight`
+    // mirrors the anchor chain below: each row is
+    // `cellHeight + 2*verticalPadding`, the gap between them collapses
+    // the focus-bleed padding (see `actionsRow.anchors.topMargin`),
+    // and the label sits pctH(3) below the actions row at pctH(7) tall.
     readonly property int _blockHeight:
         2 * (categoriesRow.cellHeight + 2 * categoriesRow.verticalPadding)
         + (categoriesRow.spacing
@@ -74,7 +74,7 @@ Item {
         + Sizing.pctH(3)
         + Sizing.pctH(7)
     readonly property int _blockY:
-        Math.round((Sizing.pctH(9) + hub.height - Sizing.pctH(6)
+        Math.round((Sizing.headerBottom + hub.height - Sizing.pctH(6)
                     - hub._blockHeight) / 2)
 
     // Static action-row data. Three fixed entries; order matches

--- a/src/ui/screens/RecentsScreen.qml
+++ b/src/ui/screens/RecentsScreen.qml
@@ -138,7 +138,7 @@ Item {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: parent.top
-        anchors.topMargin: Sizing.pctH(11)
+        anchors.topMargin: Sizing.headerBottom + Sizing.pctH(1)
         height: Sizing.pctH(7)
         title: qsTr("Recently Played")
         currentPage: recentsGrid.currentPage

--- a/src/ui/screens/ScreenManager.qml
+++ b/src/ui/screens/ScreenManager.qml
@@ -20,6 +20,7 @@ QtObject {
     readonly property string screenFavorites: "favorites"
     readonly property string screenRecents: "recents"
     readonly property string screenSettings: "settings"
+    readonly property string screenAbout: "about"
 
     // Currently-focused root screen. Persistence lives in
     // Browse.AppState — write there via Main.qml's orchestration, not

--- a/src/ui/screens/SettingsScreen.qml
+++ b/src/ui/screens/SettingsScreen.qml
@@ -40,16 +40,19 @@ Item {
     // wired, which opens the log-upload modal.
     signal requestAccept(actionId: string)
 
-    // Field registry. Each entry's `id` is read by handleAction to
-    // route the cycle to the right model setter. Keeping this as data
-    // (rather than a Repeater of typed children) makes adding fields
-    // a one-line edit and keeps the navigation logic uniform.
+    // Field registry. Each entry's `kind` is `"header"` (non-focusable
+    // group label) or `"field"` (a navigable row). Field entries also
+    // carry an `id` that handleAction routes to the right model setter.
+    // Keeping this as data (rather than a Repeater of typed children)
+    // makes adding rows a one-line edit and keeps navigation uniform.
     //
-    // Field-specific helpers below provide option lists, display labels,
-    // and model setters. This keeps the Repeater delegate presentational
-    // while handleAction remains a simple input dispatcher.
+    // Section grouping mirrors the Settings menus on Switch/Xbox/
+    // Playnite/Pegasus: a single page with non-focusable headers
+    // splitting commonly-used controls (General, Library) from rarer
+    // diagnostics-flavoured ones (Advanced).
     readonly property var fields: {
         const out = []
+        out.push({ kind: "header", label: qsTr("General") })
         // Resolution row hidden — `vmode` switching isn't reliable yet.
         // Restore by re-enabling this block once the MiSTer-side path is
         // trusted again; the picker plumbing in `_cycleResolution` and
@@ -57,35 +60,45 @@ Item {
         // wired so the row works as soon as it's added back.
         // if (Browse.Settings.is_mister) {
         //     out.push({
+        //         kind: "field",
         //         id: "resolution",
         //         label: qsTr("Resolution")
         //     })
         // }
         out.push({
+            kind: "field",
             id: "language",
             label: qsTr("Language")
         })
         out.push({
+            kind: "field",
             id: "buttonLayout",
             label: qsTr("Button style")
         })
+        out.push({ kind: "header", label: qsTr("Library") })
         out.push({
-            id: "mouseEnabled",
-            label: qsTr("Mouse support")
-        })
-        out.push({
+            kind: "field",
             id: "updateMediaDb",
             label: qsTr("Update media database")
         })
         out.push({
+            kind: "field",
             id: "runScraper",
             label: qsTr("Scrape metadata")
         })
+        out.push({ kind: "header", label: qsTr("Advanced") })
         out.push({
+            kind: "field",
+            id: "mouseEnabled",
+            label: qsTr("Mouse support")
+        })
+        out.push({
+            kind: "field",
             id: "debugLogging",
             label: qsTr("Debug logging")
         })
         out.push({
+            kind: "field",
             id: "uploadLog",
             label: qsTr("Upload log file")
         })
@@ -137,8 +150,42 @@ Item {
     }
 
     readonly property int fieldCount: settings.fields.length
+
+    // True iff `idx` points at a focusable field row (not a header,
+    // not out of bounds). All `focused*` derivations early-return on
+    // header indices so a defensive out-of-band write to currentIndex
+    // can't mis-light the help bar.
+    function _isField(idx: int): bool {
+        if (idx < 0 || idx >= settings.fieldCount)
+            return false
+        return settings.fields[idx].kind === "field"
+    }
+
+    // First focusable row in the registry. Used to seed `currentIndex`
+    // at construction; returns -1 only if every entry is a header
+    // (registry mistake — shouldn't happen).
+    function _firstNavigableIndex(): int {
+        for (let i = 0; i < settings.fieldCount; i++)
+            if (settings.fields[i].kind === "field")
+                return i
+        return -1
+    }
+
+    // Walk from `from` in `direction` (±1) until we hit a focusable
+    // row or run off the registry. Headers are transparent — Up/Down
+    // skip across them so the user feels a single flat list.
+    function _seekNavigable(from: int, direction: int): int {
+        let i = from + direction
+        while (i >= 0 && i < settings.fieldCount) {
+            if (settings.fields[i].kind === "field")
+                return i
+            i += direction
+        }
+        return from
+    }
+
     readonly property bool focusedFieldIsToggle: {
-        if (settings.fieldCount === 0)
+        if (!settings._isField(settings.currentIndex))
             return false
         const id = settings.fields[settings.currentIndex].id
         return id === "mouseEnabled" || id === "debugLogging"
@@ -146,7 +193,7 @@ Item {
     // True when the focused field is an action button (updateMediaDb,
     // runScraper, uploadLog). Drives the help-bar Accept hint.
     readonly property bool focusedFieldIsAction: {
-        if (settings.fieldCount === 0)
+        if (!settings._isField(settings.currentIndex))
             return false
         const id = settings.fields[settings.currentIndex].id
         return id === "updateMediaDb"
@@ -157,7 +204,7 @@ Item {
     // running, so the help bar can label Accept as "Cancel" rather
     // than "Start".
     readonly property bool focusedActionBusy: {
-        if (settings.fieldCount === 0)
+        if (!settings._isField(settings.currentIndex))
             return false
         const id = settings.fields[settings.currentIndex].id
         if (id === "updateMediaDb")
@@ -171,7 +218,7 @@ Item {
     // visual and lets the help bar drop the Accept hint instead of
     // promising a press that will silently no-op.
     readonly property bool focusedActionDisabled: {
-        if (settings.fieldCount === 0)
+        if (!settings._isField(settings.currentIndex))
             return false
         const id = settings.fields[settings.currentIndex].id
         if (id === "updateMediaDb")
@@ -181,7 +228,16 @@ Item {
         return false
     }
 
-    property int currentIndex: 0
+    // Initial focus: first navigable row. The binding evaluates once
+    // (no reactive dependencies inside `_firstNavigableIndex`) and is
+    // broken the first time the user moves focus — handleAction's
+    // up/down branches assign to `currentIndex` directly. Falling back
+    // to 0 covers the all-headers degenerate case; helpers below
+    // early-return on `_isField(0) === false` if it ever lands there.
+    property int currentIndex: {
+        const idx = settings._firstNavigableIndex()
+        return idx >= 0 ? idx : 0
+    }
 
     function _resolutionList(): list<string> {
         const raw = Browse.Settings.available_resolutions
@@ -304,7 +360,7 @@ Item {
     }
 
     function _cycleFocused(direction: int): void {
-        if (settings.fieldCount === 0)
+        if (!settings._isField(settings.currentIndex))
             return
         const id = settings.fields[settings.currentIndex].id
         if (id === "resolution")
@@ -322,17 +378,17 @@ Item {
 
     function handleAction(action: string): void {
         if (action === "up") {
-            if (settings.currentIndex > 0)
-                settings.currentIndex--
+            settings.currentIndex =
+                settings._seekNavigable(settings.currentIndex, -1)
         } else if (action === "down") {
-            if (settings.currentIndex < settings.fieldCount - 1)
-                settings.currentIndex++
+            settings.currentIndex =
+                settings._seekNavigable(settings.currentIndex, 1)
         } else if (action === "left") {
             settings._cycleFocused(-1)
         } else if (action === "right") {
             settings._cycleFocused(1)
         } else if (action === "accept") {
-            if (settings.fieldCount === 0)
+            if (!settings._isField(settings.currentIndex))
                 return
             const id = settings.fields[settings.currentIndex].id
             if (id === "mouseEnabled")
@@ -357,7 +413,7 @@ Item {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: parent.top
-        anchors.topMargin: Sizing.pctH(9)
+        anchors.topMargin: Sizing.headerBottom
         height: Sizing.pctH(7)
         title: qsTr("Settings")
         currentPage: 0
@@ -365,102 +421,170 @@ Item {
         totalText: ""
     }
 
-    // Form. Centered horizontally; width capped so the rows don't
-    // stretch edge-to-edge on widescreen. Each row is a SettingsField.
-    Column {
-        id: form
+    // Scroll focused row into view if it sits outside the Flickable's
+    // current viewport. No-op for header indices (they aren't focusable
+    // and currentIndex never lands on one in normal flow). Bind via
+    // onCurrentIndexChanged below; no animation — software-renderer
+    // budget can't pay for a moving column behind a focus border.
+    function _scrollFocusedIntoView(): void {
+        if (!settings._isField(settings.currentIndex))
+            return
+        const row = rowRepeater.itemAt(settings.currentIndex)
+        if (row === null)
+            return
+        const top = row.y
+        const bottom = top + row.height
+        if (top < flickable.contentY)
+            flickable.contentY = top
+        else if (bottom > flickable.contentY + flickable.height)
+            flickable.contentY = bottom - flickable.height
+    }
+
+    onCurrentIndexChanged: settings._scrollFocusedIntoView()
+
+    // Form lives in a Flickable so the section bands can grow past
+    // a single screen without dropping off-frame. Width capped so
+    // the rows don't stretch edge-to-edge on widescreen; bottom
+    // margin clears the help bar (pctH(6)) plus a small gap.
+    Flickable {
+        id: flickable
 
         anchors.top: topStrip.bottom
-        anchors.topMargin: Sizing.pctH(4)
+        anchors.topMargin: Sizing.pctH(2)
+        anchors.bottom: parent.bottom
+        anchors.bottomMargin: Sizing.pctH(8)
         anchors.horizontalCenter: parent.horizontalCenter
         width: Math.min(parent.width - Sizing.pctW(10), Sizing.pctW(70))
-        spacing: Sizing.pctH(1.5)
-        visible: settings.fieldCount > 0
+        contentWidth: width
+        contentHeight: form.implicitHeight
+        clip: true
+        boundsBehavior: Flickable.StopAtBounds
 
-        Repeater {
-            model: settings.fields
+        Column {
+            id: form
 
-            SettingsField {
-                id: fieldRow
+            width: parent.width
+            spacing: Sizing.pctH(1.5)
+            visible: settings.fieldCount > 0
 
-                required property int index
-                required property var modelData
+            Repeater {
+                id: rowRepeater
+                model: settings.fields
 
-                width: form.width
-                isFocused: index === settings.currentIndex
-                // Index and scrape can't run together; while one
-                // operation is in flight the other row dims and its
-                // MouseArea stops responding. Keyboard Accept is
-                // separately gated in `_triggerIndex`/`_triggerScrape`.
-                enabled: modelData.id === "updateMediaDb"
-                         ? !settings._scrapeBusy
-                         : modelData.id === "runScraper"
-                         ? !settings._indexBusy
-                         : true
-                label: modelData.label
-                value: modelData.id === "resolution"
-                       ? settings._resolutionDisplay(Browse.Settings.current_resolution)
-                       : modelData.id === "language"
-                       ? settings._languageDisplay(Browse.Settings.current_language)
-                       : modelData.id === "buttonLayout"
-                       ? settings._buttonLayoutDisplay(Browse.Settings.current_button_layout)
-                       : ""
-                control: modelData.id === "mouseEnabled" || modelData.id === "debugLogging"
-                         ? "toggle"
-                         : (modelData.id === "updateMediaDb"
-                            || modelData.id === "runScraper"
-                            || modelData.id === "uploadLog") ? "action"
-                         : "value"
-                checked: modelData.id === "debugLogging"
-                         ? Browse.Settings.current_debug_logging
-                         : Browse.Settings.current_mouse_enabled
-                actionStatus: modelData.id === "updateMediaDb"
-                              ? settings._indexActionStatus()
-                              : modelData.id === "runScraper"
-                              ? settings._scrapeActionStatus()
-                              : ""
-                // Pickers wrap modulo, so both arrows apply when the
-                // focused field has a populated option list.
-                canCyclePrev: (modelData.id === "resolution"
-                               && settings._resolutionList().length > 0)
-                              || (modelData.id === "language"
-                                  && settings._languageList().length > 1)
-                              || (modelData.id === "buttonLayout"
-                                  && settings._buttonLayoutList().length > 1)
-                              || (modelData.id === "mouseEnabled"
-                                  && Browse.Settings.current_mouse_enabled)
-                              || (modelData.id === "debugLogging"
-                                  && Browse.Settings.current_debug_logging)
-                canCycleNext: (modelData.id === "resolution"
-                               && settings._resolutionList().length > 0)
-                              || (modelData.id === "language"
-                                  && settings._languageList().length > 1)
-                              || (modelData.id === "buttonLayout"
-                                  && settings._buttonLayoutList().length > 1)
-                              || (modelData.id === "mouseEnabled"
-                                  && !Browse.Settings.current_mouse_enabled)
-                              || (modelData.id === "debugLogging"
-                                  && !Browse.Settings.current_debug_logging)
-                onHovered: settings.currentIndex = index
-                onClicked: {
-                    settings.currentIndex = index
-                    if (modelData.id === "mouseEnabled")
-                        settings._toggleMouseEnabled()
-                    else if (modelData.id === "debugLogging")
-                        settings._toggleDebugLogging()
-                }
-                // Action rows route through `onAccepted` only (see
-                // `SettingsField.qml`'s MouseArea), so the focus
-                // commit lives here too — clicking an action row
-                // moves focus before firing the action.
-                onAccepted: {
-                    settings.currentIndex = index
-                    if (modelData.id === "updateMediaDb")
-                        settings._triggerIndex()
-                    else if (modelData.id === "runScraper")
-                        settings._triggerScrape()
-                    else if (modelData.id === "uploadLog")
-                        settings.requestAccept("uploadLog")
+                // Wrapper row — both potential children exist but only
+                // the kind-matching one paints. A Loader would also
+                // work, but binding-through-`parent.modelData` adds
+                // static-analysis friction under
+                // ComponentBehavior:Bound; the wrapper Item is cheap
+                // (≤ 3 headers + ≤ 7 fields) and keeps every
+                // field-row binding readable in place.
+                Item {
+                    id: row
+
+                    required property int index
+                    required property var modelData
+
+                    readonly property bool isHeader:
+                        modelData.kind === "header"
+
+                    width: form.width
+                    implicitHeight: row.isHeader
+                                    ? header.implicitHeight
+                                    : field.implicitHeight
+
+                    SettingsSectionHeader {
+                        id: header
+                        visible: row.isHeader
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        label: row.modelData.label
+                    }
+
+                    SettingsField {
+                        id: field
+                        visible: !row.isHeader
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        isFocused: row.index === settings.currentIndex
+                        // Index and scrape can't run together; while
+                        // one operation is in flight the other row
+                        // dims and its MouseArea stops responding.
+                        // Keyboard Accept is separately gated in
+                        // `_triggerIndex`/`_triggerScrape`.
+                        enabled: row.modelData.id === "updateMediaDb"
+                                 ? !settings._scrapeBusy
+                                 : row.modelData.id === "runScraper"
+                                 ? !settings._indexBusy
+                                 : true
+                        label: row.modelData.label
+                        value: row.modelData.id === "resolution"
+                               ? settings._resolutionDisplay(Browse.Settings.current_resolution)
+                               : row.modelData.id === "language"
+                               ? settings._languageDisplay(Browse.Settings.current_language)
+                               : row.modelData.id === "buttonLayout"
+                               ? settings._buttonLayoutDisplay(Browse.Settings.current_button_layout)
+                               : ""
+                        control: row.modelData.id === "mouseEnabled"
+                                 || row.modelData.id === "debugLogging"
+                                 ? "toggle"
+                                 : (row.modelData.id === "updateMediaDb"
+                                    || row.modelData.id === "runScraper"
+                                    || row.modelData.id === "uploadLog") ? "action"
+                                 : "value"
+                        checked: row.modelData.id === "debugLogging"
+                                 ? Browse.Settings.current_debug_logging
+                                 : Browse.Settings.current_mouse_enabled
+                        actionStatus: row.modelData.id === "updateMediaDb"
+                                      ? settings._indexActionStatus()
+                                      : row.modelData.id === "runScraper"
+                                      ? settings._scrapeActionStatus()
+                                      : ""
+                        // Pickers wrap modulo, so both arrows apply
+                        // when the focused field has a populated
+                        // option list.
+                        canCyclePrev: (row.modelData.id === "resolution"
+                                       && settings._resolutionList().length > 0)
+                                      || (row.modelData.id === "language"
+                                          && settings._languageList().length > 1)
+                                      || (row.modelData.id === "buttonLayout"
+                                          && settings._buttonLayoutList().length > 1)
+                                      || (row.modelData.id === "mouseEnabled"
+                                          && Browse.Settings.current_mouse_enabled)
+                                      || (row.modelData.id === "debugLogging"
+                                          && Browse.Settings.current_debug_logging)
+                        canCycleNext: (row.modelData.id === "resolution"
+                                       && settings._resolutionList().length > 0)
+                                      || (row.modelData.id === "language"
+                                          && settings._languageList().length > 1)
+                                      || (row.modelData.id === "buttonLayout"
+                                          && settings._buttonLayoutList().length > 1)
+                                      || (row.modelData.id === "mouseEnabled"
+                                          && !Browse.Settings.current_mouse_enabled)
+                                      || (row.modelData.id === "debugLogging"
+                                          && !Browse.Settings.current_debug_logging)
+                        onHovered: settings.currentIndex = row.index
+                        onClicked: {
+                            settings.currentIndex = row.index
+                            if (row.modelData.id === "mouseEnabled")
+                                settings._toggleMouseEnabled()
+                            else if (row.modelData.id === "debugLogging")
+                                settings._toggleDebugLogging()
+                        }
+                        // Action rows route through `onAccepted` only
+                        // (see `SettingsField.qml`'s MouseArea), so
+                        // the focus commit lives here too — clicking
+                        // an action row moves focus before firing the
+                        // action.
+                        onAccepted: {
+                            settings.currentIndex = row.index
+                            if (row.modelData.id === "updateMediaDb")
+                                settings._triggerIndex()
+                            else if (row.modelData.id === "runScraper")
+                                settings._triggerScrape()
+                            else if (row.modelData.id === "uploadLog")
+                                settings.requestAccept("uploadLog")
+                        }
+                    }
                 }
             }
         }

--- a/src/ui/screens/SettingsScreen.qml
+++ b/src/ui/screens/SettingsScreen.qml
@@ -102,6 +102,11 @@ Item {
             id: "uploadLog",
             label: qsTr("Upload log file")
         })
+        out.push({
+            kind: "field",
+            id: "aboutLicense",
+            label: qsTr("About / License")
+        })
         return out
     }
 
@@ -191,7 +196,8 @@ Item {
         return id === "mouseEnabled" || id === "debugLogging"
     }
     // True when the focused field is an action button (updateMediaDb,
-    // runScraper, uploadLog). Drives the help-bar Accept hint.
+    // runScraper, uploadLog, aboutLicense). Drives the help-bar Accept
+    // hint and the SettingsField chevron.
     readonly property bool focusedFieldIsAction: {
         if (!settings._isField(settings.currentIndex))
             return false
@@ -199,6 +205,24 @@ Item {
         return id === "updateMediaDb"
                || id === "runScraper"
                || id === "uploadLog"
+               || id === "aboutLicense"
+    }
+    // Verb shown on the help-bar Accept hint for the focused action
+    // row. Index/scrape flip between Start and Cancel because the press
+    // toggles the in-flight operation; uploadLog and aboutLicense are
+    // single-press triggers, with aboutLicense reading "Open" because
+    // the press navigates rather than starts a job.
+    readonly property string focusedActionLabel: {
+        if (!settings._isField(settings.currentIndex))
+            return ""
+        const id = settings.fields[settings.currentIndex].id
+        if (id === "updateMediaDb" || id === "runScraper")
+            return settings.focusedActionBusy ? qsTr("Cancel") : qsTr("Start")
+        if (id === "uploadLog")
+            return qsTr("Start")
+        if (id === "aboutLicense")
+            return qsTr("Open")
+        return ""
     }
     // True when the focused action's matching operation is currently
     // running, so the help bar can label Accept as "Cancel" rather
@@ -401,6 +425,8 @@ Item {
                 settings._triggerScrape()
             else if (id === "uploadLog")
                 settings.requestAccept("uploadLog")
+            else if (id === "aboutLicense")
+                settings.requestAccept("aboutLicense")
         } else if (action === "cancel") {
             settings.requestHubScreen()
         }
@@ -529,7 +555,8 @@ Item {
                                  ? "toggle"
                                  : (row.modelData.id === "updateMediaDb"
                                     || row.modelData.id === "runScraper"
-                                    || row.modelData.id === "uploadLog") ? "action"
+                                    || row.modelData.id === "uploadLog"
+                                    || row.modelData.id === "aboutLicense") ? "action"
                                  : "value"
                         checked: row.modelData.id === "debugLogging"
                                  ? Browse.Settings.current_debug_logging
@@ -583,6 +610,8 @@ Item {
                                 settings._triggerScrape()
                             else if (row.modelData.id === "uploadLog")
                                 settings.requestAccept("uploadLog")
+                            else if (row.modelData.id === "aboutLicense")
+                                settings.requestAccept("aboutLicense")
                         }
                     }
                 }

--- a/src/ui/screens/SystemsScreen.qml
+++ b/src/ui/screens/SystemsScreen.qml
@@ -136,9 +136,8 @@ Item {
     // and the old bottom-of-grid PaginationStatus band so the screen's
     // "where am I" context all sits at the top in one row.
     //
-    // The screen Item fills the whole window, so the strip has to
-    // clear the MainLayout logo (topMargin pctH(2) + height pctH(7) —
-    // bottom edge at pctH(9)) with a pctH(2) gap.
+    // The screen Item fills the whole window, so the strip clears the
+    // MainLayout HeaderBar (Sizing.headerBottom) with a small gap.
     //
     // SystemsModel is non-paginated (every row loads eagerly on
     // category switch) — the page counter still reads off
@@ -151,7 +150,7 @@ Item {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: parent.top
-        anchors.topMargin: Sizing.pctH(11)
+        anchors.topMargin: Sizing.headerBottom + Sizing.pctH(1)
         height: Sizing.pctH(7)
         title: Browse.SystemsModel.current_category
         currentPage: systemsGrid.currentPage

--- a/src/ui/theme/Sizing.qml
+++ b/src/ui/theme/Sizing.qml
@@ -41,6 +41,19 @@ QtObject {
     // are intentionally a different shape. See docs/style.md.
     readonly property int cornerRadius: pctH(3.5)
 
+    // ── Top header (logo + status row + status pill) ──────────────────
+    // Single source of truth for the header bar that sits at the top of
+    // every screen. The logo's height is locked to the stacked-row
+    // total so the brand mark sits flush with the top of the status
+    // row and the bottom of the pill row, even when the pill is idle
+    // (its space is reserved). Screen content clears `headerBottom`.
+    readonly property int headerRowHeight: fontSize(3.4)
+    readonly property int headerStackGap: pctH(0.8)
+    readonly property int headerTopMargin: pctH(2)
+    readonly property int headerSideMargin: pctW(2)
+    readonly property int headerHeight: 2 * headerRowHeight + headerStackGap
+    readonly property int headerBottom: headerTopMargin + headerHeight
+
     function pctH(percent: real): int {
         return Math.round(screenHeight * percent / 100)
     }

--- a/src/ui/theme/Theme.qml
+++ b/src/ui/theme/Theme.qml
@@ -18,6 +18,9 @@ QtObject {
     // contrast — the page bg pattern stays visible in the gaps between
     // tiles, and each tile reads as a self-contained chip.
     readonly property color surfaceCard: "#2a2a45"
+    // Modal scrim — translucent black so the screen behind a modal
+    // dims uniformly without a blur or shader pass.
+    readonly property color scrim: "#cc000000"
 
     // Borders
     readonly property color borderSubtle: "#1a1a2e"

--- a/tests/ui/tst_navigation.qml
+++ b/tests/ui/tst_navigation.qml
@@ -204,6 +204,89 @@ TestCase {
         compare(main.hubScreen.currentIndex, 2,
                 "Left at first bottom-row index wraps to last")
     }
+
+    // Cross-row round-trip. With 4 categories on top vs 3 actions on
+    // bottom, the centered visual-nearest map can't return Up to the
+    // tile a previous Down originated from — every Down→Up shifts
+    // right by one cell. The fix is `_crossSavedIndex`: each cross
+    // saves the source-row index, the next cross restores it, any
+    // horizontal input on the destination row invalidates it.
+
+    // After Down from top[0], the saved index must hold 0 so the next
+    // Up can return there. `_mapCrossRow(0, topCount=0, 3)` puts us at
+    // bottom[2] regardless — that part is unchanged.
+    function test_cross_row_arms_saved_source_index(): void {
+        main.handleKey(Qt.Key_Down)
+        compare(main.hubScreen.currentRow, 1)
+        compare(main.hubScreen._crossSavedIndex, 0,
+                "Down from top[0] must save 0 for the round-trip back")
+    }
+
+    // Horizontal input on the destination row clears the saved index
+    // — the user has now committed to navigating within the new row,
+    // so the next cross should fall back to the centered visual map.
+    function test_cross_row_horizontal_input_clears_saved_index(): void {
+        main.handleKey(Qt.Key_Down)
+        compare(main.hubScreen._crossSavedIndex, 0)
+        main.handleKey(Qt.Key_Left)
+        compare(main.hubScreen._crossSavedIndex, -1,
+                "Left on the destination row must invalidate the round-trip")
+    }
+
+    // Mouse focus is a deliberate landing on a specific tile, same
+    // intent as a horizontal arrow press — clear the saved index so a
+    // later Up doesn't snap back to a row the user already left.
+    function test_cross_row_mouse_focus_clears_saved_index(): void {
+        main.handleKey(Qt.Key_Down)
+        compare(main.hubScreen._crossSavedIndex, 0)
+        main.hubScreen._focusAction(0)
+        compare(main.hubScreen._crossSavedIndex, -1,
+                "Mouse focus on an action tile must invalidate the round-trip")
+    }
+
+    // Restore path: when `_crossSavedIndex` is armed and within the
+    // destination row's bounds, `_crossRow` uses it directly instead
+    // of the centered visual map. The test harness has no live
+    // categories, so we drive `_crossRow` synthetically with a
+    // pretend top index whose visual map would land somewhere
+    // unrelated, then verify the restore won.
+    function test_cross_row_uses_saved_index_over_visual_map(): void {
+        main.hubScreen.currentRow = 0
+        main.hubScreen.currentIndex = 7
+        main.hubScreen._crossSavedIndex = 1
+        const moved = main.hubScreen._crossRow()
+        verify(moved, "_crossRow with non-empty destination must move")
+        compare(main.hubScreen.currentRow, 1,
+                "Cross flips to the other row")
+        compare(main.hubScreen.currentIndex, 1,
+                "Saved index 1 wins over the visual map")
+        compare(main.hubScreen._crossSavedIndex, 7,
+                "After the cross, the saved index points back to the source")
+    }
+
+    // Saved index that points past the destination row's count is
+    // ignored — the destination layout may have changed since we
+    // crossed away. Falls back to the visual map.
+    function test_cross_row_out_of_range_saved_index_falls_back(): void {
+        main.hubScreen.currentRow = 0
+        main.hubScreen.currentIndex = 0
+        main.hubScreen._crossSavedIndex = 99
+        const moved = main.hubScreen._crossRow()
+        verify(moved)
+        compare(main.hubScreen.currentRow, 1)
+        // _mapCrossRow(0, topCount=0, 3) lands at bottom[2].
+        compare(main.hubScreen.currentIndex, 2,
+                "Out-of-range saved index falls back to the visual map")
+    }
+
+    // resetFocus is the test-harness reset and the cold-launch state.
+    // It must clear the round-trip arm so a prior test's saved index
+    // can't leak into the next case.
+    function test_reset_focus_clears_saved_index(): void {
+        main.hubScreen._crossSavedIndex = 2
+        main.hubScreen.resetFocus()
+        compare(main.hubScreen._crossSavedIndex, -1)
+    }
     // qmllint enable compiler
 
     // Hold-to-repeat (dpad). The repeat state machine is driven by

--- a/tests/ui/tst_navigation.qml
+++ b/tests/ui/tst_navigation.qml
@@ -379,12 +379,14 @@ TestCase {
     // test isolation rule — no real menu opening, no handleAction.
     // Compares only the entry id sequence; labels are qsTr() and asserted
     // separately so the tests stay translation-friendly.
-    function _idsOf(entries) {
+    // qmllint disable compiler
+    function _idsOf(entries: var): var {
         const out = []
         for (let i = 0; i < entries.length; ++i)
             out.push(entries[i].id)
         return out
     }
+    // qmllint enable compiler
 
     function test_context_menu_systems_owner_is_single_launch_core(): void {
         // qmllint disable compiler


### PR DESCRIPTION
## Summary

Pre-release polish pass on the desktop shell. This branch adds the windowed-mode surfaces — header bar, settings sections, favorites and recents screens, About / License screen with build provenance, log upload modal — and finishes with a chrome unification across every modal and the context menu so the app reads as one visual family.

- **Header bar + settings sections + windowed-mode chrome** (`feat(shell)`).
- **Favorite system support** (#62).
- **Cross-row tile preservation** on Hub Down/Up round-trip (`fix(hub)`).
- **Tile cover padding + caption sink** (`refactor(tile)`).
- **About / License screen, first-run commercial notice, build provenance** (`feat(about)`).
- **Modal chrome unification**: `Modal.qml` now owns the canonical rounded-square chrome (2px white border, `Sizing.cornerRadius`, `#cc000000` scrim, content-fit height, `pctW(28)` buttons, `fontSize(2.5)` body) and exposes a `kind: \"shell\"` mode with a default content slot. `FirstRunIndexModal`, `CommercialNoticeModal`, and `LogUploadModal` drop their hand-rolled scrim/panel rectangles and become thin presenters around the shared shell. `ContextMenu` picks up the same radius (with `clip: true` so focused-row backgrounds don't bleed past the corner). `docs/style.md` replaces the stale \"Modal.qml is intentionally sharp\" rule with a Modal chrome token table — one shape, one radius across the app.
- **Quit confirm**: Hub's cancel signal now routes through a confirm modal (default focus on \"No\") instead of calling `Qt.quit()` directly so a stray B / Esc can't kill the launcher.
- **Docs proofread**: `docs/quickstart.md` corrects the `run-dev` env-var explanation and ZapScript casing; `justfile` makes `run-dev` actually point at the mock through `ZAPAROO_CORE_ENDPOINT`.

## Test plan

- [ ] `just lint` clean (clang-tidy, qmllint, rustfmt, clippy, cargo-deny)
- [ ] `just test` clean (ctest + cargo nextest)
- [ ] Cold-launch with a missing media DB → CommercialNoticeModal then FirstRunIndexModal render with identical chrome (border, radius, button shape)
- [ ] Press B on Hub → quit-confirm modal renders the same chrome and defaults focus to \"No\"
- [ ] Settings → Upload log → LogUploadModal renders identical chrome through uploading / success / error phases
- [ ] Long-press a tile → ContextMenu shows rounded corners and clipped row backgrounds, no scrim
- [ ] About / License screen reachable from Settings; build provenance line populated
- [ ] Favorites screen entry reachable from Hub; favorite toggle persists across restart
- [ ] Hub Down/Up round-trip preserves the originally focused tile when crossing rows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Embedded fullscreen build mode
  * One-time commercial-use notice with persistent acknowledgment
  * About screen showing version, commit, build date and channel
  * Quit confirmation dialog

* **Improvements**
  * Modal component: confirm/shell modes, sizing and input handling; modal scrim color
  * Header bar: status icons (NFC/Wi‑Fi/LAN/Bluetooth) and minutes-only clock; consistent header sizing
  * Settings: section headers, improved navigation and About entry
  * Better focus/restore behavior for Games and Hub; tile caption/layout tweaks

* **Tests**
  * UI navigation tests for cross-row focus behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->