### PR TITLE
fix: SIGABRT on quit, CRT preview rescale, log cleanup

### DIFF
--- a/rust/launcher/src/bind.rs
+++ b/rust/launcher/src/bind.rs
@@ -66,7 +66,7 @@ macro_rules! bind_to_endpoint {
                 $apply(self.as_mut(), projected);
 
                 let qt_thread = self.qt_thread();
-                $crate::models::global_runtime().spawn(async move {
+                $crate::models::global_handle().spawn(async move {
                     while rx.changed().await.is_ok() {
                         let projected = $select(&*rx.borrow_and_update());
                         let _ = qt_thread.queue(move |m| $apply(m, projected));

--- a/rust/launcher/src/lib.rs
+++ b/rust/launcher/src/lib.rs
@@ -39,6 +39,7 @@ use std::io::Write as _;
 use std::os::fd::AsRawFd;
 use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
+use std::time::Duration;
 use zaparoo_core::{
     client::Client,
     config::load_config,
@@ -158,7 +159,6 @@ pub extern "C" fn zaparoo_rust_video_height() -> u32 {
 /// the chained default hook); the blocking append is durable before we
 /// hand off.
 fn install_panic_hook() {
-    let default = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
         let payload = info.payload();
         let msg = payload
@@ -170,14 +170,25 @@ fn install_panic_hook() {
             || "<unknown>".to_string(),
             |l| format!("{}:{}:{}", l.file(), l.line(), l.column()),
         );
-        let thread = std::thread::current();
-        let thread_name = thread.name().unwrap_or("<unnamed>");
-        let backtrace = std::backtrace::Backtrace::capture();
+        // `std::thread::current()` and `Backtrace::capture()` both touch
+        // TLS internally; on a thread mid-destruction they would
+        // re-panic and turn this hook into an abort. Catch-unwind those
+        // and substitute fallback strings so the hook always finishes.
+        let thread_name = std::panic::catch_unwind(|| {
+            std::thread::current()
+                .name()
+                .map_or_else(|| "<unnamed>".to_string(), str::to_string)
+        })
+        .unwrap_or_else(|_| "<tls-gone>".to_string());
+        let backtrace = std::panic::catch_unwind(std::backtrace::Backtrace::capture)
+            .map_or_else(|_| String::new(), |bt| bt.to_string());
         let line = format!("thread '{thread_name}' panicked at {location}: {msg}\n{backtrace}");
 
         // Best-effort blocking write to launcher.log. Each call opens a
         // fresh fd in append mode so we don't depend on any state that
-        // a partially-corrupted process might have torn down.
+        // a partially-corrupted process might have torn down. No TLS
+        // access here — File I/O via libc::write goes straight to the
+        // kernel.
         if let Ok(mut f) = std::fs::OpenOptions::new()
             .create(true)
             .append(true)
@@ -188,8 +199,20 @@ fn install_panic_hook() {
             let _ = f.sync_data();
         }
 
-        tracing::error!(target: "panic", "{line}");
-        default(info);
+        // Mirror to stderr via the libc-backed Stderr handle (no TLS).
+        // We deliberately do not call the default panic hook or
+        // `tracing::error!` — both reach into TLS for thread-name
+        // formatting and dispatcher lookup, which on a teardown-phase
+        // thread would re-panic into SIGABRT before the original cause
+        // is even visible.
+        let mut stderr = std::io::stderr();
+        let _ = std::io::Write::write_all(&mut stderr, b"thread '");
+        let _ = std::io::Write::write_all(&mut stderr, thread_name.as_bytes());
+        let _ = std::io::Write::write_all(&mut stderr, b"' panicked at ");
+        let _ = std::io::Write::write_all(&mut stderr, location.as_bytes());
+        let _ = std::io::Write::write_all(&mut stderr, b": ");
+        let _ = std::io::Write::write_all(&mut stderr, msg.as_bytes());
+        let _ = std::io::Write::write_all(&mut stderr, b"\n");
     }));
 }
 
@@ -333,27 +356,27 @@ pub extern "C" fn zaparoo_rust_init(crt_native_path_forced: bool) -> c_int {
         .enable_all()
         .build()
     {
-        Ok(r) => Arc::new(r),
+        Ok(r) => r,
         Err(e) => {
             tracing::error!("failed to build tokio runtime: {e}");
             return 1;
         }
     };
+    let handle = runtime.handle().clone();
 
     mister_runtime::apply_pre_qt_setup(&config, crt_native_path_forced);
 
-    let client = Client::new(config.core_endpoint.clone(), &runtime);
-    platform::spawn_fetcher(client.clone(), &runtime);
-    let store = Store::new(client.clone(), runtime.clone());
+    let client = Client::new(config.core_endpoint.clone(), &handle);
+    platform::spawn_fetcher(client.clone(), &handle);
+    let store = Store::new(client.clone(), handle.clone());
 
     // Load persisted UI state up front so per-screen singletons can seed
     // their properties from a consistent snapshot during Initialize.
     let persist_state = Arc::new(Mutex::new(persist::load()));
 
-    // init_globals stores Arcs — runtime keeps running after this fn returns.
-    // The `Client` is owned by the `Store` (and the platform fetcher
-    // task), so `init_globals` no longer takes it directly; singletons
-    // reach the client through `global_store()`.
+    // init_globals takes the owning `Runtime` — the static holder is
+    // what `zaparoo_rust_shutdown` later drains via `shutdown_timeout`.
+    // Other subsystems reach the runtime through `global_handle()`.
     let core_is_local = core_endpoint_is_loopback(&config.core_endpoint);
     models::init_globals(
         runtime,
@@ -364,6 +387,20 @@ pub extern "C" fn zaparoo_rust_init(crt_native_path_forced: bool) -> c_int {
     );
 
     0
+}
+
+/// Drains the tokio runtime with a 2-second deadline. Called from the
+/// C++ side via `QGuiApplication::aboutToQuit` so workers exit while
+/// the main thread is still alive and every thread's TLS storage is
+/// still addressable. Without this, static `Runtime` drop ran during
+/// `__cxa_finalize` after main returned, racing tokio worker exits
+/// with TLS teardown — any final tracing event from a finishing
+/// worker hit `LocalKey::with` and double-panicked into SIGABRT.
+///
+/// Idempotent — safe to call more than once.
+#[no_mangle]
+pub extern "C" fn zaparoo_rust_shutdown() {
+    models::shutdown_runtime(Duration::from_secs(2));
 }
 
 /// Called by the C++ main after the QML engine has loaded but before `exec()`.

--- a/rust/launcher/src/media_image_cache.rs
+++ b/rust/launcher/src/media_image_cache.rs
@@ -38,7 +38,7 @@ use std::sync::{Arc, Mutex, OnceLock, RwLock};
 
 use base64::engine::general_purpose::{STANDARD as BASE64_STANDARD, URL_SAFE_NO_PAD};
 use base64::Engine as _;
-use tokio::runtime::Runtime;
+use tokio::runtime::Handle;
 use tokio::sync::{broadcast, Notify};
 use tracing::{debug, info, warn};
 
@@ -474,7 +474,7 @@ pub struct MediaImageCache {
 }
 
 impl MediaImageCache {
-    fn new<F>(cap_bytes: usize, runtime: &Arc<Runtime>, store_factory: F) -> Self
+    fn new<F>(cap_bytes: usize, runtime: &Handle, store_factory: F) -> Self
     where
         F: Fn() -> Arc<Store> + Send + Sync + 'static,
     {
@@ -698,7 +698,7 @@ fn drain_one_round(queue: &Arc<Mutex<VecDeque<QueueEntry>>>) -> Vec<QueueEntry> 
 }
 
 fn spawn_fetch_driver<F>(
-    runtime: &Arc<Runtime>,
+    runtime: &Handle,
     cap_bytes: usize,
     state: &Arc<RwLock<CacheState>>,
     updates_tx: &broadcast::Sender<MediaImageUpdate>,
@@ -1121,7 +1121,7 @@ static GLOBAL_MEDIA_IMAGE_CACHE: OnceLock<Arc<MediaImageCache>> = OnceLock::new(
 pub fn global_media_image_cache() -> Arc<MediaImageCache> {
     GLOBAL_MEDIA_IMAGE_CACHE
         .get_or_init(|| {
-            let runtime = crate::models::global_runtime();
+            let runtime = crate::models::global_handle();
             let cache =
                 MediaImageCache::new(CACHE_CAP_BYTES, &runtime, crate::models::global_store);
             Arc::new(cache)

--- a/rust/launcher/src/models/app_status.rs
+++ b/rust/launcher/src/models/app_status.rs
@@ -108,7 +108,7 @@ fn bind_catalog_status(mut model: Pin<&mut ffi::AppStatus>) {
     apply_catalog_state(model.as_mut(), projected);
 
     let qt_thread = model.qt_thread();
-    crate::models::global_runtime().spawn(async move {
+    crate::models::global_handle().spawn(async move {
         while rx.changed().await.is_ok() {
             let projected = project_catalog(&rx.borrow_and_update());
             let _ = qt_thread.queue(move |m| apply_catalog_state(m, projected));
@@ -128,7 +128,7 @@ fn bind_link_state(mut model: Pin<&mut ffi::AppStatus>) {
     apply_link_state(model.as_mut(), projected);
 
     let qt_thread = model.qt_thread();
-    crate::models::global_runtime().spawn(async move {
+    crate::models::global_handle().spawn(async move {
         while rx.changed().await.is_ok() {
             let projected = project_link(&rx.borrow_and_update());
             let _ = qt_thread.queue(move |m| apply_link_state(m, projected));

--- a/rust/launcher/src/models/favorites.rs
+++ b/rust/launcher/src/models/favorites.rs
@@ -22,7 +22,7 @@
 // here yet — favorites launches by `run`-ing the entry's ZapScript.
 
 use crate::media_image_cache::{global_media_image_cache, MediaImageCache, MediaKey};
-use crate::models::{global_runtime, global_store};
+use crate::models::{global_handle, global_store};
 use cxx_qt::{CxxQtType, Threading};
 use cxx_qt_lib::{
     QByteArray, QHash, QHashPair_i32_QByteArray, QList, QModelIndex, QString, QVariant,
@@ -373,7 +373,7 @@ impl ffi::FavoritesModel {
         self.as_mut().set_loading_more(true);
         let qt_thread = self.qt_thread();
         let store = global_store();
-        global_runtime().spawn(async move {
+        global_handle().spawn(async move {
             let result = store
                 .client()
                 .media_search(MediaSearchParams {
@@ -403,7 +403,7 @@ impl ffi::FavoritesModel {
         }
         let name = entry.name.clone();
         let store = global_store();
-        global_runtime().spawn(async move {
+        global_handle().spawn(async move {
             if let Err(e) = store.run_mutation::<RunMutation>(RunParams { text }).await {
                 warn!("run failed for {name}: {}", e.message);
             }
@@ -439,7 +439,7 @@ impl ffi::FavoritesModel {
         self.as_mut().set_card_write_error(QString::default());
         self.as_mut().set_card_write_pending(true);
         let qt_thread = self.qt_thread();
-        global_runtime().spawn(async move {
+        global_handle().spawn(async move {
             let result = store
                 .run_mutation::<ReadersWriteMutation>(ReadersWriteParams { text })
                 .await;
@@ -478,7 +478,7 @@ impl ffi::FavoritesModel {
         let path = entry.path.clone();
         let store = global_store();
         let qt_thread = self.qt_thread();
-        global_runtime().spawn(async move {
+        global_handle().spawn(async move {
             match store.run_mutation::<MediaTagsUpdateMutation>(params).await {
                 Ok(result) => {
                     let _ = qt_thread.queue(move |mut model| {
@@ -550,7 +550,7 @@ impl ffi::FavoritesModel {
         let cache = global_media_image_cache();
         let mut rx = cache.subscribe();
         let qt_thread = self.qt_thread();
-        let handle = global_runtime().spawn(async move {
+        let handle = global_handle().spawn(async move {
             loop {
                 match rx.recv().await {
                     Ok(update) => {
@@ -767,7 +767,7 @@ fn notify_cover_update(mut model: Pin<&mut ffi::FavoritesModel>, key: &MediaKey)
         let seq = model.rust().cover_gate_seq.clone();
         let ticket = seq.fetch_add(1, Ordering::SeqCst) + 1;
         let qt_thread = model.qt_thread();
-        let handle = global_runtime().spawn(async move {
+        let handle = global_handle().spawn(async move {
             tokio::time::sleep(Duration::from_millis(200)).await;
             let _ = qt_thread.queue(move |mut model: Pin<&mut ffi::FavoritesModel>| {
                 if seq.load(Ordering::SeqCst) != ticket {
@@ -840,7 +840,7 @@ fn arm_cover_gate(mut model: Pin<&mut ffi::FavoritesModel>) {
     let seq = model.rust().cover_gate_seq.clone();
     let ticket = seq.fetch_add(1, Ordering::SeqCst) + 1;
     let qt_thread = model.qt_thread();
-    let handle = global_runtime().spawn(async move {
+    let handle = global_handle().spawn(async move {
         tokio::time::sleep(Duration::from_secs(3)).await;
         let _ = qt_thread.queue(move |model| {
             if seq.load(Ordering::SeqCst) != ticket {

--- a/rust/launcher/src/models/games.rs
+++ b/rust/launcher/src/models/games.rs
@@ -31,7 +31,7 @@
 // when the user spams direction-arrow + Accept across a model swap.
 
 use crate::media_image_cache::{global_media_image_cache, MediaImageCache, MediaKey};
-use crate::models::{global_runtime, global_store};
+use crate::models::{global_handle, global_store};
 use cxx_qt::{CxxQtType, Threading};
 use cxx_qt_lib::{
     QByteArray, QHash, QHashPair_i32_QByteArray, QList, QModelIndex, QString, QVariant,
@@ -111,7 +111,7 @@ const FETCH_MORE_CHUNK_SIZE: i32 = 100;
 // across frames instead of one ~750 ms - 1.6 s block. The first batch
 // runs synchronously inside the original Qt-thread call so PagedGrid's
 // `_commitPendingTarget` fires within ~200 ms of the user's press; the
-// rest are posted from `global_runtime()` with one frame of breathing
+// rest are posted from `global_handle()` with one frame of breathing
 // room (`SUB_BATCH_FRAME_GAP_MS`) between batches so input + paint can
 // drain in between. 25 is one full visual page on a 5x5 dense layout
 // and roughly 190 ms of insert work warm — detectable as a hitch but
@@ -551,7 +551,7 @@ impl ffi::GamesModel {
         // append no longer belongs to the current page chain and
         // would corrupt the freshly-reset entries.
         let expected_prev_cursor = cursor.clone();
-        global_runtime().spawn(async move {
+        global_handle().spawn(async move {
             let result = store
                 .client()
                 .media_browse(MediaBrowseParams {
@@ -610,7 +610,7 @@ impl ffi::GamesModel {
         let text = entry.zap_script.clone();
         let name = entry.name.clone();
         let store = global_store();
-        global_runtime().spawn(async move {
+        global_handle().spawn(async move {
             if let Err(e) = store.run_mutation::<RunMutation>(RunParams { text }).await {
                 warn!("run failed for {name}: {}", e.message);
             }
@@ -646,7 +646,7 @@ impl ffi::GamesModel {
         self.as_mut().set_card_write_error(QString::default());
         self.as_mut().set_card_write_pending(true);
         let qt_thread = self.qt_thread();
-        global_runtime().spawn(async move {
+        global_handle().spawn(async move {
             let result = store
                 .run_mutation::<ReadersWriteMutation>(ReadersWriteParams { text })
                 .await;
@@ -688,7 +688,7 @@ impl ffi::GamesModel {
         let path = entry.path.clone();
         let store = global_store();
         let qt_thread = self.qt_thread();
-        global_runtime().spawn(async move {
+        global_handle().spawn(async move {
             match store.run_mutation::<MediaTagsUpdateMutation>(params).await {
                 Ok(result) => {
                     let _ = qt_thread.queue(move |mut model| {
@@ -789,7 +789,7 @@ impl ffi::GamesModel {
         let ticket = seq.load(Ordering::SeqCst);
         let store = global_store();
         let qt_thread = self.qt_thread();
-        global_runtime().spawn(async move {
+        global_handle().spawn(async move {
             let result = store
                 .client()
                 .media_meta(MediaMetaParams::for_media(system.clone(), path.clone()))
@@ -883,7 +883,7 @@ impl ffi::GamesModel {
         let cache = global_media_image_cache();
         let mut rx = cache.subscribe();
         let qt_thread = self.qt_thread();
-        let handle = global_runtime().spawn(async move {
+        let handle = global_handle().spawn(async move {
             loop {
                 match rx.recv().await {
                     Ok(update) => {
@@ -999,7 +999,7 @@ impl ffi::GamesModel {
         let qt_thread = self.qt_thread();
         let snapshot = status_rx.borrow_and_update().clone();
         let seq_for_loop = seq.clone();
-        let handle = global_runtime().spawn(async move {
+        let handle = global_handle().spawn(async move {
             while status_rx.changed().await.is_ok() {
                 let snapshot = status_rx.borrow_and_update().clone();
                 let seq_for_closure = seq_for_loop.clone();
@@ -1485,7 +1485,7 @@ fn notify_cover_update(mut model: Pin<&mut ffi::GamesModel>, key: &MediaKey) {
         let seq = model.rust().cover_gate_seq.clone();
         let ticket = seq.fetch_add(1, Ordering::SeqCst) + 1;
         let qt_thread = model.qt_thread();
-        let handle = global_runtime().spawn(async move {
+        let handle = global_handle().spawn(async move {
             tokio::time::sleep(Duration::from_millis(200)).await;
             let _ = qt_thread.queue(move |mut model: Pin<&mut ffi::GamesModel>| {
                 if seq.load(Ordering::SeqCst) != ticket {
@@ -1585,7 +1585,7 @@ fn arm_cover_gate(mut model: Pin<&mut ffi::GamesModel>) {
     let seq = model.rust().cover_gate_seq.clone();
     let ticket = seq.fetch_add(1, Ordering::SeqCst) + 1;
     let qt_thread = model.qt_thread();
-    let handle = global_runtime().spawn(async move {
+    let handle = global_handle().spawn(async move {
         tokio::time::sleep(Duration::from_secs(3)).await;
         let _ = qt_thread.queue(move |model| {
             if seq.load(Ordering::SeqCst) != ticket {
@@ -2117,7 +2117,7 @@ fn apply_append_page(
             //    clamp to the actual last item.
             //
             // Sub-batching note: the rest of the chunk is posted from
-            // `global_runtime()` one frame apart so the Repeater's
+            // `global_handle()` one frame apart so the Repeater's
             // per-delegate `createObject` cost (the dominant Qt-thread
             // stall on MiSTer) is spread across frames. Stale batches
             // self-disarm via the `append_seq` ticket if a new
@@ -2173,7 +2173,7 @@ fn apply_append_page(
             let seq = model.rust().append_seq.clone();
             let ticket = seq.load(Ordering::SeqCst);
             let qt_thread = model.qt_thread();
-            global_runtime().spawn(async move {
+            global_handle().spawn(async move {
                 let last_idx = batches.len().saturating_sub(1);
                 for (i, batch) in batches.into_iter().enumerate() {
                     tokio::time::sleep(Duration::from_millis(SUB_BATCH_FRAME_GAP_MS)).await;

--- a/rust/launcher/src/models/media_status.rs
+++ b/rust/launcher/src/models/media_status.rs
@@ -176,7 +176,7 @@ impl Initialize for ffi::MediaStatus {
         apply(self.as_mut(), project(&rx.borrow_and_update()));
 
         let qt_thread = self.qt_thread();
-        crate::models::global_runtime().spawn(async move {
+        crate::models::global_handle().spawn(async move {
             while rx.changed().await.is_ok() {
                 let snapshot = project(&rx.borrow_and_update());
                 let _ = qt_thread.queue(move |m| apply(m, snapshot));
@@ -188,7 +188,7 @@ impl Initialize for ffi::MediaStatus {
 impl ffi::MediaStatus {
     fn start_index(self: Pin<&mut Self>) {
         let resource = crate::models::global_store().media_status();
-        crate::models::global_runtime().spawn(async move {
+        crate::models::global_handle().spawn(async move {
             if let Err(e) = resource.start_index(MediaIndexParams::default()).await {
                 warn!("media_status: start_index failed: {}", e.message);
             }
@@ -197,7 +197,7 @@ impl ffi::MediaStatus {
 
     fn cancel_index(self: Pin<&mut Self>) {
         let resource = crate::models::global_store().media_status();
-        crate::models::global_runtime().spawn(async move {
+        crate::models::global_handle().spawn(async move {
             if let Err(e) = resource.cancel_index().await {
                 warn!("media_status: cancel_index failed: {}", e.message);
             }
@@ -206,7 +206,7 @@ impl ffi::MediaStatus {
 
     fn start_scrape(self: Pin<&mut Self>) {
         let resource = crate::models::global_store().media_status();
-        crate::models::global_runtime().spawn(async move {
+        crate::models::global_handle().spawn(async move {
             // ES gamelist.xml across every indexed system, no re-scrape.
             // Core ships this scraper in-tree (see `pkg/api/server.go`
             // wiring `gamelistxml.NewGamelistXMLScraper`) and validates
@@ -228,7 +228,7 @@ impl ffi::MediaStatus {
 
     fn cancel_scrape(self: Pin<&mut Self>) {
         let resource = crate::models::global_store().media_status();
-        crate::models::global_runtime().spawn(async move {
+        crate::models::global_handle().spawn(async move {
             if let Err(e) = resource.cancel_scrape().await {
                 warn!("media_status: cancel_scrape failed: {}", e.message);
             }

--- a/rust/launcher/src/models/mod.rs
+++ b/rust/launcher/src/models/mod.rs
@@ -49,26 +49,44 @@ pub mod systems_state;
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, OnceLock};
-use tokio::runtime::Runtime;
+use std::time::Duration;
+use tokio::runtime::{Handle, Runtime};
 use tracing::error;
 use zaparoo_core::{persist::PersistedState, store::Store};
 
-static RUNTIME: OnceLock<Arc<Runtime>> = OnceLock::new();
+// `RUNTIME_OWNER` holds the actual `Runtime` and is the only thing that
+// can call `shutdown_timeout`. `HANDLE` is what callers spawn through —
+// cloning a `Handle` is cheap and doesn't entangle Drop ordering. The
+// split exists so `zaparoo_rust_shutdown` can take the owning `Runtime`
+// out and shut it down on the main thread, draining workers while their
+// TLS storage is still alive. Without this split, the static dropped at
+// `__cxa_finalize` and worker exits raced with TLS teardown — any
+// tracing event from a half-exited worker hit `LocalKey::with` and
+// double-panicked into SIGABRT (exit 134).
+static RUNTIME_OWNER: Mutex<Option<Runtime>> = Mutex::new(None);
+static HANDLE: OnceLock<Handle> = OnceLock::new();
 static STORE: OnceLock<Arc<Store>> = OnceLock::new();
 static PERSIST_STATE: OnceLock<Arc<Mutex<PersistedState>>> = OnceLock::new();
 static INPUT_BINDINGS: OnceLock<HashMap<i32, String>> = OnceLock::new();
 static CORE_IS_LOCAL: OnceLock<bool> = OnceLock::new();
 
 pub fn init_globals(
-    runtime: Arc<Runtime>,
+    runtime: Runtime,
     store: Arc<Store>,
     persist_state: Arc<Mutex<PersistedState>>,
     input_bindings: HashMap<i32, String>,
     core_is_local: bool,
 ) {
-    RUNTIME
-        .set(runtime)
-        .unwrap_or_else(|_| panic!("RUNTIME already initialized"));
+    HANDLE
+        .set(runtime.handle().clone())
+        .unwrap_or_else(|_| panic!("HANDLE already initialized"));
+    {
+        let mut owner = RUNTIME_OWNER
+            .lock()
+            .unwrap_or_else(|_| panic!("RUNTIME_OWNER mutex poisoned"));
+        assert!(owner.is_none(), "RUNTIME_OWNER already initialized");
+        *owner = Some(runtime);
+    }
     STORE
         .set(store)
         .unwrap_or_else(|_| panic!("STORE already initialized"));
@@ -83,8 +101,35 @@ pub fn init_globals(
         .unwrap_or_else(|_| panic!("CORE_IS_LOCAL already initialized"));
 }
 
-pub fn global_runtime() -> Arc<Runtime> {
-    RUNTIME.get().expect("RUNTIME not initialized").clone()
+pub fn global_handle() -> Handle {
+    HANDLE.get().expect("HANDLE not initialized").clone()
+}
+
+/// Drains the tokio runtime on the calling thread with a hard deadline.
+/// Idempotent: a second call after the runtime has been taken is a
+/// silent no-op so the FFI shutdown entry point can be safely invoked
+/// from both `aboutToQuit` and any future cleanup paths.
+///
+/// Must run on a thread whose TLS is still alive — i.e. before main
+/// returns and before `__cxa_finalize`. That's what makes this the
+/// right answer to the SIGABRT-on-quit race: workers finish (or get
+/// cancelled) while every thread's `thread_local!` storage is still
+/// addressable, so a final tracing event from a finishing task can't
+/// land on a half-destroyed dispatcher TLS.
+pub fn shutdown_runtime(timeout: Duration) {
+    let runtime = {
+        let mut owner = match RUNTIME_OWNER.lock() {
+            Ok(g) => g,
+            Err(poisoned) => {
+                error!("RUNTIME_OWNER mutex poisoned at shutdown; recovering");
+                poisoned.into_inner()
+            }
+        };
+        owner.take()
+    };
+    if let Some(runtime) = runtime {
+        runtime.shutdown_timeout(timeout);
+    }
 }
 
 pub fn global_store() -> Arc<Store> {

--- a/rust/launcher/src/models/platform.rs
+++ b/rust/launcher/src/models/platform.rs
@@ -48,7 +48,7 @@ impl Initialize for ffi::Platform {
         apply_state(self.as_mut(), project(rx.borrow_and_update().as_ref()));
 
         let qt_thread = self.qt_thread();
-        crate::models::global_runtime().spawn(async move {
+        crate::models::global_handle().spawn(async move {
             while rx.changed().await.is_ok() {
                 let next = project(rx.borrow_and_update().as_ref());
                 let _ = qt_thread.queue(move |m| apply_state(m, next));

--- a/rust/launcher/src/models/recents.rs
+++ b/rust/launcher/src/models/recents.rs
@@ -23,7 +23,7 @@
 // here yet — recents launches by `run`-ing the entry's launcher route.
 
 use crate::media_image_cache::{global_media_image_cache, MediaImageCache, MediaKey};
-use crate::models::{global_runtime, global_store};
+use crate::models::{global_handle, global_store};
 use cxx_qt::{CxxQtType, Threading};
 use cxx_qt_lib::{
     QByteArray, QHash, QHashPair_i32_QByteArray, QList, QModelIndex, QString, QVariant,
@@ -345,7 +345,7 @@ impl ffi::RecentsModel {
         self.as_mut().set_loading_more(true);
         let qt_thread = self.qt_thread();
         let store = global_store();
-        global_runtime().spawn(async move {
+        global_handle().spawn(async move {
             let result = store
                 .client()
                 .media_history(MediaHistoryParams {
@@ -374,7 +374,7 @@ impl ffi::RecentsModel {
         }
         let name = entry.media_name.clone();
         let store = global_store();
-        global_runtime().spawn(async move {
+        global_handle().spawn(async move {
             if let Err(e) = store.run_mutation::<RunMutation>(RunParams { text }).await {
                 warn!("run failed for {name}: {}", e.message);
             }
@@ -414,7 +414,7 @@ impl ffi::RecentsModel {
         let cache = global_media_image_cache();
         let mut rx = cache.subscribe();
         let qt_thread = self.qt_thread();
-        let handle = global_runtime().spawn(async move {
+        let handle = global_handle().spawn(async move {
             loop {
                 match rx.recv().await {
                     Ok(update) => {
@@ -577,7 +577,7 @@ fn notify_cover_update(mut model: Pin<&mut ffi::RecentsModel>, key: &MediaKey) {
         let seq = model.rust().cover_gate_seq.clone();
         let ticket = seq.fetch_add(1, Ordering::SeqCst) + 1;
         let qt_thread = model.qt_thread();
-        let handle = global_runtime().spawn(async move {
+        let handle = global_handle().spawn(async move {
             tokio::time::sleep(Duration::from_millis(200)).await;
             let _ = qt_thread.queue(move |mut model: Pin<&mut ffi::RecentsModel>| {
                 if seq.load(Ordering::SeqCst) != ticket {
@@ -650,7 +650,7 @@ fn arm_cover_gate(mut model: Pin<&mut ffi::RecentsModel>) {
     let seq = model.rust().cover_gate_seq.clone();
     let ticket = seq.fetch_add(1, Ordering::SeqCst) + 1;
     let qt_thread = model.qt_thread();
-    let handle = global_runtime().spawn(async move {
+    let handle = global_handle().spawn(async move {
         tokio::time::sleep(Duration::from_secs(3)).await;
         let _ = qt_thread.queue(move |model| {
             if seq.load(Ordering::SeqCst) != ticket {

--- a/rust/launcher/src/models/system_status.rs
+++ b/rust/launcher/src/models/system_status.rs
@@ -98,7 +98,7 @@ fn bind_local_readers(mut model: Pin<&mut ffi::SystemStatus>) {
     apply_has_nfc(model.as_mut(), project_readers(&rx.borrow_and_update()));
 
     let qt_thread = model.qt_thread();
-    crate::models::global_runtime().spawn(async move {
+    crate::models::global_handle().spawn(async move {
         while rx.changed().await.is_ok() {
             let has_nfc = project_readers(&rx.borrow_and_update());
             let _ = qt_thread.queue(move |m| apply_has_nfc(m, has_nfc));
@@ -107,7 +107,7 @@ fn bind_local_readers(mut model: Pin<&mut ffi::SystemStatus>) {
 
     let mut notifications = store.subscribe_notifications();
     let resource_for_notifications = resource.clone();
-    crate::models::global_runtime().spawn(async move {
+    crate::models::global_handle().spawn(async move {
         loop {
             match notifications.recv().await {
                 Ok(notification)

--- a/rust/launcher/src/models/systems.rs
+++ b/rust/launcher/src/models/systems.rs
@@ -2,7 +2,7 @@
 // Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
-use crate::models::{global_runtime, global_store};
+use crate::models::{global_handle, global_store};
 use cxx_qt::{CxxQtType, Threading};
 use cxx_qt_lib::{QByteArray, QHash, QHashPair_i32_QByteArray, QModelIndex, QString, QVariant};
 use std::pin::Pin;
@@ -347,7 +347,7 @@ impl ffi::SystemsModel {
         let catalog = self.rust().last_ready.clone();
 
         let qt_thread = self.qt_thread();
-        let handle = global_runtime().spawn(async move {
+        let handle = global_handle().spawn(async move {
             let rows = rows_for_category(catalog.as_ref(), &cat);
             let count = rows.len() as i32;
             let cat_for_log = cat.clone();
@@ -429,7 +429,7 @@ impl ffi::SystemsModel {
         self.as_mut().set_card_write_error(QString::default());
         self.as_mut().set_card_write_pending(true);
         let qt_thread = self.qt_thread();
-        global_runtime().spawn(async move {
+        global_handle().spawn(async move {
             let result = store
                 .run_mutation::<ReadersWriteMutation>(ReadersWriteParams { text })
                 .await;
@@ -461,7 +461,7 @@ impl ffi::SystemsModel {
         let text = format!("**launch.system:{}", system.id);
         let name = system.name.clone();
         let store = global_store();
-        global_runtime().spawn(async move {
+        global_handle().spawn(async move {
             if let Err(e) = store.run_mutation::<RunMutation>(RunParams { text }).await {
                 warn!("run failed for {name}: {}", e.message);
             }

--- a/rust/zaparoo-core/src/client.rs
+++ b/rust/zaparoo-core/src/client.rs
@@ -283,7 +283,7 @@ pub struct Client {
 }
 
 impl Client {
-    pub fn new(endpoint: String, runtime: &Arc<tokio::runtime::Runtime>) -> Arc<Self> {
+    pub fn new(endpoint: String, runtime: &tokio::runtime::Handle) -> Arc<Self> {
         let (connection_tx, _) = watch::channel(ConnectionState::Disconnected);
         let pending: PendingMap = Arc::new(Mutex::new(HashMap::new()));
         let pending_clone = pending.clone();

--- a/rust/zaparoo-core/src/logger.rs
+++ b/rust/zaparoo-core/src/logger.rs
@@ -43,7 +43,7 @@ pub fn install_at(config: &Config, log_path: &Path) -> LoggerGuard {
         .with_writer(std::io::stderr)
         .with_ansi(false)
         .with_target(false)
-        .with_timer(fmt::time::LocalTime::rfc_3339());
+        .with_timer(fmt::time::UtcTime::rfc_3339());
 
     let file_layer = fmt::layer()
         .with_writer(non_blocking_file)

--- a/rust/zaparoo-core/src/platform.rs
+++ b/rust/zaparoo-core/src/platform.rs
@@ -83,7 +83,7 @@ fn publish(p: Platform) {
 /// Failure of the RPC is logged at `warn` and the platform is left at its
 /// prior value (or `None`). `systems` and other catalog fetches continue
 /// regardless.
-pub fn spawn_fetcher(client: Arc<Client>, runtime: &Arc<tokio::runtime::Runtime>) {
+pub fn spawn_fetcher(client: Arc<Client>, runtime: &tokio::runtime::Handle) {
     let mut connection_rx = client.connection.subscribe();
     runtime.spawn(async move {
         let mut state = connection_rx.borrow_and_update().clone();

--- a/rust/zaparoo-core/src/remote_resource.rs
+++ b/rust/zaparoo-core/src/remote_resource.rs
@@ -39,7 +39,7 @@
 use crate::client::{backoff_delay, Client, ClientError, ConnectionState};
 use std::future::Future;
 use std::sync::Arc;
-use tokio::runtime::Runtime;
+use tokio::runtime::Handle;
 use tokio::sync::{oneshot, watch, Notify};
 use tracing::warn;
 
@@ -103,7 +103,7 @@ impl<T: Clone + Send + Sync + 'static> RemoteResource<T> {
     /// lifetime end explicitly. Both shutdown paths are exercised by
     /// `dropping_resource_cancels_spawned_task` and the surrounding
     /// tests.
-    pub fn driven_by<F, Fut>(client: Arc<Client>, runtime: &Arc<Runtime>, fetch: F) -> Self
+    pub fn driven_by<F, Fut>(client: Arc<Client>, runtime: &Handle, fetch: F) -> Self
     where
         F: Fn(Arc<Client>) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = Result<T, ClientError>> + Send + 'static,
@@ -118,7 +118,7 @@ impl<T: Clone + Send + Sync + 'static> RemoteResource<T> {
     /// watch without standing up a real WebSocket.
     pub(crate) fn spawn_with<F, Fut>(
         mut connection_rx: watch::Receiver<ConnectionState>,
-        runtime: &Arc<Runtime>,
+        runtime: &Handle,
         fetch: F,
     ) -> Self
     where
@@ -297,13 +297,11 @@ mod tests {
     use std::time::Duration;
     use tokio::time::timeout;
 
-    fn rt() -> Arc<Runtime> {
-        Arc::new(
-            tokio::runtime::Builder::new_multi_thread()
-                .enable_all()
-                .build()
-                .unwrap(),
-        )
+    fn rt() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap()
     }
 
     /// Wait for the resource status to satisfy a predicate, with a
@@ -337,9 +335,10 @@ mod tests {
     #[test]
     fn idle_until_first_connect() {
         let runtime = rt();
-        runtime.clone().block_on(async {
+        runtime.block_on(async {
             let (conn_tx, conn_rx) = watch::channel(ConnectionState::Disconnected);
-            let res = RemoteResource::<i32>::spawn_with(conn_rx, &runtime, || async { Ok(42) });
+            let res =
+                RemoteResource::<i32>::spawn_with(conn_rx, runtime.handle(), || async { Ok(42) });
             let sub = res.subscribe();
             // Disconnected -> Idle is both the seeded initial value
             // and the task's first publish; either way the observable
@@ -353,9 +352,10 @@ mod tests {
     #[test]
     fn connected_triggers_fetch_and_publishes_ready() {
         let runtime = rt();
-        runtime.clone().block_on(async {
+        runtime.block_on(async {
             let (conn_tx, conn_rx) = watch::channel(ConnectionState::Disconnected);
-            let res = RemoteResource::<i32>::spawn_with(conn_rx, &runtime, || async { Ok(42) });
+            let res =
+                RemoteResource::<i32>::spawn_with(conn_rx, runtime.handle(), || async { Ok(42) });
             let mut sub = res.subscribe();
             conn_tx.send_replace(ConnectionState::Connected);
             let final_status = wait_for(&mut sub, |s| matches!(s, ResourceStatus::Ready(42))).await;
@@ -367,11 +367,11 @@ mod tests {
     #[test]
     fn reconnect_triggers_refetch() {
         let runtime = rt();
-        runtime.clone().block_on(async {
+        runtime.block_on(async {
             let (conn_tx, conn_rx) = watch::channel(ConnectionState::Disconnected);
             let calls = Arc::new(AtomicUsize::new(0));
             let calls_clone = calls.clone();
-            let res = RemoteResource::<usize>::spawn_with(conn_rx, &runtime, move || {
+            let res = RemoteResource::<usize>::spawn_with(conn_rx, runtime.handle(), move || {
                 let n = calls_clone.fetch_add(1, Ordering::SeqCst) + 1;
                 async move { Ok(n) }
             });
@@ -394,22 +394,23 @@ mod tests {
     #[test]
     fn error_with_socket_up_publishes_retrying_then_recovers() {
         let runtime = rt();
-        runtime.clone().block_on(async {
+        runtime.block_on(async {
             let (conn_tx, conn_rx) = watch::channel(ConnectionState::Disconnected);
             let calls = Arc::new(AtomicUsize::new(0));
             let calls_clone = calls.clone();
-            let res = RemoteResource::<&'static str>::spawn_with(conn_rx, &runtime, move || {
-                let n = calls_clone.fetch_add(1, Ordering::SeqCst) + 1;
-                async move {
-                    if n == 1 {
-                        Err(ClientError {
-                            message: "transient".into(),
-                        })
-                    } else {
-                        Ok("ok")
+            let res =
+                RemoteResource::<&'static str>::spawn_with(conn_rx, runtime.handle(), move || {
+                    let n = calls_clone.fetch_add(1, Ordering::SeqCst) + 1;
+                    async move {
+                        if n == 1 {
+                            Err(ClientError {
+                                message: "transient".into(),
+                            })
+                        } else {
+                            Ok("ok")
+                        }
                     }
-                }
-            });
+                });
             let mut sub = res.subscribe();
 
             conn_tx.send_replace(ConnectionState::Connected);
@@ -428,11 +429,11 @@ mod tests {
     #[test]
     fn dropping_resource_cancels_spawned_task() {
         let runtime = rt();
-        runtime.clone().block_on(async {
+        runtime.block_on(async {
             let (conn_tx, conn_rx) = watch::channel(ConnectionState::Connected);
             let calls = Arc::new(AtomicUsize::new(0));
             let calls_clone = calls.clone();
-            let res = RemoteResource::<i32>::spawn_with(conn_rx, &runtime, move || {
+            let res = RemoteResource::<i32>::spawn_with(conn_rx, runtime.handle(), move || {
                 calls_clone.fetch_add(1, Ordering::SeqCst);
                 async move { Ok(0) }
             });
@@ -462,9 +463,9 @@ mod tests {
     #[test]
     fn unreachable_publishes_non_retrying_error() {
         let runtime = rt();
-        runtime.clone().block_on(async {
+        runtime.block_on(async {
             let (conn_tx, conn_rx) = watch::channel(ConnectionState::Disconnected);
-            let res = RemoteResource::<i32>::spawn_with(conn_rx, &runtime, || async {
+            let res = RemoteResource::<i32>::spawn_with(conn_rx, runtime.handle(), || async {
                 Ok(0) // never called — Unreachable doesn't trigger fetch
             });
             let mut sub = res.subscribe();
@@ -493,11 +494,11 @@ mod tests {
     #[test]
     fn seed_loading_when_already_connected() {
         let runtime = rt();
-        runtime.clone().block_on(async {
+        runtime.block_on(async {
             let (_conn_tx, conn_rx) = watch::channel(ConnectionState::Connected);
             // Long-running fetch keeps the spawned task in Loading; it
             // never publishes Ready while we're checking the seed.
-            let res = RemoteResource::<i32>::spawn_with(conn_rx, &runtime, || async {
+            let res = RemoteResource::<i32>::spawn_with(conn_rx, runtime.handle(), || async {
                 tokio::time::sleep(Duration::from_secs(60)).await;
                 Ok(0)
             });
@@ -518,10 +519,11 @@ mod tests {
     #[test]
     fn seed_errored_when_unreachable() {
         let runtime = rt();
-        runtime.clone().block_on(async {
+        runtime.block_on(async {
             let (_conn_tx, conn_rx) =
                 watch::channel(ConnectionState::Unreachable("startup-failure".into()));
-            let res = RemoteResource::<i32>::spawn_with(conn_rx, &runtime, || async { Ok(0) });
+            let res =
+                RemoteResource::<i32>::spawn_with(conn_rx, runtime.handle(), || async { Ok(0) });
             let sub = res.subscribe();
             let initial = sub.borrow().clone();
             match initial {
@@ -537,11 +539,11 @@ mod tests {
     #[test]
     fn refetch_notify_triggers_refetch() {
         let runtime = rt();
-        runtime.clone().block_on(async {
+        runtime.block_on(async {
             let (conn_tx, conn_rx) = watch::channel(ConnectionState::Disconnected);
             let calls = Arc::new(AtomicUsize::new(0));
             let calls_clone = calls.clone();
-            let res = RemoteResource::<usize>::spawn_with(conn_rx, &runtime, move || {
+            let res = RemoteResource::<usize>::spawn_with(conn_rx, runtime.handle(), move || {
                 let n = calls_clone.fetch_add(1, Ordering::SeqCst) + 1;
                 async move { Ok(n) }
             });
@@ -571,11 +573,11 @@ mod tests {
     #[test]
     fn refetch_pulse_while_disconnected_does_not_fetch_until_connected() {
         let runtime = rt();
-        runtime.clone().block_on(async {
+        runtime.block_on(async {
             let (conn_tx, conn_rx) = watch::channel(ConnectionState::Disconnected);
             let calls = Arc::new(AtomicUsize::new(0));
             let calls_clone = calls.clone();
-            let res = RemoteResource::<usize>::spawn_with(conn_rx, &runtime, move || {
+            let res = RemoteResource::<usize>::spawn_with(conn_rx, runtime.handle(), move || {
                 let n = calls_clone.fetch_add(1, Ordering::SeqCst) + 1;
                 async move { Ok(n) }
             });

--- a/rust/zaparoo-core/src/store/media_status.rs
+++ b/rust/zaparoo-core/src/store/media_status.rs
@@ -24,7 +24,7 @@ use crate::media_types::{
     IndexingStatusResponse, MediaIndexParams, MediaScrapeParams, ScrapingStatusResponse,
 };
 use std::sync::Arc;
-use tokio::runtime::Runtime;
+use tokio::runtime::Handle;
 use tokio::sync::{broadcast, watch};
 use tokio::time::{sleep, Duration};
 use tracing::{debug, warn};
@@ -118,7 +118,7 @@ impl std::fmt::Debug for MediaStatusResource {
 }
 
 impl MediaStatusResource {
-    pub fn new(client: &Arc<Client>, runtime: &Arc<Runtime>) -> Arc<Self> {
+    pub fn new(client: &Arc<Client>, runtime: &Handle) -> Arc<Self> {
         let (state_tx, _) = watch::channel(MediaStatusState::default());
         let state_arc = Arc::new(state_tx);
 

--- a/rust/zaparoo-core/src/store/mod.rs
+++ b/rust/zaparoo-core/src/store/mod.rs
@@ -29,7 +29,7 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::sync::{Arc, Mutex};
-use tokio::runtime::Runtime;
+use tokio::runtime::Handle;
 use tokio::sync::broadcast;
 
 /// Cache lookup key for `Store::subscribe`. Combines the endpoint's
@@ -76,7 +76,7 @@ struct Inner {
 
 pub struct Store {
     client: Arc<Client>,
-    runtime: Arc<Runtime>,
+    runtime: Handle,
     inner: Arc<Mutex<Inner>>,
     /// Singleton media-status publisher. Eagerly constructed on
     /// `Store::new` so the seeding task starts as soon as the launcher
@@ -91,7 +91,7 @@ impl std::fmt::Debug for Store {
 }
 
 impl Store {
-    pub fn new(client: Arc<Client>, runtime: Arc<Runtime>) -> Arc<Self> {
+    pub fn new(client: Arc<Client>, runtime: Handle) -> Arc<Self> {
         let media_status = MediaStatusResource::new(&client, &runtime);
         let store = Arc::new(Self {
             client,
@@ -412,17 +412,20 @@ mod tests {
     }
 
     fn test_store() -> Arc<Store> {
-        let runtime = Arc::new(
+        // Leak the test runtime so the Handles stored in Client/Store
+        // remain valid for the test's lifetime — Handle does not keep
+        // the Runtime alive on its own.
+        let runtime: &'static tokio::runtime::Runtime = Box::leak(Box::new(
             tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
                 .expect("build runtime"),
-        );
+        ));
         // The Client spawns a reconnect task against this endpoint; the
         // test never lets the task connect, so the URL just needs to
         // parse. `subscribe` itself doesn't await anything network-y.
-        let client = Client::new("ws://127.0.0.1:1/never".to_string(), &runtime);
-        Store::new(client, runtime)
+        let client = Client::new("ws://127.0.0.1:1/never".to_string(), runtime.handle());
+        Store::new(client, runtime.handle().clone())
     }
 
     #[test]

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -46,6 +46,7 @@ constexpr int kPixmapCacheLimitKiB = 50 * 1024;
 
 extern "C" int zaparoo_rust_init(bool crtNativePathForced);
 extern "C" void zaparoo_rust_post_qt_start();
+extern "C" void zaparoo_rust_shutdown();
 extern "C" void zaparoo_log_qt(uint8_t level, const char* msg, size_t len);
 extern "C" const char* zaparoo_rust_language_code();
 extern "C" bool zaparoo_rust_crt_native_path_enabled();
@@ -337,6 +338,26 @@ int main(int argc, char* argv[])
     {
         qInfo("CRT startup decision: skipping native video writer");
     }
+
+    // Drain the tokio runtime and detach the Qt-to-Rust log bridge while
+    // the main thread is still alive and every thread's TLS storage is
+    // still addressable. `aboutToQuit` fires after `Qt.quit()` (or the
+    // last window close) but before `exec()` returns, which is the only
+    // window where we can run `Runtime::shutdown_timeout` and uninstall
+    // the message handler ahead of `__cxa_finalize`.
+    //
+    // The handler matters because Qt's own destruction emits log
+    // messages from internal threads (QThreadPool workers, plugin
+    // teardown). Left installed, those calls re-enter `zaparoo_log_qt`
+    // and the tracing dispatcher whose TLS is mid-destruction, panic
+    // with `AccessError`, and the panic-hook's own `tracing::error!`
+    // re-panics into SIGABRT (exit 134).
+    QObject::connect(&app, &QGuiApplication::aboutToQuit, &app,
+                     []()
+                     {
+                         zaparoo_rust_shutdown();
+                         qInstallMessageHandler(nullptr);
+                     });
 
     zaparoo_rust_post_qt_start();
     return QGuiApplication::exec();

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -125,7 +125,6 @@ int main(int argc, char* argv[])
     const bool crtNativePathForced = parsedArgs.crtNativePathForced;
     int qtArgc = static_cast<int>(parsedArgs.argv.size()) - 1;
     char** qtArgv = parsedArgs.argv.data();
-    qInfo("CRT startup decision: --crt argument %s", crtNativePathForced ? "present" : "absent");
 
     // Desktop CRT preview: pin Qt's high-DPI handling so logical pixels
     // map 1:1 to physical pixels. Without this, on a screen with
@@ -199,8 +198,6 @@ int main(int argc, char* argv[])
                                                     QStringLiteral("Noto Sans Devanagari"));
     qInfo("Registered application font fallbacks for CJK, Arabic, and Devanagari scripts");
     const bool crtNativePathEnabled = zaparoo_rust_crt_native_path_enabled();
-    qInfo("CRT startup decision: Rust CRT native path %s",
-          crtNativePathEnabled ? "enabled" : "disabled");
     if (crtNativePathEnabled)
     {
         QQuickWindow::setTextRenderType(QQuickWindow::NativeTextRendering);
@@ -330,13 +327,8 @@ int main(int argc, char* argv[])
 
     if (crtNativePathEnabled)
     {
-        qInfo("CRT startup decision: starting native video writer");
         startNativeVideoWriter();
         std::atexit(stopNativeVideoWriter);
-    }
-    else
-    {
-        qInfo("CRT startup decision: skipping native video writer");
     }
 
     // Drain the tokio runtime and detach the Qt-to-Rust log bridge while

--- a/src/ui/app/MainLayout.qml
+++ b/src/ui/app/MainLayout.qml
@@ -149,6 +149,31 @@ ApplicationWindow {
             root.applyCrtPreviewScale(root._crtPreviewEffectiveScale);
     }
 
+    // When the window crosses to a different screen (e.g. dev drags
+    // it from a 4K to a 1080p monitor), Qt updates Screen.width and
+    // Screen.height. The previously-picked integer scale may no
+    // longer fit the smaller screen, so recompute against the new
+    // dimensions and shrink the window if needed. Auto-scale only;
+    // an explicit ZAPAROO_CRT_PREVIEW_SCALE override is honored.
+    readonly property real _crtPreviewScreenW: Screen.width
+    readonly property real _crtPreviewScreenH: Screen.height
+    on_CrtPreviewScreenWChanged: _maybeShrinkCrtPreviewToScreen()
+    on_CrtPreviewScreenHChanged: _maybeShrinkCrtPreviewToScreen()
+
+    function _maybeShrinkCrtPreviewToScreen(): void {
+        if (!root._crtPreviewActive || root.crtPreviewScale > 0)
+            return;
+        const sw = Screen.width;
+        const sh = Screen.height;
+        if (sw <= 0 || sh <= 0)
+            return;
+        const sx = Math.floor((sw * 0.95) / root.videoWidth);
+        const sy = Math.floor((sh * 0.95) / root.videoHeight);
+        const fitScale = root._clampCrtPreviewScale(Math.max(1, Math.min(sx, sy)));
+        if (root._crtPreviewEffectiveScale > fitScale)
+            root.applyCrtPreviewScale(fitScale);
+    }
+
     Binding {
         target: Resources
         property: "buttonLayout"


### PR DESCRIPTION
## Summary

- **Prevent SIGABRT (exit 134) on graceful quit.** Tokio workers and Qt internal threads were emitting tracing events after their TLS had entered destruction. Three coordinated changes break the race: split the runtime into a take-able `Mutex<Option<Runtime>>` + `OnceLock<Handle>` and add a `zaparoo_rust_shutdown` FFI that calls `shutdown_timeout`; wire `QGuiApplication::aboutToQuit` to drain the runtime and then uninstall the Qt-to-Rust log bridge with `qInstallMessageHandler(nullptr)`; harden the panic hook so a teardown-phase TLS-access panic doesn't cascade into a second panic and SIGABRT.
- **CRT preview shrinks to fit when the window crosses monitors.** Reactive bindings on `Screen.width/height` recompute the auto fit-scale on monitor change; honors an explicit `ZAPAROO_CRT_PREVIEW_SCALE` override.
- **Drop noisy `CRT startup decision: ...` qInfo lines** that were useful while landing the native CRT path but are now just startup noise.

## Test plan

- [x] `just build` clean
- [x] `just lint` clean
- [x] `just test` 337/337
- [x] Manual: quit launcher (incl. `--crt`), confirm `echo $?` is 0 and no `*** native crash ***` marker in `~/.local/share/zaparoo/logs/launcher.log`
- [ ] Manual: drag CRT preview window between monitors of different sizes, confirm it shrinks rather than overflowing
- [ ] Manual: confirm `CRT startup decision:` lines no longer appear in the log on launch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CRT preview now auto-adjusts display scale when screen dimensions change.

* **Bug Fixes**
  * Improved application shutdown handling with 2-second timeout.
  * Enhanced crash stability during thread teardown.

* **Logging**
  * Logger timestamps now use UTC instead of local time.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ZaparooProject/zaparoo-launcher/pull/119)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->