### PR TITLE
feat(): Re-enable resolution picker

### DIFF
--- a/docs/native-core-poc.md
+++ b/docs/native-core-poc.md
@@ -39,7 +39,7 @@ vmode -r 960 720 rgb16
 
 After QML loads, the launcher also starts a native-video copy thread:
 
-- reads `/dev/fb0` as 16-bit RGB8888
+- reads `/dev/fb0` as 24-bit RGB8888
 - requires `/dev/fb0` to be at least `320x240`
 - copies only the top-left `320x240` pixels, with no scaling
 - copies pixels directly; no RGB conversion

--- a/rust/launcher/src/lib.rs
+++ b/rust/launcher/src/lib.rs
@@ -310,15 +310,15 @@ pub extern "C" fn zaparoo_rust_init(crt_native_path_forced: bool) -> c_int {
     let mut config = load_config(&config_path);
 
     // CRT mode without an explicit [video] section: fall back to the
-    // 384x224 canvas hard-coded in native_video_writer.cpp (the actual
+    // 320x240 canvas hard-coded in native_video_writer.cpp (the actual
     // pixels that reach the CRT). A user who passes `--crt` but hasn't
     // configured `[video]` would otherwise get a 1920x1080 canvas —
     // unusable on MiSTer (`vmode` would set a huge linuxfb that gets
-    // truncated to 384x224 anyway) and unusable on desktop preview (the
+    // truncated to 320x240 anyway) and unusable on desktop preview (the
     // upscaled window would dwarf any monitor).
     if crt_native_path_forced && !config.video_explicit {
-        config.video_width = 384;
-        config.video_height = 224;
+        config.video_width = 320;
+        config.video_height = 240;
     }
 
     // Cache the language override so `zaparoo_rust_language_code` (called

--- a/rust/launcher/src/models/settings.rs
+++ b/rust/launcher/src/models/settings.rs
@@ -57,6 +57,7 @@
 // and language still takes effect on the next launch because Qt installs
 // translators only at startup.
 
+use crate::mister_runtime;
 use crate::models::{with_persist_mut, with_persist_read};
 use cxx_qt::{CxxQtType, Initialize};
 use cxx_qt_lib::{QString, QStringList};
@@ -183,8 +184,7 @@ impl Initialize for ffi::Settings {
         self.as_mut().rust_mut().available_resolutions = if is_mister {
             curated_resolutions()
         } else {
-            curated_resolutions()
-            // QStringList::default()
+            QStringList::default()
         };
         self.as_mut().rust_mut().current_resolution = QString::from(merged.resolution.as_str());
         self.as_mut().rust_mut().available_languages = languages();
@@ -211,7 +211,8 @@ impl ffi::Settings {
         let value_str = value.to_string();
         // Persist before `vmode` so a runtime fault mid-switch still
         // leaves the session/state snapshot coherent for the next run.
-        persist_settings(|s| s.resolution.clone_from(&value_str));
+        let snapshot = persist_settings(|s| s.resolution.clone_from(&value_str));
+         mirror_settings_to_config(&config_file_path(), &snapshot.settings);
         // Apply the framebuffer change *before* notifying QML. `vmode`
         // swaps the linuxfb mode in place and leaves stale pixels in
         // any region Qt's dirty tracker doesn't already know about; the
@@ -223,7 +224,7 @@ impl ffi::Settings {
         //     mister_runtime::run_vmode(w, h);
         // }
         self.as_mut().rust_mut().current_resolution = value;
-        self.as_mut().current_resolution_changed();
+        // self.as_mut().current_resolution_changed();
     }
 
     #[allow(

--- a/rust/launcher/src/models/settings.rs
+++ b/rust/launcher/src/models/settings.rs
@@ -183,7 +183,8 @@ impl Initialize for ffi::Settings {
         self.as_mut().rust_mut().available_resolutions = if is_mister {
             curated_resolutions()
         } else {
-            QStringList::default()
+            curated_resolutions()
+            // QStringList::default()
         };
         self.as_mut().rust_mut().current_resolution = QString::from(merged.resolution.as_str());
         self.as_mut().rust_mut().available_languages = languages();
@@ -203,7 +204,7 @@ impl Initialize for ffi::Settings {
 }
 
 impl ffi::Settings {
-    fn set_resolution(self: Pin<&mut Self>, value: QString) {
+    fn set_resolution(mut self: Pin<&mut Self>, value: QString) {
         if self.current_resolution == value {
             return;
         }
@@ -221,8 +222,8 @@ impl ffi::Settings {
         // if let Some((w, h)) = mister_runtime::parse_resolution(&value_str) {
         //     mister_runtime::run_vmode(w, h);
         // }
-        // self.as_mut().rust_mut().current_resolution = value;
-        // self.as_mut().current_resolution_changed();
+        self.as_mut().rust_mut().current_resolution = value;
+        self.as_mut().current_resolution_changed();
     }
 
     #[allow(

--- a/rust/launcher/src/models/settings.rs
+++ b/rust/launcher/src/models/settings.rs
@@ -224,7 +224,7 @@ impl ffi::Settings {
             mister_runtime::run_vmode(w, h);
         }
         self.as_mut().rust_mut().current_resolution = value;
-        // self.as_mut().current_resolution_changed();
+        self.as_mut().current_resolution_changed();
     }
 
     #[allow(

--- a/rust/launcher/src/models/settings.rs
+++ b/rust/launcher/src/models/settings.rs
@@ -218,11 +218,12 @@ impl ffi::Settings {
         // QML side hooks `current_resolution_changed` to scrub them
         // with a one-frame full-screen repaint, which only works if
         // vmode has already finished by the time the signal fires.
+        // Runtime disabled code:
         // if let Some((w, h)) = mister_runtime::parse_resolution(&value_str) {
         //     mister_runtime::run_vmode(w, h);
         // }
-        self.as_mut().rust_mut().current_resolution = value;
-        self.as_mut().current_resolution_changed();
+        // self.as_mut().rust_mut().current_resolution = value;
+        // self.as_mut().current_resolution_changed();
     }
 
     #[allow(

--- a/rust/launcher/src/models/settings.rs
+++ b/rust/launcher/src/models/settings.rs
@@ -57,7 +57,7 @@
 // and language still takes effect on the next launch because Qt installs
 // translators only at startup.
 
-// use crate::mister_runtime;
+use crate::mister_runtime;
 use crate::models::{with_persist_mut, with_persist_read};
 use cxx_qt::{CxxQtType, Initialize};
 use cxx_qt_lib::{QString, QStringList};
@@ -220,9 +220,9 @@ impl ffi::Settings {
         // with a one-frame full-screen repaint, which only works if
         // vmode has already finished by the time the signal fires.
         // Runtime disabled code:
-        // if let Some((w, h)) = mister_runtime::parse_resolution(&value_str) {
-        //     mister_runtime::run_vmode(w, h);
-        // }
+        if let Some((w, h)) = mister_runtime::parse_resolution(&value_str) {
+            mister_runtime::run_vmode(w, h);
+        }
         self.as_mut().rust_mut().current_resolution = value;
         // self.as_mut().current_resolution_changed();
     }

--- a/rust/launcher/src/models/settings.rs
+++ b/rust/launcher/src/models/settings.rs
@@ -218,9 +218,9 @@ impl ffi::Settings {
         // QML side hooks `current_resolution_changed` to scrub them
         // with a one-frame full-screen repaint, which only works if
         // vmode has already finished by the time the signal fires.
-        if let Some((w, h)) = mister_runtime::parse_resolution(&value_str) {
-            mister_runtime::run_vmode(w, h);
-        }
+        // if let Some((w, h)) = mister_runtime::parse_resolution(&value_str) {
+        //     mister_runtime::run_vmode(w, h);
+        // }
         self.as_mut().rust_mut().current_resolution = value;
         self.as_mut().current_resolution_changed();
     }

--- a/rust/launcher/src/models/settings.rs
+++ b/rust/launcher/src/models/settings.rs
@@ -57,7 +57,6 @@
 // and language still takes effect on the next launch because Qt installs
 // translators only at startup.
 
-use crate::mister_runtime;
 use crate::models::{with_persist_mut, with_persist_read};
 use cxx_qt::{CxxQtType, Initialize};
 use cxx_qt_lib::{QString, QStringList};
@@ -204,7 +203,7 @@ impl Initialize for ffi::Settings {
 }
 
 impl ffi::Settings {
-    fn set_resolution(mut self: Pin<&mut Self>, value: QString) {
+    fn set_resolution(self: Pin<&mut Self>, value: QString) {
         if self.current_resolution == value {
             return;
         }

--- a/rust/launcher/src/models/settings.rs
+++ b/rust/launcher/src/models/settings.rs
@@ -57,7 +57,7 @@
 // and language still takes effect on the next launch because Qt installs
 // translators only at startup.
 
-use crate::mister_runtime;
+// use crate::mister_runtime;
 use crate::models::{with_persist_mut, with_persist_read};
 use cxx_qt::{CxxQtType, Initialize};
 use cxx_qt_lib::{QString, QStringList};
@@ -212,7 +212,7 @@ impl ffi::Settings {
         // Persist before `vmode` so a runtime fault mid-switch still
         // leaves the session/state snapshot coherent for the next run.
         let snapshot = persist_settings(|s| s.resolution.clone_from(&value_str));
-         mirror_settings_to_config(&config_file_path(), &snapshot.settings);
+        mirror_settings_to_config(&config_file_path(), &snapshot.settings);
         // Apply the framebuffer change *before* notifying QML. `vmode`
         // swaps the linuxfb mode in place and leaves stale pixels in
         // any region Qt's dirty tracker doesn't already know about; the

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -121,9 +121,13 @@ static ParsedArguments extractCrtArgument(int argc, char* argv[])
 
 int main(int argc, char* argv[])
 {
+
+    int returnExitCode = 0;
+
     ParsedArguments parsedArgs = extractCrtArgument(argc, argv);
     const bool crtNativePathForced = parsedArgs.crtNativePathForced;
     int qtArgc = static_cast<int>(parsedArgs.argv.size()) - 1;
+
     char** qtArgv = parsedArgs.argv.data();
 
     // Desktop CRT preview: pin Qt's high-DPI handling so logical pixels
@@ -156,231 +160,238 @@ int main(int argc, char* argv[])
     // messages are emitted.
     qInstallMessageHandler(qtMessageHandler);
 
-    QGuiApplication app(qtArgc, qtArgv);
-    QPixmapCache::setCacheLimit(kPixmapCacheLimitKiB);
-    // addApplicationFont returns -1 on failure (broken qrc path,
-    // unreadable file). Logging the failure mode keeps a refactor that
-    // breaks the resource alias from silently degrading to the default
-    // font with no clue in the logs.
-    const auto registerFont = [](const QString& path)
-    {
-        const int fontId = QFontDatabase::addApplicationFont(path);
-        if (fontId == -1)
+    do {
+
+        QGuiApplication app(qtArgc, qtArgv);
+        QPixmapCache::setCacheLimit(kPixmapCacheLimitKiB);
+        // addApplicationFont returns -1 on failure (broken qrc path,
+        // unreadable file). Logging the failure mode keeps a refactor that
+        // breaks the resource alias from silently degrading to the default
+        // font with no clue in the logs.
+        const auto registerFont = [](const QString& path)
         {
-            qWarning("Failed to register font: %s", qUtf8Printable(path));
-            return;
-        }
-        qInfo("Registered font %s: %s", qUtf8Printable(path),
-              qUtf8Printable(QFontDatabase::applicationFontFamilies(fontId).join(", ")));
-    };
-    registerFont(QStringLiteral(":/qt/qml/Zaparoo/App/resources/fonts/MxPlus_HP_100LX_6x8.ttf"));
-    registerFont(QStringLiteral(":/qt/qml/Zaparoo/App/resources/fonts/NotoSans.ttf"));
-    registerFont(QStringLiteral(":/qt/qml/Zaparoo/App/resources/fonts/NotoSansArabic.ttf"));
-    registerFont(QStringLiteral(":/qt/qml/Zaparoo/App/resources/fonts/NotoSansDevanagari.ttf"));
-    registerFont(QStringLiteral(":/qt/qml/Zaparoo/App/resources/fonts/NotoSansHebrew.ttf"));
-    registerFont(QStringLiteral(":/qt/qml/Zaparoo/App/resources/fonts/NotoSansJP.ttf"));
-    registerFont(QStringLiteral(":/qt/qml/Zaparoo/App/resources/fonts/NotoSansKR.ttf"));
-    registerFont(QStringLiteral(":/qt/qml/Zaparoo/App/resources/fonts/NotoSansTC.ttf"));
-    // Keep the primary UI fonts separated by mode (CRT = HP 100LX,
-    // standard = Noto Sans). Only register bundled CJK fallbacks so
-    // scripts the primary family lacks still resolve consistently.
-    QFontDatabase::addApplicationFallbackFontFamily(QChar::Script_Hiragana,
-                                                    QStringLiteral("Noto Sans JP"));
-    QFontDatabase::addApplicationFallbackFontFamily(QChar::Script_Katakana,
-                                                    QStringLiteral("Noto Sans JP"));
-    QFontDatabase::addApplicationFallbackFontFamily(QChar::Script_Hangul,
-                                                    QStringLiteral("Noto Sans KR"));
-    QFontDatabase::addApplicationFallbackFontFamily(QChar::Script_Han,
-                                                    QStringLiteral("Noto Sans TC"));
-    QFontDatabase::addApplicationFallbackFontFamily(QChar::Script_Arabic,
-                                                    QStringLiteral("Noto Sans Arabic"));
-    QFontDatabase::addApplicationFallbackFontFamily(QChar::Script_Devanagari,
-                                                    QStringLiteral("Noto Sans Devanagari"));
-    qInfo("Registered application font fallbacks for CJK, Arabic, and Devanagari scripts");
-    const bool crtNativePathEnabled = zaparoo_rust_crt_native_path_enabled();
-    if (crtNativePathEnabled)
-    {
-        QQuickWindow::setTextRenderType(QQuickWindow::NativeTextRendering);
-        qInfo("CRT native path: using native text rendering");
-        // Desktop CRT preview: FreeType on X11/Wayland defaults to subpixel
-        // RGB antialiasing ("ClearType"), which paints faint coloured
-        // fringes either side of every glyph. MiSTer's linuxfb FreeType
-        // does not enable subpixel AA, so the same scene reads pixel-
-        // perfect there but blurry in the desktop preview. The bitmap
-        // pixel font (MxPlus HP 100LX 6x8) is also designed to never be
-        // smoothed. Set NoAntialias on the application default font so
-        // every Text item that doesn't override styleStrategy inherits it.
-        QFont defaultFont = QGuiApplication::font();
-        defaultFont.setStyleStrategy(QFont::NoAntialias);
-        defaultFont.setHintingPreference(QFont::PreferFullHinting);
-        QGuiApplication::setFont(defaultFont);
-    }
-    QQuickStyle::setStyle("Basic");
-
-    // Install the locale .qm translator before constructing the QML engine
-    // so qsTr() lookups in Main.qml's initial bindings see translated text.
-    // The Rust side resolves `[general] language` from launcher.toml into a
-    // BCP-47 tag ("ja", "de_DE") or an empty string (follow system locale).
-    // Stack lifetime is fine — `translator` outlives app.exec() and all QML.
-    const QString langCode = QString::fromUtf8(zaparoo_rust_language_code());
-    const QLocale locale = langCode.isEmpty() ? QLocale::system() : QLocale(langCode);
-    QTranslator translator;
-    if (translator.load(locale, "launcher", "_", ":/i18n"))
-    {
-        QCoreApplication::installTranslator(&translator);
-    }
-    else
-    {
-        // Not an error on first run (English-only build ships a passthrough
-        // launcher_en.qm). Log at info so the sink records the resolved
-        // locale for bug reports without spamming at warn level.
-        qInfo("No translation catalog for %s in :/i18n; using source strings",
-              qUtf8Printable(locale.name()));
-    }
-
-    QQmlApplicationEngine engine;
-    // Engine takes ownership of the provider — it deletes it when the
-    // engine is destroyed at process shutdown. The provider is the
-    // bridge from `image://media-image/<encoded>` URLs to the
-    // Rust-side in-memory media image cache, so it must be installed
-    // before any QML type binds to a `coverKey` (every Tile inside
-    // MainLayout does).
-    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
-    engine.addImageProvider(QStringLiteral("media-image"), new MediaImageProvider());
-
-    // One-shot diagnostic: a static MiSTer Qt build configured without
-    // `-feature-png` / libpng silently lacks the PNG QImageIOHandler, so
-    // `QImage::loadFromData(<png bytes>)` returns null and every cover
-    // looks "missing" with no other signal. Logging the registered
-    // formats at startup turns that failure mode into one decisive line.
-    QStringList formatNames;
-    const QList<QByteArray> supportedFormats = QImageReader::supportedImageFormats();
-    formatNames.reserve(supportedFormats.size());
-    for (const QByteArray& fmt : supportedFormats)
-    {
-        formatNames << QString::fromLatin1(fmt);
-    }
-    qInfo("QImageReader supportedImageFormats: %s",
-          qUtf8Printable(formatNames.join(QStringLiteral(", "))));
-
-    QVariantMap initialProperties = {
-        {"crtNativePath", crtNativePathEnabled},
-    };
-#ifdef ZAPAROO_EMBEDDED_BUILD
-    // MainLayout's `fullScreen` defaults true so the binding pass during
-    // QML construction evaluates width/height/visibility against the
-    // embedded branch — no transient 1280x720 frame for the writer
-    // thread to copy into the CRT scan-out region.
-    initialProperties.insert(QStringLiteral("fullScreen"), true);
-#else
-    // Desktop preview: override the QML default so the dev workflow
-    // gets a windowed 1280x720 design canvas. The brief
-    // FullScreen→Windowed transition during construction isn't visible
-    // — the desktop compositor buffers until the first paint.
-    initialProperties.insert(QStringLiteral("fullScreen"), false);
-    // Desktop CRT preview: when --crt is passed off-MiSTer, render the
-    // QML scene at the configured logical video size and integer-
-    // upscale via a layered wrapper Item in MainLayout. Scale defaults
-    // to 0 (sentinel for "auto-pick the largest integer that fits the
-    // primary screen with a 5% margin"); ZAPAROO_CRT_PREVIEW_SCALE
-    // overrides for ad-hoc testing without rebuilding (e.g. =2 for
-    // half-size, =8 to inspect a single tile).
-    if (zaparoo_rust_crt_native_path_enabled())
-    {
-        int previewScale = 0;
-        const QByteArray envScale = qgetenv("ZAPAROO_CRT_PREVIEW_SCALE");
-        if (!envScale.isEmpty())
-        {
-            bool ok = false;
-            const int parsed = envScale.toInt(&ok);
-            if (ok && parsed > 0)
+            const int fontId = QFontDatabase::addApplicationFont(path);
+            if (fontId == -1)
             {
-                previewScale = parsed;
+                qWarning("Failed to register font: %s", qUtf8Printable(path));
+                return;
             }
-        }
-        initialProperties.insert(QStringLiteral("crtPreview"), true);
-        initialProperties.insert(QStringLiteral("crtPreviewScale"), previewScale);
-        initialProperties.insert(QStringLiteral("videoWidth"),
-                                 static_cast<int>(zaparoo_rust_video_width()));
-        initialProperties.insert(QStringLiteral("videoHeight"),
-                                 static_cast<int>(zaparoo_rust_video_height()));
-    }
-#endif
-    engine.setInitialProperties(initialProperties);
-
-    // objectCreationFailed fires before loadFromModule returns when a QML
-    // type fails to resolve or compile. Individual QML errors are already
-    // routed through qtMessageHandler → tracing; this handler adds the
-    // tying narrative ("the root object for Zaparoo.App.Main failed") so
-    // a reader of launcher.log doesn't have to infer the connection.
-    QObject::connect(
-        &engine, &QQmlApplicationEngine::objectCreationFailed, &engine, [](const QUrl& url)
-        { qCritical("QML object creation failed for %s", qUtf8Printable(url.toString())); });
-
-    engine.loadFromModule("Zaparoo.App", "Main");
-
-    if (engine.rootObjects().isEmpty())
-    {
-        qCritical("QML engine produced no root objects; startup aborted (see earlier errors)");
-        return EXIT_FAILURE;
-    }
-
-    if (crtNativePathEnabled)
-    {
-        qInfo("CRT startup decision: initialising native video writer");
-        initNativeVideoWriter();
-        std::atexit(stopNativeVideoWriter);
-        // Drive the fb0 -> DDR copy from Qt's render-finish signal so
-        // we mirror exactly one frame per actual scenegraph render
-        // (idle scenes produce no `frameSwapped` and therefore no
-        // copy and no CPU work).
-        //
-        // Qt::QueuedConnection is load-bearing: the linuxfb QPA
-        // doesn't write /dev/fb0 inside `QPlatformBackingStore::flush()`.
-        // It calls `QFbScreen::scheduleUpdate()` which only posts a
-        // `QEvent::UpdateRequest`; the actual blit to fb0 happens
-        // later, in `QFbScreen::doRedraw()`, on a subsequent event-
-        // loop iteration. `frameSwapped` is emitted *before* that
-        // posted event drains, so a DirectConnection slot would read
-        // stale fb0 and we'd publish the previous frame to the FPGA
-        // (one-frame-behind CRT output). Posting our copy via a
-        // queued connection puts it FIFO behind the UpdateRequest,
-        // so `doRedraw()` runs first and we then read the freshly
-        // updated fb0.
-        auto* rootWindow = qobject_cast<QQuickWindow*>(engine.rootObjects().first());
-        if (rootWindow != nullptr)
+            qInfo("Registered font %s: %s", qUtf8Printable(path),
+                qUtf8Printable(QFontDatabase::applicationFontFamilies(fontId).join(", ")));
+        };
+        registerFont(QStringLiteral(":/qt/qml/Zaparoo/App/resources/fonts/MxPlus_HP_100LX_6x8.ttf"));
+        registerFont(QStringLiteral(":/qt/qml/Zaparoo/App/resources/fonts/NotoSans.ttf"));
+        registerFont(QStringLiteral(":/qt/qml/Zaparoo/App/resources/fonts/NotoSansArabic.ttf"));
+        registerFont(QStringLiteral(":/qt/qml/Zaparoo/App/resources/fonts/NotoSansDevanagari.ttf"));
+        registerFont(QStringLiteral(":/qt/qml/Zaparoo/App/resources/fonts/NotoSansHebrew.ttf"));
+        registerFont(QStringLiteral(":/qt/qml/Zaparoo/App/resources/fonts/NotoSansJP.ttf"));
+        registerFont(QStringLiteral(":/qt/qml/Zaparoo/App/resources/fonts/NotoSansKR.ttf"));
+        registerFont(QStringLiteral(":/qt/qml/Zaparoo/App/resources/fonts/NotoSansTC.ttf"));
+        // Keep the primary UI fonts separated by mode (CRT = HP 100LX,
+        // standard = Noto Sans). Only register bundled CJK fallbacks so
+        // scripts the primary family lacks still resolve consistently.
+        QFontDatabase::addApplicationFallbackFontFamily(QChar::Script_Hiragana,
+                                                        QStringLiteral("Noto Sans JP"));
+        QFontDatabase::addApplicationFallbackFontFamily(QChar::Script_Katakana,
+                                                        QStringLiteral("Noto Sans JP"));
+        QFontDatabase::addApplicationFallbackFontFamily(QChar::Script_Hangul,
+                                                        QStringLiteral("Noto Sans KR"));
+        QFontDatabase::addApplicationFallbackFontFamily(QChar::Script_Han,
+                                                        QStringLiteral("Noto Sans TC"));
+        QFontDatabase::addApplicationFallbackFontFamily(QChar::Script_Arabic,
+                                                        QStringLiteral("Noto Sans Arabic"));
+        QFontDatabase::addApplicationFallbackFontFamily(QChar::Script_Devanagari,
+                                                        QStringLiteral("Noto Sans Devanagari"));
+        qInfo("Registered application font fallbacks for CJK, Arabic, and Devanagari scripts");
+        const bool crtNativePathEnabled = zaparoo_rust_crt_native_path_enabled();
+        if (crtNativePathEnabled)
         {
-            QObject::connect(
-                rootWindow, &QQuickWindow::frameSwapped, rootWindow,
-                []() { copyFrameNativeVideoWriter(); }, Qt::QueuedConnection);
+            QQuickWindow::setTextRenderType(QQuickWindow::NativeTextRendering);
+            qInfo("CRT native path: using native text rendering");
+            // Desktop CRT preview: FreeType on X11/Wayland defaults to subpixel
+            // RGB antialiasing ("ClearType"), which paints faint coloured
+            // fringes either side of every glyph. MiSTer's linuxfb FreeType
+            // does not enable subpixel AA, so the same scene reads pixel-
+            // perfect there but blurry in the desktop preview. The bitmap
+            // pixel font (MxPlus HP 100LX 6x8) is also designed to never be
+            // smoothed. Set NoAntialias on the application default font so
+            // every Text item that doesn't override styleStrategy inherits it.
+            QFont defaultFont = QGuiApplication::font();
+            defaultFont.setStyleStrategy(QFont::NoAntialias);
+            defaultFont.setHintingPreference(QFont::PreferFullHinting);
+            QGuiApplication::setFont(defaultFont);
+        }
+        QQuickStyle::setStyle("Basic");
+
+        // Install the locale .qm translator before constructing the QML engine
+        // so qsTr() lookups in Main.qml's initial bindings see translated text.
+        // The Rust side resolves `[general] language` from launcher.toml into a
+        // BCP-47 tag ("ja", "de_DE") or an empty string (follow system locale).
+        // Stack lifetime is fine — `translator` outlives app.exec() and all QML.
+        const QString langCode = QString::fromUtf8(zaparoo_rust_language_code());
+        const QLocale locale = langCode.isEmpty() ? QLocale::system() : QLocale(langCode);
+        QTranslator translator;
+        if (translator.load(locale, "launcher", "_", ":/i18n"))
+        {
+            QCoreApplication::installTranslator(&translator);
         }
         else
         {
-            qCritical("CRT startup decision: QML root is not a QQuickWindow; per-frame copy "
-                      "hook not installed (FPGA will stay on the zero-initialised slot)");
+            // Not an error on first run (English-only build ships a passthrough
+            // launcher_en.qm). Log at info so the sink records the resolved
+            // locale for bug reports without spamming at warn level.
+            qInfo("No translation catalog for %s in :/i18n; using source strings",
+                qUtf8Printable(locale.name()));
         }
-    }
 
-    // Drain the tokio runtime and detach the Qt-to-Rust log bridge while
-    // the main thread is still alive and every thread's TLS storage is
-    // still addressable. `aboutToQuit` fires after `Qt.quit()` (or the
-    // last window close) but before `exec()` returns, which is the only
-    // window where we can run `Runtime::shutdown_timeout` and uninstall
-    // the message handler ahead of `__cxa_finalize`.
-    //
-    // The handler matters because Qt's own destruction emits log
-    // messages from internal threads (QThreadPool workers, plugin
-    // teardown). Left installed, those calls re-enter `zaparoo_log_qt`
-    // and the tracing dispatcher whose TLS is mid-destruction, panic
-    // with `AccessError`, and the panic-hook's own `tracing::error!`
-    // re-panics into SIGABRT (exit 134).
-    QObject::connect(&app, &QGuiApplication::aboutToQuit, &app,
-                     []()
-                     {
-                         zaparoo_rust_shutdown();
-                         qInstallMessageHandler(nullptr);
-                     });
+        QQmlApplicationEngine engine;
+        // Engine takes ownership of the provider — it deletes it when the
+        // engine is destroyed at process shutdown. The provider is the
+        // bridge from `image://media-image/<encoded>` URLs to the
+        // Rust-side in-memory media image cache, so it must be installed
+        // before any QML type binds to a `coverKey` (every Tile inside
+        // MainLayout does).
+        // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+        engine.addImageProvider(QStringLiteral("media-image"), new MediaImageProvider());
 
-    zaparoo_rust_post_qt_start();
-    return QGuiApplication::exec();
+        // One-shot diagnostic: a static MiSTer Qt build configured without
+        // `-feature-png` / libpng silently lacks the PNG QImageIOHandler, so
+        // `QImage::loadFromData(<png bytes>)` returns null and every cover
+        // looks "missing" with no other signal. Logging the registered
+        // formats at startup turns that failure mode into one decisive line.
+        QStringList formatNames;
+        const QList<QByteArray> supportedFormats = QImageReader::supportedImageFormats();
+        formatNames.reserve(supportedFormats.size());
+        for (const QByteArray& fmt : supportedFormats)
+        {
+            formatNames << QString::fromLatin1(fmt);
+        }
+        qInfo("QImageReader supportedImageFormats: %s",
+            qUtf8Printable(formatNames.join(QStringLiteral(", "))));
+
+        QVariantMap initialProperties = {
+            {"crtNativePath", crtNativePathEnabled},
+        };
+    #ifdef ZAPAROO_EMBEDDED_BUILD
+        // MainLayout's `fullScreen` defaults true so the binding pass during
+        // QML construction evaluates width/height/visibility against the
+        // embedded branch — no transient 1280x720 frame for the writer
+        // thread to copy into the CRT scan-out region.
+        initialProperties.insert(QStringLiteral("fullScreen"), true);
+    #else
+        // Desktop preview: override the QML default so the dev workflow
+        // gets a windowed 1280x720 design canvas. The brief
+        // FullScreen→Windowed transition during construction isn't visible
+        // — the desktop compositor buffers until the first paint.
+        initialProperties.insert(QStringLiteral("fullScreen"), false);
+        // Desktop CRT preview: when --crt is passed off-MiSTer, render the
+        // QML scene at the configured logical video size and integer-
+        // upscale via a layered wrapper Item in MainLayout. Scale defaults
+        // to 0 (sentinel for "auto-pick the largest integer that fits the
+        // primary screen with a 5% margin"); ZAPAROO_CRT_PREVIEW_SCALE
+        // overrides for ad-hoc testing without rebuilding (e.g. =2 for
+        // half-size, =8 to inspect a single tile).
+        if (zaparoo_rust_crt_native_path_enabled())
+        {
+            int previewScale = 0;
+            const QByteArray envScale = qgetenv("ZAPAROO_CRT_PREVIEW_SCALE");
+            if (!envScale.isEmpty())
+            {
+                bool ok = false;
+                const int parsed = envScale.toInt(&ok);
+                if (ok && parsed > 0)
+                {
+                    previewScale = parsed;
+                }
+            }
+            initialProperties.insert(QStringLiteral("crtPreview"), true);
+            initialProperties.insert(QStringLiteral("crtPreviewScale"), previewScale);
+            initialProperties.insert(QStringLiteral("videoWidth"),
+                                    static_cast<int>(zaparoo_rust_video_width()));
+            initialProperties.insert(QStringLiteral("videoHeight"),
+                                    static_cast<int>(zaparoo_rust_video_height()));
+        }
+    #endif
+        engine.setInitialProperties(initialProperties);
+
+        // objectCreationFailed fires before loadFromModule returns when a QML
+        // type fails to resolve or compile. Individual QML errors are already
+        // routed through qtMessageHandler → tracing; this handler adds the
+        // tying narrative ("the root object for Zaparoo.App.Main failed") so
+        // a reader of launcher.log doesn't have to infer the connection.
+        QObject::connect(
+            &engine, &QQmlApplicationEngine::objectCreationFailed, &engine, [](const QUrl& url)
+            { qCritical("QML object creation failed for %s", qUtf8Printable(url.toString())); });
+
+        engine.loadFromModule("Zaparoo.App", "Main");
+
+        if (engine.rootObjects().isEmpty())
+        {
+            qCritical("QML engine produced no root objects; startup aborted (see earlier errors)");
+            return EXIT_FAILURE;
+        }
+
+        if (crtNativePathEnabled)
+        {
+            qInfo("CRT startup decision: initialising native video writer");
+            initNativeVideoWriter();
+            std::atexit(stopNativeVideoWriter);
+            // Drive the fb0 -> DDR copy from Qt's render-finish signal so
+            // we mirror exactly one frame per actual scenegraph render
+            // (idle scenes produce no `frameSwapped` and therefore no
+            // copy and no CPU work).
+            //
+            // Qt::QueuedConnection is load-bearing: the linuxfb QPA
+            // doesn't write /dev/fb0 inside `QPlatformBackingStore::flush()`.
+            // It calls `QFbScreen::scheduleUpdate()` which only posts a
+            // `QEvent::UpdateRequest`; the actual blit to fb0 happens
+            // later, in `QFbScreen::doRedraw()`, on a subsequent event-
+            // loop iteration. `frameSwapped` is emitted *before* that
+            // posted event drains, so a DirectConnection slot would read
+            // stale fb0 and we'd publish the previous frame to the FPGA
+            // (one-frame-behind CRT output). Posting our copy via a
+            // queued connection puts it FIFO behind the UpdateRequest,
+            // so `doRedraw()` runs first and we then read the freshly
+            // updated fb0.
+            auto* rootWindow = qobject_cast<QQuickWindow*>(engine.rootObjects().first());
+            if (rootWindow != nullptr)
+            {
+                QObject::connect(
+                    rootWindow, &QQuickWindow::frameSwapped, rootWindow,
+                    []() { copyFrameNativeVideoWriter(); }, Qt::QueuedConnection);
+            }
+            else
+            {
+                qCritical("CRT startup decision: QML root is not a QQuickWindow; per-frame copy "
+                        "hook not installed (FPGA will stay on the zero-initialised slot)");
+            }
+        }
+
+        // Drain the tokio runtime and detach the Qt-to-Rust log bridge while
+        // the main thread is still alive and every thread's TLS storage is
+        // still addressable. `aboutToQuit` fires after `Qt.quit()` (or the
+        // last window close) but before `exec()` returns, which is the only
+        // window where we can run `Runtime::shutdown_timeout` and uninstall
+        // the message handler ahead of `__cxa_finalize`.
+        //
+        // The handler matters because Qt's own destruction emits log
+        // messages from internal threads (QThreadPool workers, plugin
+        // teardown). Left installed, those calls re-enter `zaparoo_log_qt`
+        // and the tracing dispatcher whose TLS is mid-destruction, panic
+        // with `AccessError`, and the panic-hook's own `tracing::error!`
+        // re-panics into SIGABRT (exit 134).
+        QObject::connect(&app, &QGuiApplication::aboutToQuit, &app,
+                        []()
+                        {
+                            zaparoo_rust_shutdown();
+                            qInstallMessageHandler(nullptr);
+                        });
+
+        zaparoo_rust_post_qt_start();
+
+        returnExitCode = QGuiApplication::exec();
+        qCritical("Return exit code %i", returnExitCode);
+    } while (returnExitCode == 1000);
+
+    return returnExitCode;
 }

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -155,12 +155,11 @@ int main(int argc, char* argv[])
         return EXIT_FAILURE;
     }
 
-    // Install after zaparoo_rust_init() so tracing is live before any Qt
-    // messages are emitted.
-    qInstallMessageHandler(qtMessageHandler);
-
     do
     {
+        // Install after zaparoo_rust_init() so tracing is live before any Qt
+        // messages are emitted.
+        qInstallMessageHandler(qtMessageHandler);
         QGuiApplication app(qtArgc, qtArgv);
         QPixmapCache::setCacheLimit(kPixmapCacheLimitKiB);
         // addApplicationFont returns -1 on failure (broken qrc path,
@@ -339,7 +338,6 @@ int main(int argc, char* argv[])
         {
             qInfo("CRT startup decision: initialising native video writer");
             initNativeVideoWriter();
-            std::atexit(stopNativeVideoWriter);
             // Drive the fb0 -> DDR copy from Qt's render-finish signal so
             // we mirror exactly one frame per actual scenegraph render
             // (idle scenes produce no `frameSwapped` and therefore no
@@ -388,6 +386,10 @@ int main(int argc, char* argv[])
                          []()
                          {
                              zaparoo_rust_shutdown();
+                             if (crtNativePathEnabled)
+                             {
+                                 stopNativeVideoWriter();
+                             }
                              qInstallMessageHandler(nullptr);
                          });
 

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -119,7 +119,7 @@ static ParsedArguments extractCrtArgument(int argc, char* argv[])
     return parsed;
 }
 
-int main(int argc, char* argv[])
+int main(int argc, char* argv[]) // NO_LINT
 {
     int returnExitCode = 0;
 

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -119,7 +119,7 @@ static ParsedArguments extractCrtArgument(int argc, char* argv[])
     return parsed;
 }
 
-int main(int argc, char* argv[]) // NO_LINT
+int main(int argc, char* argv[]) // NOLINT
 {
     int returnExitCode = 0;
 

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -386,10 +386,7 @@ int main(int argc, char* argv[])
                          []()
                          {
                              zaparoo_rust_shutdown();
-                             if (crtNativePathEnabled)
-                             {
-                                 stopNativeVideoWriter();
-                             }
+                             stopNativeVideoWriter();
                              qInstallMessageHandler(nullptr);
                          });
 

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -121,7 +121,6 @@ static ParsedArguments extractCrtArgument(int argc, char* argv[])
 
 int main(int argc, char* argv[])
 {
-
     int returnExitCode = 0;
 
     ParsedArguments parsedArgs = extractCrtArgument(argc, argv);
@@ -160,8 +159,8 @@ int main(int argc, char* argv[])
     // messages are emitted.
     qInstallMessageHandler(qtMessageHandler);
 
-    do {
-
+    do
+    {
         QGuiApplication app(qtArgc, qtArgv);
         QPixmapCache::setCacheLimit(kPixmapCacheLimitKiB);
         // addApplicationFont returns -1 on failure (broken qrc path,
@@ -177,9 +176,10 @@ int main(int argc, char* argv[])
                 return;
             }
             qInfo("Registered font %s: %s", qUtf8Printable(path),
-                qUtf8Printable(QFontDatabase::applicationFontFamilies(fontId).join(", ")));
+                  qUtf8Printable(QFontDatabase::applicationFontFamilies(fontId).join(", ")));
         };
-        registerFont(QStringLiteral(":/qt/qml/Zaparoo/App/resources/fonts/MxPlus_HP_100LX_6x8.ttf"));
+        registerFont(
+            QStringLiteral(":/qt/qml/Zaparoo/App/resources/fonts/MxPlus_HP_100LX_6x8.ttf"));
         registerFont(QStringLiteral(":/qt/qml/Zaparoo/App/resources/fonts/NotoSans.ttf"));
         registerFont(QStringLiteral(":/qt/qml/Zaparoo/App/resources/fonts/NotoSansArabic.ttf"));
         registerFont(QStringLiteral(":/qt/qml/Zaparoo/App/resources/fonts/NotoSansDevanagari.ttf"));
@@ -241,7 +241,7 @@ int main(int argc, char* argv[])
             // launcher_en.qm). Log at info so the sink records the resolved
             // locale for bug reports without spamming at warn level.
             qInfo("No translation catalog for %s in :/i18n; using source strings",
-                qUtf8Printable(locale.name()));
+                  qUtf8Printable(locale.name()));
         }
 
         QQmlApplicationEngine engine;
@@ -267,18 +267,18 @@ int main(int argc, char* argv[])
             formatNames << QString::fromLatin1(fmt);
         }
         qInfo("QImageReader supportedImageFormats: %s",
-            qUtf8Printable(formatNames.join(QStringLiteral(", "))));
+              qUtf8Printable(formatNames.join(QStringLiteral(", "))));
 
         QVariantMap initialProperties = {
             {"crtNativePath", crtNativePathEnabled},
         };
-    #ifdef ZAPAROO_EMBEDDED_BUILD
+#ifdef ZAPAROO_EMBEDDED_BUILD
         // MainLayout's `fullScreen` defaults true so the binding pass during
         // QML construction evaluates width/height/visibility against the
         // embedded branch — no transient 1280x720 frame for the writer
         // thread to copy into the CRT scan-out region.
         initialProperties.insert(QStringLiteral("fullScreen"), true);
-    #else
+#else
         // Desktop preview: override the QML default so the dev workflow
         // gets a windowed 1280x720 design canvas. The brief
         // FullScreen→Windowed transition during construction isn't visible
@@ -307,15 +307,15 @@ int main(int argc, char* argv[])
             initialProperties.insert(QStringLiteral("crtPreview"), true);
             initialProperties.insert(QStringLiteral("crtPreviewScale"), previewScale);
             initialProperties.insert(QStringLiteral("videoWidth"),
-                                    static_cast<int>(zaparoo_rust_video_width()));
+                                     static_cast<int>(zaparoo_rust_video_width()));
             initialProperties.insert(QStringLiteral("videoHeight"),
-                                    static_cast<int>(zaparoo_rust_video_height()));
+                                     static_cast<int>(zaparoo_rust_video_height()));
         }
-    #endif
+#endif
         initialProperties.insert(QStringLiteral("videoWidth"),
-                                static_cast<int>(zaparoo_rust_video_width()));
+                                 static_cast<int>(zaparoo_rust_video_width()));
         initialProperties.insert(QStringLiteral("videoHeight"),
-                                static_cast<int>(zaparoo_rust_video_height()));
+                                 static_cast<int>(zaparoo_rust_video_height()));
         engine.setInitialProperties(initialProperties);
 
         // objectCreationFailed fires before loadFromModule returns when a QML
@@ -367,7 +367,7 @@ int main(int argc, char* argv[])
             else
             {
                 qCritical("CRT startup decision: QML root is not a QQuickWindow; per-frame copy "
-                        "hook not installed (FPGA will stay on the zero-initialised slot)");
+                          "hook not installed (FPGA will stay on the zero-initialised slot)");
             }
         }
 
@@ -385,11 +385,11 @@ int main(int argc, char* argv[])
         // with `AccessError`, and the panic-hook's own `tracing::error!`
         // re-panics into SIGABRT (exit 134).
         QObject::connect(&app, &QGuiApplication::aboutToQuit, &app,
-                        []()
-                        {
-                            zaparoo_rust_shutdown();
-                            qInstallMessageHandler(nullptr);
-                        });
+                         []()
+                         {
+                             zaparoo_rust_shutdown();
+                             qInstallMessageHandler(nullptr);
+                         });
 
         zaparoo_rust_post_qt_start();
         returnExitCode = QGuiApplication::exec();

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -155,7 +155,7 @@ int main(int argc, char* argv[]) // NOLINT
         return EXIT_FAILURE;
     }
 
-    do
+    do // NOLINT
     {
         // Install after zaparoo_rust_init() so tracing is live before any Qt
         // messages are emitted.

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -291,7 +291,7 @@ int main(int argc, char* argv[])
         // primary screen with a 5% margin"); ZAPAROO_CRT_PREVIEW_SCALE
         // overrides for ad-hoc testing without rebuilding (e.g. =2 for
         // half-size, =8 to inspect a single tile).
-        if (zaparoo_rust_crt_native_path_enabled())
+        if (crtNativePathEnabled)
         {
             int previewScale = 0;
             const QByteArray envScale = qgetenv("ZAPAROO_CRT_PREVIEW_SCALE");
@@ -312,6 +312,10 @@ int main(int argc, char* argv[])
                                     static_cast<int>(zaparoo_rust_video_height()));
         }
     #endif
+        initialProperties.insert(QStringLiteral("videoWidth"),
+                                static_cast<int>(zaparoo_rust_video_width()));
+        initialProperties.insert(QStringLiteral("videoHeight"),
+                                static_cast<int>(zaparoo_rust_video_height()));
         engine.setInitialProperties(initialProperties);
 
         // objectCreationFailed fires before loadFromModule returns when a QML
@@ -388,7 +392,6 @@ int main(int argc, char* argv[])
                         });
 
         zaparoo_rust_post_qt_start();
-
         returnExitCode = QGuiApplication::exec();
         qCritical("Return exit code %i", returnExitCode);
     } while (returnExitCode == 1000);

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -966,7 +966,7 @@ MainLayout {
     onQuitConfirmAccepted: Qt.quit()
 
     onAcceptRestart: root.restartApp()
-    onCancelRestart: root.closeSettingNeedsRestartModal();
+    onCancelRestart: root.closeSettingNeedsRestartModal()
 
     // List-picker lifecycle. Settings screens emit requestListPicker
     // with a fieldId that round-trips through the modal so the accept
@@ -1019,8 +1019,7 @@ MainLayout {
             Browse.Settings.set_resolution(selectedId);
             root.closeListPickerModal();
             root.openSettingNeedsRestartModal();
-        }
-        else if (fieldId === "screensaverTimeout")
+        } else if (fieldId === "screensaverTimeout")
             Browse.Settings.set_screensaver_timeout(selectedId);
         root.closeListPickerModal();
     }

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -40,6 +40,8 @@ MainLayout {
     readonly property string modalLogUpload: "log_upload"
     readonly property string modalQuitConfirm: "quit_confirm"
     readonly property string modalListPicker: "list_picker"
+    readonly property string modalSettingNeedsRestart: "restart_confirm"
+
     // One-shot session flag: the first-run modal is shown at most
     // once per launcher process, even if the WS link drops and the
     // mediadb-empty condition would otherwise be satisfied again.
@@ -613,6 +615,12 @@ MainLayout {
         function onRequestListPicker(title: string, entries: var, initialId: string, fieldId: string): void {
             root.openListPickerModal(title, entries, initialId, fieldId);
         }
+        function onAcceptRestart(): void {
+            
+        }
+        function onCancelRestart(): void {
+            root.closeSettingNeedsRestartModal();
+        }
     }
     Connections {
         target: root.aboutScreen
@@ -987,6 +995,18 @@ MainLayout {
             ScreenManager.popModal();
     }
 
+    function openSettingNeedsRestartModal(): void {
+        root.settingNeedsResetModalVisible = true;
+        if (ScreenManager.topModal !== root.modalSettingNeedsRestart)
+            ScreenManager.pushModal(root.modalSettingNeedsRestart);
+    }
+
+    function closeSettingNeedsRestartModal(): void {
+        root.settingNeedsResetModalVisible = false;
+        if (ScreenManager.topModal === root.modalSettingNeedsRestart)
+            ScreenManager.popModal();
+    }
+
     onListPickerAccepted: (fieldId, selectedId) => {
         if (fieldId === "language")
             Browse.Settings.set_language(selectedId);
@@ -996,6 +1016,7 @@ MainLayout {
             Browse.Settings.set_button_layout(selectedId);
         else if (fieldId === "resolution")
             Browse.Settings.set_resolution(selectedId);
+            root.openSettingNeedsRestartModal();
         else if (fieldId === "screensaverTimeout")
             Browse.Settings.set_screensaver_timeout(selectedId);
         root.closeListPickerModal();
@@ -1134,6 +1155,8 @@ MainLayout {
             } else if (ScreenManager.topModal === root.modalLogUpload) {
                 root.logUploadModal.handleAction(action);
             } else if (ScreenManager.topModal === root.modalQuitConfirm) {
+                root.quitConfirmModal.handleAction(action);
+            } else if (ScreenManager.topModal === root.modalSettingNeedsRestart) {
                 root.quitConfirmModal.handleAction(action);
             } else if (ScreenManager.topModal === root.modalListPicker) {
                 root.listPickerModal.handleAction(action);

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -616,7 +616,7 @@ MainLayout {
             root.openListPickerModal(title, entries, initialId, fieldId);
         }
         function onAcceptRestart(): void {
-            
+            root.closeSettingNeedsRestartModal();
         }
         function onCancelRestart(): void {
             root.closeSettingNeedsRestartModal();
@@ -1014,9 +1014,11 @@ MainLayout {
             Browse.Settings.set_browse_layout(selectedId);
         else if (fieldId === "buttonLayout")
             Browse.Settings.set_button_layout(selectedId);
-        else if (fieldId === "resolution")
+        else if (fieldId === "resolution") {
             Browse.Settings.set_resolution(selectedId);
+            root.closeListPickerModal();
             root.openSettingNeedsRestartModal();
+        }
         else if (fieldId === "screensaverTimeout")
             Browse.Settings.set_screensaver_timeout(selectedId);
         root.closeListPickerModal();
@@ -1157,7 +1159,7 @@ MainLayout {
             } else if (ScreenManager.topModal === root.modalQuitConfirm) {
                 root.quitConfirmModal.handleAction(action);
             } else if (ScreenManager.topModal === root.modalSettingNeedsRestart) {
-                root.quitConfirmModal.handleAction(action);
+                root.settingNeedsRestartModal.handleAction(action);
             } else if (ScreenManager.topModal === root.modalListPicker) {
                 root.listPickerModal.handleAction(action);
             }

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -615,12 +615,6 @@ MainLayout {
         function onRequestListPicker(title: string, entries: var, initialId: string, fieldId: string): void {
             root.openListPickerModal(title, entries, initialId, fieldId);
         }
-        function onAcceptRestart(): void {
-            root.closeSettingNeedsRestartModal();
-        }
-        function onCancelRestart(): void {
-            root.closeSettingNeedsRestartModal();
-        }
     }
     Connections {
         target: root.aboutScreen
@@ -971,6 +965,9 @@ MainLayout {
     onCloseQuitConfirmRequested: root.closeQuitConfirmModal()
     onQuitConfirmAccepted: Qt.quit()
 
+    onAcceptRestart: root.restartApp()
+    onCancelRestart: root.closeSettingNeedsRestartModal();
+
     // List-picker lifecycle. Settings screens emit requestListPicker
     // with a fieldId that round-trips through the modal so the accept
     // handler can dispatch the chosen id back to the matching
@@ -1005,6 +1002,10 @@ MainLayout {
         root.settingNeedsResetModalVisible = false;
         if (ScreenManager.topModal === root.modalSettingNeedsRestart)
             ScreenManager.popModal();
+    }
+
+    function restartApp() {
+        Qt.exit(1000);
     }
 
     onListPickerAccepted: (fieldId, selectedId) => {
@@ -1510,6 +1511,7 @@ MainLayout {
             // so there's no framebuffer to scrub there. Gate on
             // is_mister to keep the desktop dev-loop free of cosmetic
             // flashes when toggling resolutions for testing.
+            // Edit: not needed anymore with reboot after res change
             if (Browse.Settings.is_mister)
                 root._forceFullRepaint();
         }

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -993,13 +993,13 @@ MainLayout {
     }
 
     function openSettingNeedsRestartModal(): void {
-        root.settingNeedsResetModalVisible = true;
+        root.settingNeedsRestartModalVisible = true;
         if (ScreenManager.topModal !== root.modalSettingNeedsRestart)
             ScreenManager.pushModal(root.modalSettingNeedsRestart);
     }
 
     function closeSettingNeedsRestartModal(): void {
-        root.settingNeedsResetModalVisible = false;
+        root.settingNeedsRestartModalVisible = false;
         if (ScreenManager.topModal === root.modalSettingNeedsRestart)
             ScreenManager.popModal();
     }

--- a/src/ui/app/MainLayout.qml
+++ b/src/ui/app/MainLayout.qml
@@ -226,6 +226,7 @@ ApplicationWindow {
     property bool logUploadModalVisible: false
     property bool quitConfirmModalVisible: false
     property bool listPickerModalVisible: false
+    property bool settingNeedsResetModalVisible: false
     // Round-trip state for the list picker. The router writes these
     // when opening the modal (Settings emits requestListPicker with
     // fieldId so the accept handler can dispatch back to the right
@@ -720,22 +721,7 @@ ApplicationWindow {
                             label: qsTr("I understand")
                         }
                     ];
-                if (root.quitConfirmModalVisible)
-                    return [
-                        {
-                            button: "Dpad",
-                            label: qsTr("Move")
-                        },
-                        {
-                            button: "ButtonA",
-                            label: qsTr("Select")
-                        },
-                        {
-                            button: "ButtonB",
-                            label: qsTr("Cancel")
-                        }
-                    ];
-                if (root.listPickerModalVisible)
+                if (root.quitConfirmModalVisible || root.settingNeedsResetModalVisible || root.listPickerModalVisible)
                     return [
                         {
                             button: "Dpad",

--- a/src/ui/app/MainLayout.qml
+++ b/src/ui/app/MainLayout.qml
@@ -524,7 +524,6 @@ ApplicationWindow {
 
         // ── Card writer modal ────────────────────────────────────────────────────
 
-
         Modal {
             id: settingNeedsRestartModal
 

--- a/src/ui/app/MainLayout.qml
+++ b/src/ui/app/MainLayout.qml
@@ -227,7 +227,7 @@ ApplicationWindow {
     property bool logUploadModalVisible: false
     property bool quitConfirmModalVisible: false
     property bool listPickerModalVisible: false
-    property bool settingNeedsResetModalVisible: false
+    property bool settingNeedsRestartModalVisible: false
     // Round-trip state for the list picker. The router writes these
     // when opening the modal (Settings emits requestListPicker with
     // fieldId so the accept handler can dispatch back to the right
@@ -522,12 +522,12 @@ ApplicationWindow {
             onCancelRequested: root.cancelCardWriteRequested()
         }
 
-        // ── Card writer modal ────────────────────────────────────────────────────
+        // ── Setting restart prompt modal ────────────────────────────────────────────────────
 
         Modal {
             id: settingNeedsRestartModal
 
-            open: root.settingNeedsResetModalVisible
+            open: root.settingNeedsRestartModalVisible
             kind: "confirm"
             title: qsTr("Quit and restart Zaparoo Launcher?")
             body: qsTr("In order to apply this setting we need to restart the launcher.")
@@ -737,7 +737,7 @@ ApplicationWindow {
                             label: qsTr("I understand")
                         }
                     ];
-                if (root.quitConfirmModalVisible || root.settingNeedsResetModalVisible || root.listPickerModalVisible)
+                if (root.quitConfirmModalVisible || root.settingNeedsRestartModalVisible || root.listPickerModalVisible)
                     return [
                         {
                             button: "Dpad",

--- a/src/ui/app/MainLayout.qml
+++ b/src/ui/app/MainLayout.qml
@@ -293,6 +293,8 @@ ApplicationWindow {
     signal quitConfirmAccepted
     signal listPickerAccepted(string fieldId, string selectedId)
     signal listPickerCloseRequested(string fieldId)
+    signal acceptRestart
+    signal cancelRestart
 
     // Two-way sync between root.activeScreen and ScreenManager.activeScreen.
     // Binding-breaking assignments (tests setting root.activeScreen = "games")
@@ -518,6 +520,20 @@ ApplicationWindow {
             failed: root.cardWriteFailed
             title: root.cardWriteFailed ? qsTr("Writing failed") : qsTr("Put a writable card near the reader")
             onCancelRequested: root.cancelCardWriteRequested()
+        }
+
+        // ── Card writer modal ────────────────────────────────────────────────────
+
+
+        Modal {
+            id: settingNeedsRestartModal
+
+            open: root.settingNeedsResetModalVisible
+            kind: "confirm"
+            title: qsTr("Quit and restart Zaparoo Launcher?")
+            body: qsTr("In order to apply this setting we need to restart the launcher.")
+            onConfirmed: root.acceptRestart()
+            onCancelRequested: root.cancelRestart()
         }
 
         ContextMenu {

--- a/src/ui/app/MainLayout.qml
+++ b/src/ui/app/MainLayout.qml
@@ -208,6 +208,7 @@ ApplicationWindow {
     property alias firstRunIndexModal: firstRunIndexModal
     property alias logUploadModal: logUploadModal
     property alias quitConfirmModal: quitConfirmModal
+    property alias settingNeedsRestartModal: settingNeedsRestartModal
     property alias listPickerModal: listPickerModal
     property alias headerBar: headerBar
     property alias screensaverOverlay: screensaverOverlay

--- a/src/ui/screens/SettingsScreen.qml
+++ b/src/ui/screens/SettingsScreen.qml
@@ -44,9 +44,6 @@ Item {
     // matching `Browse.Settings` setter (keyed off `fieldId`).
     signal requestListPicker(title: string, entries: var, initialId: string, fieldId: string)
 
-    signal acceptRestart
-    signal cancelRestart
-
     // Field registry. Each entry's `kind` is `"header"` (non-focusable
     // group label) or `"field"` (a navigable row). Field entries also
     // carry an `id` that handleAction routes to the right model setter.
@@ -68,13 +65,13 @@ Item {
         // trusted again; the picker plumbing in `_cycleResolution` and
         // the Settings model's `current_resolution` property are still
         // wired so the row works as soon as it's added back.
-        if (Browse.Settings.is_mister) {
+        // if (Browse.Settings.is_mister) {
             out.push({
                 kind: "field",
                 id: "resolution",
                 label: qsTr("Resolution")
             })
-        }
+        // }
         out.push({
             kind: "field",
             id: "language",
@@ -134,19 +131,6 @@ Item {
             label: qsTr("About / License")
         });
         return out;
-    }
-
-
-
-    Modal {
-        id: settingNeedsRestartModal
-
-        open: root.settingNeedsResetModalVisible
-        kind: "confirm"
-        title: qsTr("Quit and restart Zaparoo Launcher?")
-        body: qsTr("In order to apply this setting we need to restart the launcher.")
-        onConfirmed: root.acceptRestart()
-        onCancelRequested: root.cancelRestart()
     }
 
     // Live-state caption helpers for the action rows. While the matching

--- a/src/ui/screens/SettingsScreen.qml
+++ b/src/ui/screens/SettingsScreen.qml
@@ -44,6 +44,9 @@ Item {
     // matching `Browse.Settings` setter (keyed off `fieldId`).
     signal requestListPicker(title: string, entries: var, initialId: string, fieldId: string)
 
+    signal acceptRestart
+    signal cancelRestart
+
     // Field registry. Each entry's `kind` is `"header"` (non-focusable
     // group label) or `"field"` (a navigable row). Field entries also
     // carry an `id` that handleAction routes to the right model setter.
@@ -65,13 +68,13 @@ Item {
         // trusted again; the picker plumbing in `_cycleResolution` and
         // the Settings model's `current_resolution` property are still
         // wired so the row works as soon as it's added back.
-        // if (Browse.Settings.is_mister) {
-        //     out.push({
-        //         kind: "field",
-        //         id: "resolution",
-        //         label: qsTr("Resolution")
-        //     })
-        // }
+        if (Browse.Settings.is_mister) {
+            out.push({
+                kind: "field",
+                id: "resolution",
+                label: qsTr("Resolution")
+            })
+        }
         out.push({
             kind: "field",
             id: "language",
@@ -131,6 +134,16 @@ Item {
             label: qsTr("About / License")
         });
         return out;
+    }
+
+    Modal {
+        id: settingsRestartModal
+
+        open: root.settingsRestartModalVisible
+        kind: "transient"
+        title: qsTr("Restart for settings to take effect.")
+        onAcceptRestart: root.acceptRestart()
+        onCancelRestart: root.cancelRestart()
     }
 
     // Live-state caption helpers for the action rows. While the matching

--- a/src/ui/screens/SettingsScreen.qml
+++ b/src/ui/screens/SettingsScreen.qml
@@ -66,11 +66,11 @@ Item {
         // the Settings model's `current_resolution` property are still
         // wired so the row works as soon as it's added back.
         // if (Browse.Settings.is_mister) {
-            out.push({
-                kind: "field",
-                id: "resolution",
-                label: qsTr("Resolution")
-            })
+        out.push({
+            kind: "field",
+            id: "resolution",
+            label: qsTr("Resolution")
+        });
         // }
         out.push({
             kind: "field",

--- a/src/ui/screens/SettingsScreen.qml
+++ b/src/ui/screens/SettingsScreen.qml
@@ -136,14 +136,17 @@ Item {
         return out;
     }
 
-    Modal {
-        id: settingsRestartModal
 
-        open: root.settingsRestartModalVisible
-        kind: "transient"
-        title: qsTr("Restart for settings to take effect.")
-        onAcceptRestart: root.acceptRestart()
-        onCancelRestart: root.cancelRestart()
+
+    Modal {
+        id: settingNeedsRestartModal
+
+        open: root.settingNeedsResetModalVisible
+        kind: "confirm"
+        title: qsTr("Quit and restart Zaparoo Launcher?")
+        body: qsTr("In order to apply this setting we need to restart the launcher.")
+        onConfirmed: root.acceptRestart()
+        onCancelRequested: root.cancelRestart()
     }
 
     // Live-state caption helpers for the action rows. While the matching


### PR DESCRIPTION
<!-- Thanks for the pull request. Please fill this out before requesting review. -->

## Summary

<!-- What changed, and why? One or two sentences is usually enough. -->

## Motivation

<!-- Link the issue or discussion that led to this. Delete this section if it does not apply. -->

## Screenshots / recordings

<!-- Required for visual changes. Include the FPS counter at 720p and, if possible, 240p. -->

## Test plan

<!-- How did you verify this? Manual steps and automated tests are both fine. -->

## Checklist

- [ ] `just lint` is green (zero warnings)
- [ ] `just test` passes
- [ ] If this touches QML, the FPS counter stays green (≥ 55) at 720p+ and ≥ 30 at 240p
- [ ] If this could affect the MiSTer build, I considered ARM32 implications (see `docs/architecture.md`)
- [ ] If this adds user-visible strings, they are wrapped in `qsTr()` (QML) or `tr()` (C++)
- [ ] I have signed the [CLA](../.github/CLA.md) (first-time contributors only)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added restart confirmation when changing settings that require restart; changes persist but apply after restart.
  * App now supports an internal restart/relaunch flow to apply such changes.

* **UX**
  * Resolution picker restored in Settings and triggers the restart-confirm flow.
  * Unified modal handling so restart/quit/list-picker modals share consistent help cues.

* **Behavior**
  * Default CRT logical canvas updated from 384x224 to 320x240.
  * Resolution changes no longer apply live or emit immediate UI notifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ZaparooProject/zaparoo-launcher/pull/129)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->