### PR TITLE
fix(ui): bind window size to Screen.* on first paint

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -240,8 +240,17 @@ int main(int argc, char* argv[])
         {"crtNativePath", crtNativePathEnabled},
     };
 #ifdef ZAPAROO_EMBEDDED_BUILD
+    // MainLayout's `fullScreen` defaults true so the binding pass during
+    // QML construction evaluates width/height/visibility against the
+    // embedded branch — no transient 1280x720 frame for the writer
+    // thread to copy into the CRT scan-out region.
     initialProperties.insert(QStringLiteral("fullScreen"), true);
 #else
+    // Desktop preview: override the QML default so the dev workflow
+    // gets a windowed 1280x720 design canvas. The brief
+    // FullScreen→Windowed transition during construction isn't visible
+    // — the desktop compositor buffers until the first paint.
+    initialProperties.insert(QStringLiteral("fullScreen"), false);
     // Desktop CRT preview: when --crt is passed off-MiSTer, render the
     // QML scene at the configured logical video size and integer-
     // upscale via a layered wrapper Item in MainLayout. Scale defaults

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -27,10 +27,10 @@ MainLayout {
 
     // Fullscreen builds (MiSTer) fill the screen; desktop windowed
     // builds inherit MainLayout's 1280x720 design defaults so the user
-    // can resize freely. The fullscreen override is a one-shot in
-    // Component.onCompleted (below) rather than a binding — a binding
-    // here would re-assert 1280 after any user resize, fighting the
-    // OS resize gesture.
+    // can resize freely. MainLayout binds width/height to Screen.* when
+    // fullScreen is true so the first paint is at the correct dims;
+    // doing it imperatively here would land after the first frame and
+    // leave a 1280x720 slice on screen for one frame.
 
     readonly property string modalCardWrite: "card_write"
     readonly property string modalContextMenu: "context_menu"
@@ -78,16 +78,12 @@ MainLayout {
         value: root.scene.height
     }
     Component.onCompleted: {
-        // One-shot window sizing for the embedded fullscreen path.
-        // Imperative (rather than a binding) so a user resize on a
-        // windowed build can never be undone by a re-evaluation.
         // Desktop CRT preview applies one initial integer scale here,
         // then MainLayout snaps later user resizes to the supported
-        // 3x..5x steps.
-        if (root.fullScreen) {
-            root.width = Screen.width;
-            root.height = Screen.height;
-        } else if (root._crtPreviewActive) {
+        // 3x..5x steps. Fullscreen embedded sizing is handled by
+        // MainLayout's width/height bindings so first paint matches
+        // the FB layout.
+        if (!root.fullScreen && root._crtPreviewActive) {
             root.applyCrtPreviewScale(root._crtPreviewInitialScale);
         }
         Browse.GamesModel.page_size = root._gamesPageSize;

--- a/src/ui/app/MainLayout.qml
+++ b/src/ui/app/MainLayout.qml
@@ -38,7 +38,16 @@ ApplicationWindow {
     // Runtime state. `activeScreen` mirrors ScreenManager's property
     // (two-way synced below so direct assignment from tests still
     // works).
-    property bool fullScreen: false
+    //
+    // `fullScreen` defaults true so the embedded build's first binding
+    // pass for `width`/`height`/`visibility` evaluates against the
+    // correct branch — Qt's createWithInitialProperties runs bindings
+    // BEFORE applying initialProperties, so a `false` default would
+    // commit width=1280/height=720 for one pass, then re-bind. On
+    // linuxfb that one pass is what the writer thread copies to the
+    // CRT region (visible as a whole-frame size snap on first paint).
+    // Desktop preview sets fullScreen=false via initialProperties.
+    property bool fullScreen: true
     property bool crtNativePath: false
     property string activeScreen: ScreenManager.activeScreen
 
@@ -112,12 +121,17 @@ ApplicationWindow {
     }
 
     // Defaults keep the design canvas at a sensible aspect for Design
-    // Studio. Main.qml overrides these at runtime with Screen.width /
-    // Screen.height for fullscreen embedded builds. Preview mode
-    // now applies an initial integer scale, then lets desktop users
-    // resize within the supported 3x..5x band.
-    width: 1280
-    height: 720
+    // Studio. Fullscreen embedded builds (MiSTer) need the screen
+    // dims applied at construction so the first paint matches the
+    // FB layout — Component.onCompleted fires after the first frame,
+    // so an imperative override there leaves a wrong-size first
+    // frame on screen (visible as a zoomed top-left slice on CRT,
+    // where the launcher's writer thread copies that slice into the
+    // FPGA's 320x240 scan-out region). For windowed/preview builds
+    // the binding only evaluates once at construction (Screen.width
+    // is constant per session) so it doesn't fight user resizes.
+    width: root.fullScreen ? Screen.width : 1280
+    height: root.fullScreen ? Screen.height : 720
     minimumWidth: _crtPreviewActive ? root.videoWidth * (root.crtPreviewScale > 0 ? root._clampCrtPreviewScale(root.crtPreviewScale) : root._crtPreviewMinScale) : 426
     minimumHeight: _crtPreviewActive ? root.videoHeight * (root.crtPreviewScale > 0 ? root._clampCrtPreviewScale(root.crtPreviewScale) : root._crtPreviewMinScale) : 240
     maximumWidth: _crtPreviewActive ? root.videoWidth * (root.crtPreviewScale > 0 ? root._clampCrtPreviewScale(root.crtPreviewScale) : root._crtPreviewMaxScale) : 16777215

--- a/tests/ui/tst_navigation.qml
+++ b/tests/ui/tst_navigation.qml
@@ -18,6 +18,7 @@ TestCase {
 
     Main {
         id: main
+        fullScreen: false
         width: 1280
         height: 720
     }

--- a/tests/ui/tst_persistence.qml
+++ b/tests/ui/tst_persistence.qml
@@ -28,6 +28,7 @@ TestCase {
 
     Main {
         id: main
+        fullScreen: false
         width: 1280
         height: 720
     }

--- a/tests/ui/tst_sizing.qml
+++ b/tests/ui/tst_sizing.qml
@@ -16,6 +16,7 @@ TestCase {
 
     Main {
         id: main
+        fullScreen: false
         width: 1280
         height: 720
     }

--- a/tests/ui/tst_smoke.qml
+++ b/tests/ui/tst_smoke.qml
@@ -36,6 +36,7 @@ TestCase {
     Main {
         id: mainWindow
 
+        fullScreen: false
         width: 1280
         height: 720
     }


### PR DESCRIPTION
## Summary
- MainLayout.fullScreen now defaults true; width/height bind to Screen.width/Screen.height when set, so the first binding pass during QML construction commits the FB-correct size.
- Desktop preview opts out via initialProperties (fullScreen=false), preserving the 1280x720 design canvas and user-resize behavior.
- Removes the imperative Component.onCompleted size assignment in Main.qml, which fired after the first frame.

The bug: on the embedded MiSTer build, the previous flow let the first binding pass commit width=1280/height=720, then re-bind to Screen dims after Component.onCompleted. linuxfb had already scanned out that frame, so the writer thread copied a 1280x720 top-left slice into the FPGA's 320x240 CRT scan-out region, visible as a one-frame wrong-size flash on cold start.

## Test plan
- [ ] Cold-start MiSTer launcher; confirm no first-frame size flash on the CRT output
- [ ] Desktop \`just run\` opens a 1280x720 window that resizes freely
- [ ] Desktop \`just run-dev --crt\` still applies an integer scale on first paint
- [ ] \`just lint\` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App now defaults to fullscreen on startup.

* **Bug Fixes**
  * Initial render uses correct fullscreen dimensions without a post-load resize.
  * CRT preview scaling is applied only in windowed mode to avoid size glitches on first paint.

* **Tests**
  * UI tests updated to run deterministically in windowed mode.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ZaparooProject/zaparoo-launcher/pull/118)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->