### PR TITLE
fix(crt): pixel-perfect text in desktop CRT preview

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -11,6 +11,7 @@
 
 #include <QByteArray>
 #include <QChar>
+#include <QFont>
 #include <QFontDatabase>
 #include <QGuiApplication>
 #include <QImageReader>
@@ -125,6 +126,22 @@ int main(int argc, char* argv[])
     char** qtArgv = parsedArgs.argv.data();
     qInfo("CRT startup decision: --crt argument %s", crtNativePathForced ? "present" : "absent");
 
+    // Desktop CRT preview: pin Qt's high-DPI handling so logical pixels
+    // map 1:1 to physical pixels. Without this, on a screen with
+    // devicePixelRatio != 1 the GL backend bilinear-filters the final
+    // logical-to-physical present step, smearing the integer-upscaled
+    // CRT output even when `layer.smooth: false` is set on the
+    // upscale wrapper. Forcing scale factor to 1 keeps the window at
+    // physical pixel size and the wrapper's nearest-neighbour scale
+    // produces the literal pixel grid the preview is meant to expose.
+    if (crtNativePathForced)
+    {
+        qputenv("QT_ENABLE_HIGHDPI_SCALING", "0");
+        qputenv("QT_SCALE_FACTOR", "1");
+        QGuiApplication::setHighDpiScaleFactorRoundingPolicy(
+            Qt::HighDpiScaleFactorRoundingPolicy::Floor);
+    }
+
     QGuiApplication::setApplicationName("Zaparoo Launcher");
     QGuiApplication::setApplicationVersion("0.1.0");
     QGuiApplication::setOrganizationName("Zaparoo");
@@ -187,6 +204,18 @@ int main(int argc, char* argv[])
     {
         QQuickWindow::setTextRenderType(QQuickWindow::NativeTextRendering);
         qInfo("CRT native path: using native text rendering");
+        // Desktop CRT preview: FreeType on X11/Wayland defaults to subpixel
+        // RGB antialiasing ("ClearType"), which paints faint coloured
+        // fringes either side of every glyph. MiSTer's linuxfb FreeType
+        // does not enable subpixel AA, so the same scene reads pixel-
+        // perfect there but blurry in the desktop preview. The bitmap
+        // pixel font (MxPlus HP 100LX 6x8) is also designed to never be
+        // smoothed. Set NoAntialias on the application default font so
+        // every Text item that doesn't override styleStrategy inherits it.
+        QFont defaultFont = QGuiApplication::font();
+        defaultFont.setStyleStrategy(QFont::NoAntialias);
+        defaultFont.setHintingPreference(QFont::PreferFullHinting);
+        QGuiApplication::setFont(defaultFont);
     }
     QQuickStyle::setStyle("Basic");
 

--- a/src/ui/app/MainLayout.qml
+++ b/src/ui/app/MainLayout.qml
@@ -281,9 +281,12 @@ ApplicationWindow {
     // `smooth: false` and `layer.smooth: false` together preserve
     // the pixel grid; without both, Qt bilinear-filters the upscale
     // and the CRT artefacts the preview is meant to expose get
-    // smeared out. `layer.enabled` is software-renderer safe (Qt's
-    // Software adaptation has a real QSGSoftwareLayer) -- no
-    // ShaderEffect, no GraphicalEffects.
+    // smeared out.
+    //
+    // The desktop preview pins Qt's high-DPI scaling to 1 in main.cpp
+    // when --crt is set, so logical pixels map 1:1 to physical pixels
+    // and the GL backend's final logical-to-physical present step is
+    // a no-op (no bilinear filtering smearing the integer upscale).
     Item {
         id: scene
 


### PR DESCRIPTION
## Summary
- Disable font antialiasing on the application default font when CRT native path is on, eliminating subpixel RGB ("ClearType") colour fringes around glyphs in the `--crt` desktop preview. MiSTer's linuxfb FreeType doesn't apply subpixel AA, so the same scene was pixel-perfect on hardware but blurry in the preview.
- Pin Qt's high-DPI scaling to 1 when `--crt` is passed so the GL backend doesn't bilinear-filter the final logical-to-physical present step on screens with `devicePixelRatio != 1`.

## Test plan
- [ ] `just run -- --crt` on a HiDPI desktop: text reads as a hard 1-bit glyph mask with no coloured fringes either side
- [ ] `just run -- --crt` on a 1x desktop: same pixel-perfect output as before, no regression
- [ ] `just run` (no `--crt`): unchanged - normal AA + DPR behaviour
- [ ] MiSTer deploy still renders pixel-perfect (the codepath is gated on `crtNativePathEnabled` which is true on both)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced CRT preview rendering with pixel-perfect display and improved text rendering when using the `--crt` mode. High-DPI scaling is now configured for precise 1:1 pixel mapping.

* **Documentation**
  * Updated CRT preview documentation to reflect rendering behavior changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ZaparooProject/zaparoo-launcher/pull/117)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->