### PR TITLE
extra logs and switch to 320x240p

### DIFF
--- a/docs/native-core-poc.md
+++ b/docs/native-core-poc.md
@@ -48,7 +48,7 @@ After QML loads, the launcher also starts a native-video copy thread:
 ```text
 0x3A000000  control word: (frame_counter << 2) | active_buffer
 0x3A000100  buffer 0: 320x240 RGB8888
-0x3A02A200  buffer 1: 320x240 RGB8888
+0x3A04B100  buffer 1: 320x240 RGB8888
 ```
 
 ## Current CRT UI Constraints

--- a/docs/native-core-poc.md
+++ b/docs/native-core-poc.md
@@ -39,7 +39,7 @@ vmode -r 960 720 rgb16
 
 After QML loads, the launcher also starts a native-video copy thread:
 
-- reads `/dev/fb0` as 16-bit RGB565
+- reads `/dev/fb0` as 16-bit RGB8888
 - requires `/dev/fb0` to be at least `320x240`
 - copies only the top-left `320x240` pixels, with no scaling
 - copies pixels directly; no RGB conversion

--- a/docs/native-core-poc.md
+++ b/docs/native-core-poc.md
@@ -40,15 +40,15 @@ vmode -r 960 720 rgb16
 After QML loads, the launcher also starts a native-video copy thread:
 
 - reads `/dev/fb0` as 16-bit RGB565
-- requires `/dev/fb0` to be at least `384x224`
-- copies only the top-left `384x224` pixels, with no scaling
+- requires `/dev/fb0` to be at least `320x240`
+- copies only the top-left `320x240` pixels, with no scaling
 - copies pixels directly; no RGB conversion
 - writes frames to the 3S-ARM native-video DDR layout:
 
 ```text
 0x3A000000  control word: (frame_counter << 2) | active_buffer
-0x3A000100  buffer 0: 384x224 RGB565
-0x3A02A200  buffer 1: 384x224 RGB565
+0x3A000100  buffer 0: 320x240 RGB8888
+0x3A02A200  buffer 1: 320x240 RGB8888
 ```
 
 ## Current CRT UI Constraints
@@ -86,7 +86,7 @@ DDR layout above while it drives CRT timing itself.
 
 1. Launcher starts and logs `--crt: applying linuxfb mode ... rgb16`.
 2. `/dev/fb0` mode is the configured framebuffer size.
-3. Launcher logs `native video writer: copying top-left 384x224 RGB565 from /dev/fb0 ...`.
+3. Launcher logs `native video writer: copying top-left 320x240 RGB8888 from /dev/fb0 ...`.
 4. Custom core produces analog video without MiSTer `vga_fb` scaler output.
 5. Navigation changes launcher pixels in the native-video DDR buffers.
 6. No regression when `--crt` is omitted; default remains the normal `linuxfb`

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -122,6 +122,8 @@ int main(int argc, char* argv[])
     const bool crtNativePathForced = parsedArgs.crtNativePathForced;
     int qtArgc = static_cast<int>(parsedArgs.argv.size()) - 1;
     char** qtArgv = parsedArgs.argv.data();
+    qInfo("CRT startup decision: --crt argument %s",
+          crtNativePathForced ? "present" : "absent");
 
     QGuiApplication::setApplicationName("Zaparoo Launcher");
     QGuiApplication::setApplicationVersion("0.1.0");
@@ -159,7 +161,10 @@ int main(int argc, char* argv[])
     registerFont(
         QStringLiteral(":/qt/qml/Zaparoo/App/resources/fonts/AtkinsonHyperlegible-Bold.ttf"));
     registerFont(QStringLiteral(":/qt/qml/Zaparoo/App/resources/fonts/Bongo-8 Mono.ttf"));
-    if (zaparoo_rust_crt_native_path_enabled())
+    const bool crtNativePathEnabled = zaparoo_rust_crt_native_path_enabled();
+    qInfo("CRT startup decision: Rust CRT native path %s",
+          crtNativePathEnabled ? "enabled" : "disabled");
+    if (crtNativePathEnabled)
     {
         QQuickWindow::setTextRenderType(QQuickWindow::NativeTextRendering);
         qInfo("CRT native path: using native text rendering");
@@ -213,7 +218,7 @@ int main(int argc, char* argv[])
           qUtf8Printable(formatNames.join(QStringLiteral(", "))));
 
     QVariantMap initialProperties = {
-        {"crtNativePath", zaparoo_rust_crt_native_path_enabled()},
+        {"crtNativePath", crtNativePathEnabled},
     };
 #ifdef ZAPAROO_EMBEDDED_BUILD
     initialProperties.insert(QStringLiteral("fullScreen"), true);
@@ -265,10 +270,15 @@ int main(int argc, char* argv[])
         return EXIT_FAILURE;
     }
 
-    if (zaparoo_rust_crt_native_path_enabled())
+    if (crtNativePathEnabled)
     {
+        qInfo("CRT startup decision: starting native video writer");
         startNativeVideoWriter();
         std::atexit(stopNativeVideoWriter);
+    }
+    else
+    {
+        qInfo("CRT startup decision: skipping native video writer");
     }
 
     zaparoo_rust_post_qt_start();

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -122,8 +122,7 @@ int main(int argc, char* argv[])
     const bool crtNativePathForced = parsedArgs.crtNativePathForced;
     int qtArgc = static_cast<int>(parsedArgs.argv.size()) - 1;
     char** qtArgv = parsedArgs.argv.data();
-    qInfo("CRT startup decision: --crt argument %s",
-          crtNativePathForced ? "present" : "absent");
+    qInfo("CRT startup decision: --crt argument %s", crtNativePathForced ? "present" : "absent");
 
     QGuiApplication::setApplicationName("Zaparoo Launcher");
     QGuiApplication::setApplicationVersion("0.1.0");

--- a/src/app/native_video_writer.cpp
+++ b/src/app/native_video_writer.cpp
@@ -162,7 +162,7 @@ void writerLoop()
     memset(const_cast<uint8_t*>(nativeBase + kBuffer1Offset), 0, kOutputBytes);
     *reinterpret_cast<volatile uint32_t*>(const_cast<uint8_t*>(nativeBase + kControlOffset)) = 0;
 
-    qInfo("native video writer: copying top-left 320x240 RGB565 from /dev/fb0 %ux%u to native DDR",
+    qInfo("native video writer: copying top-left 320x240 RGB8888 from /dev/fb0 %ux%u to native DDR",
           var.xres, var.yres);
 
     uint32_t frame = 0;

--- a/src/app/native_video_writer.cpp
+++ b/src/app/native_video_writer.cpp
@@ -243,6 +243,8 @@ void stopNativeVideoWriter()
 
 #else
 
+#include <QLoggingCategory>
+
 void startNativeVideoWriter()
 {
     qInfo("native video writer: start requested on unsupported build/platform");

--- a/src/app/native_video_writer.cpp
+++ b/src/app/native_video_writer.cpp
@@ -22,14 +22,14 @@ namespace
 {
 
 constexpr uintptr_t kNativeVideoBase = 0x3A000000u;
-constexpr size_t kNativeVideoRegionSize = 0x00060000u;
+constexpr size_t kNativeVideoRegionSize = 0x000A0000u;
 constexpr size_t kControlOffset = 0x00000000u;
 constexpr size_t kBuffer0Offset = 0x00000100u;
-constexpr int kOutputWidth = 384;
-constexpr int kOutputHeight = 224;
-constexpr int kOutputBytes = kOutputWidth * kOutputHeight * 2;
-constexpr size_t kBuffer1Offset = 0x0002A200u;
-constexpr size_t kSourceBytesPerPixel = 2;
+constexpr int kOutputWidth = 320;
+constexpr int kOutputHeight = 240;
+constexpr size_t kSourceBytesPerPixel = 4;
+constexpr int kOutputBytes = kOutputWidth * kOutputHeight * kSourceBytesPerPixel;
+constexpr size_t kBuffer1Offset = 0x0004B100u;
 constexpr size_t kOutputRowBytes = kOutputWidth * kSourceBytesPerPixel;
 
 std::atomic<bool> g_running{false};
@@ -38,11 +38,11 @@ std::thread g_thread;
 bool validateFramebufferWindow(const fb_fix_screeninfo& fixed, const fb_var_screeninfo& var,
                                size_t fbSize)
 {
-    if (var.bits_per_pixel != 16 || var.xres < kOutputWidth || var.yres < kOutputHeight ||
+    if (var.bits_per_pixel != 32 || var.xres < kOutputWidth || var.yres < kOutputHeight ||
         fixed.line_length < kOutputRowBytes)
     {
         qWarning("native video writer: unsupported fb0 mode %ux%u %u bpp; expected at least "
-                 "384x224 16 bpp",
+                 "320x240 32 bpp",
                  var.xres, var.yres, var.bits_per_pixel);
         return false;
     }
@@ -51,7 +51,7 @@ bool validateFramebufferWindow(const fb_fix_screeninfo& fixed, const fb_var_scre
         var.xres_virtual - var.xoffset < kOutputWidth ||
         var.yres_virtual - var.yoffset < kOutputHeight)
     {
-        qWarning("native video writer: visible fb0 window %u,%u in %ux%u cannot cover 384x224",
+        qWarning("native video writer: visible fb0 window %u,%u in %ux%u cannot cover 320x240",
                  var.xoffset, var.yoffset, var.xres_virtual, var.yres_virtual);
         return false;
     }
@@ -60,7 +60,7 @@ bool validateFramebufferWindow(const fb_fix_screeninfo& fixed, const fb_var_scre
         (static_cast<size_t>(var.xoffset) + kOutputWidth) * kSourceBytesPerPixel;
     if (fixed.line_length < sourceRowBytes)
     {
-        qWarning("native video writer: fb0 stride %u too small for visible 384x224 window",
+        qWarning("native video writer: fb0 stride %u too small for visible 320x240 window",
                  fixed.line_length);
         return false;
     }
@@ -162,7 +162,7 @@ void writerLoop()
     memset(const_cast<uint8_t*>(nativeBase + kBuffer1Offset), 0, kOutputBytes);
     *reinterpret_cast<volatile uint32_t*>(const_cast<uint8_t*>(nativeBase + kControlOffset)) = 0;
 
-    qInfo("native video writer: copying top-left 384x224 RGB565 from /dev/fb0 %ux%u to native DDR",
+    qInfo("native video writer: copying top-left 320x240 RGB565 from /dev/fb0 %ux%u to native DDR",
           var.xres, var.yres);
 
     uint32_t frame = 0;
@@ -219,23 +219,37 @@ void startNativeVideoWriter()
     bool expected = false;
     if (!g_running.compare_exchange_strong(expected, true))
     {
+        qInfo("native video writer: start requested but writer already running");
         return;
     }
+    qInfo("native video writer: start requested, launching writer thread");
     g_thread = std::thread(writerLoop);
 }
 
 void stopNativeVideoWriter()
 {
+    qInfo("native video writer: stop requested");
     g_running.store(false);
     if (g_thread.joinable())
     {
         g_thread.join();
+        qInfo("native video writer: writer thread joined");
+    }
+    else
+    {
+        qInfo("native video writer: no running thread to join");
     }
 }
 
 #else
 
-void startNativeVideoWriter() {}
-void stopNativeVideoWriter() {}
+void startNativeVideoWriter()
+{
+    qInfo("native video writer: start requested on unsupported build/platform");
+}
+void stopNativeVideoWriter()
+{
+    qInfo("native video writer: stop requested on unsupported build/platform");
+}
 
 #endif


### PR DESCRIPTION
<!-- Thanks for the pull request. Please fill this out before requesting review. -->

## Summary

This PR switches the expected crt resolution to 320x240p

## Motivation

<!-- Link the issue or discussion that led to this. Delete this section if it does not apply. -->

## Screenshots / recordings

<!-- Required for visual changes. Include the FPS counter at 720p and, if possible, 240p. -->

## Test plan

<!-- How did you verify this? Manual steps and automated tests are both fine. -->

## Checklist

- [ ] `just lint` is green (zero warnings)
- [ ] `just test` passes
- [ ] If this touches QML, the FPS counter stays green (≥ 55) at 720p+ and ≥ 30 at 240p
- [ ] If this could affect the MiSTer build, I considered ARM32 implications (see `docs/architecture.md`)
- [ ] If this adds user-visible strings, they are wrapped in `qsTr()` (QML) or `tr()` (C++)
- [ ] I have signed the [CLA](../.github/CLA.md) (first-time contributors only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Native video output now uses 32-bit RGB and a 320×240 top-left capture region for improved framebuffer compatibility and clearer validation.

* **Chores**
  * Improved lifecycle and decision logging for native video and startup paths; unsupported builds now emit clear log messages.

* **Documentation**
  * Updated native-core POC docs and success-log expectations to reflect the new native-video behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->