### PR TITLE
[codex] Outline hub favorites icon

### DIFF
--- a/resources/images/icons/HeartOutline.svg
+++ b/resources/images/icons/HeartOutline.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg class="lucide lucide-heart-icon lucide-heart" width="24" height="24" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" version="1.1" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+ <path d="M2 9.5a5.5 5.5 0 0 1 9.591-3.676.56.56 0 0 0 .818 0A5.49 5.49 0 0 1 22 9.5c0 2.29-1.5 4-3 5.5l-5.492 5.313a2 2 0 0 1-2.816 0L5 15c-1.5-1.5-3-3.2-3-5.5" stroke="#fff"/>
+</svg>

--- a/src/ui/screens/HubScreen.qml
+++ b/src/ui/screens/HubScreen.qml
@@ -84,7 +84,7 @@ Item {
     // bound to `actionEntries[i].text` pick up the new values
     // automatically.
     readonly property var actionEntries: [
-        { id: "favorites", coverKey: "icons/Heart",    text: qsTr("Favorites") },
+        { id: "favorites", coverKey: "icons/HeartOutline", text: qsTr("Favorites") },
         { id: "recents",  coverKey: "icons/History",  text: qsTr("Recently Played") },
         { id: "settings", coverKey: "icons/Settings", text: qsTr("Settings") }
     ]


### PR DESCRIPTION
## Summary

- add a white outline heart icon with the same 1.5 stroke used by the hub action icons
- switch only the Hub Favorites action to the outline icon
- leave the filled tile favorite icon unchanged

## Validation

- `xmllint --noout resources/images/icons/HeartOutline.svg`
- confirmed `Tile.qml` still uses `Resources.iconUrl("Heart")`

Compilation and runtime testing intentionally skipped at requester direction.
