### PR TITLE
feat: add arcade alternate discovery

### DIFF
--- a/rust/launcher/build.rs
+++ b/rust/launcher/build.rs
@@ -24,6 +24,7 @@ fn main() {
     .qt_module("Quick")
     .qt_module("QuickControls2")
     .files([
+        "src/models/alternate_versions.rs",
         "src/models/categories.rs",
         "src/models/systems.rs",
         "src/models/games.rs",

--- a/rust/launcher/src/models/alternate_versions.rs
+++ b/rust/launcher/src/models/alternate_versions.rs
@@ -68,7 +68,10 @@ impl Initialize for ffi::AlternateVersions {
 }
 
 impl ffi::AlternateVersions {
-    #[allow(clippy::needless_pass_by_value)]
+    #[allow(
+        clippy::needless_pass_by_value,
+        reason = "cxx-qt qinvokable signatures use by-value QString"
+    )]
     fn discover_for(mut self: Pin<&mut Self>, system_id: QString, name: QString, path: QString) {
         let system_id = system_id.to_string();
         let name = name.to_string();

--- a/rust/launcher/src/models/alternate_versions.rs
+++ b/rust/launcher/src/models/alternate_versions.rs
@@ -68,6 +68,7 @@ impl Initialize for ffi::AlternateVersions {
 }
 
 impl ffi::AlternateVersions {
+    #[allow(clippy::needless_pass_by_value)]
     fn discover_for(mut self: Pin<&mut Self>, system_id: QString, name: QString, path: QString) {
         let system_id = system_id.to_string();
         let name = name.to_string();

--- a/rust/launcher/src/models/alternate_versions.rs
+++ b/rust/launcher/src/models/alternate_versions.rs
@@ -7,8 +7,8 @@ use cxx_qt::{CxxQtType, Initialize, Threading};
 use cxx_qt_lib::QString;
 use std::collections::HashSet;
 use std::pin::Pin;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use tracing::warn;
 use zaparoo_core::endpoints::run::RunMutation;
 use zaparoo_core::media_types::{
@@ -158,7 +158,10 @@ async fn discover_alternate_versions(
         return Ok(Vec::new());
     }
     let canonical_title = client
-        .media_meta(MediaMetaParams::for_media(system_id.to_string(), selected_path.to_string()))
+        .media_meta(MediaMetaParams::for_media(
+            system_id.to_string(),
+            selected_path.to_string(),
+        ))
         .await
         .ok()
         .map(|result| result.media.title.name.trim().to_string())
@@ -264,7 +267,7 @@ fn media_item_from_browse_entry(entry: BrowseEntry) -> MediaItem {
 fn normalize_name(value: &str) -> String {
     value
         .chars()
-        .filter(|ch| ch.is_ascii_alphanumeric())
+        .filter(char::is_ascii_alphanumeric)
         .flat_map(char::to_lowercase)
         .collect()
 }
@@ -286,7 +289,7 @@ fn normalize_seed_title(value: &str) -> String {
     normalize_name(trimmed)
 }
 
-fn strip_trailing_group<'a>(value: &'a str, open: char, close: char) -> Option<&'a str> {
+fn strip_trailing_group(value: &str, open: char, close: char) -> Option<&str> {
     let value = value.trim_end();
     if !value.ends_with(close) {
         return None;
@@ -345,8 +348,14 @@ mod tests {
     #[test]
     fn normalize_seed_title_drops_trailing_variant_groups() {
         assert_eq!(normalize_seed_title("Bubble Bobble"), "bubblebobble");
-        assert_eq!(normalize_seed_title("Bubble Bobble (Japan)"), "bubblebobble");
-        assert_eq!(normalize_seed_title("Bubble Bobble [Bootleg]"), "bubblebobble");
+        assert_eq!(
+            normalize_seed_title("Bubble Bobble (Japan)"),
+            "bubblebobble"
+        );
+        assert_eq!(
+            normalize_seed_title("Bubble Bobble [Bootleg]"),
+            "bubblebobble"
+        );
         assert_eq!(
             normalize_seed_title("Bubble Bobble Lost Cave"),
             "bubblebobblelostcave"
@@ -356,7 +365,9 @@ mod tests {
     #[test]
     fn alternate_folder_path_returns_deepest_alternate_folder() {
         assert_eq!(
-            alternate_folder_path("/media/fat/_Arcade/_alternatives/Bubble Bobble/Bubble Bobble.mra"),
+            alternate_folder_path(
+                "/media/fat/_Arcade/_alternatives/Bubble Bobble/Bubble Bobble.mra"
+            ),
             Some("/media/fat/_Arcade/_alternatives/Bubble Bobble".into())
         );
     }
@@ -394,8 +405,7 @@ mod tests {
         let item = media_item_from_browse_entry(BrowseEntry {
             media_id: Some(42),
             name: "Bubble Bobble (Japan)".into(),
-            path: "/media/fat/_Arcade/_alternatives/Bubble Bobble/Bubble Bobble (Japan).mra"
-                .into(),
+            path: "/media/fat/_Arcade/_alternatives/Bubble Bobble/Bubble Bobble (Japan).mra".into(),
             system_id: "Arcade".into(),
             relative_path: "_alternatives/Bubble Bobble/Bubble Bobble (Japan).mra".into(),
             zap_script: "**launch:\"/x\"".into(),

--- a/rust/launcher/src/models/alternate_versions.rs
+++ b/rust/launcher/src/models/alternate_versions.rs
@@ -1,0 +1,422 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+use crate::models::{global_handle, global_store};
+use cxx_qt::{CxxQtType, Initialize, Threading};
+use cxx_qt_lib::QString;
+use std::collections::HashSet;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use tracing::warn;
+use zaparoo_core::endpoints::run::RunMutation;
+use zaparoo_core::media_types::{
+    BrowseEntry, MediaBrowseParams, MediaItem, MediaMetaParams, MediaSearchParams, RunParams,
+};
+
+const ARCADE_SYSTEM_ID: &str = "Arcade";
+const MAX_ALT_RESULTS: u32 = 64;
+
+#[derive(Default)]
+pub struct AlternateVersionsRust {
+    count: i32,
+    loading: bool,
+    error_message: QString,
+    entries: Vec<MediaItem>,
+    seq: Arc<AtomicU64>,
+}
+
+#[cxx_qt::bridge]
+pub mod ffi {
+    unsafe extern "C++" {
+        include!("model_includes.h");
+
+        type QString = cxx_qt_lib::QString;
+    }
+
+    unsafe extern "RustQt" {
+        #[qobject]
+        #[qml_element]
+        #[qml_singleton]
+        #[qproperty(i32, count, READ, NOTIFY)]
+        #[qproperty(bool, loading, READ, NOTIFY)]
+        #[qproperty(QString, error_message, READ, NOTIFY)]
+        type AlternateVersions = super::AlternateVersionsRust;
+
+        #[qinvokable]
+        fn discover_for(
+            self: Pin<&mut AlternateVersions>,
+            system_id: QString,
+            name: QString,
+            path: QString,
+        );
+
+        #[qinvokable]
+        fn name_at(self: &AlternateVersions, index: i32) -> QString;
+
+        #[qinvokable]
+        fn launch_at(self: Pin<&mut AlternateVersions>, index: i32);
+    }
+
+    impl cxx_qt::Threading for AlternateVersions {}
+    impl cxx_qt::Initialize for AlternateVersions {}
+}
+
+impl Initialize for ffi::AlternateVersions {
+    fn initialize(self: Pin<&mut Self>) {}
+}
+
+impl ffi::AlternateVersions {
+    fn discover_for(mut self: Pin<&mut Self>, system_id: QString, name: QString, path: QString) {
+        let system_id = system_id.to_string();
+        let name = name.to_string();
+        let path = path.to_string();
+        let ticket = self.rust().seq.fetch_add(1, Ordering::SeqCst) + 1;
+        self.as_mut().rust_mut().entries.clear();
+        self.as_mut().rust_mut().count = 0;
+        self.as_mut().count_changed();
+        self.as_mut().rust_mut().error_message = QString::default();
+        self.as_mut().error_message_changed();
+        self.as_mut().rust_mut().loading = true;
+        self.as_mut().loading_changed();
+        let qt_thread = self.qt_thread();
+        let seq = self.rust().seq.clone();
+        let store = global_store();
+        global_handle().spawn(async move {
+            let client = store.client();
+            let result = discover_alternate_versions(
+                &client,
+                system_id.as_str(),
+                name.as_str(),
+                path.as_str(),
+            )
+            .await;
+            let _ = qt_thread.queue(move |mut model| {
+                if seq.load(Ordering::SeqCst) != ticket {
+                    return;
+                }
+                match result {
+                    Ok(entries) => {
+                        let count = entries.len() as i32;
+                        model.as_mut().rust_mut().entries = entries;
+                        model.as_mut().rust_mut().count = count;
+                        model.as_mut().count_changed();
+                        model.as_mut().rust_mut().error_message = QString::default();
+                        model.as_mut().error_message_changed();
+                    }
+                    Err(message) => {
+                        warn!("discover alternate versions failed: {message}");
+                        model.as_mut().rust_mut().entries.clear();
+                        model.as_mut().rust_mut().count = 0;
+                        model.as_mut().count_changed();
+                        model.as_mut().rust_mut().error_message = QString::from(message.as_str());
+                        model.as_mut().error_message_changed();
+                    }
+                }
+                model.as_mut().rust_mut().loading = false;
+                model.as_mut().loading_changed();
+            });
+        });
+    }
+
+    fn name_at(&self, index: i32) -> QString {
+        if index < 0 || index >= self.count {
+            return QString::default();
+        }
+        let entry = &self.entries[index as usize];
+        let label = file_stem_or_name(&entry.path);
+        QString::from(label.as_str())
+    }
+
+    fn launch_at(self: Pin<&mut Self>, index: i32) {
+        if index < 0 || index >= self.count {
+            return;
+        }
+        let entry = &self.entries[index as usize];
+        if entry.zap_script.is_empty() {
+            return;
+        }
+        let text = entry.zap_script.clone();
+        let name = entry.name.clone();
+        let store = global_store();
+        global_handle().spawn(async move {
+            if let Err(e) = store.run_mutation::<RunMutation>(RunParams { text }).await {
+                warn!("run failed for alternate {name}: {}", e.message);
+            }
+        });
+    }
+}
+
+async fn discover_alternate_versions(
+    client: &zaparoo_core::client::Client,
+    system_id: &str,
+    name: &str,
+    selected_path: &str,
+) -> Result<Vec<MediaItem>, String> {
+    if system_id != ARCADE_SYSTEM_ID || name.trim().is_empty() || selected_path.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+    let canonical_title = client
+        .media_meta(MediaMetaParams::for_media(system_id.to_string(), selected_path.to_string()))
+        .await
+        .ok()
+        .map(|result| result.media.title.name.trim().to_string())
+        .filter(|title| !title.is_empty())
+        .unwrap_or_else(|| name.trim().to_string());
+    let result = client
+        .media_search(MediaSearchParams {
+            query: Some(canonical_title.clone()),
+            systems: vec![ARCADE_SYSTEM_ID.to_string()],
+            max_results: Some(MAX_ALT_RESULTS),
+            ..MediaSearchParams::default()
+        })
+        .await
+        .map_err(|e| e.message)?;
+    let selected_norm = normalize_seed_title(&canonical_title);
+    let mut alternate_folders = HashSet::new();
+    for entry in result.results {
+        if !is_alternate_candidate(&entry, selected_path) {
+            continue;
+        }
+        if normalize_seed_title(&entry.name) != selected_norm {
+            continue;
+        }
+        if let Some(folder) = alternate_folder_path(&entry.path) {
+            alternate_folders.insert(folder);
+        }
+    }
+    if alternate_folders.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut seen_paths = HashSet::new();
+    let mut discovered = Vec::new();
+    for folder in alternate_folders {
+        let page = client
+            .media_browse(MediaBrowseParams {
+                path: folder,
+                systems: vec![ARCADE_SYSTEM_ID.to_string()],
+                max_results: Some(1000),
+                ..MediaBrowseParams::default()
+            })
+            .await
+            .map_err(|e| e.message)?;
+        for entry in page.entries {
+            if entry.is_folder() || entry.path.is_empty() || entry.path == selected_path {
+                continue;
+            }
+            if !seen_paths.insert(entry.path.clone()) {
+                continue;
+            }
+            discovered.push(media_item_from_browse_entry(entry));
+        }
+    }
+    Ok(discovered)
+}
+
+fn is_alternate_candidate(entry: &MediaItem, selected_path: &str) -> bool {
+    if entry.path.is_empty() || entry.path == selected_path {
+        return false;
+    }
+    entry.path.contains("_alternat")
+        || entry
+            .relative_path
+            .as_deref()
+            .is_some_and(|path| path.contains("_alternat"))
+}
+
+fn alternate_folder_path(path: &str) -> Option<String> {
+    let trimmed = path.trim_matches('/');
+    let parts: Vec<&str> = trimmed.split('/').filter(|part| !part.is_empty()).collect();
+    for (index, part) in parts.iter().enumerate() {
+        if !part.contains("_alternat") {
+            continue;
+        }
+        let folder_end = if index + 2 <= parts.len() {
+            index + 2
+        } else {
+            index + 1
+        };
+        return Some(format!("/{}", parts[..folder_end].join("/")));
+    }
+    None
+}
+
+fn media_item_from_browse_entry(entry: BrowseEntry) -> MediaItem {
+    MediaItem {
+        media_id: entry.media_id,
+        name: entry.name,
+        path: entry.path,
+        zap_script: entry.zap_script,
+        system: zaparoo_core::media_types::System {
+            id: entry.system_id,
+            ..Default::default()
+        },
+        tags: entry.tags,
+        relative_path: if entry.relative_path.is_empty() {
+            None
+        } else {
+            Some(entry.relative_path)
+        },
+    }
+}
+
+fn normalize_name(value: &str) -> String {
+    value
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
+fn normalize_seed_title(value: &str) -> String {
+    let mut trimmed = value.trim();
+    loop {
+        let candidate = trimmed.trim_end();
+        if let Some(prefix) = strip_trailing_group(candidate, '(', ')') {
+            trimmed = prefix;
+            continue;
+        }
+        if let Some(prefix) = strip_trailing_group(candidate, '[', ']') {
+            trimmed = prefix;
+            continue;
+        }
+        break;
+    }
+    normalize_name(trimmed)
+}
+
+fn strip_trailing_group<'a>(value: &'a str, open: char, close: char) -> Option<&'a str> {
+    let value = value.trim_end();
+    if !value.ends_with(close) {
+        return None;
+    }
+    let mut depth = 0usize;
+    for (index, ch) in value.char_indices().rev() {
+        if ch == close {
+            depth += 1;
+        } else if ch == open {
+            depth = depth.saturating_sub(1);
+            if depth == 0 {
+                return Some(value[..index].trim_end());
+            }
+        }
+    }
+    None
+}
+
+fn file_stem_or_name(path: &str) -> String {
+    let file = path
+        .trim_end_matches(['/', '\\'])
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or_default();
+    let stem = file.rsplit_once('.').map_or(file, |(stem, _)| stem).trim();
+    if stem.is_empty() {
+        path.trim().to_string()
+    } else {
+        stem.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        alternate_folder_path, file_stem_or_name, is_alternate_candidate,
+        media_item_from_browse_entry, normalize_name, normalize_seed_title,
+    };
+    use zaparoo_core::media_types::{BrowseEntry, MediaItem};
+
+    fn media_item(name: &str, path: &str, relative_path: Option<&str>) -> MediaItem {
+        MediaItem {
+            name: name.into(),
+            path: path.into(),
+            relative_path: relative_path.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn normalize_name_strips_non_alnum_and_case() {
+        assert_eq!(normalize_name("Bubble Bobble!"), "bubblebobble");
+        assert_eq!(normalize_name("Bubble-Bobble"), "bubblebobble");
+    }
+
+    #[test]
+    fn normalize_seed_title_drops_trailing_variant_groups() {
+        assert_eq!(normalize_seed_title("Bubble Bobble"), "bubblebobble");
+        assert_eq!(normalize_seed_title("Bubble Bobble (Japan)"), "bubblebobble");
+        assert_eq!(normalize_seed_title("Bubble Bobble [Bootleg]"), "bubblebobble");
+        assert_eq!(
+            normalize_seed_title("Bubble Bobble Lost Cave"),
+            "bubblebobblelostcave"
+        );
+    }
+
+    #[test]
+    fn alternate_folder_path_returns_deepest_alternate_folder() {
+        assert_eq!(
+            alternate_folder_path("/media/fat/_Arcade/_alternatives/Bubble Bobble/Bubble Bobble.mra"),
+            Some("/media/fat/_Arcade/_alternatives/Bubble Bobble".into())
+        );
+    }
+
+    #[test]
+    fn alternate_folder_path_returns_none_when_missing_marker() {
+        assert_eq!(
+            alternate_folder_path("/media/fat/_Arcade/Bubble Bobble/Bubble Bobble.mra"),
+            None
+        );
+    }
+
+    #[test]
+    fn alternate_candidate_accepts_alternate_path_and_rejects_selected() {
+        assert!(is_alternate_candidate(
+            &media_item(
+                "Bubble Bobble",
+                "/media/fat/_Arcade/_alternatives/Bubble Bobble/Bubble Bobble (Japan).mra",
+                Some("_alternatives/Bubble Bobble/Bubble Bobble (Japan).mra"),
+            ),
+            "/media/fat/_Arcade/Bubble Bobble.mra",
+        ));
+        assert!(!is_alternate_candidate(
+            &media_item(
+                "Bubble Bobble",
+                "/media/fat/_Arcade/Bubble Bobble.mra",
+                Some("Bubble Bobble.mra"),
+            ),
+            "/media/fat/_Arcade/Bubble Bobble.mra",
+        ));
+    }
+
+    #[test]
+    fn media_item_from_browse_entry_preserves_core_fields() {
+        let item = media_item_from_browse_entry(BrowseEntry {
+            media_id: Some(42),
+            name: "Bubble Bobble (Japan)".into(),
+            path: "/media/fat/_Arcade/_alternatives/Bubble Bobble/Bubble Bobble (Japan).mra"
+                .into(),
+            system_id: "Arcade".into(),
+            relative_path: "_alternatives/Bubble Bobble/Bubble Bobble (Japan).mra".into(),
+            zap_script: "**launch:\"/x\"".into(),
+            ..Default::default()
+        });
+        assert_eq!(item.media_id, Some(42));
+        assert_eq!(item.system.id, "Arcade");
+        assert_eq!(
+            item.relative_path.as_deref(),
+            Some("_alternatives/Bubble Bobble/Bubble Bobble (Japan).mra")
+        );
+        assert_eq!(item.zap_script, "**launch:\"/x\"");
+    }
+
+    #[test]
+    fn file_stem_or_name_prefers_filename_stem() {
+        assert_eq!(
+            file_stem_or_name(
+                "/media/fat/_Arcade/_alternatives/Bubble Bobble/Bubble Bobble (Japan).mra"
+            ),
+            "Bubble Bobble (Japan)"
+        );
+    }
+}

--- a/rust/launcher/src/models/favorites.rs
+++ b/rust/launcher/src/models/favorites.rs
@@ -164,6 +164,9 @@ pub mod ffi {
         fn path_at(self: &FavoritesModel, index: i32) -> QString;
 
         #[qinvokable]
+        fn system_id_at(self: &FavoritesModel, index: i32) -> QString;
+
+        #[qinvokable]
         fn index_for_path(self: &FavoritesModel, path: &QString) -> i32;
 
         #[inherit]
@@ -529,6 +532,13 @@ impl ffi::FavoritesModel {
             return QString::default();
         }
         QString::from(self.entries[index as usize].path.as_str())
+    }
+
+    fn system_id_at(&self, index: i32) -> QString {
+        if index < 0 || index >= self.count {
+            return QString::default();
+        }
+        QString::from(self.entries[index as usize].system.id.as_str())
     }
 
     fn index_for_path(&self, path: &QString) -> i32 {

--- a/rust/launcher/src/models/games.rs
+++ b/rust/launcher/src/models/games.rs
@@ -380,6 +380,9 @@ pub mod ffi {
         fn path_at(self: &GamesModel, index: i32) -> QString;
 
         #[qinvokable]
+        fn system_id_at(self: &GamesModel, index: i32) -> QString;
+
+        #[qinvokable]
         fn entry_type_at(self: &GamesModel, index: i32) -> QString;
 
         #[qinvokable]
@@ -855,6 +858,13 @@ impl ffi::GamesModel {
             return QString::default();
         }
         QString::from(self.entries[index as usize].path.as_str())
+    }
+
+    fn system_id_at(&self, index: i32) -> QString {
+        if index < 0 || index >= self.count {
+            return QString::default();
+        }
+        QString::from(entry_system_id(&self.entries[index as usize]).as_str())
     }
 
     fn entry_type_at(&self, index: i32) -> QString {

--- a/rust/launcher/src/models/mod.rs
+++ b/rust/launcher/src/models/mod.rs
@@ -25,6 +25,7 @@
 
 pub mod app_state;
 pub mod app_status;
+pub mod alternate_versions;
 pub mod browse;
 pub mod build_info;
 pub mod categories;

--- a/rust/launcher/src/models/mod.rs
+++ b/rust/launcher/src/models/mod.rs
@@ -23,9 +23,9 @@
     reason = "process-local init invariants: any violation is a wiring bug and must be fatal"
 )]
 
+pub mod alternate_versions;
 pub mod app_state;
 pub mod app_status;
-pub mod alternate_versions;
 pub mod browse;
 pub mod build_info;
 pub mod categories;

--- a/rust/launcher/src/models/recents.rs
+++ b/rust/launcher/src/models/recents.rs
@@ -136,6 +136,9 @@ pub mod ffi {
         fn path_at(self: &RecentsModel, index: i32) -> QString;
 
         #[qinvokable]
+        fn system_id_at(self: &RecentsModel, index: i32) -> QString;
+
+        #[qinvokable]
         fn index_for_path(self: &RecentsModel, path: &QString) -> i32;
 
         #[inherit]
@@ -393,6 +396,13 @@ impl ffi::RecentsModel {
             return QString::default();
         }
         QString::from(self.entries[index as usize].media_path.as_str())
+    }
+
+    fn system_id_at(&self, index: i32) -> QString {
+        if index < 0 || index >= self.count {
+            return QString::default();
+        }
+        QString::from(self.entries[index as usize].system_id.as_str())
     }
 
     fn index_for_path(&self, path: &QString) -> i32 {

--- a/rust/launcher/src/models/settings.rs
+++ b/rust/launcher/src/models/settings.rs
@@ -52,8 +52,9 @@
 // read on the next process launch. Button layout only changes the QML
 // resource path used by help-bar icons, browse layout selects the game
 // browsing presentation, mouse support drives the QML cursor/input blocker,
-// and language still takes effect on the next launch because Qt installs
-// translators only at startup.
+// discover-arcade-alternate-versions gates placeholder menu affordances for
+// MiSTer arcade alternates, and language still takes effect on the next launch
+// because Qt installs translators only at startup.
 
 use crate::models::{with_persist_mut, with_persist_read};
 use cxx_qt::{CxxQtType, Initialize};
@@ -110,6 +111,7 @@ pub struct SettingsRust {
     available_button_layouts: QStringList,
     current_button_layout: QString,
     current_mouse_enabled: bool,
+    current_discover_arcade_alternate_versions: bool,
     current_debug_logging: bool,
     available_screensaver_timeouts: QStringList,
     current_screensaver_timeout: QString,
@@ -138,6 +140,7 @@ pub mod ffi {
         #[qproperty(QStringList, available_button_layouts, READ, CONSTANT)]
         #[qproperty(QString, current_button_layout, READ, WRITE = set_button_layout, NOTIFY)]
         #[qproperty(bool, current_mouse_enabled, READ, WRITE = set_mouse_enabled, NOTIFY)]
+        #[qproperty(bool, current_discover_arcade_alternate_versions, READ, WRITE = set_discover_arcade_alternate_versions, NOTIFY)]
         #[qproperty(bool, current_debug_logging, READ, WRITE = set_debug_logging, NOTIFY)]
         #[qproperty(QStringList, available_screensaver_timeouts, READ, CONSTANT)]
         #[qproperty(QString, current_screensaver_timeout, READ, WRITE = set_screensaver_timeout, NOTIFY)]
@@ -157,6 +160,9 @@ pub mod ffi {
 
         #[qinvokable]
         fn set_mouse_enabled(self: Pin<&mut Settings>, value: bool);
+
+        #[qinvokable]
+        fn set_discover_arcade_alternate_versions(self: Pin<&mut Settings>, value: bool);
 
         #[qinvokable]
         fn set_debug_logging(self: Pin<&mut Settings>, value: bool);
@@ -193,6 +199,8 @@ impl Initialize for ffi::Settings {
         self.as_mut().rust_mut().current_button_layout =
             QString::from(merged.button_layout.as_str());
         self.as_mut().rust_mut().current_mouse_enabled = merged.mouse_enabled;
+        self.as_mut().rust_mut().current_discover_arcade_alternate_versions =
+            merged.discover_arcade_alternate_versions;
         self.as_mut().rust_mut().current_debug_logging = merged.debug_logging;
         self.as_mut().rust_mut().available_screensaver_timeouts = screensaver_timeouts();
         self.as_mut().rust_mut().current_screensaver_timeout =
@@ -269,6 +277,17 @@ impl ffi::Settings {
         self.as_mut().current_mouse_enabled_changed();
     }
 
+    fn set_discover_arcade_alternate_versions(mut self: Pin<&mut Self>, value: bool) {
+        if self.current_discover_arcade_alternate_versions == value {
+            return;
+        }
+        let snapshot = persist_settings(|s| s.discover_arcade_alternate_versions = value);
+        mirror_settings_to_config(&config_file_path(), &snapshot.settings);
+        self.as_mut().rust_mut().current_discover_arcade_alternate_versions = value;
+        self.as_mut()
+            .current_discover_arcade_alternate_versions_changed();
+    }
+
     fn set_debug_logging(mut self: Pin<&mut Self>, value: bool) {
         if self.current_debug_logging == value {
             return;
@@ -324,6 +343,7 @@ fn mirror_settings_to_config(config_path: &std::path::Path, settings: &SettingsS
             browse_layout: settings.browse_layout.as_str(),
             button_layout: settings.button_layout.as_str(),
             mouse_enabled: settings.mouse_enabled,
+            discover_arcade_alternate_versions: settings.discover_arcade_alternate_versions,
             debug_logging: settings.debug_logging,
             screensaver_timeout: settings.screensaver_timeout.as_str(),
         },
@@ -363,6 +383,10 @@ fn merge_settings(snapshot: &SettingsState, config: &Config) -> SettingsState {
             .settings
             .mouse_enabled
             .unwrap_or(snapshot.mouse_enabled),
+        discover_arcade_alternate_versions: config
+            .settings
+            .discover_arcade_alternate_versions
+            .unwrap_or(snapshot.discover_arcade_alternate_versions),
         // Config wins so launcher.toml is the durable source of truth on
         // MiSTer (state.toml lives on tmpfs).
         debug_logging: config.debug_logging,

--- a/rust/launcher/src/models/settings.rs
+++ b/rust/launcher/src/models/settings.rs
@@ -199,8 +199,9 @@ impl Initialize for ffi::Settings {
         self.as_mut().rust_mut().current_button_layout =
             QString::from(merged.button_layout.as_str());
         self.as_mut().rust_mut().current_mouse_enabled = merged.mouse_enabled;
-        self.as_mut().rust_mut().current_discover_arcade_alternate_versions =
-            merged.discover_arcade_alternate_versions;
+        self.as_mut()
+            .rust_mut()
+            .current_discover_arcade_alternate_versions = merged.discover_arcade_alternate_versions;
         self.as_mut().rust_mut().current_debug_logging = merged.debug_logging;
         self.as_mut().rust_mut().available_screensaver_timeouts = screensaver_timeouts();
         self.as_mut().rust_mut().current_screensaver_timeout =
@@ -283,7 +284,9 @@ impl ffi::Settings {
         }
         let snapshot = persist_settings(|s| s.discover_arcade_alternate_versions = value);
         mirror_settings_to_config(&config_file_path(), &snapshot.settings);
-        self.as_mut().rust_mut().current_discover_arcade_alternate_versions = value;
+        self.as_mut()
+            .rust_mut()
+            .current_discover_arcade_alternate_versions = value;
         self.as_mut()
             .current_discover_arcade_alternate_versions_changed();
     }

--- a/rust/launcher/src/models/settings.rs
+++ b/rust/launcher/src/models/settings.rs
@@ -99,7 +99,10 @@ const DEFAULT_SCREENSAVER_TIMEOUT: &str = "300";
 #[cfg(debug_assertions)]
 const SCREENSAVER_TIMEOUTS_DEBUG: &[&str] = &["1"];
 
-#[allow(clippy::struct_excessive_bools)]
+#[allow(
+    clippy::struct_excessive_bools,
+    reason = "settings qobject is a persisted toggle bag exposed to QML"
+)]
 #[derive(Default)]
 pub struct SettingsRust {
     is_mister: bool,

--- a/rust/launcher/src/models/settings.rs
+++ b/rust/launcher/src/models/settings.rs
@@ -99,6 +99,7 @@ const DEFAULT_SCREENSAVER_TIMEOUT: &str = "300";
 #[cfg(debug_assertions)]
 const SCREENSAVER_TIMEOUTS_DEBUG: &[&str] = &["1"];
 
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Default)]
 pub struct SettingsRust {
     is_mister: bool,

--- a/rust/zaparoo-core/src/config.rs
+++ b/rust/zaparoo-core/src/config.rs
@@ -47,6 +47,7 @@ pub struct SettingsConfig {
     pub browse_layout: Option<String>,
     pub button_layout: Option<String>,
     pub mouse_enabled: Option<bool>,
+    pub discover_arcade_alternate_versions: Option<bool>,
     pub screensaver_timeout: Option<String>,
 }
 
@@ -57,6 +58,7 @@ pub struct SettingsMirror<'a> {
     pub browse_layout: &'a str,
     pub button_layout: &'a str,
     pub mouse_enabled: bool,
+    pub discover_arcade_alternate_versions: bool,
     pub debug_logging: bool,
     pub screensaver_timeout: &'a str,
 }
@@ -132,6 +134,7 @@ struct RawSettings {
     browse_layout: Option<String>,
     button_layout: Option<String>,
     mouse_enabled: Option<bool>,
+    discover_arcade_alternate_versions: Option<bool>,
     screensaver_timeout: Option<String>,
 }
 
@@ -207,6 +210,7 @@ pub fn load_config(path: &Path) -> Config {
             .button_layout
             .map(|value| value.trim().to_string()),
         mouse_enabled: raw.settings.mouse_enabled,
+        discover_arcade_alternate_versions: raw.settings.discover_arcade_alternate_versions,
         screensaver_timeout: raw
             .settings
             .screensaver_timeout
@@ -280,6 +284,10 @@ pub fn save_settings_mirror(path: &Path, mirror: SettingsMirror<'_>) -> Result<(
     settings.insert(
         "mouse_enabled".into(),
         toml::Value::Boolean(mirror.mouse_enabled),
+    );
+    settings.insert(
+        "discover_arcade_alternate_versions".into(),
+        toml::Value::Boolean(mirror.discover_arcade_alternate_versions),
     );
     settings.insert(
         "screensaver_timeout".into(),
@@ -422,6 +430,7 @@ mod tests {
         assert_eq!(cfg.settings.browse_layout, None);
         assert_eq!(cfg.settings.button_layout, None);
         assert_eq!(cfg.settings.mouse_enabled, None);
+        assert_eq!(cfg.settings.discover_arcade_alternate_versions, None);
         assert!(!cfg.notice.commercial_ack);
         // Default keyboard bindings populate the map.
         assert!(!cfg.key_to_action.is_empty());
@@ -594,6 +603,7 @@ mod tests {
                 browse_layout: "list",
                 button_layout: "b",
                 mouse_enabled: false,
+                discover_arcade_alternate_versions: true,
                 debug_logging: true,
                 screensaver_timeout: "300",
             },
@@ -607,6 +617,7 @@ mod tests {
         assert_eq!(cfg.settings.browse_layout.as_deref(), Some("list"));
         assert_eq!(cfg.settings.button_layout.as_deref(), Some("b"));
         assert_eq!(cfg.settings.mouse_enabled, Some(false));
+        assert_eq!(cfg.settings.discover_arcade_alternate_versions, Some(true));
         assert_eq!(cfg.settings.screensaver_timeout.as_deref(), Some("300"));
         assert!(cfg.debug_logging);
     }
@@ -624,6 +635,7 @@ mod tests {
                 browse_layout: "grid",
                 button_layout: "a",
                 mouse_enabled: true,
+                discover_arcade_alternate_versions: false,
                 debug_logging: false,
                 screensaver_timeout: "60",
             },
@@ -639,6 +651,7 @@ mod tests {
         assert_eq!(cfg.settings.browse_layout.as_deref(), Some("grid"));
         assert_eq!(cfg.settings.button_layout.as_deref(), Some("a"));
         assert_eq!(cfg.settings.mouse_enabled, Some(true));
+        assert_eq!(cfg.settings.discover_arcade_alternate_versions, Some(false));
         assert_eq!(cfg.settings.screensaver_timeout.as_deref(), Some("60"));
         assert!(!cfg.debug_logging);
     }
@@ -654,6 +667,7 @@ mod tests {
                 browse_layout: "list",
                 button_layout: "c",
                 mouse_enabled: false,
+                discover_arcade_alternate_versions: true,
                 debug_logging: true,
                 screensaver_timeout: "off",
             },
@@ -664,6 +678,7 @@ mod tests {
         assert!(written.contains("browse_layout = \"list\""));
         assert!(written.contains("button_layout = \"c\""));
         assert!(written.contains("mouse_enabled = false"));
+        assert!(written.contains("discover_arcade_alternate_versions = true"));
         assert!(written.contains("screensaver_timeout = \"off\""));
         assert!(written.contains("debug = true"));
         let cfg = load_config(f.path());
@@ -672,6 +687,7 @@ mod tests {
         assert_eq!(cfg.settings.browse_layout.as_deref(), Some("list"));
         assert_eq!(cfg.settings.button_layout.as_deref(), Some("c"));
         assert_eq!(cfg.settings.mouse_enabled, Some(false));
+        assert_eq!(cfg.settings.discover_arcade_alternate_versions, Some(true));
         assert_eq!(cfg.settings.screensaver_timeout.as_deref(), Some("off"));
         assert!(cfg.debug_logging);
     }

--- a/rust/zaparoo-core/src/persist.rs
+++ b/rust/zaparoo-core/src/persist.rs
@@ -104,6 +104,8 @@ pub struct SettingsState {
     #[serde(default = "default_mouse_enabled")]
     pub mouse_enabled: bool,
     #[serde(default)]
+    pub discover_arcade_alternate_versions: bool,
+    #[serde(default)]
     pub debug_logging: bool,
     #[serde(default = "default_screensaver_timeout")]
     pub screensaver_timeout: String,
@@ -117,6 +119,7 @@ impl Default for SettingsState {
             browse_layout: default_browse_layout(),
             button_layout: default_button_layout(),
             mouse_enabled: default_mouse_enabled(),
+            discover_arcade_alternate_versions: false,
             debug_logging: false,
             screensaver_timeout: default_screensaver_timeout(),
         }
@@ -270,6 +273,7 @@ mod tests {
                 browse_layout: "list".into(),
                 button_layout: "b".into(),
                 mouse_enabled: false,
+                discover_arcade_alternate_versions: true,
                 debug_logging: true,
                 screensaver_timeout: "300".into(),
             },

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -48,7 +48,10 @@ MainLayout {
     property bool _firstRunIndexShown: false
     property string _pendingLanguageSelection: ""
     property string _pendingResolutionSelection: ""
+    property bool _discoverMenuPending: false
+    property var _discoverParentEntries: []
     property string cardWriteOwner: ""
+    property string contextMenuMode: "main"
     property string contextMenuOwner: ""
     property int contextMenuIndex: -1
     readonly property bool activeCardWritePending: root.cardWriteOwner === "systems" ? Browse.SystemsModel.card_write_pending : root.cardWriteOwner === "games" ? Browse.GamesModel.card_write_pending : root.cardWriteOwner === "favorites" ? Browse.FavoritesModel.card_write_pending : false
@@ -702,8 +705,35 @@ MainLayout {
     onActiveCardWriteErrorChanged: root.handleCardWriteStatus()
     onCancelCardWriteRequested: root.cancelCardWrite()
     onCloseQrCodeRequested: root.closeQrCodeModal()
-    onContextMenuCloseRequested: root.closeContextMenu()
+    onContextMenuCloseRequested: root.handleContextMenuCloseRequested()
     onContextMenuAccepted: id => root.handleContextMenuAccepted(id)
+    Connections {
+        target: Browse.AlternateVersions
+        function onLoadingChanged(): void {
+            if (Browse.AlternateVersions.loading || !root._discoverMenuPending)
+                return;
+            root._discoverMenuPending = false;
+            if (!root.contextMenuVisible || root.contextMenuMode !== "main")
+                return;
+            if (Browse.AlternateVersions.count <= 0)
+                root._replaceContextMenuEntryLabel("discover_loading", "No alternates found", "discover_unavailable");
+            if (Browse.AlternateVersions.count <= 0)
+                return;
+            const entries = [];
+            for (let i = 0; i < Browse.AlternateVersions.count; i++) {
+                entries.push({
+                    id: "alternate_version:" + i,
+                    label: Browse.AlternateVersions.name_at(i)
+                });
+            }
+            if (entries.length === 0)
+                return;
+            root._discoverParentEntries = root.contextMenuEntries;
+            root.contextMenuEntries = entries;
+            root.contextMenuMode = "alternate_versions";
+            root.contextMenu.currentIndex = 0;
+        }
+    }
 
     // Pure helper — owner/entryType/hasNfc/isFavorite → list of `{id,label}` entries.
     // Empty list = no menu (caller bails out of openContextMenu).
@@ -723,12 +753,18 @@ MainLayout {
             ];
         }
         if (owner === "recents") {
-            return [
+            const entries = [
                 {
                     id: "launch_game",
                     label: qsTr("Launch game")
                 }
             ];
+            if (Browse.Settings.current_discover_arcade_alternate_versions)
+                entries.unshift({
+                    id: "discover",
+                    label: "Discover alt. versions"
+                });
+            return entries;
         }
         if (owner === "games" || owner === "favorites") {
             if (entryType === "directory" || entryType === "root")
@@ -748,6 +784,12 @@ MainLayout {
                 id: "qr_code",
                 label: qsTr("QR code")
             });
+            if (Browse.Settings.current_discover_arcade_alternate_versions) {
+                entries.push({
+                    id: "discover",
+                    label: "Discover alt. versions"
+                });
+            }
             entries.push({
                 id: "launch_game",
                 label: qsTr("Launch game")
@@ -762,6 +804,38 @@ MainLayout {
     // hands the scanned zapscript back to a Core/launcher pairing.
     function _buildQrPayload(zapscript: string): string {
         return "https://zaparoo.app/write?v=" + encodeURIComponent(zapscript);
+    }
+
+    function _replaceContextMenuEntryLabel(targetId: string, nextLabel: string, nextId: string): void {
+        const entries = [];
+        for (let i = 0; i < root.contextMenuEntries.length; i++) {
+            const entry = root.contextMenuEntries[i];
+            if (entry.id === targetId) {
+                entries.push({
+                    id: nextId === undefined ? entry.id : nextId,
+                    label: nextLabel
+                });
+            } else {
+                entries.push(entry);
+            }
+        }
+        root.contextMenuEntries = entries;
+    }
+
+    function _restoreDiscoverContextMenuEntry(entriesIn: var): var {
+        const entries = [];
+        for (let i = 0; i < entriesIn.length; i++) {
+            const entry = entriesIn[i];
+            if (entry.id === "discover_loading" || entry.id === "discover_unavailable") {
+                entries.push({
+                    id: "discover",
+                    label: "Discover alt. versions"
+                });
+            } else {
+                entries.push(entry);
+            }
+        }
+        return entries;
     }
 
     function openContextMenu(owner: string, index: int, anchorRect): void {
@@ -788,16 +862,33 @@ MainLayout {
         root.contextMenuEntries = entries;
         root.contextMenuOwner = owner;
         root.contextMenuIndex = index;
+        root.contextMenuMode = "main";
+        root._discoverParentEntries = [];
+        root._discoverMenuPending = false;
         root.contextMenuAnchor = anchorRect;
         root.contextMenuVisible = true;
         if (ScreenManager.topModal !== root.modalContextMenu)
             ScreenManager.pushModal(root.modalContextMenu);
     }
 
+    function handleContextMenuCloseRequested(): void {
+        if (root.contextMenuMode === "alternate_versions") {
+            root.contextMenuEntries = root._restoreDiscoverContextMenuEntry(root._discoverParentEntries);
+            root._discoverParentEntries = [];
+            root.contextMenuMode = "main";
+            root._discoverMenuPending = false;
+            return;
+        }
+        root.closeContextMenu();
+    }
+
     function closeContextMenu(): void {
         root.contextMenuVisible = false;
         root.contextMenuOwner = "";
         root.contextMenuIndex = -1;
+        root.contextMenuMode = "main";
+        root._discoverParentEntries = [];
+        root._discoverMenuPending = false;
         root.contextMenuEntries = [];
         if (ScreenManager.topModal === root.modalContextMenu)
             ScreenManager.popModal();
@@ -806,10 +897,36 @@ MainLayout {
     function handleContextMenuAccepted(id: string): void {
         const owner = root.contextMenuOwner;
         const targetIndex = root.contextMenuIndex;
-        root.closeContextMenu();
         if (targetIndex < 0)
             return;
-        if (id === "launch_system") {
+        if (id === "discover") {
+            let systemId = "";
+            let name = "";
+            let path = "";
+            if (owner === "games") {
+                systemId = Browse.GamesModel.system_id_at(targetIndex);
+                name = Browse.GamesModel.name_at(targetIndex);
+                path = Browse.GamesModel.path_at(targetIndex);
+            } else if (owner === "favorites") {
+                systemId = Browse.FavoritesModel.system_id_at(targetIndex);
+                name = Browse.FavoritesModel.name_at(targetIndex);
+                path = Browse.FavoritesModel.path_at(targetIndex);
+            } else if (owner === "recents") {
+                systemId = Browse.RecentsModel.system_id_at(targetIndex);
+                name = Browse.RecentsModel.name_at(targetIndex);
+                path = Browse.RecentsModel.path_at(targetIndex);
+            }
+            root._discoverMenuPending = true;
+            root._replaceContextMenuEntryLabel("discover", "Searching....", "discover_loading");
+            Browse.AlternateVersions.discover_for(systemId, name, path);
+            return;
+        }
+        root.closeContextMenu();
+        if (id.startsWith("alternate_version:")) {
+            const altIndex = Number(id.slice("alternate_version:".length));
+            if (!Number.isNaN(altIndex))
+                Browse.AlternateVersions.launch_at(altIndex);
+        } else if (id === "launch_system") {
             Browse.SystemsModel.launch_at(targetIndex);
         } else if (id === "launch_game") {
             if (owner === "favorites")
@@ -840,6 +957,8 @@ MainLayout {
                 Browse.QrCode.generate(root._buildQrPayload(text));
                 root.openQrCodeModal();
             }
+        } else if (id === "discover_unavailable" || id === "discover_loading") {
+            return;
         }
     }
 

--- a/src/ui/components/ContextMenu.qml
+++ b/src/ui/components/ContextMenu.qml
@@ -38,7 +38,7 @@ Item {
     readonly property int rowHeight: Sizing.pctH(6)
     readonly property int rowSpacing: Sizing.pctH(1)
     readonly property int horizontalPadding: Sizing.pctW(2)
-    readonly property int panelWidth: Math.min(Math.max(Sizing.pctW(26), Sizing.pctH(44)), Math.max(0, width - 2 * margin))
+    readonly property int panelWidth: Math.min(Math.max(Sizing.pctW(42), Sizing.pctH(56)), Math.max(0, width - 2 * margin))
     // Top/bottom margins inside the panel are sized to the panel
     // radius so a focused row's accent ring never intersects the
     // rounded corners — see the panel `Rectangle` below.
@@ -56,6 +56,15 @@ Item {
     onOpenChanged: {
         if (open)
             currentIndex = 0;
+    }
+
+    onEntriesChanged: {
+        if (menu.entries.length <= 0) {
+            currentIndex = 0;
+            return;
+        }
+        if (menu.currentIndex >= menu.entries.length)
+            currentIndex = menu.entries.length - 1;
     }
 
     function move(delta: int): void {

--- a/src/ui/screens/SettingsScreen.qml
+++ b/src/ui/screens/SettingsScreen.qml
@@ -93,6 +93,11 @@ Item {
         });
         out.push({
             kind: "field",
+            id: "discoverArcadeAlternateVersions",
+            label: qsTr("Discover arcade alternate versions")
+        });
+        out.push({
+            kind: "field",
             id: "updateMediaDb",
             label: qsTr("Update media database")
         });
@@ -228,7 +233,7 @@ Item {
         if (!settings._isField(settings.currentIndex))
             return false;
         const id = settings.fields[settings.currentIndex].id;
-        return id === "mouseEnabled" || id === "debugLogging";
+        return id === "mouseEnabled" || id === "discoverArcadeAlternateVersions" || id === "debugLogging";
     }
     // True when the focused field is a list-picker row (Accept opens a
     // modal; left/right is a no-op — pickers don't cycle inline). Drives
@@ -483,6 +488,14 @@ Item {
         Browse.Settings.set_debug_logging(!Browse.Settings.current_debug_logging);
     }
 
+    function _setDiscoverArcadeAlternateVersions(direction: int): void {
+        Browse.Settings.set_discover_arcade_alternate_versions(direction > 0);
+    }
+
+    function _toggleDiscoverArcadeAlternateVersions(): void {
+        Browse.Settings.set_discover_arcade_alternate_versions(!Browse.Settings.current_discover_arcade_alternate_versions);
+    }
+
     function _cycleFocused(direction: int): void {
         if (!settings._isField(settings.currentIndex))
             return;
@@ -492,6 +505,8 @@ Item {
         // direction presses (left = off, right = on).
         if (id === "mouseEnabled")
             settings._setMouseEnabled(direction);
+        else if (id === "discoverArcadeAlternateVersions")
+            settings._setDiscoverArcadeAlternateVersions(direction);
         else if (id === "debugLogging")
             settings._setDebugLogging(direction);
     }
@@ -511,6 +526,8 @@ Item {
             const id = settings.fields[settings.currentIndex].id;
             if (id === "mouseEnabled")
                 settings._toggleMouseEnabled();
+            else if (id === "discoverArcadeAlternateVersions")
+                settings._toggleDiscoverArcadeAlternateVersions();
             else if (id === "debugLogging")
                 settings._toggleDebugLogging();
             else if (id === "updateMediaDb")
@@ -651,14 +668,16 @@ Item {
                         enabled: row.modelData.id === "updateMediaDb" ? !settings._scrapeBusy : row.modelData.id === "runScraper" ? !settings._indexBusy : true
                         label: row.modelData.label
                         value: row.modelData.id === "resolution" ? settings._resolutionDisplay(Browse.Settings.current_resolution) : row.modelData.id === "language" ? settings._languageDisplay(Browse.Settings.current_language) : row.modelData.id === "browseLayout" ? settings._browseLayoutDisplay(Browse.Settings.current_browse_layout) : row.modelData.id === "buttonLayout" ? settings._buttonLayoutDisplay(Browse.Settings.current_button_layout) : row.modelData.id === "screensaverTimeout" ? settings._screensaverTimeoutDisplay(Browse.Settings.current_screensaver_timeout) : ""
-                        control: row.modelData.id === "mouseEnabled" || row.modelData.id === "debugLogging" ? "toggle" : row.modelData.id === "aboutLicense" ? "navigate" : (row.modelData.id === "updateMediaDb" || row.modelData.id === "runScraper" || row.modelData.id === "uploadLog") ? "action" : "picker"
-                        checked: row.modelData.id === "debugLogging" ? Browse.Settings.current_debug_logging : Browse.Settings.current_mouse_enabled
+                        control: row.modelData.id === "mouseEnabled" || row.modelData.id === "discoverArcadeAlternateVersions" || row.modelData.id === "debugLogging" ? "toggle" : row.modelData.id === "aboutLicense" ? "navigate" : (row.modelData.id === "updateMediaDb" || row.modelData.id === "runScraper" || row.modelData.id === "uploadLog") ? "action" : "picker"
+                        checked: row.modelData.id === "debugLogging" ? Browse.Settings.current_debug_logging : row.modelData.id === "discoverArcadeAlternateVersions" ? Browse.Settings.current_discover_arcade_alternate_versions : Browse.Settings.current_mouse_enabled
                         actionStatus: row.modelData.id === "updateMediaDb" ? settings._indexActionStatus() : row.modelData.id === "runScraper" ? settings._scrapeActionStatus() : ""
                         onHovered: settings.currentIndex = row.index
                         onClicked: {
                             settings.currentIndex = row.index;
                             if (row.modelData.id === "mouseEnabled")
                                 settings._toggleMouseEnabled();
+                            else if (row.modelData.id === "discoverArcadeAlternateVersions")
+                                settings._toggleDiscoverArcadeAlternateVersions();
                             else if (row.modelData.id === "debugLogging")
                                 settings._toggleDebugLogging();
                         }


### PR DESCRIPTION
## Summary
- add a persistent setting to enable arcade alternate discovery from tile context menus
- add alternate discovery/search flow, loading/empty states, and submenu navigation for Arcade titles
- add Rust helper tests for alternate-folder/path matching and menu item labeling

close #125

## Verification
- cargo test alternate_versions
- just build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Discover and launch alternate Arcade game versions from the item context menu.
  * New Settings toggle ("Discover alt. versions") with gamepad and keyboard support.

* **Bug Fixes / UI**
  * Context menu entries update dynamically during discovery (including "No alternates found") and restore on close.
  * Context menu sizing and selection now avoid stale/invalid selections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ZaparooProject/zaparoo-launcher/pull/134)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->