### PR TITLE
perf(crt): frame-driven fb0 mirror, drop 60Hz writer thread

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -332,6 +332,23 @@ int main(int argc, char* argv[])
         qInfo("CRT startup decision: starting native video writer");
         startNativeVideoWriter();
         std::atexit(stopNativeVideoWriter);
+        // Drive the fb0 -> DDR copy from Qt's render-finish signal so
+        // we mirror exactly one frame per actual scenegraph render.
+        // `frameSwapped` fires after the QPA backing store has been
+        // flushed to /dev/fb0, so by the time the slot copies pixels
+        // out, fb0 already holds the new frame. Idle scenes produce
+        // no `frameSwapped` and therefore no copy and no CPU work.
+        auto* rootWindow = qobject_cast<QQuickWindow*>(engine.rootObjects().first());
+        if (rootWindow != nullptr)
+        {
+            QObject::connect(rootWindow, &QQuickWindow::frameSwapped, rootWindow,
+                             []() { copyFrameNativeVideoWriter(); });
+        }
+        else
+        {
+            qCritical("CRT startup decision: QML root is not a QQuickWindow; per-frame copy "
+                      "hook not installed (FPGA will stay on the zero-initialised slot)");
+        }
     }
     else
     {

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -329,20 +329,32 @@ int main(int argc, char* argv[])
 
     if (crtNativePathEnabled)
     {
-        qInfo("CRT startup decision: starting native video writer");
-        startNativeVideoWriter();
+        qInfo("CRT startup decision: initialising native video writer");
+        initNativeVideoWriter();
         std::atexit(stopNativeVideoWriter);
         // Drive the fb0 -> DDR copy from Qt's render-finish signal so
-        // we mirror exactly one frame per actual scenegraph render.
-        // `frameSwapped` fires after the QPA backing store has been
-        // flushed to /dev/fb0, so by the time the slot copies pixels
-        // out, fb0 already holds the new frame. Idle scenes produce
-        // no `frameSwapped` and therefore no copy and no CPU work.
+        // we mirror exactly one frame per actual scenegraph render
+        // (idle scenes produce no `frameSwapped` and therefore no
+        // copy and no CPU work).
+        //
+        // Qt::QueuedConnection is load-bearing: the linuxfb QPA
+        // doesn't write /dev/fb0 inside `QPlatformBackingStore::flush()`.
+        // It calls `QFbScreen::scheduleUpdate()` which only posts a
+        // `QEvent::UpdateRequest`; the actual blit to fb0 happens
+        // later, in `QFbScreen::doRedraw()`, on a subsequent event-
+        // loop iteration. `frameSwapped` is emitted *before* that
+        // posted event drains, so a DirectConnection slot would read
+        // stale fb0 and we'd publish the previous frame to the FPGA
+        // (one-frame-behind CRT output). Posting our copy via a
+        // queued connection puts it FIFO behind the UpdateRequest,
+        // so `doRedraw()` runs first and we then read the freshly
+        // updated fb0.
         auto* rootWindow = qobject_cast<QQuickWindow*>(engine.rootObjects().first());
         if (rootWindow != nullptr)
         {
-            QObject::connect(rootWindow, &QQuickWindow::frameSwapped, rootWindow,
-                             []() { copyFrameNativeVideoWriter(); });
+            QObject::connect(
+                rootWindow, &QQuickWindow::frameSwapped, rootWindow,
+                []() { copyFrameNativeVideoWriter(); }, Qt::QueuedConnection);
         }
         else
         {

--- a/src/app/native_video_writer.cpp
+++ b/src/app/native_video_writer.cpp
@@ -112,8 +112,8 @@ void initNativeVideoWriter()
     // Menu fork core expects, and silently copying the top-left slice
     // would mask that misconfiguration.
     if (var.bits_per_pixel != 32 || var.xres != static_cast<uint32_t>(kOutputWidth) ||
-        var.yres != static_cast<uint32_t>(kOutputHeight) ||
-        fixed.line_length != kOutputStride || var.xoffset != 0 || var.yoffset != 0)
+        var.yres != static_cast<uint32_t>(kOutputHeight) || fixed.line_length != kOutputStride ||
+        var.xoffset != 0 || var.yoffset != 0)
     {
         qWarning("native video writer: fb0 mode %ux%u %ubpp stride=%u offset=(%u,%u) does not "
                  "match required %dx%d 32bpp stride=%zu at (0,0); writer disabled",
@@ -214,9 +214,7 @@ void initNativeVideoWriter()
 {
     qInfo("native video writer: init requested on unsupported build/platform");
 }
-void copyFrameNativeVideoWriter()
-{
-}
+void copyFrameNativeVideoWriter() {}
 void stopNativeVideoWriter()
 {
     qInfo("native video writer: stop requested on unsupported build/platform");

--- a/src/app/native_video_writer.cpp
+++ b/src/app/native_video_writer.cpp
@@ -78,11 +78,11 @@ void cleanup()
 
 } // namespace
 
-void startNativeVideoWriter()
+void initNativeVideoWriter()
 {
     if (g_initialized)
     {
-        qInfo("native video writer: start requested but already initialised");
+        qInfo("native video writer: init requested but already initialised");
         return;
     }
 
@@ -159,6 +159,12 @@ void startNativeVideoWriter()
     memset(const_cast<uint8_t*>(g_slot[0]), 0, kOutputBytes);
     memset(const_cast<uint8_t*>(g_slot[1]), 0, kOutputBytes);
     *g_ctrl = 0;
+    // Control word's slot bit is 0, so the FPGA scans slot 0. Point
+    // the first write at slot 1 so the very first frame goes into
+    // the slot the FPGA is NOT reading; without this the initial
+    // memcpy races the scanout and produces a one-frame tear at
+    // startup.
+    g_active = 1;
 
     g_initialized = true;
     qInfo("native video writer: initialised, fb0 %ux%u stride=%u -> DDR slots at "
@@ -204,9 +210,9 @@ void stopNativeVideoWriter()
 
 #include <QLoggingCategory>
 
-void startNativeVideoWriter()
+void initNativeVideoWriter()
 {
-    qInfo("native video writer: start requested on unsupported build/platform");
+    qInfo("native video writer: init requested on unsupported build/platform");
 }
 void copyFrameNativeVideoWriter()
 {

--- a/src/app/native_video_writer.cpp
+++ b/src/app/native_video_writer.cpp
@@ -8,14 +8,12 @@
 
 #include <QLoggingCategory>
 #include <atomic>
-#include <chrono>
 #include <cstdint>
 #include <cstring>
 #include <fcntl.h>
 #include <linux/fb.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
-#include <thread>
 #include <unistd.h>
 
 namespace
@@ -25,220 +23,181 @@ constexpr uintptr_t kNativeVideoBase = 0x3A000000u;
 constexpr size_t kNativeVideoRegionSize = 0x000A0000u;
 constexpr size_t kControlOffset = 0x00000000u;
 constexpr size_t kBuffer0Offset = 0x00000100u;
+constexpr size_t kBuffer1Offset = 0x0004B100u;
 constexpr int kOutputWidth = 320;
 constexpr int kOutputHeight = 240;
 constexpr size_t kSourceBytesPerPixel = 4;
-constexpr int kOutputBytes = kOutputWidth * kOutputHeight * kSourceBytesPerPixel;
-constexpr size_t kBuffer1Offset = 0x0004B100u;
-constexpr size_t kOutputRowBytes = kOutputWidth * kSourceBytesPerPixel;
+constexpr size_t kOutputStride = kOutputWidth * kSourceBytesPerPixel;
+constexpr size_t kOutputBytes = kOutputStride * kOutputHeight;
 
-std::atomic<bool> g_running{false};
-std::thread g_thread;
+int g_fbFd = -1;
+int g_memFd = -1;
+const uint8_t* g_fb = nullptr;
+size_t g_fbSize = 0;
+volatile uint8_t* g_nativeBase = nullptr;
+volatile uint8_t* g_slot[2] = {nullptr, nullptr};
+volatile uint32_t* g_ctrl = nullptr;
+uint32_t g_frame = 0;
+int g_active = 0;
+bool g_initialized = false;
 
-bool validateFramebufferWindow(const fb_fix_screeninfo& fixed, const fb_var_screeninfo& var,
-                               size_t fbSize)
+void cleanup()
 {
-    if (var.bits_per_pixel != 32 || var.xres < kOutputWidth || var.yres < kOutputHeight ||
-        fixed.line_length < kOutputRowBytes)
+    if (g_ctrl != nullptr)
     {
-        qWarning("native video writer: unsupported fb0 mode %ux%u %u bpp; expected at least "
-                 "320x240 32 bpp",
-                 var.xres, var.yres, var.bits_per_pixel);
-        return false;
+        *g_ctrl = 0;
+        g_ctrl = nullptr;
     }
-
-    if (var.xres_virtual < var.xoffset || var.yres_virtual < var.yoffset ||
-        var.xres_virtual - var.xoffset < kOutputWidth ||
-        var.yres_virtual - var.yoffset < kOutputHeight)
+    g_slot[0] = nullptr;
+    g_slot[1] = nullptr;
+    if (g_nativeBase != nullptr)
     {
-        qWarning("native video writer: visible fb0 window %u,%u in %ux%u cannot cover 320x240",
-                 var.xoffset, var.yoffset, var.xres_virtual, var.yres_virtual);
-        return false;
+        munmap(const_cast<uint8_t*>(g_nativeBase), kNativeVideoRegionSize);
+        g_nativeBase = nullptr;
     }
-
-    const size_t sourceRowBytes =
-        (static_cast<size_t>(var.xoffset) + kOutputWidth) * kSourceBytesPerPixel;
-    if (fixed.line_length < sourceRowBytes)
+    if (g_fb != nullptr)
     {
-        qWarning("native video writer: fb0 stride %u too small for visible 320x240 window",
-                 fixed.line_length);
-        return false;
+        munmap(const_cast<uint8_t*>(g_fb), g_fbSize);
+        g_fb = nullptr;
+        g_fbSize = 0;
     }
-
-    const size_t visibleOffset = static_cast<size_t>(var.yoffset) * fixed.line_length +
-                                 static_cast<size_t>(var.xoffset) * kSourceBytesPerPixel;
-    const size_t lastByte = visibleOffset +
-                            static_cast<size_t>(kOutputHeight - 1) * fixed.line_length +
-                            static_cast<size_t>(kOutputWidth) * kSourceBytesPerPixel;
-    if (lastByte > fbSize)
+    if (g_memFd >= 0)
     {
-        qWarning("native video writer: visible fb0 window exceeds mapped framebuffer");
-        return false;
+        close(g_memFd);
+        g_memFd = -1;
     }
-
-    return true;
-}
-
-class Fd
-{
-  public:
-    explicit Fd(const char* path, int flags) : m_fd(open(path, flags)) {}
-
-    ~Fd()
+    if (g_fbFd >= 0)
     {
-        if (m_fd >= 0)
-        {
-            close(m_fd);
-        }
+        close(g_fbFd);
+        g_fbFd = -1;
     }
-
-    Fd(const Fd&) = delete;
-    Fd& operator=(const Fd&) = delete;
-
-    int get() const
-    {
-        return m_fd;
-    }
-    bool ok() const
-    {
-        return m_fd >= 0;
-    }
-
-  private:
-    int m_fd = -1;
-};
-
-void writerLoop()
-{
-    Fd fbFd("/dev/fb0", O_RDONLY | O_CLOEXEC);
-    if (!fbFd.ok())
-    {
-        qWarning("native video writer: failed to open /dev/fb0");
-        return;
-    }
-
-    fb_fix_screeninfo fixed = {};
-    fb_var_screeninfo var = {};
-    if (ioctl(fbFd.get(), FBIOGET_FSCREENINFO, &fixed) < 0 ||
-        ioctl(fbFd.get(), FBIOGET_VSCREENINFO, &var) < 0)
-    {
-        qWarning("native video writer: failed to inspect /dev/fb0");
-        return;
-    }
-    const size_t fbSize = fixed.smem_len != 0
-                              ? fixed.smem_len
-                              : static_cast<size_t>(fixed.line_length) * var.yres_virtual;
-    if (!validateFramebufferWindow(fixed, var, fbSize))
-    {
-        return;
-    }
-
-    auto* fb = static_cast<uint8_t*>(mmap(nullptr, fbSize, PROT_READ, MAP_SHARED, fbFd.get(), 0));
-    if (fb == MAP_FAILED)
-    {
-        qWarning("native video writer: failed to map /dev/fb0");
-        return;
-    }
-
-    Fd memFd("/dev/mem", O_RDWR | O_SYNC | O_CLOEXEC);
-    if (!memFd.ok())
-    {
-        munmap(fb, fbSize);
-        qWarning("native video writer: failed to open /dev/mem");
-        return;
-    }
-
-    auto* nativeBase =
-        static_cast<volatile uint8_t*>(mmap(nullptr, kNativeVideoRegionSize, PROT_READ | PROT_WRITE,
-                                            MAP_SHARED, memFd.get(), kNativeVideoBase));
-    if (nativeBase == MAP_FAILED)
-    {
-        munmap(fb, fbSize);
-        qWarning("native video writer: failed to map native video DDR");
-        return;
-    }
-
-    memset(const_cast<uint8_t*>(nativeBase + kBuffer0Offset), 0, kOutputBytes);
-    memset(const_cast<uint8_t*>(nativeBase + kBuffer1Offset), 0, kOutputBytes);
-    *reinterpret_cast<volatile uint32_t*>(const_cast<uint8_t*>(nativeBase + kControlOffset)) = 0;
-
-    qInfo("native video writer: copying top-left 320x240 RGB8888 from /dev/fb0 %ux%u to native DDR",
-          var.xres, var.yres);
-
-    uint32_t frame = 0;
-    int active = 0;
-    auto nextFrame = std::chrono::steady_clock::now();
-    while (g_running.load(std::memory_order_relaxed))
-    {
-        if (ioctl(fbFd.get(), FBIOGET_VSCREENINFO, &var) < 0)
-        {
-            qWarning("native video writer: failed to refresh /dev/fb0 state");
-            break;
-        }
-        if (!validateFramebufferWindow(fixed, var, fbSize))
-        {
-            break;
-        }
-
-        const auto* visible = fb + static_cast<size_t>(var.yoffset) * fixed.line_length +
-                              static_cast<size_t>(var.xoffset) * kSourceBytesPerPixel;
-        const size_t dstOffset = active == 0 ? kBuffer0Offset : kBuffer1Offset;
-        const size_t dstAddress = kNativeVideoBase + dstOffset;
-        auto* dst = const_cast<uint8_t*>(nativeBase + dstOffset);
-
-        for (int y = 0; y < kOutputHeight; ++y)
-        {
-            const auto* srcRow = visible + static_cast<size_t>(y) * fixed.line_length;
-            auto* dstRow = dst + static_cast<size_t>(y) * kOutputRowBytes;
-            memcpy(dstRow, srcRow, kOutputRowBytes);
-        }
-
-        std::atomic_thread_fence(std::memory_order_seq_cst);
-        ++frame;
-        *reinterpret_cast<volatile uint32_t*>(const_cast<uint8_t*>(nativeBase + kControlOffset)) =
-            (frame << 2) | static_cast<uint32_t>(active);
-        if (frame % 59 == 0)
-        {
-            qInfo("Copying frame buffer content to 0x%08zx", dstAddress);
-        }
-        active ^= 1;
-
-        nextFrame += std::chrono::microseconds(16667);
-        std::this_thread::sleep_until(nextFrame);
-    }
-
-    *reinterpret_cast<volatile uint32_t*>(const_cast<uint8_t*>(nativeBase + kControlOffset)) = 0;
-    munmap(const_cast<uint8_t*>(nativeBase), kNativeVideoRegionSize);
-    munmap(fb, fbSize);
+    g_frame = 0;
+    g_active = 0;
+    g_initialized = false;
 }
 
 } // namespace
 
 void startNativeVideoWriter()
 {
-    bool expected = false;
-    if (!g_running.compare_exchange_strong(expected, true))
+    if (g_initialized)
     {
-        qInfo("native video writer: start requested but writer already running");
+        qInfo("native video writer: start requested but already initialised");
         return;
     }
-    qInfo("native video writer: start requested, launching writer thread");
-    g_thread = std::thread(writerLoop);
+
+    g_fbFd = open("/dev/fb0", O_RDONLY | O_CLOEXEC);
+    if (g_fbFd < 0)
+    {
+        qWarning("native video writer: failed to open /dev/fb0");
+        cleanup();
+        return;
+    }
+
+    fb_fix_screeninfo fixed = {};
+    fb_var_screeninfo var = {};
+    if (ioctl(g_fbFd, FBIOGET_FSCREENINFO, &fixed) < 0 ||
+        ioctl(g_fbFd, FBIOGET_VSCREENINFO, &var) < 0)
+    {
+        qWarning("native video writer: failed to inspect /dev/fb0");
+        cleanup();
+        return;
+    }
+
+    // Single-memcpy precondition: fb0 must be exactly the 320x240 RGB8888
+    // surface the Menu fork core scans, with a tight stride and no pan
+    // offsets, so one bulk copy reaches every pixel. MiSTer_Zaparoo's
+    // wrapper sets fb0 up before the launcher starts; any deviation here
+    // means the host configured the framebuffer differently than the
+    // Menu fork core expects, and silently copying the top-left slice
+    // would mask that misconfiguration.
+    if (var.bits_per_pixel != 32 || var.xres != static_cast<uint32_t>(kOutputWidth) ||
+        var.yres != static_cast<uint32_t>(kOutputHeight) ||
+        fixed.line_length != kOutputStride || var.xoffset != 0 || var.yoffset != 0)
+    {
+        qWarning("native video writer: fb0 mode %ux%u %ubpp stride=%u offset=(%u,%u) does not "
+                 "match required %dx%d 32bpp stride=%zu at (0,0); writer disabled",
+                 var.xres, var.yres, var.bits_per_pixel, fixed.line_length, var.xoffset,
+                 var.yoffset, kOutputWidth, kOutputHeight, kOutputStride);
+        cleanup();
+        return;
+    }
+
+    g_fbSize = fixed.smem_len != 0 ? fixed.smem_len : kOutputBytes;
+    void* fbMap = mmap(nullptr, g_fbSize, PROT_READ, MAP_SHARED, g_fbFd, 0);
+    if (fbMap == MAP_FAILED)
+    {
+        qWarning("native video writer: failed to map /dev/fb0");
+        cleanup();
+        return;
+    }
+    g_fb = static_cast<const uint8_t*>(fbMap);
+
+    g_memFd = open("/dev/mem", O_RDWR | O_SYNC | O_CLOEXEC);
+    if (g_memFd < 0)
+    {
+        qWarning("native video writer: failed to open /dev/mem");
+        cleanup();
+        return;
+    }
+
+    void* ddrMap = mmap(nullptr, kNativeVideoRegionSize, PROT_READ | PROT_WRITE, MAP_SHARED,
+                        g_memFd, static_cast<off_t>(kNativeVideoBase));
+    if (ddrMap == MAP_FAILED)
+    {
+        qWarning("native video writer: failed to map native video DDR at 0x%08zx",
+                 kNativeVideoBase);
+        cleanup();
+        return;
+    }
+    g_nativeBase = static_cast<volatile uint8_t*>(ddrMap);
+    g_slot[0] = g_nativeBase + kBuffer0Offset;
+    g_slot[1] = g_nativeBase + kBuffer1Offset;
+    g_ctrl =
+        reinterpret_cast<volatile uint32_t*>(const_cast<uint8_t*>(g_nativeBase + kControlOffset));
+
+    memset(const_cast<uint8_t*>(g_slot[0]), 0, kOutputBytes);
+    memset(const_cast<uint8_t*>(g_slot[1]), 0, kOutputBytes);
+    *g_ctrl = 0;
+
+    g_initialized = true;
+    qInfo("native video writer: initialised, fb0 %ux%u stride=%u -> DDR slots at "
+          "0x%08zx / 0x%08zx, control at 0x%08zx",
+          var.xres, var.yres, fixed.line_length, kNativeVideoBase + kBuffer0Offset,
+          kNativeVideoBase + kBuffer1Offset, kNativeVideoBase + kControlOffset);
+}
+
+void copyFrameNativeVideoWriter()
+{
+    if (!g_initialized)
+    {
+        return;
+    }
+
+    // Single bulk copy: fb0 is validated as a contiguous 320x240x4 block
+    // at (0,0), so the entire frame is one memcpy from the cached fb0
+    // mapping to the uncached DDR slot. The cached -> uncached burst is
+    // what makes this cheap on Cortex-A9; per-pixel uncached writes
+    // from QPainter would not be.
+    memcpy(const_cast<uint8_t*>(g_slot[g_active]), g_fb, kOutputBytes);
+
+    // Publish the freshly written slot to the FPGA. The fence ensures
+    // the memcpy's stores are visible at the DDR controller before the
+    // control word advertises the slot index.
+    std::atomic_thread_fence(std::memory_order_seq_cst);
+    ++g_frame;
+    *g_ctrl = (g_frame << 2) | static_cast<uint32_t>(g_active);
+    g_active ^= 1;
 }
 
 void stopNativeVideoWriter()
 {
-    qInfo("native video writer: stop requested");
-    g_running.store(false);
-    if (g_thread.joinable())
+    if (!g_initialized && g_fbFd < 0 && g_memFd < 0)
     {
-        g_thread.join();
-        qInfo("native video writer: writer thread joined");
+        return;
     }
-    else
-    {
-        qInfo("native video writer: no running thread to join");
-    }
+    qInfo("native video writer: stopping");
+    cleanup();
 }
 
 #else
@@ -248,6 +207,9 @@ void stopNativeVideoWriter()
 void startNativeVideoWriter()
 {
     qInfo("native video writer: start requested on unsupported build/platform");
+}
+void copyFrameNativeVideoWriter()
+{
 }
 void stopNativeVideoWriter()
 {

--- a/src/app/native_video_writer.h
+++ b/src/app/native_video_writer.h
@@ -8,14 +8,14 @@
 // and prime both DDR slots and the control word. Idempotent; on
 // failure leaves the writer disabled and `copyFrameNativeVideoWriter()`
 // becomes a no-op.
-void startNativeVideoWriter();
+void initNativeVideoWriter();
 
 // One 320x240 RGB8888 memcpy from /dev/fb0 to the currently inactive
 // Menu fork DDR slot, then publish the slot via the control word and
 // flip the active slot. Intended to be invoked from a Qt
 // render-finish hook (e.g. `QQuickWindow::frameSwapped`) so the copy
 // happens once per actually-rendered frame and not on a free-running
-// timer. No-op if `startNativeVideoWriter()` did not initialise
+// timer. No-op if `initNativeVideoWriter()` did not initialise
 // cleanly.
 void copyFrameNativeVideoWriter();
 

--- a/src/app/native_video_writer.h
+++ b/src/app/native_video_writer.h
@@ -4,5 +4,22 @@
 
 #pragma once
 
+// Open /dev/fb0 and the Menu fork DDR region, validate fb0 geometry,
+// and prime both DDR slots and the control word. Idempotent; on
+// failure leaves the writer disabled and `copyFrameNativeVideoWriter()`
+// becomes a no-op.
 void startNativeVideoWriter();
+
+// One 320x240 RGB8888 memcpy from /dev/fb0 to the currently inactive
+// Menu fork DDR slot, then publish the slot via the control word and
+// flip the active slot. Intended to be invoked from a Qt
+// render-finish hook (e.g. `QQuickWindow::frameSwapped`) so the copy
+// happens once per actually-rendered frame and not on a free-running
+// timer. No-op if `startNativeVideoWriter()` did not initialise
+// cleanly.
+void copyFrameNativeVideoWriter();
+
+// Zero the control word, unmap both regions, and close the
+// descriptors. Safe to call from `std::atexit` or
+// `QGuiApplication::aboutToQuit`.
 void stopNativeVideoWriter();


### PR DESCRIPTION
## Summary

CRT scan-out now mirrors `/dev/fb0` → Menu fork DDR slots **once per actually-rendered frame** instead of polling at 60 Hz on a dedicated thread. Idle scenes do no work; active frames do **one** bulk memcpy instead of 240 per-row copies.

## What changed

- `src/app/native_video_writer.cpp`: dropped the `std::thread` + sleep-paced loop. The writer is now three free functions called explicitly:
  - `initNativeVideoWriter()` opens `/dev/fb0` + `/dev/mem`, validates that fb0 is **exactly** 320×240 RGB8888 stride=1280 at offset (0,0), zeros both DDR slots and the control word. The strict validation is what lets the copy be a single bulk memcpy.
  - `copyFrameNativeVideoWriter()` performs one ~300 KB `memcpy(slot[active], fb, kOutputBytes)`, then `atomic_thread_fence(seq_cst)` and publishes `(frame << 2) | active` to the control word, flipping `active` for the next call. Same FPGA control-word protocol as before.
  - `stopNativeVideoWriter()` zeros the control word, unmaps, closes (`std::atexit`).
- `src/app/main.cpp`: hooks `QQuickWindow::frameSwapped` to `copyFrameNativeVideoWriter()` via **`Qt::QueuedConnection`**.
- Init sets `g_active = 1` so the first write targets the slot the FPGA is *not* scanning (ctrl=0 → FPGA on slot 0), avoiding a first-frame tear.
- Renamed `startNativeVideoWriter` → `initNativeVideoWriter` (nothing 'starts' anymore — it just initialises mappings).

## Why `Qt::QueuedConnection` is load-bearing

Qt's `linuxfb` plugin doesn't write `/dev/fb0` inside `QPlatformBackingStore::flush()`. The chain is:

```
QFbBackingStore::flush()         → marks dirty
  QFbWindow::repaint()           → QFbScreen::setDirty()
    QFbScreen::scheduleUpdate()  → postEvent(UpdateRequest)   ← async!
return up the stack
  → emit frameSwapped            ← fires HERE, BEFORE the post drains
... next event-loop tick ...
QFbScreen::doRedraw()            ← actually writes /dev/fb0 NOW
```

A `DirectConnection` slot fires while fb0 still holds the *previous* frame, so we'd publish the wrong slot to the FPGA and the CRT would show one frame behind permanently (visible on screensaver→menu transitions, focus moves, etc). `QueuedConnection` posts our copy as a `QMetaCallEvent` after the pending `UpdateRequest`, so `doRedraw()` blits fb0 first and we then read fresh pixels.

The previous 60 Hz polling thread accidentally avoided this because its tick was always tens of ms after the relevant `doRedraw()` — the new tighter coupling is what made the latency visible.

## Motivation

- Idle CPU on the launcher drops to ~zero (no thread polling, no copy when no render).
- Active frames are one ~300 KB cached→uncached burst (cheap on Cortex-A9) instead of 240 row-sized memcpys.
- Frame-driven mirroring removes a class of races where the writer thread could capture a mid-flush fb0.

## Test plan

- [ ] `just lint` is green (zero warnings)
- [ ] `just test` passes
- [ ] `just deploy-mister` to a MiSTer with the Menu fork core, then verify:
  - CRT shows the current frame (no lag on screensaver exit, focus moves, screen transitions).
  - Launcher process idle CPU is near zero with the UI sitting still.
  - First-frame paint has no visible tear (validates the `g_active = 1` init).
  - On launcher exit, the CRT goes black (`*ctrl = 0` in `stopNativeVideoWriter`).

## Checklist

- [ ] `just lint` is green (zero warnings)
- [ ] `just test` passes
- [ ] If this touches QML, the FPS counter stays green (≥ 55) at 720p+ and ≥ 30 at 240p
- [ ] If this could affect the MiSTer build, I considered ARM32 implications (see `docs/architecture.md`)
- [ ] If this adds user-visible strings, they are wrapped in `qsTr()` (QML) or `tr()` (C++)
- [ ] I have signed the [CLA](../.github/CLA.md) (first-time contributors only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Restructured native video rendering to use an explicit initialization and per-frame processing API, improving integration with the application's render lifecycle.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ZaparooProject/zaparoo-launcher/pull/127)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<img width="929" height="229" alt="image" src="https://github.com/user-attachments/assets/0fc5f389-8c5e-4dc0-a2e5-2e5b1e0dc0af" />

