### PR TITLE
fix(build): forward git commit/date into ARM32 Docker build

### DIFF
--- a/Dockerfile.arm32
+++ b/Dockerfile.arm32
@@ -26,6 +26,14 @@ FROM ${TOOLCHAIN_IMAGE} AS app-build
 # presence-only, so we only export the env var when the ARG is non-empty.
 ARG ZAPAROO_OFFICIAL_BUILD=
 
+# Build provenance forwarded from the host. The container has no `.git/` in
+# its context (we only COPY source dirs below), so build.rs cannot resolve
+# the commit itself — without these args it falls back to "unknown".
+# Computed by scripts/build-arm32.sh on the host and exported into the
+# build environment so build.rs picks them up.
+ARG ZAPAROO_BUILD_COMMIT=
+ARG ZAPAROO_BUILD_DATE=
+
 # cxx-qt's build script resolves Qt paths via qmake, which returns
 # sysroot-prefixed paths (e.g. {sysroot}/opt/qt6-arm32/...). Symlink Qt
 # into the sysroot so those paths resolve on the build host.
@@ -44,6 +52,12 @@ COPY rust/ rust/
 RUN mkdir build && cd build && \
     if [ -n "${ZAPAROO_OFFICIAL_BUILD}" ]; then \
         export ZAPAROO_OFFICIAL_BUILD="${ZAPAROO_OFFICIAL_BUILD}"; \
+    fi && \
+    if [ -n "${ZAPAROO_BUILD_COMMIT}" ]; then \
+        export ZAPAROO_BUILD_COMMIT="${ZAPAROO_BUILD_COMMIT}"; \
+    fi && \
+    if [ -n "${ZAPAROO_BUILD_DATE}" ]; then \
+        export ZAPAROO_BUILD_DATE="${ZAPAROO_BUILD_DATE}"; \
     fi && \
     /opt/qt6-arm32/bin/qt-cmake .. \
         -G Ninja \

--- a/rust/launcher/build.rs
+++ b/rust/launcher/build.rs
@@ -63,6 +63,8 @@ fn main() {
     println!("cargo:rerun-if-env-changed=ZAPAROO_RUNTIME");
     println!("cargo:rerun-if-env-changed=ZAPAROO_DEV_BUILD");
     println!("cargo:rerun-if-env-changed=ZAPAROO_OFFICIAL_BUILD");
+    println!("cargo:rerun-if-env-changed=ZAPAROO_BUILD_COMMIT");
+    println!("cargo:rerun-if-env-changed=ZAPAROO_BUILD_DATE");
 
     // Rerun when HEAD or any branch ref moves so ZAPAROO_BUILD_COMMIT /
     // ZAPAROO_BUILD_DATE refresh after rebases, branch switches, and
@@ -93,25 +95,43 @@ fn main() {
     // "this binary is from this source tree at this date, and it is /
     // is not an official package", not DRM. Failures fall back to
     // "unknown" / "dev"; the build still succeeds.
-    let commit = std::process::Command::new("git")
-        .args(["rev-parse", "--short=7", "HEAD"])
-        .output()
+    //
+    // Prefer values supplied via env so cross-builds that don't have
+    // `.git/` in their build context (e.g. the ARM32 Docker build,
+    // which COPYs only source dirs) can be told the commit and date by
+    // the host. Fall back to running `git` / `date` when the env vars
+    // are absent or empty, which is the common path for host builds.
+    let commit = std::env::var("ZAPAROO_BUILD_COMMIT")
         .ok()
-        .filter(|o| o.status.success())
-        .and_then(|o| String::from_utf8(o.stdout).ok())
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty())
+        .or_else(|| {
+            std::process::Command::new("git")
+                .args(["rev-parse", "--short=7", "HEAD"])
+                .output()
+                .ok()
+                .filter(|o| o.status.success())
+                .and_then(|o| String::from_utf8(o.stdout).ok())
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+        })
         .unwrap_or_else(|| "unknown".to_string());
     println!("cargo:rustc-env=ZAPAROO_BUILD_COMMIT={commit}");
 
-    let build_date = std::process::Command::new("date")
-        .args(["-u", "+%Y-%m-%d"])
-        .output()
+    let build_date = std::env::var("ZAPAROO_BUILD_DATE")
         .ok()
-        .filter(|o| o.status.success())
-        .and_then(|o| String::from_utf8(o.stdout).ok())
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty())
+        .or_else(|| {
+            std::process::Command::new("date")
+                .args(["-u", "+%Y-%m-%d"])
+                .output()
+                .ok()
+                .filter(|o| o.status.success())
+                .and_then(|o| String::from_utf8(o.stdout).ok())
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+        })
         .unwrap_or_else(|| "unknown".to_string());
     println!("cargo:rustc-env=ZAPAROO_BUILD_DATE={build_date}");
 

--- a/scripts/build-arm32.sh
+++ b/scripts/build-arm32.sh
@@ -79,11 +79,20 @@ echo "Using toolchain image: ${TOOLCHAIN_IMAGE}"
 echo "Docker platform: ${DOCKER_PLATFORM}"
 mkdir -p "${OUTPUT_DIR}"
 
+# Resolve build provenance on the host. The Dockerfile only COPYs source
+# dirs (no `.git/`), so without forwarding these the in-container build.rs
+# falls back to commit = "unknown". Empty values fall back to build.rs's
+# own defaults inside the container.
+ZAPAROO_BUILD_COMMIT="${ZAPAROO_BUILD_COMMIT:-$(git -C "${PROJECT_ROOT}" rev-parse --short=7 HEAD 2>/dev/null || true)}"
+ZAPAROO_BUILD_DATE="${ZAPAROO_BUILD_DATE:-$(date -u +%Y-%m-%d)}"
+
 docker buildx build \
     --platform "${DOCKER_PLATFORM}" \
     -f "${PROJECT_ROOT}/Dockerfile.arm32" \
     --build-arg "TOOLCHAIN_IMAGE=${TOOLCHAIN_IMAGE}" \
     --build-arg "ZAPAROO_OFFICIAL_BUILD=${ZAPAROO_OFFICIAL_BUILD:-}" \
+    --build-arg "ZAPAROO_BUILD_COMMIT=${ZAPAROO_BUILD_COMMIT}" \
+    --build-arg "ZAPAROO_BUILD_DATE=${ZAPAROO_BUILD_DATE}" \
     --output "type=local,dest=${OUTPUT_DIR}" \
     --target export \
     "${PROJECT_ROOT}"


### PR DESCRIPTION
## Summary

ARM32 release builds were showing `commit "unknown"` on the About screen.

`Dockerfile.arm32` only `COPY`s source directories (`src/`, `rust/`, `cmake/`, `resources/`, `CMakeLists.txt`) into the image — `.git/` is never in the build context. So when `rust/launcher/build.rs` ran `git rev-parse --short=7 HEAD` inside the container, it failed and the commit fell back to the `"unknown"` sentinel. The desktop half of `just release` runs on the host with `.git/` present, so it always reported a real commit; only the ARM32 half was broken.

Fix: resolve commit + build date on the host in `scripts/build-arm32.sh`, pass them as Docker `--build-arg`s, and have `build.rs` prefer the env-provided values, falling back to the existing `git`/`date` probe when unset (the host path is unchanged). The `ZAPAROO_OFFICIAL_BUILD` plumbing already followed this exact pattern; the new args mirror it.

## Test plan

- [x] `just lint-rust` clean
- [x] `shellcheck scripts/build-arm32.sh` clean
- [x] Verified env-override path: `ZAPAROO_BUILD_COMMIT=deadbee ZAPAROO_BUILD_DATE=2099-01-01 cargo build` bakes both values into `libzaparoo_launcher_rs.a`
- [x] Verified host fallback path: plain `cargo build` still bakes the real `git rev-parse --short=7 HEAD`
- [ ] `just release` and check the About screen on the resulting MiSTer binary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build infrastructure for ARM32 builds with improved provenance tracking capabilities. Build commit and date information can now be controlled via environment variables, with automatic fallbacks to git and system date commands when needed.
  * Strengthened cross-compilation support by ensuring consistent availability of build metadata across different build environments and scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->