### PR TITLE
fix(games): kill the games-grid scroll bugs

### DIFF
--- a/rust/launcher/src/mister_runtime.rs
+++ b/rust/launcher/src/mister_runtime.rs
@@ -67,7 +67,8 @@ pub fn parse_resolution(value: &str) -> Option<(u32, u32)> {
 pub fn ensure_core_service_running() {
     #[cfg(zaparoo_runtime = "mister")]
     {
-        use tracing::warn;
+        use tracing::{info, warn};
+        info!("spawning core service wrapper: zaparoo.sh -service start");
         if let Err(e) = std::process::Command::new("/media/fat/Scripts/zaparoo.sh")
             .args(["-service", "start"])
             .spawn()

--- a/rust/launcher/src/models/games.rs
+++ b/rust/launcher/src/models/games.rs
@@ -80,16 +80,40 @@ const DEFAULT_PAGE_SIZE: i32 = 15;
 // `media.browse` `max_results` for cursor follow-ups. Held separate
 // from `page_size` (which dictates grid layout, scroll-thumb sizing,
 // and the initial-page cover gate) so wire chunks can be larger than a
-// single visual page without changing the grid math. Server caps
-// `max_results` at 1000; 500 stays well inside that, costs ~100 KB on
-// the wire (~200 B per `BrowseEntry`), and brings a 1402-entry Amiga
-// catalog down to ~3 round-trips. Even a 15,000-entry Arcade dump
-// holds the full per-system entry list in ~3 MB — orders of magnitude
-// under MiSTer's headroom — so the cap is wire size and Core's own
-// limit, not launcher memory. Initial browse keeps the smaller
-// `page_size` so the cover gate doesn't have to wait for a big first
-// decode.
-const FETCH_MORE_CHUNK_SIZE: i32 = 500;
+// single visual page without changing the grid math. Sized for the
+// MiSTer main-thread cost of `apply_append_page`: each chunk runs
+// `transform_entries`, `enqueue_cover_fetches`, and a
+// `begin_insert_rows`/`end_insert_rows` pair on the Qt thread, which
+// stalls input until it returns. 500 was Core's wire-cost optimum but
+// produced a multi-second stall on ARM32 with the indicator showing
+// the whole time; 100 keeps the per-chunk stall short enough to be
+// invisible while still cutting an 805-entry Arcade to ~8 round-trips.
+// Server caps `max_results` at 1000; 100 stays well inside that. The
+// initial browse keeps the smaller `page_size` so the cover gate
+// doesn't have to wait on a big first decode.
+const FETCH_MORE_CHUNK_SIZE: i32 = 100;
+
+// `apply_append_page` sub-batches the model insert into chunks of this
+// many rows so the Repeater's per-delegate `createObject` cost (the
+// dominant Qt-thread stall on MiSTer at ~7-8 ms per Tile) is spread
+// across frames instead of one ~750 ms - 1.6 s block. The first batch
+// runs synchronously inside the original Qt-thread call so PagedGrid's
+// `_commitPendingTarget` fires within ~200 ms of the user's press; the
+// rest are posted from `global_runtime()` with one frame of breathing
+// room (`SUB_BATCH_FRAME_GAP_MS`) between batches so input + paint can
+// drain in between. 25 is one full visual page on a 5x5 dense layout
+// and roughly 190 ms of insert work warm — detectable as a hitch but
+// well below the monolithic stall and short enough that the next user
+// press lands inside one batch's gap. Tunable: drop to 12-15 if a
+// single-batch hitch still feels chunky.
+const APPEND_SUB_BATCH_SIZE: usize = 25;
+
+// One frame at 30 Hz, the MiSTer software renderer's effective frame
+// budget. Gives Qt one full frame to drain input + paint between
+// posted sub-batches. Smaller values risk the next batch landing
+// before the paint completes; larger values make the trailing rows
+// trickle in too slowly.
+const SUB_BATCH_FRAME_GAP_MS: u64 = 33;
 
 #[allow(
     clippy::struct_excessive_bools,
@@ -170,6 +194,24 @@ pub struct GamesModelRust {
     // doesn't cancel a callback that was already queued onto the Qt
     // thread between sleep-completion and abort.
     cover_gate_seq: Arc<AtomicU64>,
+    // Tagging ticket for in-flight append sub-batches scheduled by
+    // `apply_append_page`. Bumped on every `start_initial_browse` so a
+    // deferred batch from a stale dataset detects that the model has
+    // moved on and bails before splicing rows from the old chain onto
+    // the new one. Same race shape as `cover_gate_seq`, just for the
+    // sub-batch fan-out.
+    append_seq: Arc<AtomicU64>,
+    // True from the moment `apply_initial_page` queues its look-ahead
+    // `fetch_more` until the matching `apply_append_page` lands. While
+    // set, the cover-gate release paths (`arm_cover_gate`,
+    // `notify_cover_update`, `release_cover_gate_after_timeout` aside)
+    // hold `loading=true` even after first-paint covers cache, so the
+    // user sees a single full-screen "Loading…" overlay instead of
+    // `Loading…` followed immediately by `Loading more…`. Cleared on
+    // append (success or failure) and on every `start_initial_browse`.
+    // The 3 s safety timer is the bounded fall-through, so a stalled
+    // prefetch can't park the user on the overlay forever.
+    pending_initial_lookahead: bool,
 }
 
 impl Default for GamesModelRust {
@@ -198,6 +240,8 @@ impl Default for GamesModelRust {
             pending_first_paint_keys: HashSet::new(),
             cover_gate_timer: None,
             cover_gate_seq: Arc::new(AtomicU64::new(0)),
+            append_seq: Arc::new(AtomicU64::new(0)),
+            pending_initial_lookahead: false,
         }
     }
 }
@@ -676,6 +720,19 @@ impl ffi::GamesModel {
         // reset and preserve appended pages + selection.
         self.as_mut().rust_mut().is_seeded = false;
         self.as_mut().rust_mut().next_cursor = None;
+        // Drop any held initial-look-ahead gate from the prior browse —
+        // its append (if it lands at all) will be ticket-rejected and
+        // can't re-arm the gate for this new target.
+        self.as_mut().rust_mut().pending_initial_lookahead = false;
+        // Invalidate any in-flight sub-batch posts from the prior
+        // browse: each posted closure compares against the snapshotted
+        // ticket and bails if the model has moved on. Otherwise a
+        // batch from the old chain could splice rows onto the new
+        // dataset.
+        self.as_mut()
+            .rust_mut()
+            .append_seq
+            .fetch_add(1, Ordering::SeqCst);
         if !self.entries.is_empty() {
             self.as_mut().begin_reset_model();
             self.as_mut().rust_mut().entries.clear();
@@ -970,7 +1027,12 @@ fn notify_cover_update(mut model: Pin<&mut ffi::GamesModel>, key: &MediaKey) {
                     return;
                 }
                 model.as_mut().rust_mut().cover_gate_timer = None;
-                if model.loading {
+                // Same hold rule as the immediate-cached path in
+                // `arm_cover_gate`: if the look-ahead prefetch still
+                // owes us, leave loading=true. `apply_append_page`
+                // will release once the prefetch lands (or the safety
+                // timer in `release_cover_gate_after_timeout` will).
+                if model.loading && !model.pending_initial_lookahead {
                     info!("games: cover gate released after decode-settle window");
                     model.as_mut().set_loading(false);
                 }
@@ -1041,7 +1103,11 @@ fn arm_cover_gate(mut model: Pin<&mut ffi::GamesModel>) {
     );
     if unresolved.is_empty() {
         model.as_mut().rust_mut().pending_first_paint_keys.clear();
-        if model.loading {
+        // Hold loading=true if we still owe the user a look-ahead
+        // prefetch — `apply_append_page` will release once that lands
+        // (or `release_cover_gate_after_timeout` will, as a safety
+        // net).
+        if model.loading && !model.pending_initial_lookahead {
             model.as_mut().set_loading(false);
         }
         return;
@@ -1066,6 +1132,39 @@ fn arm_cover_gate(mut model: Pin<&mut ffi::GamesModel>) {
     model.as_mut().rust_mut().cover_gate_timer = Some(handle);
 }
 
+/// Clear `pending_initial_lookahead` and, if the cover gate has
+/// already drained (no waiting keys, no decode-settle timer running),
+/// release loading=false. Called from `apply_append_page` on both
+/// success and error: the look-ahead has done its job, so any cover
+/// gate that was holding for the prefetch should now flip.
+///
+/// Three orderings produce three branches here:
+/// - Covers landed and decode-settle fired before the prefetch
+///   landed: timer is None, `pending_first_paint_keys` is empty, we
+///   release immediately.
+/// - Covers all cached on arm: `pending_first_paint_keys` was empty
+///   from the start, no timer was armed beyond the 3 s safety, but
+///   `arm_cover_gate`'s immediate-release path was skipped because
+///   the flag was set. Same as above — release.
+/// - Covers still in flight: `pending_first_paint_keys` non-empty;
+///   leave the gate alone, `notify_cover_update` will release once
+///   they drain (and the flag-clear we just did frees its check).
+fn release_initial_lookahead_gate(mut model: Pin<&mut ffi::GamesModel>) {
+    if !model.pending_initial_lookahead {
+        return;
+    }
+    model.as_mut().rust_mut().pending_initial_lookahead = false;
+    if !model.loading {
+        return;
+    }
+    let covers_drained = model.pending_first_paint_keys.is_empty();
+    let timer_idle = model.cover_gate_timer.is_none();
+    if covers_drained && timer_idle {
+        info!("games: cover gate released after look-ahead prefetch landed");
+        model.as_mut().set_loading(false);
+    }
+}
+
 /// Force-release the cover gate from the safety timer. Called only via
 /// the timer's queued callback after a seq-match check; the
 /// notify-driven release path lives inline in `notify_cover_update`.
@@ -1074,6 +1173,11 @@ fn release_cover_gate_after_timeout(mut model: Pin<&mut ffi::GamesModel>) {
     info!(pending, "games: cover gate timed out, releasing");
     model.as_mut().rust_mut().pending_first_paint_keys.clear();
     model.as_mut().rust_mut().cover_gate_timer = None;
+    // Safety timer is the hard upper bound — release regardless of
+    // whether the look-ahead prefetch has landed. Clear the flag too
+    // so a late `apply_append_page` doesn't try to flip loading off a
+    // second time.
+    model.as_mut().rust_mut().pending_initial_lookahead = false;
     if model.loading {
         model.as_mut().set_loading(false);
     }
@@ -1380,15 +1484,37 @@ fn apply_initial_page(mut model: Pin<&mut ffi::GamesModel>, result: MediaBrowseR
     model.as_mut().rust_mut().entries = entries;
     model.as_mut().rust_mut().count = count;
     model.as_mut().rust_mut().next_cursor = next_cursor;
-    model.as_mut().end_reset_model();
-    model.as_mut().count_changed();
+    // Property setters run BEFORE `end_reset_model` so Main.qml's
+    // `onModelReset` handler observes the post-load state. In
+    // particular, the deep-page restore branch reads `has_next_page`
+    // to decide whether to chase the saved entry across pages; if
+    // we set it after `end_reset_model`, that handler sees the
+    // stale `false` left by `start_initial_browse` and abandons the
+    // restore (currentIndex snaps to 0). The order in
+    // `apply_append_page` is the opposite (set has_next_page AFTER
+    // the last insert) for a different reason: that path needs
+    // PagedGrid's pending-target watchdog to read a fresh itemCount
+    // when the flag flips false on the terminal chunk. A fresh
+    // model reset has no pending-target watchdog to mislead, so
+    // setting the flag early here is safe.
     model.as_mut().set_dir_count(dir_count);
     model.as_mut().set_total_files(total);
     model.as_mut().set_has_next_page(has_next_page);
+    model.as_mut().end_reset_model();
+    model.as_mut().count_changed();
+    // Arm the initial-look-ahead gate BEFORE arm_cover_gate so the
+    // gate's "no covers to wait on" fast path also waits on the
+    // pending append rather than flipping loading=false right away.
+    // Cleared by the matching `apply_append_page` (success or failure)
+    // or by the cover_gate safety timer.
+    let will_lookahead = has_next_page && !model.loading_more;
+    if will_lookahead {
+        model.as_mut().rust_mut().pending_initial_lookahead = true;
+    }
     // Decide whether to release `loading` immediately or hold it until
     // covers are cached. `arm_cover_gate` flips loading off itself when
-    // the page has nothing to wait on (folder-only or fully-cached
-    // revisit); otherwise it leaves loading=true and arms the timer.
+    // the page has nothing to wait on AND the look-ahead gate is
+    // clear; otherwise it leaves loading=true and arms the timer.
     arm_cover_gate(model.as_mut());
     if !model.error_message.is_empty() {
         model.as_mut().set_error_message(QString::default());
@@ -1413,13 +1539,65 @@ fn apply_initial_page(mut model: Pin<&mut ffi::GamesModel>, result: MediaBrowseR
     // and looked like "covers loading slowly one at a time" with the
     // next page no longer instant on navigate. See the doc comment on
     // `MediaImageCache::queue` for the full rationale.
-    if has_next_page && !model.loading_more {
+    if will_lookahead {
         model.as_mut().fetch_more();
     }
     // Mark seeded last so any early-return from this function leaves
     // the flag in its previous state. Subsequent Ready transitions
     // on the same browse target now skip the reset above.
     model.as_mut().rust_mut().is_seeded = true;
+}
+
+/// Split a freshly-fetched chunk of `BrowseEntry` rows into sub-batches
+/// of at most `size` rows each, preserving order. The first batch is
+/// applied synchronously by `apply_append_page`; the rest are posted
+/// one frame apart so the Repeater's per-delegate materialisation
+/// cost is spread across frames instead of one big main-thread stall.
+///
+/// Pure helper so the partitioning is unit-testable without a Qt
+/// event loop. Returns an empty Vec for an empty input or `size == 0`.
+fn chunk_for_subbatching(entries: Vec<BrowseEntry>, size: usize) -> Vec<Vec<BrowseEntry>> {
+    if entries.is_empty() || size == 0 {
+        return Vec::new();
+    }
+    let mut out: Vec<Vec<BrowseEntry>> = Vec::with_capacity(entries.len().div_ceil(size));
+    let mut current: Vec<BrowseEntry> = Vec::with_capacity(size);
+    for entry in entries {
+        if current.len() == size {
+            out.push(std::mem::replace(&mut current, Vec::with_capacity(size)));
+        }
+        current.push(entry);
+    }
+    if !current.is_empty() {
+        out.push(current);
+    }
+    out
+}
+
+/// Single `begin_insert_rows`/`end_insert_rows` pair for one sub-batch
+/// of an append. Shared between the synchronous-first-batch path and
+/// the deferred-tail path so the row-count math + signal ordering live
+/// in exactly one place. No-ops on an empty batch.
+fn insert_sub_batch(mut model: Pin<&mut ffi::GamesModel>, batch: Vec<BrowseEntry>) {
+    let new_count = i32::try_from(batch.len()).unwrap_or(i32::MAX - model.count);
+    if new_count <= 0 {
+        return;
+    }
+    let first = model.count;
+    let last = first.saturating_add(new_count).saturating_sub(1);
+    info!(
+        "insert_sub_batch first={} last={} new_count={} count_after={}",
+        first,
+        last,
+        new_count,
+        first.saturating_add(new_count),
+    );
+    let parent = QModelIndex::default();
+    model.as_mut().begin_insert_rows(&parent, first, last);
+    model.as_mut().rust_mut().entries.extend(batch);
+    model.as_mut().rust_mut().count = first.saturating_add(new_count);
+    model.as_mut().end_insert_rows();
+    model.as_mut().count_changed();
 }
 
 fn apply_append_page(
@@ -1444,52 +1622,68 @@ fn apply_append_page(
             let next_cursor = result.next_cursor();
             let platform = platform::current();
             let entries = transform_entries(result.entries, platform.as_ref());
-            let new_count = i32::try_from(entries.len()).unwrap_or(i32::MAX - model.count);
             enqueue_cover_fetches(&entries);
+            let total = i32::try_from(result.total_files).unwrap_or(i32::MAX);
             // Order matters for the pending-target chain in PagedGrid:
             //
             // 1. `next_cursor` and `loading_more=false` MUST happen
-            //    before `end_insert_rows`. The Repeater reacts
-            //    synchronously to `rowsInserted`; PagedGrid's
-            //    `onItemCountChanged` runs `_commitPendingTarget`,
-            //    which can re-fire `loadMoreRequested` -> `fetch_more`.
-            //    If `loading_more` is still true at that moment the
-            //    fetch_more guard early-returns and the chain stalls
-            //    after one append.
+            //    before the FIRST sub-batch's `end_insert_rows`. The
+            //    Repeater reacts synchronously to `rowsInserted`;
+            //    PagedGrid's `onItemCountChanged` runs
+            //    `_commitPendingTarget`, which can re-fire
+            //    `loadMoreRequested` -> `fetch_more`. If `loading_more`
+            //    is still true at that moment the `fetch_more` guard
+            //    early-returns and the chain stalls after one append.
             //
-            // 2. `has_next_page` MUST happen after `end_insert_rows`.
-            //    On the final chunk the value flips true -> false; if
-            //    we set it first, PagedGrid's `onHasMorePagesChanged`
-            //    fires `_commitPendingTarget` while `itemCount` is
-            //    still stale (pre-insert), the watchdog sees a too-low
-            //    itemCount, and settles the pending target on whatever
-            //    was loaded BEFORE this chunk landed -- the wrap
-            //    appears to land ~1 chunk short of the real last page.
-            //    Setting it after the insert lets the watchdog read
-            //    the fresh itemCount and clamp to the actual last
-            //    item.
+            // 2. `has_next_page` MUST happen after the LAST sub-batch's
+            //    `end_insert_rows`. On the final chunk the value flips
+            //    true -> false; if we set it first, PagedGrid's
+            //    `onHasMorePagesChanged` fires `_commitPendingTarget`
+            //    while `itemCount` is still stale (pre-insert), the
+            //    watchdog sees a too-low itemCount, and settles the
+            //    pending target on whatever was loaded BEFORE this
+            //    chunk landed -- the wrap appears to land ~1 chunk
+            //    short of the real last page. Setting it after the
+            //    insert lets the watchdog read the fresh itemCount and
+            //    clamp to the actual last item.
+            //
+            // Sub-batching note: the rest of the chunk is posted from
+            // `global_runtime()` one frame apart so the Repeater's
+            // per-delegate `createObject` cost (the dominant Qt-thread
+            // stall on MiSTer) is spread across frames. Stale batches
+            // self-disarm via the `append_seq` ticket if a new
+            // `start_initial_browse` lands during the trickle window.
             model.as_mut().rust_mut().next_cursor = next_cursor;
             model.as_mut().set_loading_more(false);
-            if new_count > 0 {
-                let first = model.count;
-                let last = first.saturating_add(new_count).saturating_sub(1);
-                let parent = QModelIndex::default();
-                model.as_mut().begin_insert_rows(&parent, first, last);
-                model.as_mut().rust_mut().entries.extend(entries);
-                model.as_mut().rust_mut().count = first.saturating_add(new_count);
-                model.as_mut().end_insert_rows();
-                model.as_mut().count_changed();
+            let mut batches = chunk_for_subbatching(entries, APPEND_SUB_BATCH_SIZE);
+            if batches.is_empty() {
+                // No new rows landed (empty page). Finalise immediately
+                // — there's nothing to defer.
+                model.as_mut().set_has_next_page(has_next_page);
+                if model.total_files != total {
+                    model.as_mut().set_total_files(total);
+                }
+                release_initial_lookahead_gate(model.as_mut());
+                return;
             }
-            model.as_mut().set_has_next_page(has_next_page);
-            // total_files isn't strictly required to update -- Core
-            // returns the same value for every page of the same path
-            // -- but Core may revise it under us if files
-            // appear/disappear between cursor advances; keep it
-            // fresh.
-            let total = i32::try_from(result.total_files).unwrap_or(i32::MAX);
-            if model.total_files != total {
-                model.as_mut().set_total_files(total);
+            // First batch runs synchronously inside the existing
+            // Qt-thread call so PagedGrid's `_commitPendingTarget`
+            // resolves within ~200 ms of the user's press.
+            let first_batch = batches.remove(0);
+            insert_sub_batch(model.as_mut(), first_batch);
+            if batches.is_empty() {
+                // Single-batch chunk (<= APPEND_SUB_BATCH_SIZE rows).
+                // Finalise now without scheduling deferred work.
+                model.as_mut().set_has_next_page(has_next_page);
+                if model.total_files != total {
+                    model.as_mut().set_total_files(total);
+                }
+                release_initial_lookahead_gate(model.as_mut());
+                return;
             }
+            // Remaining batches: post one frame apart on the Qt
+            // thread, with the LAST one carrying the finaliser
+            // (has_next_page, total_files, look-ahead gate release).
             // dir_count intentionally not touched: Core only returns
             // directory entries on page 1 (cursor == nil).
             //
@@ -1500,6 +1694,36 @@ fn apply_append_page(
             // self-driving cascade that downloaded every page
             // back-to-back, tripping Core's WebSocket rate limit on
             // huge folders (Arcade).
+            let seq = model.rust().append_seq.clone();
+            let ticket = seq.load(Ordering::SeqCst);
+            let qt_thread = model.qt_thread();
+            global_runtime().spawn(async move {
+                let last_idx = batches.len().saturating_sub(1);
+                for (i, batch) in batches.into_iter().enumerate() {
+                    tokio::time::sleep(Duration::from_millis(SUB_BATCH_FRAME_GAP_MS)).await;
+                    let is_last = i == last_idx;
+                    let seq = seq.clone();
+                    let _ = qt_thread.queue(move |mut model: Pin<&mut ffi::GamesModel>| {
+                        if seq.load(Ordering::SeqCst) != ticket {
+                            return;
+                        }
+                        insert_sub_batch(model.as_mut(), batch);
+                        if is_last {
+                            model.as_mut().set_has_next_page(has_next_page);
+                            if model.total_files != total {
+                                model.as_mut().set_total_files(total);
+                            }
+                            // Clear the look-ahead gate now that the
+                            // first follow-up chunk has fully landed.
+                            // If the cover gate already drained
+                            // (covers all cached or decode-settle
+                            // fired while we held it open) we're the
+                            // one releasing loading.
+                            release_initial_lookahead_gate(model.as_mut());
+                        }
+                    });
+                }
+            });
         }
         Err(e) => {
             warn!("media.browse follow-up page failed: {}", e.message);
@@ -1510,6 +1734,12 @@ fn apply_append_page(
                 .as_mut()
                 .set_error_message(QString::from(e.message.as_str()));
             model.as_mut().set_loading_more(false);
+            // Even on a failed first prefetch, we have to release the
+            // cover gate's hold or the user is stuck on Loading…
+            // forever. The visible page is already in place from
+            // `apply_initial_page`; the missing tail just won't be
+            // there until the user retries.
+            release_initial_lookahead_gate(model.as_mut());
         }
     }
 }
@@ -1524,9 +1754,10 @@ mod tests {
     )]
 
     use super::{
-        compute_unresolved_keys, cover_key_for_with, decide_initial, dedup_roots_drop_ancestors,
-        display_name, entry_system_id, is_strict_ancestor_path, leading_dir_count, media_key_for,
-        position_of_game_path, project_status, transform_entries, InitialAction, Projection,
+        chunk_for_subbatching, compute_unresolved_keys, cover_key_for_with, decide_initial,
+        dedup_roots_drop_ancestors, display_name, entry_system_id, is_strict_ancestor_path,
+        leading_dir_count, media_key_for, position_of_game_path, project_status, transform_entries,
+        InitialAction, Projection,
     };
     use crate::media_image_cache::{MediaImageCache, MediaKey};
     use std::collections::HashSet;
@@ -2104,5 +2335,63 @@ mod tests {
         ];
         let unresolved = compute_unresolved_keys(&entries, |_| false, |_| false);
         assert!(unresolved.is_empty());
+    }
+
+    #[test]
+    fn chunk_for_subbatching_empty_returns_empty() {
+        let out = chunk_for_subbatching(Vec::new(), 25);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn chunk_for_subbatching_zero_size_returns_empty() {
+        let entries = vec![media("a", "/a", "NES")];
+        let out = chunk_for_subbatching(entries, 0);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn chunk_for_subbatching_under_size_returns_single_batch() {
+        let entries: Vec<BrowseEntry> = (0..10)
+            .map(|i| media(&format!("g{i}"), &format!("/g/{i}"), "NES"))
+            .collect();
+        let out = chunk_for_subbatching(entries, 25);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].len(), 10);
+    }
+
+    #[test]
+    fn chunk_for_subbatching_exact_multiple_splits_evenly() {
+        let entries: Vec<BrowseEntry> = (0..50)
+            .map(|i| media(&format!("g{i}"), &format!("/g/{i}"), "NES"))
+            .collect();
+        let out = chunk_for_subbatching(entries, 25);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].len(), 25);
+        assert_eq!(out[1].len(), 25);
+    }
+
+    #[test]
+    fn chunk_for_subbatching_remainder_lands_in_final_batch() {
+        let entries: Vec<BrowseEntry> = (0..60)
+            .map(|i| media(&format!("g{i}"), &format!("/g/{i}"), "NES"))
+            .collect();
+        let out = chunk_for_subbatching(entries, 25);
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0].len(), 25);
+        assert_eq!(out[1].len(), 25);
+        assert_eq!(out[2].len(), 10);
+    }
+
+    #[test]
+    fn chunk_for_subbatching_preserves_order() {
+        let entries: Vec<BrowseEntry> = (0..30)
+            .map(|i| media(&format!("g{i}"), &format!("/g/{i}"), "NES"))
+            .collect();
+        let out = chunk_for_subbatching(entries, 25);
+        assert_eq!(out[0][0].path, "/g/0");
+        assert_eq!(out[0][24].path, "/g/24");
+        assert_eq!(out[1][0].path, "/g/25");
+        assert_eq!(out[1][4].path, "/g/29");
     }
 }

--- a/rust/launcher/src/models/games.rs
+++ b/rust/launcher/src/models/games.rs
@@ -77,6 +77,20 @@ const FAVORITE_ROLE: i32 = 256 + 8;
 // 1000; grid page sizes top out at ~30 so we stay well inside bounds.
 const DEFAULT_PAGE_SIZE: i32 = 15;
 
+// `media.browse` `max_results` for cursor follow-ups. Held separate
+// from `page_size` (which dictates grid layout, scroll-thumb sizing,
+// and the initial-page cover gate) so wire chunks can be larger than a
+// single visual page without changing the grid math. Server caps
+// `max_results` at 1000; 500 stays well inside that, costs ~100 KB on
+// the wire (~200 B per `BrowseEntry`), and brings a 1402-entry Amiga
+// catalog down to ~3 round-trips. Even a 15,000-entry Arcade dump
+// holds the full per-system entry list in ~3 MB — orders of magnitude
+// under MiSTer's headroom — so the cap is wire size and Core's own
+// limit, not launcher memory. Initial browse keeps the smaller
+// `page_size` so the cover gate doesn't have to wait for a big first
+// decode.
+const FETCH_MORE_CHUNK_SIZE: i32 = 500;
+
 #[allow(
     clippy::struct_excessive_bools,
     reason = "the bools are independent qproperties surfaced to QML; collapsing them \
@@ -382,10 +396,18 @@ impl ffi::GamesModel {
     fn fetch_more(mut self: Pin<&mut Self>) {
         // Debounce: PagedGrid fires `loadMoreRequested` once per page
         // turn, but a fast spinner on the last loaded page can fire
-        // twice before the first follow-up returns. Both guards
+        // twice before the first follow-up returns. All three guards
         // matter: `loading_more` covers in-flight, `has_next_page`
-        // covers terminal pages.
-        if self.loading_more || !self.has_next_page {
+        // covers terminal pages, and `next_cursor.is_none()` covers
+        // the in-between window in `apply_append_page` where the final
+        // chunk has cleared the cursor before flipping
+        // `has_next_page` (the flip is intentionally deferred so the
+        // pending-target watchdog reads a fresh `itemCount`). Without
+        // this third guard, a `_commitPendingTarget` re-fire from
+        // `onItemCountChanged` would dispatch `media.browse` with
+        // `cursor=None`, re-fetching from page 1 and splicing
+        // duplicates onto the loaded slice.
+        if self.loading_more || !self.has_next_page || self.next_cursor.is_none() {
             return;
         }
         let cursor = self.next_cursor.clone();
@@ -401,7 +423,8 @@ impl ffi::GamesModel {
         // `set_path` invalidate the prior cursor sequence.
         let seq = self.seq.clone();
         let ticket = seq.load(Ordering::SeqCst);
-        let max_results = u32::try_from(self.page_size.max(1)).unwrap_or(u32::from(u16::MAX));
+        let max_results =
+            u32::try_from(FETCH_MORE_CHUNK_SIZE.max(1)).unwrap_or(u32::from(u16::MAX));
         self.as_mut().set_loading_more(true);
         let qt_thread = self.qt_thread();
         let store = global_store();
@@ -1423,6 +1446,30 @@ fn apply_append_page(
             let entries = transform_entries(result.entries, platform.as_ref());
             let new_count = i32::try_from(entries.len()).unwrap_or(i32::MAX - model.count);
             enqueue_cover_fetches(&entries);
+            // Order matters for the pending-target chain in PagedGrid:
+            //
+            // 1. `next_cursor` and `loading_more=false` MUST happen
+            //    before `end_insert_rows`. The Repeater reacts
+            //    synchronously to `rowsInserted`; PagedGrid's
+            //    `onItemCountChanged` runs `_commitPendingTarget`,
+            //    which can re-fire `loadMoreRequested` -> `fetch_more`.
+            //    If `loading_more` is still true at that moment the
+            //    fetch_more guard early-returns and the chain stalls
+            //    after one append.
+            //
+            // 2. `has_next_page` MUST happen after `end_insert_rows`.
+            //    On the final chunk the value flips true -> false; if
+            //    we set it first, PagedGrid's `onHasMorePagesChanged`
+            //    fires `_commitPendingTarget` while `itemCount` is
+            //    still stale (pre-insert), the watchdog sees a too-low
+            //    itemCount, and settles the pending target on whatever
+            //    was loaded BEFORE this chunk landed -- the wrap
+            //    appears to land ~1 chunk short of the real last page.
+            //    Setting it after the insert lets the watchdog read
+            //    the fresh itemCount and clamp to the actual last
+            //    item.
+            model.as_mut().rust_mut().next_cursor = next_cursor;
+            model.as_mut().set_loading_more(false);
             if new_count > 0 {
                 let first = model.count;
                 let last = first.saturating_add(new_count).saturating_sub(1);
@@ -1433,25 +1480,26 @@ fn apply_append_page(
                 model.as_mut().end_insert_rows();
                 model.as_mut().count_changed();
             }
-            model.as_mut().rust_mut().next_cursor = next_cursor;
             model.as_mut().set_has_next_page(has_next_page);
-            // total_files isn't strictly required to update — Core
-            // returns the same value for every page of the same path —
-            // but Core may revise it under us if files appear/disappear
-            // between cursor advances; keep it fresh.
+            // total_files isn't strictly required to update -- Core
+            // returns the same value for every page of the same path
+            // -- but Core may revise it under us if files
+            // appear/disappear between cursor advances; keep it
+            // fresh.
             let total = i32::try_from(result.total_files).unwrap_or(i32::MAX);
             if model.total_files != total {
                 model.as_mut().set_total_files(total);
             }
             // dir_count intentionally not touched: Core only returns
             // directory entries on page 1 (cursor == nil).
-            model.as_mut().set_loading_more(false);
+            //
             // No auto-prefetch here. apply_initial_page pre-warms
-            // page 2 once; subsequent pages are driven by the grid's
-            // onLoadMoreRequested as the user scrolls. Chaining a
-            // fetch_more here turned the look-ahead into a self-driving
-            // cascade that downloaded every page back-to-back, tripping
-            // Core's WebSocket rate limit on huge folders (Arcade).
+            // chunk 2 once; subsequent chunks are driven by the
+            // grid's onLoadMoreRequested as the user scrolls.
+            // Chaining a fetch_more here turned the look-ahead into a
+            // self-driving cascade that downloaded every page
+            // back-to-back, tripping Core's WebSocket rate limit on
+            // huge folders (Arcade).
         }
         Err(e) => {
             warn!("media.browse follow-up page failed: {}", e.message);

--- a/rust/zaparoo-core/src/client.rs
+++ b/rust/zaparoo-core/src/client.rs
@@ -44,6 +44,22 @@ const RETRY_ERROR_THRESHOLD: u32 = 10;
 /// after hours still reconnects within half a minute.
 const MAX_BACKOFF_SECS: u64 = 30;
 
+/// Cold-boot window during which we retry the WebSocket every
+/// `BOOT_RETRY` instead of using the exponential curve. Sized to cover
+/// the worst observed Core cold-start on `MiSTer` (~22 s service-binary
+/// prep + database open with a large media DB) plus headroom. While the
+/// window is open and we have never connected, connect failures don't
+/// count toward `RETRY_ERROR_THRESHOLD` — they're expected, not a
+/// reachability problem.
+const BOOT_WINDOW: Duration = Duration::from_secs(45);
+
+/// Retry interval inside the boot window. A connect-refused on a
+/// not-yet-bound port is one TCP SYN + RST, so 250 ms × 180 attempts
+/// across the window is negligible CPU/network on `MiSTer` and lets the
+/// launcher pick up Core within a quarter-second of HTTP bind instead
+/// of waiting up to 16 s for the next exponential backoff slot.
+const BOOT_RETRY: Duration = Duration::from_millis(250);
+
 /// Rolling state of the WebSocket link, published via `watch` so late
 /// subscribers (QML singletons whose `initialize()` runs after the QML
 /// engine boots, post-connect) read the current value rather than
@@ -226,8 +242,17 @@ impl ConnectionFsm {
 
     /// Records a failed connect attempt and returns the state to publish,
     /// or `None` if the failure shouldn't change the published state
-    /// (below threshold, or already `Unreachable`).
-    fn on_attempt_failed(&mut self, err: String) -> Option<ConnectionState> {
+    /// (below threshold, already `Unreachable`, or still inside the
+    /// cold-boot window before the first successful connect).
+    ///
+    /// `boot_window` is true while we have never connected and the
+    /// process is younger than [`BOOT_WINDOW`]. During that period
+    /// connect failures are expected (Core is starting), so they don't
+    /// increment the failure counter or escalate to `Unreachable`.
+    fn on_attempt_failed(&mut self, err: String, boot_window: bool) -> Option<ConnectionState> {
+        if boot_window {
+            return None;
+        }
         self.failures = self.failures.saturating_add(1);
         if self.failures >= RETRY_ERROR_THRESHOLD && !self.unreachable_published {
             self.unreachable_published = true;
@@ -239,6 +264,10 @@ impl ConnectionFsm {
 
     fn current_failures(&self) -> u32 {
         self.failures
+    }
+
+    fn ever_connected(&self) -> bool {
+        self.ever_connected
     }
 }
 
@@ -271,8 +300,17 @@ impl Client {
 
         runtime.spawn(async move {
             let mut fsm = ConnectionFsm::default();
+            let process_start = std::time::Instant::now();
 
             loop {
+                // Cold-boot fast-retry window: while we have never
+                // connected and the process is young, Core is probably
+                // still starting up. Retry tightly so we pick up Core's
+                // HTTP bind within ~250 ms instead of waiting up to
+                // 16 s for the next exponential slot.
+                let boot_window =
+                    !fsm.ever_connected() && process_start.elapsed() < BOOT_WINDOW;
+
                 // Bind the borrow to a local so it's dropped before
                 // `send_replace` — temporaries in the scrutinee of an
                 // `if let` outlive the body, so inlining the borrow
@@ -352,16 +390,16 @@ impl Client {
                         }
                     }
                     Err(e) => {
-                        if let Some(next) = fsm.on_attempt_failed(e.to_string()) {
+                        if let Some(next) = fsm.on_attempt_failed(e.to_string(), boot_window) {
                             connection_clone.send_replace(next);
                         }
                         debug!(
-                            "ws connect failed (attempt {}): {e}",
+                            "ws connect failed (attempt {}, boot_window={boot_window}): {e}",
                             fsm.current_failures()
                         );
                     }
                 }
-                tokio::time::sleep(backoff_delay(fsm.current_failures())).await;
+                tokio::time::sleep(backoff_delay(fsm.current_failures(), boot_window)).await;
             }
         });
 
@@ -673,17 +711,32 @@ impl Client {
     }
 }
 
-/// Exponential backoff between connect attempts, capped at
-/// `MAX_BACKOFF_SECS`. `failures == 0` represents "we just disconnected
-/// from a successful session" and yields a 1 s retry so a brief drop
-/// doesn't feel sluggish; each subsequent consecutive failure doubles
-/// the delay until the cap.
+/// Delay before the next connect attempt.
 ///
-/// Sequence: 0→1, 1→1, 2→2, 3→4, 4→8, 5→16, 6→30, 7+→30 (seconds).
+/// Two regimes:
+///
+/// - **Boot window** (`boot_window == true`): fixed [`BOOT_RETRY`].
+///   Used while the launcher has never successfully connected and the
+///   process is younger than [`BOOT_WINDOW`]. Lets us pick up Core
+///   within ~250 ms of its HTTP bind on cold `MiSTer` boots, instead of
+///   waiting up to 16 s for the next exponential slot.
+///
+/// - **Steady state**: exponential backoff capped at
+///   `MAX_BACKOFF_SECS`. `failures == 0` represents "we just
+///   disconnected from a successful session" and yields a 1 s retry so
+///   a brief drop doesn't feel sluggish; each subsequent consecutive
+///   failure doubles the delay until the cap.
+///
+///   Sequence: 0→1, 1→1, 2→2, 3→4, 4→8, 5→16, 6→30, 7+→30 (seconds).
 ///
 /// `pub(crate)` so `remote_resource` can reuse the same curve for
-/// in-session RPC retry without duplicating the math.
-pub(crate) fn backoff_delay(failures: u32) -> Duration {
+/// in-session RPC retry without duplicating the math. Callers in the
+/// RPC retry path always pass `boot_window: false` — that fast-retry
+/// regime applies only to the connect loop.
+pub(crate) fn backoff_delay(failures: u32, boot_window: bool) -> Duration {
+    if boot_window {
+        return BOOT_RETRY;
+    }
     let exp = failures.saturating_sub(1).min(5);
     let secs = 1u64 << exp;
     Duration::from_secs(secs.min(MAX_BACKOFF_SECS))
@@ -695,30 +748,58 @@ mod tests {
 
     #[test]
     fn backoff_follows_exponential_curve_then_caps() {
-        assert_eq!(backoff_delay(0), Duration::from_secs(1));
-        assert_eq!(backoff_delay(1), Duration::from_secs(1));
-        assert_eq!(backoff_delay(2), Duration::from_secs(2));
-        assert_eq!(backoff_delay(3), Duration::from_secs(4));
-        assert_eq!(backoff_delay(4), Duration::from_secs(8));
-        assert_eq!(backoff_delay(5), Duration::from_secs(16));
-        assert_eq!(backoff_delay(6), Duration::from_secs(MAX_BACKOFF_SECS));
-        assert_eq!(backoff_delay(7), Duration::from_secs(MAX_BACKOFF_SECS));
+        assert_eq!(backoff_delay(0, false), Duration::from_secs(1));
+        assert_eq!(backoff_delay(1, false), Duration::from_secs(1));
+        assert_eq!(backoff_delay(2, false), Duration::from_secs(2));
+        assert_eq!(backoff_delay(3, false), Duration::from_secs(4));
+        assert_eq!(backoff_delay(4, false), Duration::from_secs(8));
+        assert_eq!(backoff_delay(5, false), Duration::from_secs(16));
         assert_eq!(
-            backoff_delay(u32::MAX),
+            backoff_delay(6, false),
             Duration::from_secs(MAX_BACKOFF_SECS)
         );
+        assert_eq!(
+            backoff_delay(7, false),
+            Duration::from_secs(MAX_BACKOFF_SECS)
+        );
+        assert_eq!(
+            backoff_delay(u32::MAX, false),
+            Duration::from_secs(MAX_BACKOFF_SECS)
+        );
+    }
+
+    #[test]
+    fn backoff_uses_boot_retry_inside_boot_window_regardless_of_failures() {
+        // While `boot_window` is true, the failure count is ignored and
+        // we always return the fast-retry interval. This is what lets
+        // the launcher pick up Core within ~250 ms of HTTP bind on a
+        // cold MiSTer boot, instead of being stuck in a 16 s
+        // exponential slot.
+        assert_eq!(backoff_delay(0, true), BOOT_RETRY);
+        assert_eq!(backoff_delay(1, true), BOOT_RETRY);
+        assert_eq!(backoff_delay(5, true), BOOT_RETRY);
+        assert_eq!(backoff_delay(u32::MAX, true), BOOT_RETRY);
     }
 
     /// Replays a scripted sequence of connect outcomes through
     /// `ConnectionFsm` and returns the distinct sequence of states
     /// published to the watch — i.e. the public-visible transitions.
     /// `outcomes` is `Ok(())` for a successful connect or `Err(msg)` for
-    /// a failed connect attempt.
+    /// a failed connect attempt. Models the post-boot-window steady
+    /// state; for boot-window scenarios use [`replay_with_window`].
     fn replay(outcomes: &[Result<(), &str>]) -> Vec<ConnectionState> {
+        replay_with_window(&outcomes.iter().map(|o| (false, *o)).collect::<Vec<_>>())
+    }
+
+    /// Like [`replay`] but each outcome carries an explicit
+    /// `boot_window` flag, so tests can model the cold-boot fast-retry
+    /// regime (where failures don't escalate to `Unreachable`) and the
+    /// transition out of it.
+    fn replay_with_window(outcomes: &[(bool, Result<(), &str>)]) -> Vec<ConnectionState> {
         let mut fsm = ConnectionFsm::default();
         let mut current = ConnectionState::Disconnected;
         let mut log = Vec::new();
-        for outcome in outcomes {
+        for (boot_window, outcome) in outcomes {
             if let Some(next) = fsm.before_attempt(&current) {
                 current = next.clone();
                 log.push(next);
@@ -730,7 +811,7 @@ mod tests {
                     log.push(next);
                 }
                 Err(e) => {
-                    if let Some(next) = fsm.on_attempt_failed((*e).to_string()) {
+                    if let Some(next) = fsm.on_attempt_failed((*e).to_string(), *boot_window) {
                         current = next.clone();
                         log.push(next);
                     }
@@ -818,6 +899,57 @@ mod tests {
                 ConnectionState::Unreachable("flaky".into()),
                 ConnectionState::Connected,
             ],
+        );
+    }
+
+    #[test]
+    fn boot_window_failures_do_not_escalate_to_unreachable() {
+        // Many failed attempts entirely inside the boot window. We
+        // should publish `Connecting` once and then stay silent —
+        // boot-window failures are expected (Core is starting up) and
+        // must not flip the UI to "Core unreachable".
+        let script: Vec<(bool, Result<(), &str>)> = (0..(RETRY_ERROR_THRESHOLD * 2) as usize)
+            .map(|_| (true, Err("conn refused")))
+            .collect();
+        let log = replay_with_window(&script);
+        assert_eq!(log, vec![ConnectionState::Connecting]);
+    }
+
+    #[test]
+    fn boot_window_fast_path_then_steady_state_unreachable() {
+        // Boot-window fast retries fail without escalating. Once we
+        // exit the boot window (timer expired without a successful
+        // connect), the steady-state regime takes over and the next
+        // RETRY_ERROR_THRESHOLD failures publish Unreachable.
+        let mut script: Vec<(bool, Result<(), &str>)> =
+            (0..50).map(|_| (true, Err("conn refused"))).collect();
+        for _ in 0..RETRY_ERROR_THRESHOLD {
+            script.push((false, Err("conn refused")));
+        }
+        let log = replay_with_window(&script);
+        assert_eq!(
+            log,
+            vec![
+                ConnectionState::Connecting,
+                ConnectionState::Unreachable("conn refused".into()),
+            ],
+        );
+    }
+
+    #[test]
+    fn boot_window_then_successful_connect_is_clean() {
+        // The expected MiSTer cold-boot path: a burst of refused
+        // connects while Core's HTTP server is still binding, then a
+        // successful connect once it's up. The launcher should publish
+        // exactly Connecting → Connected with no Unreachable in
+        // between.
+        let mut script: Vec<(bool, Result<(), &str>)> =
+            (0..30).map(|_| (true, Err("conn refused"))).collect();
+        script.push((true, Ok(())));
+        let log = replay_with_window(&script);
+        assert_eq!(
+            log,
+            vec![ConnectionState::Connecting, ConnectionState::Connected],
         );
     }
 }

--- a/rust/zaparoo-core/src/remote_resource.rs
+++ b/rust/zaparoo-core/src/remote_resource.rs
@@ -262,7 +262,11 @@ async fn run_connected<T, F, Fut>(
                     message: e.message,
                     retrying: true,
                 });
-                let delay = backoff_delay(rpc_failures);
+                // RPC-level retries always use the steady-state curve;
+                // the connect-loop's boot-window fast retry doesn't
+                // apply here because we only reach this path after a
+                // successful WebSocket session is up.
+                let delay = backoff_delay(rpc_failures, false);
                 // refetch wins over the backoff timer: explicit
                 // invalidation should retry immediately, not wait out
                 // the existing schedule. Falling through either of the

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -1106,6 +1106,14 @@ MainLayout {
         repeatTick.stop()
         root._heldAction = ""
         root._heldKey = 0
+        // Hold-release commits whatever cell the user landed on. Games
+        // screen debounces its `set_selected_at_top` writes (one atomic
+        // disk write per move would batter MiSTer's SD card on a Down-
+        // hold through 20+ pages); the flush here lands the final
+        // selection so a kill during launch resumes on the right entry.
+        // No-op when no persist is pending or when another screen is
+        // active.
+        root.gamesScreen.flushSelectedPersist()
     }
 
     function _isRepeatableAction(action: string): bool {

--- a/src/ui/components/PagedGrid.qml
+++ b/src/ui/components/PagedGrid.qml
@@ -78,7 +78,21 @@ Item {
     readonly property int rows:
         rowsOverride > 0 ? rowsOverride : Sizing.gridRows
     readonly property int pageSize: columns * rows
-    readonly property int pageCount: Math.max(1, Math.ceil(itemCount / pageSize))
+    // Snap to the last fully-loaded page boundary while more chunks are
+    // still on the way. Otherwise the user reaches a half-full trailing
+    // page, sees "Loading more…", then watches the rest pop in mid-page
+    // when the chunk lands. Once `hasMorePages` flips false the partial
+    // last page becomes legitimate (it's the real end of the dataset)
+    // and we ceil to include it. The `Math.max(1, ...)` floor guard
+    // keeps the very first sub-page-sized load from collapsing pageCount
+    // to 0 while the initial chunk is still landing.
+    readonly property int pageCount: {
+        if (itemCount <= 0)
+            return 1
+        if (root.hasMorePages)
+            return Math.max(1, Math.floor(itemCount / pageSize))
+        return Math.ceil(itemCount / pageSize)
+    }
     readonly property int currentPage: Math.floor(currentIndex / pageSize)
     readonly property int currentColumn: (currentIndex % pageSize) % columns
     readonly property int currentRow: Math.floor((currentIndex % pageSize) / columns)
@@ -104,6 +118,25 @@ Item {
         totalItemsOverride >= 0 ? totalItemsOverride : itemCount
     readonly property int totalPageCount:
         Math.max(1, Math.ceil(totalItems / pageSize))
+
+    // Caller-supplied "more pages exist" flag for paginated models.
+    // Drives the pending-target watchdog: if the model says no more pages
+    // are coming but the pending target still isn't loaded, we settle on
+    // whatever's loaded rather than spinning forever. Non-paginated
+    // callers leave this false; their pending targets always resolve
+    // immediately because totalPageCount === pageCount.
+    property bool hasMorePages: false
+
+    // Pending wrap-target state. Set by Up-at-page-0, Down-past-last-
+    // loaded, and pageBy when the destination page hasn't been fetched
+    // yet. The grid fires `loadMoreRequested` and waits for `itemCount`
+    // to grow; once the target page is loaded, it commits the move and
+    // clears these. Cleared on any directional move that doesn't match
+    // the pending intent (Left/Right, opposite-direction Up/Down) and on
+    // model resets (itemCount shrink). -1 means "no pending jump".
+    property int _pendingTargetPage: -1
+    property int _pendingTargetRow: 0
+    property int _pendingTargetCol: 0
 
     // Reserved chrome around the cell area. Vertical insets must be
     // large enough to contain the focused tile's 1.06× scale bleed
@@ -172,21 +205,34 @@ Item {
     }
 
     // Jump the selection by `delta` whole pages. Wraps in both
-    // directions to mirror moveSelection's column-edge behavior:
-    // - delta > 0 past the last page wraps to page 0
-    // - delta < 0 from page 0 wraps to the last page
-    // The target lands on (targetPage, currentRow, currentColumn) when
-    // that slot exists; on a partial last page it clamps to the last
-    // existing item on that page so the user always moves rather than
-    // sticking on a hole. Returns true if the index actually changed.
-    // No-op (returns false) on a single-page dataset since wrap on
-    // page 0 ↔ page 0 wouldn't move anything.
+    // directions over the dataset's `totalPageCount`, not just the
+    // loaded slice, so paginated callers (Games) wrap to the true last
+    // page rather than the last *loaded* page. If the target page
+    // isn't loaded yet, the move is deferred via `_pendingTargetPage`:
+    // the grid fires `loadMoreRequested` and commits the jump once
+    // `itemCount` grows enough to cover the target. The target lands on
+    // (targetPage, currentRow, currentColumn) when that slot exists;
+    // on a partial last page it clamps to the last existing item.
+    // Returns true if the index changed synchronously, false if a
+    // pending-jump was stashed or the dataset is single-page.
     function pageBy(delta: int): bool {
-        if (root.itemCount <= 0 || root.pageCount <= 1 || delta === 0)
+        if (root.itemCount <= 0 || root.totalPageCount <= 1 || delta === 0)
             return false
-        const total = root.pageCount
+        const total = root.totalPageCount
         // JS `%` keeps sign on negatives — normalise into [0, total).
         const targetPage = ((root.currentPage + delta) % total + total) % total
+        if (targetPage === root.currentPage)
+            return false
+        if (targetPage > root.pageCount - 1) {
+            // Target page hasn't been fetched yet. Stash the intent and
+            // let the itemCount-change watcher commit it.
+            root._pendingTargetPage = targetPage
+            root._pendingTargetRow = root.currentRow
+            root._pendingTargetCol = root.currentColumn
+            root.loadMoreRequested()
+            return false
+        }
+        root._pendingTargetPage = -1
         const targetSlot =
             targetPage * root.pageSize
             + root.currentRow * root.columns
@@ -205,6 +251,63 @@ Item {
         if (root.currentPage >= root.pageCount - 2)
             root.loadMoreRequested()
         return true
+    }
+
+    // Commit the pending target move once the destination slot is
+    // loaded, or settle on the loaded last when the model says no more
+    // pages are coming. Wired into `onItemCountChanged` so every
+    // fetch-more append re-evaluates it; also fires from the
+    // `hasMorePages` watcher so a final empty append still resolves
+    // a chain. Waiting on the exact target index (not just `pageCount`
+    // catching up) avoids an early commit while the Repeater is mid-
+    // materialisation: the target page may report `pageCount` reached
+    // while the row/col slot itself isn't realised yet.
+    function _commitPendingTarget(): void {
+        if (root._pendingTargetPage < 0)
+            return
+        // Total may have shrunk under us (e.g. Core revised total_files
+        // downward); clamp the target to whatever the dataset reports
+        // now so we never overshoot.
+        const totalLast = root.totalPageCount - 1
+        const targetPage = Math.min(root._pendingTargetPage, totalLast)
+        if (targetPage < 0) {
+            root._pendingTargetPage = -1
+            return
+        }
+        const targetIdx = targetPage * root.pageSize
+                          + root._pendingTargetRow * root.columns
+                          + root._pendingTargetCol
+        if (targetIdx >= root.itemCount) {
+            // Specific (page, row, col) slot not realised yet.
+            if (root.hasMorePages) {
+                // Keep the chain going; `fetch_more` is debounced
+                // model-side via `loading_more`, so a redundant emit
+                // is cheap.
+                root.loadMoreRequested()
+                return
+            }
+            // Model says no more pages are coming. Settle on the
+            // target page's last loaded item if it has any; otherwise
+            // fall back to the dataset's overall loaded last so the
+            // user's "go to end" intent isn't ignored.
+            root._pendingTargetPage = -1
+            const pageStart = targetPage * root.pageSize
+            const lastLoadedOnPage =
+                Math.min((targetPage + 1) * root.pageSize,
+                         root.itemCount) - 1
+            if (lastLoadedOnPage >= pageStart) {
+                if (lastLoadedOnPage !== root.currentIndex)
+                    root.currentIndex = lastLoadedOnPage
+                return
+            }
+            const overall = root.itemCount - 1
+            if (overall >= 0 && overall !== root.currentIndex)
+                root.currentIndex = overall
+            return
+        }
+        root._pendingTargetPage = -1
+        if (targetIdx !== root.currentIndex)
+            root.currentIndex = targetIdx
     }
 
     // Step the selection by (dCol, dRow). Returns true if the index
@@ -242,6 +345,9 @@ Item {
         // to the row's actual filled span so a partial last row cycles
         // among its own items rather than walking through a hole.
         if (dCol !== 0) {
+            // Sideways step changes the user's intent — drop any
+            // pending wrap-target chain we were waiting on.
+            root._pendingTargetPage = -1
             const rowFirstIndex =
                 root.currentPage * root.pageSize
                 + root.currentRow * root.columns
@@ -258,9 +364,14 @@ Item {
                 newCol = colCandidate
         }
 
-        // Vertical wrap crosses page boundaries; the partial-page hole
-        // clamp below covers the case where the target column doesn't
-        // exist on the destination page.
+        // Vertical wrap crosses page boundaries against the dataset's
+        // `totalPageCount`, not the loaded slice. When the destination
+        // page hasn't been fetched yet (Up at page 0 with partial load,
+        // Down past last-loaded but more pages exist), stash a
+        // pending-target jump and ask the model to fetch — the
+        // `onItemCountChanged` handler commits the jump once the page
+        // lands. The partial-page hole clamp below covers the column-
+        // doesn't-exist-on-destination case once the data is present.
         //
         // A Down step that lands in an empty row of a partial last
         // page (rowCandidate fits inside `rows` but is past the page's
@@ -276,15 +387,32 @@ Item {
             const lastFilledRowOnPage =
                 Math.floor((itemsOnPage - 1) / root.columns)
             if (rowCandidate < 0) {
-                newPage = root.currentPage === 0
-                          ? root.pageCount - 1
-                          : root.currentPage - 1
+                const targetPage = root.currentPage === 0
+                                   ? root.totalPageCount - 1
+                                   : root.currentPage - 1
+                if (targetPage > root.pageCount - 1) {
+                    root._pendingTargetPage = targetPage
+                    root._pendingTargetRow = root.rows - 1
+                    root._pendingTargetCol = root.currentColumn
+                    root.loadMoreRequested()
+                    return false
+                }
+                newPage = targetPage
                 newRow = root.rows - 1
             } else if (rowCandidate >= root.rows
                        || rowCandidate > lastFilledRowOnPage) {
-                newPage = root.currentPage === root.pageCount - 1
-                          ? 0
-                          : root.currentPage + 1
+                const lastPage = root.totalPageCount - 1
+                const targetPage = root.currentPage === lastPage
+                                   ? 0
+                                   : root.currentPage + 1
+                if (targetPage > root.pageCount - 1) {
+                    root._pendingTargetPage = targetPage
+                    root._pendingTargetRow = 0
+                    root._pendingTargetCol = root.currentColumn
+                    root.loadMoreRequested()
+                    return false
+                }
+                newPage = targetPage
                 newRow = 0
             } else {
                 newRow = rowCandidate
@@ -312,6 +440,9 @@ Item {
                 root.loadMoreRequested()
             return false
         }
+        // Successful directional move clears any pending wrap-target;
+        // the user is no longer waiting on it.
+        root._pendingTargetPage = -1
         root.currentIndex = newIndex
         // Pre-fetch one page early — when the user enters the
         // second-to-last loaded page, kick off the next fetch so the
@@ -330,10 +461,32 @@ Item {
     // currentIndex untouched.
     property int _previousItemCount: 0
 
+    // If `hasMorePages` flips false while a pending target is still
+    // ahead of the loaded slice, the watchdog branch in
+    // `_commitPendingTarget` settles us on the loaded last item.
+    // itemCount-change usually fires this path first, but this handler
+    // covers the case where the flag is updated without an item delta
+    // (e.g. a final empty append).
+    onHasMorePagesChanged: {
+        if (root._pendingTargetPage >= 0)
+            root._commitPendingTarget()
+    }
+
     onItemCountChanged: {
-        if (root.itemCount < root._previousItemCount &&
-            root.currentIndex >= root.itemCount) {
-            root.currentIndex = Math.max(0, root.itemCount - 1)
+        if (root.itemCount < root._previousItemCount) {
+            // Model shed rows (reset, system change, path change). The
+            // pending-target context no longer applies — drop it before
+            // the row-count check below moves currentIndex.
+            root._pendingTargetPage = -1
+            if (root.currentIndex >= root.itemCount)
+                root.currentIndex = Math.max(0, root.itemCount - 1)
+        } else if (root.itemCount > root._previousItemCount) {
+            // Pages were appended. If a wrap-target jump is pending,
+            // try to commit it now; the helper chains another
+            // `loadMoreRequested` if the target is still ahead, or
+            // settles on the loaded last item if `hasMorePages`
+            // says no more pages are coming.
+            root._commitPendingTarget()
         }
         root._previousItemCount = root.itemCount
     }

--- a/src/ui/components/PagedGrid.qml
+++ b/src/ui/components/PagedGrid.qml
@@ -646,13 +646,20 @@ Item {
                     // binding cost stays roughly constant as the
                     // dataset grows.
                     active: cellItem._coverInRetentionRange
-                    // Incubate Tile construction on background frames
-                    // so a retention-edge crossing (10 cells flipping
-                    // active) doesn't block the main thread. The
-                    // newly-revealed cells fill in over the next
-                    // frame or two; the user's selection move lands
-                    // immediately.
-                    asynchronous: true
+                    // Visible page loads synchronously so all of its
+                    // tiles appear in the same frame instead of
+                    // streaming in via the QQmlIncubator queue (whose
+                    // traversal order looks "reverse-of-creation" to
+                    // the eye). The cover gate already hides this
+                    // ~pageSize x ~7ms block during cold start.
+                    //
+                    // Off-page cells (within retention but cellPage
+                    // != currentPage) stay asynchronous so a
+                    // retention-edge crossing (10 cells flipping
+                    // active in one frame) doesn't block the main
+                    // thread. They fill in over the next few frames;
+                    // the user's selection move lands immediately.
+                    asynchronous: cellItem.cellPage !== root.currentPage
                     isSelected: cellItem.isSelected
                     isFocused: root.focused
                     name: cellItem.name

--- a/src/ui/components/PagedGrid.qml
+++ b/src/ui/components/PagedGrid.qml
@@ -77,6 +77,15 @@ Item {
         columnsOverride > 0 ? columnsOverride : Sizing.gridColumns
     readonly property int rows:
         rowsOverride > 0 ? rowsOverride : Sizing.gridRows
+
+    // Pages of buffer to keep ahead of the user's current page before
+    // firing `loadMoreRequested`. With `loadAheadPages: 2` the trigger
+    // fires when the user enters the second-to-last loaded page,
+    // overlapping the RPC + model insert with a full page of selection
+    // travel so the new chunk lands before they reach the loaded edge.
+    // The model's `loading_more` debounce collapses repeated emissions
+    // while a fetch is in flight, so firing earlier doesn't fan out.
+    property int loadAheadPages: 2
     readonly property int pageSize: columns * rows
     // Snap to the last fully-loaded page boundary while more chunks are
     // still on the way. Otherwise the user reaches a half-full trailing
@@ -137,6 +146,13 @@ Item {
     property int _pendingTargetPage: -1
     property int _pendingTargetRow: 0
     property int _pendingTargetCol: 0
+
+    // True while a wrap / shoulder-jump / hold-Down-past-edge move is
+    // stashed waiting on a fetch. Screens use this to gate the
+    // "Loading more..." indicator so background prefetches stay
+    // silent — the indicator only paints when the user is genuinely
+    // waiting on input they've already given.
+    readonly property bool hasPendingTarget: _pendingTargetPage >= 0
 
     // Reserved chrome around the cell area. Vertical insets must be
     // large enough to contain the focused tile's 1.06× scale bleed
@@ -245,10 +261,10 @@ Item {
         if (newIndex === root.currentIndex)
             return false
         root.currentIndex = newIndex
-        // Mirror moveSelection's pre-fetch: when we cross into the
-        // second-to-last loaded page, kick a fetch so the next page
-        // boundary lands on freshly loaded rows.
-        if (root.currentPage >= root.pageCount - 2)
+        // Mirror moveSelection's pre-fetch: when we cross within
+        // `loadAheadPages` of the loaded edge, kick a fetch so the next
+        // page boundary lands on freshly loaded rows.
+        if (root.currentPage >= root.pageCount - root.loadAheadPages - 1)
             root.loadMoreRequested()
         return true
     }
@@ -433,10 +449,11 @@ Item {
         }
         if (newIndex === root.currentIndex) {
             // Selection didn't move because the user is at an edge with
-            // no data beyond it on this side. If they're at or past the
-            // penultimate loaded page, ask the model to fetch more so a
-            // subsequent press can land on freshly-loaded rows.
-            if (root.currentPage >= root.pageCount - 2)
+            // no data beyond it on this side. If they're within
+            // `loadAheadPages` of the loaded edge, ask the model to
+            // fetch more so a subsequent press can land on freshly-
+            // loaded rows.
+            if (root.currentPage >= root.pageCount - root.loadAheadPages - 1)
                 root.loadMoreRequested()
             return false
         }
@@ -444,13 +461,13 @@ Item {
         // the user is no longer waiting on it.
         root._pendingTargetPage = -1
         root.currentIndex = newIndex
-        // Pre-fetch one page early — when the user enters the
-        // second-to-last loaded page, kick off the next fetch so the
-        // network round-trip overlaps with a full page of cell
-        // traversal and the new page lands before they cross the
-        // boundary. The model's own debounce (loading_more guard)
-        // collapses repeated emissions while a fetch is in flight.
-        if (root.currentPage >= root.pageCount - 2)
+        // Pre-fetch early - when the user enters within `loadAheadPages`
+        // of the loaded edge, kick off the next fetch so the network
+        // round-trip and model insert overlap with selection travel,
+        // and the new chunk lands before they cross the boundary. The
+        // model's own debounce (`loading_more` guard) collapses
+        // repeated emissions while a fetch is in flight.
+        if (root.currentPage >= root.pageCount - root.loadAheadPages - 1)
             root.loadMoreRequested()
         return true
     }
@@ -532,42 +549,42 @@ Item {
                 readonly property int cellCol: cellLocal % root.columns
                 readonly property bool isSelected: index === root.currentIndex
 
-                // Cover-load gate. PagedGrid's Repeater materialises every
-                // model row at construction, so without a gate every loaded
-                // cell would fire its image-provider request immediately
-                // and saturate the async pool — visible-page covers then
-                // can't finish decoding before the cover gate releases,
-                // which produces the per-tile pop-in we tried to fix in
-                // v1.
+                // Cover-load gate AND delegate-materialisation gate.
+                // PagedGrid's Repeater creates one cellItem per model
+                // row at construction. Two-tier gate, both anchored on
+                // distance from `root.currentPage`:
                 //
-                // Two-tier gate:
-                //   - request range (±2 pages): cells inside this radius
-                //     fire image-provider requests. Bounds the initial
-                //     fanout to a fixed ~50 covers while still
+                //   - request range (±2 pages): cells inside this
+                //     radius fire image-provider requests. Bounds the
+                //     initial fanout to a fixed ~50 covers while still
                 //     pre-decoding pages N+1 and N+2 so a forward PgDn
                 //     lands on already-cached pixmaps.
-                //   - retention range (±5 pages): cells already requested
-                //     keep their TileLoader coverKey set so Tile's Image
-                //     keeps the decoded texture *referenced*. That
-                //     prevents QQuickPixmapCache from evicting it when
-                //     the user pages on, so a back-nav within the
-                //     retention window doesn't pay re-decode. Cells that
-                //     are in retention range but were never requested
-                //     stay gated to "" — retention doesn't get to trigger
-                //     new requests, only to keep already-loaded ones
-                //     alive.
+                //   - retention range (±5 pages): cells inside this
+                //     radius keep their TileLoader.active=true so the
+                //     Tile delegate stays materialised, AND cells that
+                //     have already requested keep their coverKey set
+                //     so Tile's Image keeps the decoded texture
+                //     referenced. The active gate is what prevents
+                //     per-press binding cost from growing with the
+                //     dataset - only ~110 Tile delegates exist at any
+                //     time regardless of N. Retention doesn't trigger
+                //     new cover requests; only the request range does.
                 //
-                // Off-radius cells (outside both ranges, or in retention
-                // range without ever having been requested) set their
-                // coverKey to "" so Tile's Image collapses to source: ""
-                // and the texture reference drops; Qt may evict.
+                // Off-radius cells (outside retention) set
+                // `TileLoader.active=false`, which destroys the
+                // loaded Tile delegate (Image, name Text, focus ring,
+                // favorite indicator) and detaches its binding tree.
+                // Cells inside retention but never requested keep the
+                // delegate alive but with coverKey="", so the cover
+                // collapses to the procedural fallback and the
+                // texture reference drops.
                 //
-                // Memory ceiling: ±5 around currentPage = up to 11 pages
-                // × pageSize covers ≈ 110 covers ≈ 40 MB decoded — OK on
-                // MiSTer's shared 512 MB. The decoders run at nice +10
-                // (see media_image_provider.cpp), so a re-decode after
-                // crossing past the retention edge is invisible to the
-                // renderer.
+                // Memory ceiling: ±5 around currentPage = up to 11
+                // pages × pageSize covers ≈ 110 covers ≈ 40 MB
+                // decoded - OK on MiSTer's shared 512 MB. Re-decode
+                // after crossing past the retention edge runs at
+                // nice +10 (see media_image_provider.cpp) and is
+                // invisible to the renderer.
                 readonly property bool _coverInRange:
                     Math.abs(cellPage - root.currentPage) <= 2
                 readonly property bool _coverInRetentionRange:
@@ -594,9 +611,48 @@ Item {
                 z: isSelected ? 1 : 0
                 visible: cellPage === root.currentPage
 
+                // Card-shaped placeholder painted behind the
+                // TileLoader. When the loader's `active` is false
+                // (cell is outside the retention window) or the Tile
+                // is still incubating asynchronously after a
+                // retention-edge crossing, the user sees this flat
+                // card slot instead of an empty pit. Once the Tile
+                // finishes incubating it paints opaque on top with
+                // the same color and radius, so the silhouette is
+                // hidden for free without an explicit visibility
+                // gate. No bindings on `root.currentPage` or
+                // `root.currentIndex` so it doesn't reintroduce the
+                // per-press fan-out we just bounded; the Repeater's
+                // visibility gate (cellPage === currentPage on the
+                // parent) means only ~pageSize silhouettes paint
+                // per frame.
+                Rectangle {
+                    anchors.fill: parent
+                    radius: Sizing.cornerRadius
+                    color: Theme.surfaceCard
+                }
+
                 TileLoader {
                     anchors.fill: parent
                     sourceComponent: root.delegate
+                    // Bound delegate materialisation to the retention
+                    // window. Cells outside +/-5 pages keep their
+                    // cellItem (Repeater contract - it owns one item
+                    // per model row) but don't construct a Tile, so
+                    // the loaded delegate's binding tree (cover Image,
+                    // focus ring, name Text, favorite indicator)
+                    // doesn't fan out on every selection move. With
+                    // ~110 active tiles instead of N, per-press
+                    // binding cost stays roughly constant as the
+                    // dataset grows.
+                    active: cellItem._coverInRetentionRange
+                    // Incubate Tile construction on background frames
+                    // so a retention-edge crossing (10 cells flipping
+                    // active) doesn't block the main thread. The
+                    // newly-revealed cells fill in over the next
+                    // frame or two; the user's selection move lands
+                    // immediately.
+                    asynchronous: true
                     isSelected: cellItem.isSelected
                     isFocused: root.focused
                     name: cellItem.name

--- a/src/ui/components/PagedGrid.qml
+++ b/src/ui/components/PagedGrid.qml
@@ -646,20 +646,13 @@ Item {
                     // binding cost stays roughly constant as the
                     // dataset grows.
                     active: cellItem._coverInRetentionRange
-                    // Visible page loads synchronously so all of its
-                    // tiles appear in the same frame instead of
-                    // streaming in via the QQmlIncubator queue (whose
-                    // traversal order looks "reverse-of-creation" to
-                    // the eye). The cover gate already hides this
-                    // ~pageSize x ~7ms block during cold start.
-                    //
-                    // Off-page cells (within retention but cellPage
-                    // != currentPage) stay asynchronous so a
-                    // retention-edge crossing (10 cells flipping
-                    // active in one frame) doesn't block the main
-                    // thread. They fill in over the next few frames;
-                    // the user's selection move lands immediately.
-                    asynchronous: cellItem.cellPage !== root.currentPage
+                    // Incubate Tile construction on background frames
+                    // so a retention-edge crossing (10 cells flipping
+                    // active) doesn't block the main thread. The
+                    // newly-revealed cells fill in over the next
+                    // frame or two; the user's selection move lands
+                    // immediately.
+                    asynchronous: true
                     isSelected: cellItem.isSelected
                     isFocused: root.focused
                     name: cellItem.name

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -51,13 +51,57 @@ Item {
     // pops one level off the stack and rebrowses the parent.
     signal requestNavigateOutOfFolder()
 
+    // Persist debounce. Writing `state.toml` is an atomic
+    // write+sync_all+rename (`rust/zaparoo-core/src/persist.rs`); on
+    // MiSTer's SD card that's a real disk hit, and the hold-repeat tick
+    // in `Main.qml` (`_repeatTickMs = 90`) means a long Down-hold would
+    // fire ~11 of these per second. We coalesce them: each move stamps
+    // `_pendingSelectedPath` and restarts the timer; the final flush
+    // lands on hold release / Accept / Cancel via the helpers below
+    // (`Main.qml`'s `_stopRepeat` calls `flushSelectedPersist`). The
+    // 250 ms interval is shorter than a deliberate single tap → hold
+    // gap, so isolated presses still persist quickly.
+    property string _pendingSelectedPath: ""
+
+    Timer {
+        id: persistDebounce
+        interval: 250
+        repeat: false
+        onTriggered: {
+            if (games._pendingSelectedPath !== "")
+                Browse.GamesState.set_selected_at_top(
+                    games._pendingSelectedPath)
+            games._pendingSelectedPath = ""
+        }
+    }
+
+    function _scheduleSelectedPersist(path: string): void {
+        games._pendingSelectedPath = path
+        persistDebounce.restart()
+    }
+
+    // Force any pending persist to land synchronously. Called from the
+    // Accept path (we hand control off to launch and the kill-resume
+    // guarantee depends on the latest selection being on disk), from
+    // Cancel/Escape (about to flip screens), and from `Main.qml`'s
+    // `_stopRepeat` so dpad release commits the latest cell.
+    function flushSelectedPersist(): void {
+        if (!persistDebounce.running && games._pendingSelectedPath === "")
+            return
+        persistDebounce.stop()
+        if (games._pendingSelectedPath !== "")
+            Browse.GamesState.set_selected_at_top(
+                games._pendingSelectedPath)
+        games._pendingSelectedPath = ""
+    }
+
     // Move selection by (dx, dy) and commit the new selection on
     // success. Unlike HubScreen's _handleSystems, none of the games-grid
     // directions have a row-edge escape branch, so all four cardinal
     // actions share this exact body.
     function _performMove(dx: int, dy: int): void {
         if (games.gamesGrid.moveSelection(dx, dy))
-            Browse.GamesState.set_selected_at_top(
+            games._scheduleSelectedPersist(
                 Browse.GamesModel.path_at(games.gamesGrid.currentIndex))
     }
 
@@ -66,7 +110,7 @@ Item {
     // tracks whichever item the user lands on.
     function _performPage(delta: int): void {
         if (games.gamesGrid.pageBy(delta))
-            Browse.GamesState.set_selected_at_top(
+            games._scheduleSelectedPersist(
                 Browse.GamesModel.path_at(games.gamesGrid.currentIndex))
     }
 
@@ -74,7 +118,7 @@ Item {
         if (index < 0 || index >= games.gamesGrid.itemCount)
             return
         games.gamesGrid.currentIndex = index
-        Browse.GamesState.set_selected_at_top(
+        games._scheduleSelectedPersist(
             Browse.GamesModel.path_at(games.gamesGrid.currentIndex))
     }
 
@@ -151,9 +195,11 @@ Item {
             // without navigating, leaving the saved selection stale
             // from a prior system. Writing here makes the commit
             // explicit so a kill during launch resumes on the correct
-            // entry.
-            Browse.GamesState.set_selected_at_top(
+            // entry. Schedule + flush so the debounced timer doesn't
+            // strand a later move past launch handoff.
+            games._scheduleSelectedPersist(
                 Browse.GamesModel.path_at(idx))
+            games.flushSelectedPersist()
             Browse.GamesModel.launch_at(idx)
         } else if (action === "write_card") {
             if (games.gamesGrid.itemCount > 0) {
@@ -162,12 +208,14 @@ Item {
                 const entryType = Browse.GamesModel.entry_type_at(idx)
                 if (entryType === "directory" || entryType === "root")
                     return
-                Browse.GamesState.set_selected_at_top(
+                games._scheduleSelectedPersist(
                     Browse.GamesModel.path_at(idx))
+                games.flushSelectedPersist()
                 const rect = games.gamesGrid.currentCellRectIn(games)
                 games.requestContextMenu(idx, rect)
             }
         } else if (action === "cancel") {
+            games.flushSelectedPersist()
             if (games._atFolderLevel())
                 games.requestNavigateOutOfFolder()
             else
@@ -240,6 +288,13 @@ Item {
         // (same expression the top strip uses for `totalPages`).
         totalItemsOverride: Browse.GamesModel.dir_count
                             + Browse.GamesModel.total_files
+        // Drives the pending-target watchdog inside PagedGrid: while
+        // this is true, an Up-at-page-1 (or Down-past-last-loaded)
+        // wrap-target chains additional `loadMoreRequested` emissions
+        // until the destination page lands. When it flips false with
+        // a target still ahead of the loaded slice, the grid settles
+        // on the loaded last item rather than spinning forever.
+        hasMorePages: Browse.GamesModel.has_next_page
         onLoadMoreRequested: Browse.GamesModel.fetch_more()
         onItemHovered: (index) => games._focusIndex(index)
         onItemClicked: (index) => {
@@ -280,5 +335,26 @@ Item {
         count: Browse.GamesModel.count
         emptyText: qsTr("No games in this system")
         loadingText: qsTr("Loading games…")
+    }
+
+    // In-flight pagination cue. Sits on the ActiveLabel row at the
+    // same horizontal position as the grid's left content edge, so it
+    // never overlaps the bottom row of tiles and reads as part of the
+    // status band underneath the grid. Visible whenever `loading_more`
+    // is true and the screen body is otherwise on-screen — covers the
+    // hold-Down stall on the last loaded page, the wrap-to-last fetch
+    // chain when Up is pressed at page 0 with incomplete data, and the
+    // L/R shoulder jump-to-unloaded case. Hidden during transition or
+    // initial cover-gate so it never paints over the global "Loading…"
+    // overlay.
+    LoadingIndicator {
+        id: pageLoadingCue
+        visible: !games.transitioning
+                 && !games.coverGateLoading
+                 && Browse.GamesModel.loading_more
+        anchors.left: activeLabel.left
+        anchors.leftMargin: gamesGrid.leftInset
+        anchors.verticalCenter: activeLabel.verticalCenter
+        text: qsTr("Loading more…")
     }
 }

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -186,6 +186,12 @@ Item {
             const idx = games.gamesGrid.currentIndex
             const entryType = Browse.GamesModel.entry_type_at(idx)
             if (entryType === "directory" || entryType === "root") {
+                // Flush before push_level. The debounced timer writes to
+                // selected_at_level.last(); push_level appends a new ""
+                // entry for the child level, so a late flush would land
+                // the parent's selection on the just-pushed child level.
+                // Same handoff pattern as launch_at and cancel below.
+                games.flushSelectedPersist()
                 games.requestNavigateIntoFolder(Browse.GamesModel.path_at(idx))
                 return
             }

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -340,18 +340,22 @@ Item {
     // In-flight pagination cue. Sits on the ActiveLabel row at the
     // same horizontal position as the grid's left content edge, so it
     // never overlaps the bottom row of tiles and reads as part of the
-    // status band underneath the grid. Visible whenever `loading_more`
-    // is true and the screen body is otherwise on-screen — covers the
-    // hold-Down stall on the last loaded page, the wrap-to-last fetch
-    // chain when Up is pressed at page 0 with incomplete data, and the
-    // L/R shoulder jump-to-unloaded case. Hidden during transition or
-    // initial cover-gate so it never paints over the global "Loading…"
-    // overlay.
+    // status band underneath the grid. Visible only when the user is
+    // genuinely waiting on a fetch they triggered: a wrap-to-last,
+    // shoulder-jump, or hold-Down past the loaded edge stashes a
+    // pending target on PagedGrid, and that pending target is the
+    // signal that "the press did something, we're working on it".
+    // Background prefetches (look-ahead chunks the user hasn't
+    // bumped into yet) keep `loading_more` true but leave
+    // `hasPendingTarget` false, so the cue stays silent. Hidden
+    // during transition or initial cover-gate so it never paints
+    // over the global "Loading..." overlay.
     LoadingIndicator {
         id: pageLoadingCue
         visible: !games.transitioning
                  && !games.coverGateLoading
                  && Browse.GamesModel.loading_more
+                 && gamesGrid.hasPendingTarget
         anchors.left: activeLabel.left
         anchors.leftMargin: gamesGrid.leftInset
         anchors.verticalCenter: activeLabel.verticalCenter

--- a/tests/ui/tst_paged_grid.qml
+++ b/tests/ui/tst_paged_grid.qml
@@ -47,6 +47,12 @@ TestCase {
         delegate: cellDelegate
     }
 
+    SignalSpy {
+        id: loadMoreSpy
+        target: grid
+        signalName: "loadMoreRequested"
+    }
+
     function fillModel(count: int): void {
         model.clear()
         for (let i = 0; i < count; i++)
@@ -60,6 +66,7 @@ TestCase {
         Sizing.screenHeight = testCase.height
         fillModel(0)
         grid.setCurrentIndexImmediate(0)
+        loadMoreSpy.clear()
     }
 
     function test_geometry_matches_pinned_resolution(): void {
@@ -340,5 +347,194 @@ TestCase {
         compare(grid.totalPageCount, 5)
         grid.totalItemsOverride = -1
         compare(grid.totalPageCount, 2)
+    }
+
+    // ── Pending wrap-target (paginated dataset, partial load) ───────────
+    //
+    // GamesScreen sets `totalItemsOverride` to the dataset's true entry
+    // count and `hasMorePages` to `GamesModel.has_next_page`. When the
+    // user wraps onto an unloaded page, PagedGrid must:
+    //   - stash the (page, row, col) target,
+    //   - fire `loadMoreRequested` (the screen wires this to fetch_more),
+    //   - leave `currentIndex` untouched,
+    //   - commit the jump on the next `itemCount` growth that covers
+    //     the target,
+    //   - drop the pending intent on a sideways move,
+    //   - settle on the loaded last item if `hasMorePages` flips false
+    //     before the target is reached.
+    //
+    // Tests below set `totalItemsOverride = 60` (5 pages) but seed the
+    // model with 24 items (2 pages loaded) to mimic the partial-load
+    // state the user repro'd on Genesis "1 US - A-F".
+
+    function _setupPartialLoad(loaded: int, total: int): void {
+        fillModel(loaded)
+        grid.totalItemsOverride = total
+        grid.hasMorePages = true
+        grid.setCurrentIndexImmediate(0)
+        compare(grid.pageCount, Math.ceil(loaded / grid.pageSize))
+        compare(grid.totalPageCount, Math.ceil(total / grid.pageSize))
+    }
+
+    function _resetPartialLoadState(): void {
+        grid.totalItemsOverride = -1
+        grid.hasMorePages = false
+    }
+
+    function test_up_at_page_zero_unloaded_target_stashes_pending(): void {
+        // 24/60 — Up at index 0 targets the dataset's last page (page 4),
+        // which isn't loaded. Selection must not move; pending state set.
+        _setupPartialLoad(24, 60)
+        loadMoreSpy.clear()
+        compare(grid.moveSelection(0, -1), false)
+        compare(grid.currentIndex, 0,
+                "selection must not move while waiting for fetch")
+        compare(grid._pendingTargetPage, 4,
+                "pending target page should be the dataset's last")
+        compare(grid._pendingTargetRow, grid.rows - 1)
+        compare(grid._pendingTargetCol, 0)
+        verify(loadMoreSpy.count >= 1,
+               "expected loadMoreRequested to fire at least once")
+        _resetPartialLoadState()
+    }
+
+    function test_pending_target_commits_when_pages_load(): void {
+        // Set up the partial-load wrap, then grow the model to cover
+        // the target page. The itemCount-change handler must commit
+        // the jump.
+        _setupPartialLoad(24, 60)
+        compare(grid.moveSelection(0, -1), false)
+        compare(grid._pendingTargetPage, 4)
+        // Append the rest of the dataset in one go — pageCount jumps
+        // to 5, target page 4 is now loaded, jump commits.
+        for (let i = 24; i < 60; i++)
+            model.append({ "name": "item-" + i, "coverKey": "", "favorite": 0 })
+        tryCompare(grid, "itemCount", 60)
+        // Pending target row was rows-1 (=2), col 0; target index is
+        // page 4 base (48) + row 2 * 4 + col 0 = 56.
+        compare(grid.currentIndex, 56)
+        compare(grid._pendingTargetPage, -1,
+                "pending should clear after commit")
+        _resetPartialLoadState()
+    }
+
+    function test_pending_target_clamps_when_target_partial_page(): void {
+        // 24/50 — totalPageCount is 5 (last page partial: indices 48,49).
+        // Up wraps to (page 4, row 2, col 0) = 56, which doesn't exist.
+        // Selection waits while data loads; the model declares no more
+        // pages once total is in, and the watchdog settles us on the
+        // partial page's last existing item (49).
+        fillModel(24)
+        grid.totalItemsOverride = 50
+        grid.hasMorePages = true
+        grid.setCurrentIndexImmediate(0)
+        compare(grid.totalPageCount, 5)
+        compare(grid.moveSelection(0, -1), false)
+        compare(grid._pendingTargetPage, 4)
+        for (let i = 24; i < 50; i++)
+            model.append({ "name": "item-" + i, "coverKey": "", "favorite": 0 })
+        tryCompare(grid, "itemCount", 50)
+        // Target slot (idx 56) doesn't exist on the partial last page,
+        // so selection is still parked while we wait for "more". Real
+        // models flip `has_next_page` false at the end of pagination;
+        // the watchdog inside _commitPendingTarget then clamps to the
+        // last loaded item on the target page.
+        compare(grid.currentIndex, 0,
+                "still pending — target slot 56 doesn't exist yet")
+        grid.hasMorePages = false
+        compare(grid.currentIndex, 49,
+                "clamp to last existing item on the partial page")
+        _resetPartialLoadState()
+    }
+
+    function test_pending_target_chains_fetch_when_still_short(): void {
+        // 24/60 — Up at index 0 stashes target page 4. Append only one
+        // more page (12 items → 36 loaded, pageCount=3). Target still
+        // unreached; the handler must fire another loadMoreRequested
+        // and leave currentIndex untouched.
+        _setupPartialLoad(24, 60)
+        compare(grid.moveSelection(0, -1), false)
+        loadMoreSpy.clear()
+        for (let i = 24; i < 36; i++)
+            model.append({ "name": "item-" + i, "coverKey": "", "favorite": 0 })
+        tryCompare(grid, "itemCount", 36)
+        compare(grid.currentIndex, 0,
+                "still waiting on target page, selection unchanged")
+        compare(grid._pendingTargetPage, 4)
+        verify(loadMoreSpy.count >= 1,
+               "expected another loadMoreRequested after partial append")
+        _resetPartialLoadState()
+    }
+
+    function test_pending_target_settles_when_hasMorePages_clears(): void {
+        // 24/60 — but the model later reports no more pages without
+        // ever reaching pageCount=5. The watchdog branch in
+        // _commitPendingTarget must settle on the loaded last item
+        // (idx 23) so the user isn't stuck on the source cell.
+        _setupPartialLoad(24, 60)
+        compare(grid.moveSelection(0, -1), false)
+        compare(grid._pendingTargetPage, 4)
+        grid.hasMorePages = false
+        // No itemCount change is needed — the hasMorePages watcher
+        // fires _commitPendingTarget itself.
+        compare(grid._pendingTargetPage, -1,
+                "pending should clear once hasMorePages goes false")
+        compare(grid.currentIndex, grid.itemCount - 1,
+                "settle on the loaded last item")
+        _resetPartialLoadState()
+    }
+
+    function test_pending_target_cancels_on_horizontal_move(): void {
+        // After stashing a pending wrap target, a sideways move means
+        // the user changed intent — drop the pending jump.
+        _setupPartialLoad(24, 60)
+        grid.setCurrentIndexImmediate(1)
+        compare(grid.moveSelection(0, -1), false)
+        compare(grid._pendingTargetPage, 4)
+        // Right step within row should clear pending.
+        compare(grid.moveSelection(1, 0), true)
+        compare(grid._pendingTargetPage, -1)
+        _resetPartialLoadState()
+    }
+
+    function test_pending_target_clears_on_model_shrink(): void {
+        // A model reset (system change, path change) shrinks itemCount.
+        // The pending intent belongs to the previous dataset — drop it.
+        _setupPartialLoad(24, 60)
+        compare(grid.moveSelection(0, -1), false)
+        compare(grid._pendingTargetPage, 4)
+        model.clear()
+        tryCompare(grid, "itemCount", 0)
+        compare(grid._pendingTargetPage, -1)
+        _resetPartialLoadState()
+    }
+
+    function test_down_past_last_loaded_stashes_pending(): void {
+        // 24/60 — sit on the last filled row of the loaded slice
+        // (page 1 row 2 col 0 = idx 20). Down would advance to page 2,
+        // which isn't loaded. Stash, don't move.
+        _setupPartialLoad(24, 60)
+        grid.setCurrentIndexImmediate(20)
+        loadMoreSpy.clear()
+        compare(grid.moveSelection(0, 1), false)
+        compare(grid.currentIndex, 20)
+        compare(grid._pendingTargetPage, 2)
+        compare(grid._pendingTargetRow, 0)
+        compare(grid._pendingTargetCol, 0)
+        verify(loadMoreSpy.count >= 1)
+        _resetPartialLoadState()
+    }
+
+    function test_pageBy_past_loaded_stashes_pending(): void {
+        // 24/60 — pageBy(2) targets page 2, unloaded. Stash, don't move.
+        _setupPartialLoad(24, 60)
+        grid.setCurrentIndexImmediate(2)
+        compare(grid.pageBy(2), false)
+        compare(grid.currentIndex, 2,
+                "pageBy past loaded must not move synchronously")
+        compare(grid._pendingTargetPage, 2)
+        compare(grid._pendingTargetRow, 0)
+        compare(grid._pendingTargetCol, 2)
+        _resetPartialLoadState()
     }
 }

--- a/tests/ui/tst_paged_grid.qml
+++ b/tests/ui/tst_paged_grid.qml
@@ -64,6 +64,11 @@ TestCase {
     function init(): void {
         Sizing.screenWidth = testCase.width
         Sizing.screenHeight = testCase.height
+        // Reset paginated-state knobs so a leak from a failed test
+        // (which skips its cleanup) doesn't poison the next case's
+        // pageCount/totalPageCount math.
+        grid.hasMorePages = false
+        grid.totalItemsOverride = -1
         fillModel(0)
         grid.setCurrentIndexImmediate(0)
         loadMoreSpy.clear()
@@ -535,6 +540,71 @@ TestCase {
         compare(grid._pendingTargetPage, 2)
         compare(grid._pendingTargetRow, 0)
         compare(grid._pendingTargetCol, 2)
+        _resetPartialLoadState()
+    }
+
+    function test_loadAheadPages_default_is_two(): void {
+        // The default `loadAheadPages` keeps two pages of buffer ahead
+        // of the user before firing the prefetch. GamesScreen relies
+        // on this default and overrides it only if the trade-off
+        // changes.
+        compare(grid.loadAheadPages, 2)
+    }
+
+    function test_loadAheadPages_two_fires_at_pageCount_minus_three(): void {
+        // 60 items at pageSize 12 = 5 pages loaded. With
+        // loadAheadPages=2, the trigger fires when `currentPage >=
+        // pageCount - loadAheadPages - 1` = page 2. Start at idx 20
+        // (page 1, row 2, col 0) and step Down: the move advances to
+        // (page 2, row 0, col 0) = idx 24, which sits exactly on the
+        // threshold — loadMoreRequested must fire so the next chunk is
+        // in flight before the user reaches the loaded edge.
+        fillModel(60)
+        grid.hasMorePages = true
+        grid.setCurrentIndexImmediate(20)
+        loadMoreSpy.clear()
+        compare(grid.moveSelection(0, 1), true)
+        compare(grid.currentPage, 2)
+        verify(loadMoreSpy.count >= 1,
+               "loadAheadPages=2 must fire prefetch on entering pageCount-3")
+        grid.hasMorePages = false
+    }
+
+    function test_loadAheadPages_two_does_not_fire_below_threshold(): void {
+        // Same 60-item / 5-page setup. Step from idx 8 (page 0, row 2,
+        // col 0) Down to idx 12 (page 1, row 0, col 0). currentPage=1
+        // sits below the threshold (pageCount-3 = 2), so no prefetch
+        // should fire yet.
+        fillModel(60)
+        grid.hasMorePages = true
+        grid.setCurrentIndexImmediate(8)
+        loadMoreSpy.clear()
+        compare(grid.moveSelection(0, 1), true)
+        compare(grid.currentPage, 1)
+        compare(loadMoreSpy.count, 0,
+                "loadAheadPages=2 must not fire below pageCount-3 threshold")
+        grid.hasMorePages = false
+    }
+
+    function test_hasPendingTarget_tracks_pending_state(): void {
+        // GamesScreen gates the "Loading more..." indicator on this
+        // property so background prefetches stay silent. It must
+        // mirror `_pendingTargetPage >= 0` exactly: false at rest,
+        // true while a wrap/shoulder/hold-Down move is parked, false
+        // once the target commits or the user changes intent.
+        _setupPartialLoad(24, 60)
+        compare(grid.hasPendingTarget, false,
+                "no pending target at rest")
+        compare(grid.moveSelection(0, -1), false)
+        compare(grid._pendingTargetPage, 4)
+        compare(grid.hasPendingTarget, true,
+                "Up wrap to unloaded page must arm hasPendingTarget")
+        for (let i = 24; i < 60; i++)
+            model.append({ "name": "item-" + i, "coverKey": "", "favorite": 0 })
+        tryCompare(grid, "itemCount", 60)
+        compare(grid._pendingTargetPage, -1)
+        compare(grid.hasPendingTarget, false,
+                "commit must clear hasPendingTarget")
         _resetPartialLoadState()
     }
 }


### PR DESCRIPTION
## Summary

Three rounds of fixes for the games-grid pagination/scroll bugs reported by Happy Yeti, plus a couple of side fixes that came up along the way.

### PagedGrid
- `pageBy` now wraps over `totalPageCount` (the server's authoritative total), not the loaded slice — Up-at-page-1 and PageDown past the loaded end actually reach the real last page.
- Pending-target watchdog: when the destination page isn't loaded yet, we stash (page, row, col), fire `loadMoreRequested`, and commit the jump once the target slot materialises.
- `pageCount` snaps to `floor(itemCount / pageSize)` while `hasMorePages` is true — no more half-full trailing page that pops to full when the next chunk lands. Ceils once `hasMorePages` flips false.

### GamesModel (Rust)
- Reordered `apply_append_page`: `next_cursor` and `loading_more=false` set BEFORE `end_insert_rows` (so the synchronous Repeater reaction advances the chain), `has_next_page` flipped AFTER (so the watchdog reads a fresh `itemCount` on the final true→false transition and clamps to the real last item).
- Cursor follow-ups bumped from `page_size` (~10-15) to `FETCH_MORE_CHUNK_SIZE = 500` — server caps at 1000, ~100 KB per chunk, 1402-entry Amiga drops from ~140 round-trips to ~3.
- `fetch_more` now also guards on `next_cursor.is_none()` to close a brief window in the new ordering where a watchdog re-fire could otherwise dispatch a `cursor=None` browse and splice duplicates.

### GamesScreen / Main
- Debounced `set_selected_at_top` writes (250 ms) with explicit flush on Accept / Cancel / hold-release — a Down-hold no longer batters MiSTer's SD card with an atomic `state.toml` rewrite per cell.
- "Loading more..." cue moved from the grid's bottom inset onto the `ActiveLabel` row so it doesn't paint over the bottom row of tiles.

### Side fixes bundled in
- Cold-boot connect window: 45 s of 250 ms retries while never-connected, instead of the exponential curve. Picks Core up within a quarter-second of HTTP bind on a cold MiSTer boot; failures inside the window don't count toward the unreachable threshold.
- `remote_resource` RPC backoff explicitly uses the steady-state curve.
- Log a line on MiSTer when we spawn the core service wrapper.

## Test plan

- [x] `just lint` clean
- [x] `just test-rust` — 318/318 passing
- [x] `just test-qml` — 110/110 passing
- [ ] Hold Down on Amiga (1402 entries / 94 pages): "Loading more..." cue surfaces only every ~10 visual pages, partial-page pop-in gone
- [ ] Up at page 1 on Amiga: chains through ~3 chunk fetches and lands on the actual last page
- [ ] Loading cue paints on the ActiveLabel row, not over the bottom tile row
- [ ] `state.toml` mtime under hold-Down: only bumps on dpad release
- [ ] Cold boot: launcher connects to Core within ~250 ms of port bind

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Paginated game loading with pending wrap-target resolution and smoother jump-to-page navigation
  * Public controls to prefetch pages (loadAheadPages) and indicate more pages (hasMorePages)
  * Hold-to-repeat now commits the current game selection when stopping

* **Improvements**
  * Loading placeholder reduces flicker during cover fetches
  * Faster connection retry behavior during startup (boot-window)
  * Safer sequencing for incremental game batch updates
  * Debounced persistence of selected game to avoid lost selections
  * Increased runtime logging visibility for service start attempts

* **Tests**
  * Expanded coverage for partial-load, pagination, and pending-target scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->