### PR TITLE
fix(): Padding/Margin tweaking for crt

### DIFF
--- a/scripts/run-macos-mister-core.sh
+++ b/scripts/run-macos-mister-core.sh
@@ -17,5 +17,5 @@ fi
 
 export ZAPAROO_CORE_ENDPOINT="ws://192.168.1.176:7497/api/v0.1"
 export ZAPAROO_CRT_PREVIEW_SCALE=3
-exec "${LAUNCHER}"
-# exec "${LAUNCHER}" --crt
+# exec "${LAUNCHER}"
+exec "${LAUNCHER}" --crt

--- a/src/ui/app/MainLayout.qml
+++ b/src/ui/app/MainLayout.qml
@@ -283,6 +283,23 @@ ApplicationWindow {
     readonly property string hubScreenState: (Browse.CategoriesModel.error_message ?? "") !== "" ? "error" : (Browse.CategoriesModel.count === 0 ? "empty" : "ready")
 
     readonly property string recentsScreenState: Browse.RecentsModel.loading ? "loading" : ((Browse.RecentsModel.error_message ?? "") !== "" ? "error" : (Browse.RecentsModel.count === 0 ? "empty" : "ready"))
+    readonly property bool _crtGridBrowseLayout: root.crtNativePath && Browse.Settings.current_browse_layout !== "list"
+    readonly property string _crtGamesHeaderTitle: {
+        const sid = Browse.GamesModel.current_system_id;
+        if (sid === "")
+            return "";
+        const idx = Browse.SystemsModel.index_for_system_id(sid);
+        return idx >= 0 ? Browse.SystemsModel.system_name_at(idx) : sid;
+    }
+    readonly property string crtHeaderTitle: {
+        if (!root._crtGridBrowseLayout)
+            return "";
+        if (root.activeScreen === root.screenSystems)
+            return Browse.SystemsModel.current_category;
+        if (root.activeScreen === root.screenGames)
+            return root._crtGamesHeaderTitle;
+        return "";
+    }
 
     signal cancelCardWriteRequested
     signal closeQrCodeRequested
@@ -403,6 +420,7 @@ ApplicationWindow {
             anchors.right: parent.right
             anchors.top: parent.top
             anchors.topMargin: Sizing.headerTopMargin
+            crtTitle: root.crtHeaderTitle
             z: 200
         }
 

--- a/src/ui/app/MainLayout.qml
+++ b/src/ui/app/MainLayout.qml
@@ -284,6 +284,8 @@ ApplicationWindow {
 
     readonly property string recentsScreenState: Browse.RecentsModel.loading ? "loading" : ((Browse.RecentsModel.error_message ?? "") !== "" ? "error" : (Browse.RecentsModel.count === 0 ? "empty" : "ready"))
     readonly property bool _crtGridBrowseLayout: root.crtNativePath && Browse.Settings.current_browse_layout !== "list"
+    readonly property var _browseTileLayout: root._crtGridBrowseLayout ? BrowseLayouts.crtTile : BrowseLayouts.defaultTile
+    readonly property var _contextMenuLayout: root.crtNativePath ? BrowseLayouts.crtTile : BrowseLayouts.defaultTile
     readonly property string _crtGamesHeaderTitle: {
         const sid = Browse.GamesModel.current_system_id;
         if (sid === "")
@@ -291,7 +293,7 @@ ApplicationWindow {
         const idx = Browse.SystemsModel.index_for_system_id(sid);
         return idx >= 0 ? Browse.SystemsModel.system_name_at(idx) : sid;
     }
-    readonly property string crtHeaderTitle: {
+    readonly property string browseHeaderTitle: {
         if (!root._crtGridBrowseLayout)
             return "";
         if (root.activeScreen === root.screenSystems)
@@ -420,7 +422,8 @@ ApplicationWindow {
             anchors.right: parent.right
             anchors.top: parent.top
             anchors.topMargin: Sizing.headerTopMargin
-            crtTitle: root.crtHeaderTitle
+            layoutProfile: root._browseTileLayout
+            browseTitle: root.browseHeaderTitle
             z: 200
         }
 
@@ -559,6 +562,7 @@ ApplicationWindow {
             open: root.contextMenuVisible
             anchorRect: root.contextMenuAnchor
             entries: root.contextMenuEntries
+            bottomUnsafeHeight: root._contextMenuLayout.bottomUnsafeHeight
             onAccepted: id => root.contextMenuAccepted(id)
             onCloseRequested: root.contextMenuCloseRequested()
         }

--- a/src/ui/components/ContextMenu.qml
+++ b/src/ui/components/ContextMenu.qml
@@ -29,6 +29,7 @@ Item {
     // dynamic per-owner menus silently re-shuffled the index/action map.
     property var entries: []
     property int currentIndex: 0
+    property int bottomUnsafeHeight: Sizing.pctH(6) + Sizing.pctH(2)
 
     signal accepted(string id)
     signal closeRequested
@@ -38,8 +39,7 @@ Item {
     readonly property int rowHeight: Sizing.pctH(6)
     readonly property int rowSpacing: Sizing.pctH(1)
     readonly property int horizontalPadding: Sizing.pctW(2)
-    readonly property int _bottomUnsafeHeight: Theme.crtNativePath ? 16 : Sizing.pctH(6) + Sizing.pctH(2)
-    readonly property int _usableBottom: Math.max(menu.margin, height - _bottomUnsafeHeight - menu.margin)
+    readonly property int _usableBottom: Math.max(menu.margin, height - menu.bottomUnsafeHeight - menu.margin)
     readonly property int panelWidth: Math.min(Math.max(Sizing.pctW(42), Sizing.pctH(56)), Math.max(0, width - 2 * margin))
     // Top/bottom margins inside the panel are sized to the panel
     // radius so a focused row's accent ring never intersects the

--- a/src/ui/components/ContextMenu.qml
+++ b/src/ui/components/ContextMenu.qml
@@ -38,12 +38,14 @@ Item {
     readonly property int rowHeight: Sizing.pctH(6)
     readonly property int rowSpacing: Sizing.pctH(1)
     readonly property int horizontalPadding: Sizing.pctW(2)
+    readonly property int _bottomUnsafeHeight: Theme.crtNativePath ? 16 : Sizing.pctH(6) + Sizing.pctH(2)
+    readonly property int _usableBottom: Math.max(menu.margin, height - _bottomUnsafeHeight - menu.margin)
     readonly property int panelWidth: Math.min(Math.max(Sizing.pctW(42), Sizing.pctH(56)), Math.max(0, width - 2 * margin))
     // Top/bottom margins inside the panel are sized to the panel
     // radius so a focused row's accent ring never intersects the
     // rounded corners — see the panel `Rectangle` below.
     readonly property int panelRadius: Sizing.half(Sizing.cornerRadius)
-    readonly property int panelHeight: Math.min(entries.length * rowHeight + Math.max(0, entries.length - 1) * rowSpacing + 2 * panelRadius, Math.max(0, height - 2 * margin))
+    readonly property int panelHeight: Math.min(entries.length * rowHeight + Math.max(0, entries.length - 1) * rowSpacing + 2 * panelRadius, Math.max(0, _usableBottom - menu.margin))
     readonly property bool preferRight: anchorRect.x + anchorRect.width + gap + panelWidth <= width - margin
     readonly property int preferredX: preferRight ? Sizing.px(anchorRect.x + anchorRect.width + gap) : Sizing.px(anchorRect.x - gap - panelWidth)
     readonly property int preferredY: Sizing.px(anchorRect.y + Sizing.center(anchorRect.height, panelHeight))
@@ -148,7 +150,7 @@ Item {
         id: panel
 
         x: Sizing.px(Math.max(menu.margin, Math.min(menu.preferredX, menu.width - menu.margin - menu.panelWidth)))
-        y: Sizing.px(Math.max(menu.margin, Math.min(menu.preferredY, menu.height - menu.margin - menu.panelHeight)))
+        y: Sizing.px(Math.max(menu.margin, Math.min(menu.preferredY, menu._usableBottom - menu.panelHeight)))
         width: menu.panelWidth
         height: menu.panelHeight
         color: Theme.bgPanel

--- a/src/ui/components/HeaderBar.qml
+++ b/src/ui/components/HeaderBar.qml
@@ -24,6 +24,7 @@ Item {
     // on-screen geometry (mapToItem + paintedWidth/Height) and start
     // the bouncing copy at exactly the same position.
     property alias logoItem: logo
+    property string crtTitle: ""
 
     height: Sizing.headerHeight
 
@@ -58,7 +59,8 @@ Item {
     Row {
         id: topHud
 
-        anchors.top: parent.top
+        anchors.top: Theme.crtNativePath ? undefined : parent.top
+        anchors.bottom: Theme.crtNativePath ? parent.bottom : undefined
         anchors.right: parent.right
         anchors.rightMargin: Sizing.headerSideMargin
         spacing: Sizing.pctW(1)
@@ -126,14 +128,42 @@ Item {
         }
     }
 
+    TextMetrics {
+        id: crtTitleMetrics
+
+        text: header.crtTitle
+        font.family: Theme.fontUi
+        font.pixelSize: Sizing.headerRowHeight
+        font.weight: Font.Medium
+    }
+
+    Text {
+        id: crtTitleLabel
+
+        visible: Theme.crtNativePath && header.crtTitle !== ""
+        x: Sizing.center(parent.width, width)
+        y: parent.height - height
+        width: Math.min(Math.floor(parent.width / 3), Math.ceil(Math.max(crtTitleMetrics.advanceWidth, crtTitleMetrics.boundingRect.width)))
+        height: Sizing.headerRowHeight
+        elide: Text.ElideRight
+        horizontalAlignment: Text.AlignLeft
+        verticalAlignment: Text.AlignVCenter
+        text: header.crtTitle
+        font.family: Theme.fontUi
+        font.pixelSize: Sizing.headerRowHeight
+        font.weight: Font.Medium
+        color: Theme.textPrimary
+        renderType: Text.NativeRendering
+    }
+
     // Mutually-exclusive Core / indexing / scraper status surface. Sits
     // on its own line directly under `topHud`, right-aligned to the
     // same edge as the clock. The pill collapses to zero size when
     // idle, but its slot stays reserved by the header's fixed height
     // so the logo and the surrounding layout don't shift.
     CoreStatusPill {
-        anchors.top: topHud.bottom
+        anchors.top: Theme.crtNativePath ? parent.top : topHud.bottom
         anchors.right: topHud.right
-        anchors.topMargin: Sizing.headerStackGap
+        anchors.topMargin: Theme.crtNativePath ? 0 : Sizing.headerStackGap
     }
 }

--- a/src/ui/components/HeaderBar.qml
+++ b/src/ui/components/HeaderBar.qml
@@ -24,7 +24,8 @@ Item {
     // on-screen geometry (mapToItem + paintedWidth/Height) and start
     // the bouncing copy at exactly the same position.
     property alias logoItem: logo
-    property string crtTitle: ""
+    property var layoutProfile: null
+    property string browseTitle: ""
 
     height: Sizing.headerHeight
 
@@ -59,8 +60,8 @@ Item {
     Row {
         id: topHud
 
-        anchors.top: Theme.crtNativePath ? undefined : parent.top
-        anchors.bottom: Theme.crtNativePath ? parent.bottom : undefined
+        anchors.top: header.layoutProfile && header.layoutProfile.headerHudBottomAligned ? undefined : parent.top
+        anchors.bottom: header.layoutProfile && header.layoutProfile.headerHudBottomAligned ? parent.bottom : undefined
         anchors.right: parent.right
         anchors.rightMargin: Sizing.headerSideMargin
         spacing: Sizing.pctW(1)
@@ -131,7 +132,7 @@ Item {
     TextMetrics {
         id: crtTitleMetrics
 
-        text: header.crtTitle
+        text: header.browseTitle
         font.family: Theme.fontUi
         font.pixelSize: Sizing.headerRowHeight
         font.weight: Font.Medium
@@ -140,7 +141,7 @@ Item {
     Text {
         id: crtTitleLabel
 
-        visible: Theme.crtNativePath && header.crtTitle !== ""
+        visible: header.layoutProfile && header.layoutProfile.showHeaderTitleInHeader && header.browseTitle !== ""
         x: Sizing.center(parent.width, width)
         y: parent.height - height
         width: Math.min(Math.floor(parent.width / 3), Math.ceil(Math.max(crtTitleMetrics.advanceWidth, crtTitleMetrics.boundingRect.width)))
@@ -148,7 +149,7 @@ Item {
         elide: Text.ElideRight
         horizontalAlignment: Text.AlignLeft
         verticalAlignment: Text.AlignVCenter
-        text: header.crtTitle
+        text: header.browseTitle
         font.family: Theme.fontUi
         font.pixelSize: Sizing.headerRowHeight
         font.weight: Font.Medium
@@ -162,8 +163,8 @@ Item {
     // idle, but its slot stays reserved by the header's fixed height
     // so the logo and the surrounding layout don't shift.
     CoreStatusPill {
-        anchors.top: Theme.crtNativePath ? parent.top : topHud.bottom
+        anchors.top: header.layoutProfile && header.layoutProfile.headerStatusPillPinnedTop ? parent.top : topHud.bottom
         anchors.right: topHud.right
-        anchors.topMargin: Theme.crtNativePath ? 0 : Sizing.headerStackGap
+        anchors.topMargin: header.layoutProfile && header.layoutProfile.headerStatusPillPinnedTop ? 0 : Sizing.headerStackGap
     }
 }

--- a/src/ui/components/PagedGrid.qml
+++ b/src/ui/components/PagedGrid.qml
@@ -50,6 +50,7 @@ Item {
     // Defaults to true so call sites that don't care keep working
     // untouched.
     property bool focused: true
+    property var layoutProfile: null
 
     // Emitted when the user is sitting on the last loaded page after a
     // selection move. Models with more data fetch the next page in
@@ -163,31 +164,19 @@ Item {
     // not as another cell, so a full inter-cell gap looks like wasted
     // space next to it. The gutter stays reserved on a single page
     // (just hidden) so cells don't reflow when paging activates.
-    property int leftInsetOverride: -1
-    property int rightInsetOverride: -1
-    property int gutterWidthOverride: -1
-    property int gutterGapOverride: -1
-    property int cellSpacingXOverride: -1
-    property int topInsetOverride: -1
-    property int bottomInsetOverride: -1
-    property int cellSpacingYOverride: -1
-    property int scrollThumbWidthOverride: -1
-    property int scrollThumbRightInsetOverride: -1
-    property int scrollArrowSizeOverride: -1
-    property bool packHorizontalRemainderAfterGutter: false
-    readonly property int leftInset: leftInsetOverride >= 0 ? leftInsetOverride : Sizing.pctW(5)
-    readonly property int rightInset: rightInsetOverride >= 0 ? rightInsetOverride : Sizing.pctW(5)
-    readonly property int gutterWidth: gutterWidthOverride >= 0 ? gutterWidthOverride : Sizing.pctW(3)
-    readonly property int gutterGap: gutterGapOverride >= 0 ? gutterGapOverride : Sizing.pctW(1.5)
-    readonly property int scrollThumbWidth: scrollThumbWidthOverride >= 0 ? scrollThumbWidthOverride : Sizing.pctW(1.2)
-    readonly property int scrollThumbRightInset: scrollThumbRightInsetOverride >= 0 ? scrollThumbRightInsetOverride : 0
-    readonly property int scrollArrowSize: scrollArrowSizeOverride >= 0 ? scrollArrowSizeOverride : Math.min(gutterWidth, Sizing.pctH(4))
-    readonly property int topInset: topInsetOverride >= 0 ? topInsetOverride : Sizing.pctH(2)
-    readonly property int bottomInset: bottomInsetOverride >= 0 ? bottomInsetOverride : Sizing.pctH(2)
-    readonly property int cellSpacingX: cellSpacingXOverride >= 0 ? cellSpacingXOverride : Sizing.pctW(3)
-    readonly property int cellSpacingY: cellSpacingYOverride >= 0 ? cellSpacingYOverride : Sizing.pctH(4)
+    readonly property int leftInset: root.layoutProfile ? root.layoutProfile.gridLeftInset : Sizing.pctW(5)
+    readonly property int rightInset: root.layoutProfile ? root.layoutProfile.gridRightInset : Sizing.pctW(5)
+    readonly property int gutterWidth: root.layoutProfile ? root.layoutProfile.gridGutterWidth : Sizing.pctW(3)
+    readonly property int gutterGap: root.layoutProfile ? root.layoutProfile.gridGutterGap : Sizing.pctW(1.5)
+    readonly property int scrollThumbWidth: root.layoutProfile ? root.layoutProfile.scrollThumbWidth : Sizing.pctW(1.2)
+    readonly property int scrollThumbRightInset: root.layoutProfile ? root.layoutProfile.scrollThumbRightInset : 0
+    readonly property int scrollArrowSize: root.layoutProfile ? root.layoutProfile.scrollArrowSize : Math.min(gutterWidth, Sizing.pctH(4))
+    readonly property int topInset: root.layoutProfile ? root.layoutProfile.gridTopInset : Sizing.pctH(2)
+    readonly property int bottomInset: root.layoutProfile ? root.layoutProfile.gridBottomInset : Sizing.pctH(2)
+    readonly property int cellSpacingX: root.layoutProfile ? root.layoutProfile.gridColumnGap : Sizing.pctW(3)
+    readonly property int cellSpacingY: root.layoutProfile ? root.layoutProfile.gridRowGap : Sizing.pctH(4)
     readonly property int _contentWidth: root.columns * root.cellWidth + (root.columns - 1) * root.cellSpacingX
-    readonly property int _scrollGutterX: root.packHorizontalRemainderAfterGutter ? root.leftInset + root._contentWidth + root.gutterGap : width - root.rightInset - root.gutterWidth
+    readonly property int _scrollGutterX: root.layoutProfile && root.layoutProfile.packHorizontalRemainderAfterGutter ? root.leftInset + root._contentWidth + root.gutterGap : width - root.rightInset - root.gutterWidth
 
     // Computed cell dimensions — fill the available area, divided by
     // gridColumns × gridRows. Callers don't override. The cell area

--- a/src/ui/components/PagedGrid.qml
+++ b/src/ui/components/PagedGrid.qml
@@ -167,14 +167,27 @@ Item {
     property int rightInsetOverride: -1
     property int gutterWidthOverride: -1
     property int gutterGapOverride: -1
+    property int cellSpacingXOverride: -1
+    property int topInsetOverride: -1
+    property int bottomInsetOverride: -1
+    property int cellSpacingYOverride: -1
+    property int scrollThumbWidthOverride: -1
+    property int scrollThumbRightInsetOverride: -1
+    property int scrollArrowSizeOverride: -1
+    property bool packHorizontalRemainderAfterGutter: false
     readonly property int leftInset: leftInsetOverride >= 0 ? leftInsetOverride : Sizing.pctW(5)
     readonly property int rightInset: rightInsetOverride >= 0 ? rightInsetOverride : Sizing.pctW(5)
     readonly property int gutterWidth: gutterWidthOverride >= 0 ? gutterWidthOverride : Sizing.pctW(3)
     readonly property int gutterGap: gutterGapOverride >= 0 ? gutterGapOverride : Sizing.pctW(1.5)
-    readonly property int topInset: Sizing.pctH(2)
-    readonly property int bottomInset: Sizing.pctH(2)
-    readonly property int cellSpacingX: Sizing.pctW(3)
-    readonly property int cellSpacingY: Sizing.pctH(4)
+    readonly property int scrollThumbWidth: scrollThumbWidthOverride >= 0 ? scrollThumbWidthOverride : Sizing.pctW(1.2)
+    readonly property int scrollThumbRightInset: scrollThumbRightInsetOverride >= 0 ? scrollThumbRightInsetOverride : 0
+    readonly property int scrollArrowSize: scrollArrowSizeOverride >= 0 ? scrollArrowSizeOverride : Math.min(gutterWidth, Sizing.pctH(4))
+    readonly property int topInset: topInsetOverride >= 0 ? topInsetOverride : Sizing.pctH(2)
+    readonly property int bottomInset: bottomInsetOverride >= 0 ? bottomInsetOverride : Sizing.pctH(2)
+    readonly property int cellSpacingX: cellSpacingXOverride >= 0 ? cellSpacingXOverride : Sizing.pctW(3)
+    readonly property int cellSpacingY: cellSpacingYOverride >= 0 ? cellSpacingYOverride : Sizing.pctH(4)
+    readonly property int _contentWidth: root.columns * root.cellWidth + (root.columns - 1) * root.cellSpacingX
+    readonly property int _scrollGutterX: root.packHorizontalRemainderAfterGutter ? root.leftInset + root._contentWidth + root.gutterGap : width - root.rightInset - root.gutterWidth
 
     // Computed cell dimensions — fill the available area, divided by
     // gridColumns × gridRows. Callers don't override. The cell area
@@ -658,8 +671,7 @@ Item {
     Item {
         id: scrollGutter
 
-        anchors.right: parent.right
-        anchors.rightMargin: root.rightInset
+        x: root._scrollGutterX
         anchors.top: parent.top
         anchors.topMargin: root.topInset
         anchors.bottom: parent.bottom
@@ -667,13 +679,11 @@ Item {
         width: root.gutterWidth
         visible: root.totalPageCount > 1
 
-        readonly property int arrowSize: Math.min(width, Sizing.pctH(4))
-
         Image {
             id: upArrow
             source: Resources.iconUrl("ScrollUp")
-            width: scrollGutter.arrowSize
-            height: scrollGutter.arrowSize
+            width: root.scrollArrowSize
+            height: root.scrollArrowSize
             anchors.top: parent.top
             anchors.horizontalCenter: parent.horizontalCenter
             fillMode: Image.PreserveAspectFit
@@ -692,8 +702,8 @@ Item {
         Image {
             id: downArrow
             source: Resources.iconUrl("ScrollDown")
-            width: scrollGutter.arrowSize
-            height: scrollGutter.arrowSize
+            width: root.scrollArrowSize
+            height: root.scrollArrowSize
             anchors.bottom: parent.bottom
             anchors.horizontalCenter: parent.horizontalCenter
             fillMode: Image.PreserveAspectFit
@@ -715,10 +725,12 @@ Item {
         Item {
             id: scrollRegion
             anchors.top: parent.top
-            anchors.topMargin: scrollGutter.arrowSize + Sizing.pctH(1)
+            anchors.topMargin: root.scrollArrowSize + Sizing.pctH(1)
             anchors.bottom: parent.bottom
-            anchors.bottomMargin: scrollGutter.arrowSize + Sizing.pctH(1)
-            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.bottomMargin: root.scrollArrowSize + Sizing.pctH(1)
+            anchors.right: parent.right
+            anchors.rightMargin: root.scrollThumbRightInset
+            width: root.scrollThumbWidth
 
             // Standard paginated-scrollbar formulas (cf. Qt
             // `ScrollBar.size`/`position`, GTK `Gtk.Scrollbar`, Apple
@@ -732,9 +744,9 @@ Item {
 
             Rectangle {
                 id: scrollThumb
-                width: Sizing.pctW(1.2)
+                width: root.scrollThumbWidth
                 height: scrollRegion._thumbHeight
-                anchors.horizontalCenter: parent.horizontalCenter
+                anchors.right: parent.right
                 y: scrollRegion._thumbY
                 color: Theme.textPrimary
                 radius: Sizing.half(width)

--- a/src/ui/components/PagedGrid.qml
+++ b/src/ui/components/PagedGrid.qml
@@ -163,10 +163,14 @@ Item {
     // not as another cell, so a full inter-cell gap looks like wasted
     // space next to it. The gutter stays reserved on a single page
     // (just hidden) so cells don't reflow when paging activates.
-    readonly property int leftInset: Sizing.pctW(5)
-    readonly property int rightInset: Sizing.pctW(5)
-    readonly property int gutterWidth: Sizing.pctW(3)
-    readonly property int gutterGap: Sizing.pctW(1.5)
+    property int leftInsetOverride: -1
+    property int rightInsetOverride: -1
+    property int gutterWidthOverride: -1
+    property int gutterGapOverride: -1
+    readonly property int leftInset: leftInsetOverride >= 0 ? leftInsetOverride : Sizing.pctW(5)
+    readonly property int rightInset: rightInsetOverride >= 0 ? rightInsetOverride : Sizing.pctW(5)
+    readonly property int gutterWidth: gutterWidthOverride >= 0 ? gutterWidthOverride : Sizing.pctW(3)
+    readonly property int gutterGap: gutterGapOverride >= 0 ? gutterGapOverride : Sizing.pctW(1.5)
     readonly property int topInset: Sizing.pctH(2)
     readonly property int bottomInset: Sizing.pctH(2)
     readonly property int cellSpacingX: Sizing.pctW(3)

--- a/src/ui/components/Tile.qml
+++ b/src/ui/components/Tile.qml
@@ -70,6 +70,7 @@ Item {
     readonly property string delegateName: parent.name
     readonly property string delegateCoverKey: parent.coverKey
     readonly property bool delegateFavorite: parent.favorite !== 0
+    property var layoutProfile: null
     // Opt-in per-tile name caption. Off by default so Hub and Systems
     // keep their full-bleed logo layout. Cover-art screens (Games,
     // Recents) flip this on at the delegate template.
@@ -86,7 +87,7 @@ Item {
     readonly property int _captionHeight: Sizing.pctH(5.5)
     readonly property int _captionGap: Sizing.pctH(0.4)
     readonly property int _captionTextSize: Sizing.fontSize(2.2)
-    readonly property int _tileCornerRadius: Theme.crtNativePath ? 4 : Sizing.cornerRadius
+    readonly property int _tileCornerRadius: root.layoutProfile ? root.layoutProfile.tileCornerRadius : Sizing.cornerRadius
     readonly property int _captionTextMaxWidth: Math.max(0, root.width - 2 * root._tileCornerRadius)
     readonly property int _textMeasureSlack: Theme.crtNativePath ? 0 : 2
     readonly property int _captionMeasuredWidth: Math.ceil(Math.max(captionMetrics.advanceWidth, captionMetrics.boundingRect.width) + root._textMeasureSlack)

--- a/src/ui/components/Tile.qml
+++ b/src/ui/components/Tile.qml
@@ -86,7 +86,8 @@ Item {
     readonly property int _captionHeight: Sizing.pctH(5.5)
     readonly property int _captionGap: Sizing.pctH(0.4)
     readonly property int _captionTextSize: Sizing.fontSize(2.2)
-    readonly property int _captionTextMaxWidth: Math.max(0, root.width - 2 * Sizing.cornerRadius)
+    readonly property int _tileCornerRadius: Theme.crtNativePath ? 4 : Sizing.cornerRadius
+    readonly property int _captionTextMaxWidth: Math.max(0, root.width - 2 * root._tileCornerRadius)
     readonly property int _textMeasureSlack: Theme.crtNativePath ? 0 : 2
     readonly property int _captionMeasuredWidth: Math.ceil(Math.max(captionMetrics.advanceWidth, captionMetrics.boundingRect.width) + root._textMeasureSlack)
     readonly property int _captionTextWidth: Math.min(root._captionTextMaxWidth, root._captionMeasuredWidth)
@@ -127,7 +128,7 @@ Item {
     // selection.
     Rectangle {
         anchors.fill: parent
-        radius: Sizing.cornerRadius
+        radius: root._tileCornerRadius
         color: Theme.surfaceCard
         border.color: Theme.borderMid
         border.width: Sizing.stroke(1)
@@ -160,7 +161,7 @@ Item {
         anchors.fill: parent
         anchors.margins: root._outlineGap
         color: Theme.accent
-        radius: Math.max(0, Sizing.cornerRadius - root._outlineGap)
+        radius: Math.max(0, root._tileCornerRadius - root._outlineGap)
         antialiasing: true
         visible: root._focusedSelection
     }

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -461,13 +461,21 @@ Item {
         anchors.right: parent.right
         anchors.top: topStrip.bottom
         anchors.bottom: parent.bottom
-        anchors.bottomMargin: games._crtGridLayout ? Sizing.pctH(6) + Sizing.px(2) + Sizing.pctH(7) : Sizing.pctH(15)
+        anchors.bottomMargin: games._crtGridLayout ? Sizing.pctH(6) + Sizing.px(4) + 8 : Sizing.pctH(15)
         focused: games.gridFocused
         model: Browse.GamesModel
         leftInsetOverride: games._crtGridLayout ? 4 : -1
-        rightInsetOverride: games._crtGridLayout ? 4 : -1
-        gutterWidthOverride: games._crtGridLayout ? 4 : -1
+        rightInsetOverride: games._crtGridLayout ? 0 : -1
+        gutterWidthOverride: games._crtGridLayout ? 8 : -1
         gutterGapOverride: games._crtGridLayout ? 4 : -1
+        cellSpacingXOverride: games._crtGridLayout ? 4 : -1
+        topInsetOverride: games._crtGridLayout ? 2 : -1
+        bottomInsetOverride: games._crtGridLayout ? 4 : -1
+        cellSpacingYOverride: games._crtGridLayout ? 4 : -1
+        scrollThumbWidthOverride: games._crtGridLayout ? 4 : -1
+        scrollThumbRightInsetOverride: games._crtGridLayout ? 2 : -1
+        scrollArrowSizeOverride: games._crtGridLayout ? 8 : -1
+        packHorizontalRemainderAfterGutter: games._crtGridLayout
         delegate: Tile {
             showCaption: true
         }
@@ -525,8 +533,8 @@ Item {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.bottom: parent.bottom
-        anchors.bottomMargin: games._crtGridLayout ? Sizing.pctH(6) + Sizing.px(2) : Sizing.pctH(8)
-        height: Sizing.pctH(7)
+        anchors.bottomMargin: games._crtGridLayout ? Sizing.pctH(6) + Sizing.px(4) : Sizing.pctH(8)
+        height: games._crtGridLayout ? 8 : Sizing.pctH(7)
         text: gamesGrid.itemCount > 0 ? Browse.GamesModel.name_at(gamesGrid.currentIndex) : ""
     }
 

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -38,6 +38,7 @@ Item {
     readonly property real _listBandScale: 0.85
     readonly property int _listPageSize: 10
     readonly property int _browsePageSize: games._listLayout ? games._listPageSize : gamesGrid.pageSize
+    readonly property bool _crtGridLayout: Theme.crtNativePath && !games._listLayout
     property bool _currentMoveIsRepeat: false
 
     // Cover-gate flag: true while `GamesModel` is holding `loading`
@@ -345,13 +346,15 @@ Item {
     // the precise entry count for the path.
     TopStatusStrip {
         id: topStrip
-        visible: !games.transitioning && !games.coverGateLoading
+        visible: !games.transitioning && !games.coverGateLoading && !games._crtGridLayout
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: parent.top
         anchors.topMargin: Sizing.headerBottom + Sizing.pctH(1)
-        height: Sizing.pctH(7)
+        height: games._crtGridLayout ? 0 : Sizing.pctH(7)
         title: {
+            if (games._crtGridLayout)
+                return "";
             const sid = Browse.GamesModel.current_system_id;
             if (sid === "")
                 return "";
@@ -359,8 +362,8 @@ Item {
             return idx >= 0 ? Browse.SystemsModel.system_name_at(idx) : sid;
         }
         currentPage: Math.floor(gamesGrid.currentIndex / games._browsePageSize)
-        totalPages: Math.max(1, Math.ceil((Browse.GamesModel.dir_count + Browse.GamesModel.total_files) / games._browsePageSize))
-        totalText: Browse.GamesModel.total_files > 0 ? qsTr("%1 files").arg(Browse.GamesModel.total_files) : ""
+        totalPages: games._crtGridLayout ? 1 : Math.max(1, Math.ceil((Browse.GamesModel.dir_count + Browse.GamesModel.total_files) / games._browsePageSize))
+        totalText: games._crtGridLayout ? "" : (Browse.GamesModel.total_files > 0 ? qsTr("%1 files").arg(Browse.GamesModel.total_files) : "")
     }
 
     Item {
@@ -458,9 +461,13 @@ Item {
         anchors.right: parent.right
         anchors.top: topStrip.bottom
         anchors.bottom: parent.bottom
-        anchors.bottomMargin: Sizing.pctH(15)
+        anchors.bottomMargin: games._crtGridLayout ? Sizing.pctH(6) + Sizing.px(2) + Sizing.pctH(7) : Sizing.pctH(15)
         focused: games.gridFocused
         model: Browse.GamesModel
+        leftInsetOverride: games._crtGridLayout ? 4 : -1
+        rightInsetOverride: games._crtGridLayout ? 4 : -1
+        gutterWidthOverride: games._crtGridLayout ? 4 : -1
+        gutterGapOverride: games._crtGridLayout ? 4 : -1
         delegate: Tile {
             showCaption: true
         }
@@ -517,9 +524,45 @@ Item {
         visible: !games.transitioning && !games.coverGateLoading && !games._listLayout
         anchors.left: parent.left
         anchors.right: parent.right
-        anchors.top: gamesGrid.bottom
+        anchors.bottom: parent.bottom
+        anchors.bottomMargin: games._crtGridLayout ? Sizing.pctH(6) + Sizing.px(2) : Sizing.pctH(8)
         height: Sizing.pctH(7)
         text: gamesGrid.itemCount > 0 ? Browse.GamesModel.name_at(gamesGrid.currentIndex) : ""
+    }
+
+    Text {
+        id: bottomTotalText
+        visible: games._crtGridLayout && !games.transitioning && !games.coverGateLoading && Browse.GamesModel.total_files > 0
+        anchors.left: parent.left
+        anchors.leftMargin: 4
+        anchors.verticalCenter: activeLabel.verticalCenter
+        width: Sizing.px(parent.width / 3) - 4
+        height: Sizing.fontSize(2.9)
+        elide: Text.ElideRight
+        horizontalAlignment: Text.AlignLeft
+        verticalAlignment: Text.AlignVCenter
+        text: qsTr("%1 files").arg(Browse.GamesModel.total_files)
+        font.family: Theme.fontUi
+        font.pixelSize: Sizing.fontSize(2.9)
+        color: Theme.textPrimary
+        renderType: Text.NativeRendering
+    }
+
+    Text {
+        visible: games._crtGridLayout && !games.transitioning && !games.coverGateLoading && Math.ceil((Browse.GamesModel.dir_count + Browse.GamesModel.total_files) / games._browsePageSize) > 1
+        anchors.right: parent.right
+        anchors.rightMargin: Sizing.pctW(5)
+        anchors.verticalCenter: activeLabel.verticalCenter
+        width: Sizing.px(parent.width / 3) - Sizing.pctW(5)
+        height: Sizing.fontSize(2.9)
+        elide: Text.ElideRight
+        horizontalAlignment: Text.AlignRight
+        verticalAlignment: Text.AlignVCenter
+        text: qsTr("%1 / %2").arg(Math.floor(gamesGrid.currentIndex / games._browsePageSize) + 1).arg(Math.max(1, Math.ceil((Browse.GamesModel.dir_count + Browse.GamesModel.total_files) / games._browsePageSize)))
+        font.family: Theme.fontUi
+        font.pixelSize: Sizing.fontSize(2.9)
+        color: Theme.textPrimary
+        renderType: Text.NativeRendering
     }
 
     ScreenStateOverlay {
@@ -551,7 +594,7 @@ Item {
         id: pageLoadingCue
         visible: !games.transitioning && !games.coverGateLoading && Browse.GamesModel.loading_more && gamesGrid.hasPendingTarget
         anchors.left: activeLabel.left
-        anchors.leftMargin: gamesGrid.leftInset
+        anchors.leftMargin: games._crtGridLayout && bottomTotalText.visible ? bottomTotalText.x + bottomTotalText.width + 4 : gamesGrid.leftInset
         anchors.verticalCenter: activeLabel.verticalCenter
         text: qsTr("Loading more…")
     }

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -39,6 +39,7 @@ Item {
     readonly property int _listPageSize: 10
     readonly property int _browsePageSize: games._listLayout ? games._listPageSize : gamesGrid.pageSize
     readonly property bool _crtGridLayout: Theme.crtNativePath && !games._listLayout
+    readonly property var _tileLayout: games._crtGridLayout ? BrowseLayouts.crtTile : BrowseLayouts.defaultTile
     property bool _currentMoveIsRepeat: false
 
     // Cover-gate flag: true while `GamesModel` is holding `loading`
@@ -346,14 +347,14 @@ Item {
     // the precise entry count for the path.
     TopStatusStrip {
         id: topStrip
-        visible: !games.transitioning && !games.coverGateLoading && !games._crtGridLayout
+        visible: !games.transitioning && !games.coverGateLoading && games._tileLayout.showTopStrip
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: parent.top
         anchors.topMargin: Sizing.headerBottom + Sizing.pctH(1)
-        height: games._crtGridLayout ? 0 : Sizing.pctH(7)
+        height: games._tileLayout.showTopStrip ? Sizing.pctH(7) : 0
         title: {
-            if (games._crtGridLayout)
+            if (games._tileLayout.showHeaderTitleInHeader)
                 return "";
             const sid = Browse.GamesModel.current_system_id;
             if (sid === "")
@@ -362,8 +363,8 @@ Item {
             return idx >= 0 ? Browse.SystemsModel.system_name_at(idx) : sid;
         }
         currentPage: Math.floor(gamesGrid.currentIndex / games._browsePageSize)
-        totalPages: games._crtGridLayout ? 1 : Math.max(1, Math.ceil((Browse.GamesModel.dir_count + Browse.GamesModel.total_files) / games._browsePageSize))
-        totalText: games._crtGridLayout ? "" : (Browse.GamesModel.total_files > 0 ? qsTr("%1 files").arg(Browse.GamesModel.total_files) : "")
+        totalPages: games._tileLayout.showBottomStatusRow ? 1 : Math.max(1, Math.ceil((Browse.GamesModel.dir_count + Browse.GamesModel.total_files) / games._browsePageSize))
+        totalText: games._tileLayout.showBottomStatusRow ? "" : (Browse.GamesModel.total_files > 0 ? qsTr("%1 files").arg(Browse.GamesModel.total_files) : "")
     }
 
     Item {
@@ -461,22 +462,12 @@ Item {
         anchors.right: parent.right
         anchors.top: topStrip.bottom
         anchors.bottom: parent.bottom
-        anchors.bottomMargin: games._crtGridLayout ? Sizing.pctH(6) + Sizing.px(4) + 8 : Sizing.pctH(15)
+        anchors.bottomMargin: Sizing.pctH(6) + games._tileLayout.activeLabelBottomMargin + games._tileLayout.activeLabelHeight
         focused: games.gridFocused
         model: Browse.GamesModel
-        leftInsetOverride: games._crtGridLayout ? 4 : -1
-        rightInsetOverride: games._crtGridLayout ? 0 : -1
-        gutterWidthOverride: games._crtGridLayout ? 8 : -1
-        gutterGapOverride: games._crtGridLayout ? 4 : -1
-        cellSpacingXOverride: games._crtGridLayout ? 4 : -1
-        topInsetOverride: games._crtGridLayout ? 2 : -1
-        bottomInsetOverride: games._crtGridLayout ? 4 : -1
-        cellSpacingYOverride: games._crtGridLayout ? 4 : -1
-        scrollThumbWidthOverride: games._crtGridLayout ? 4 : -1
-        scrollThumbRightInsetOverride: games._crtGridLayout ? 2 : -1
-        scrollArrowSizeOverride: games._crtGridLayout ? 8 : -1
-        packHorizontalRemainderAfterGutter: games._crtGridLayout
+        layoutProfile: games._tileLayout
         delegate: Tile {
+            layoutProfile: games._tileLayout
             showCaption: true
         }
         // Cover-art tiles run taller than systems logos, so a 5x3
@@ -533,18 +524,18 @@ Item {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.bottom: parent.bottom
-        anchors.bottomMargin: games._crtGridLayout ? Sizing.pctH(6) + Sizing.px(4) : Sizing.pctH(8)
-        height: games._crtGridLayout ? 8 : Sizing.pctH(7)
+        anchors.bottomMargin: games._tileLayout.activeLabelBottomMargin
+        height: games._tileLayout.activeLabelHeight
         text: gamesGrid.itemCount > 0 ? Browse.GamesModel.name_at(gamesGrid.currentIndex) : ""
     }
 
     Text {
         id: bottomTotalText
-        visible: games._crtGridLayout && !games.transitioning && !games.coverGateLoading && Browse.GamesModel.total_files > 0
+        visible: games._tileLayout.showBottomStatusRow && !games.transitioning && !games.coverGateLoading && Browse.GamesModel.total_files > 0
         anchors.left: parent.left
-        anchors.leftMargin: 4
+        anchors.leftMargin: games._tileLayout.bottomStatusLeftMargin
         anchors.verticalCenter: activeLabel.verticalCenter
-        width: Sizing.px(parent.width / 3) - 4
+        width: Sizing.px(parent.width / 3) - games._tileLayout.bottomStatusLeftMargin
         height: Sizing.fontSize(2.9)
         elide: Text.ElideRight
         horizontalAlignment: Text.AlignLeft
@@ -557,11 +548,11 @@ Item {
     }
 
     Text {
-        visible: games._crtGridLayout && !games.transitioning && !games.coverGateLoading && Math.ceil((Browse.GamesModel.dir_count + Browse.GamesModel.total_files) / games._browsePageSize) > 1
+        visible: games._tileLayout.showBottomStatusRow && !games.transitioning && !games.coverGateLoading && Math.ceil((Browse.GamesModel.dir_count + Browse.GamesModel.total_files) / games._browsePageSize) > 1
         anchors.right: parent.right
-        anchors.rightMargin: Sizing.pctW(5)
+        anchors.rightMargin: games._tileLayout.bottomStatusRightMargin
         anchors.verticalCenter: activeLabel.verticalCenter
-        width: Sizing.px(parent.width / 3) - Sizing.pctW(5)
+        width: Sizing.px(parent.width / 3) - games._tileLayout.bottomStatusRightMargin
         height: Sizing.fontSize(2.9)
         elide: Text.ElideRight
         horizontalAlignment: Text.AlignRight
@@ -602,7 +593,7 @@ Item {
         id: pageLoadingCue
         visible: !games.transitioning && !games.coverGateLoading && Browse.GamesModel.loading_more && gamesGrid.hasPendingTarget
         anchors.left: activeLabel.left
-        anchors.leftMargin: games._crtGridLayout && bottomTotalText.visible ? bottomTotalText.x + bottomTotalText.width + 4 : gamesGrid.leftInset
+        anchors.leftMargin: games._tileLayout.showBottomStatusRow && bottomTotalText.visible ? bottomTotalText.x + bottomTotalText.width + games._tileLayout.bottomStatusLeftMargin : gamesGrid.leftInset
         anchors.verticalCenter: activeLabel.verticalCenter
         text: qsTr("Loading more…")
     }

--- a/src/ui/screens/SystemsScreen.qml
+++ b/src/ui/screens/SystemsScreen.qml
@@ -233,13 +233,21 @@ Item {
         anchors.right: parent.right
         anchors.top: topStrip.bottom
         anchors.bottom: parent.bottom
-        anchors.bottomMargin: systems._crtGridLayout ? Sizing.pctH(6) + Sizing.px(2) + Sizing.pctH(7) : Sizing.pctH(15)
+        anchors.bottomMargin: systems._crtGridLayout ? Sizing.pctH(6) + Sizing.px(4) + 8 : Sizing.pctH(15)
         focused: systems.gridFocused
         model: Browse.SystemsModel
         leftInsetOverride: systems._crtGridLayout ? 4 : -1
-        rightInsetOverride: systems._crtGridLayout ? 4 : -1
-        gutterWidthOverride: systems._crtGridLayout ? 4 : -1
+        rightInsetOverride: systems._crtGridLayout ? 0 : -1
+        gutterWidthOverride: systems._crtGridLayout ? 8 : -1
         gutterGapOverride: systems._crtGridLayout ? 4 : -1
+        cellSpacingXOverride: systems._crtGridLayout ? 4 : -1
+        topInsetOverride: systems._crtGridLayout ? 2 : -1
+        bottomInsetOverride: systems._crtGridLayout ? 4 : -1
+        cellSpacingYOverride: systems._crtGridLayout ? 4 : -1
+        scrollThumbWidthOverride: systems._crtGridLayout ? 4 : -1
+        scrollThumbRightInsetOverride: systems._crtGridLayout ? 2 : -1
+        scrollArrowSizeOverride: systems._crtGridLayout ? 8 : -1
+        packHorizontalRemainderAfterGutter: systems._crtGridLayout
         delegate: Tile {}
         onItemHovered: index => systems._focusIndex(index)
         onItemClicked: index => {
@@ -268,8 +276,8 @@ Item {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.bottom: parent.bottom
-        anchors.bottomMargin: systems._crtGridLayout ? Sizing.pctH(6) + Sizing.px(2) : Sizing.pctH(8)
-        height: Sizing.pctH(7)
+        anchors.bottomMargin: systems._crtGridLayout ? Sizing.pctH(6) + Sizing.px(4) : Sizing.pctH(8)
+        height: systems._crtGridLayout ? 8 : Sizing.pctH(7)
         text: systemsGrid.itemCount > 0 ? Browse.SystemsModel.system_name_at(systemsGrid.currentIndex) : ""
         visible: !systems.transitioning && !systems._listLayout
     }

--- a/src/ui/screens/SystemsScreen.qml
+++ b/src/ui/screens/SystemsScreen.qml
@@ -38,6 +38,7 @@ Item {
     property bool gridFocused: true
     readonly property bool _listLayout: Browse.Settings.current_browse_layout === "list"
     readonly property bool _crtGridLayout: Theme.crtNativePath && !systems._listLayout
+    readonly property var _tileLayout: systems._crtGridLayout ? BrowseLayouts.crtTile : BrowseLayouts.defaultTile
 
     signal requestAccept(systemId: string)
     signal requestHubScreen
@@ -176,12 +177,12 @@ Item {
         anchors.right: parent.right
         anchors.top: parent.top
         anchors.topMargin: Sizing.headerBottom + Sizing.pctH(1)
-        height: systems._crtGridLayout ? 0 : Sizing.pctH(7)
-        title: systems._crtGridLayout ? "" : Browse.SystemsModel.current_category
+        height: systems._tileLayout.showTopStrip ? Sizing.pctH(7) : 0
+        title: systems._tileLayout.showHeaderTitleInHeader ? "" : Browse.SystemsModel.current_category
         currentPage: systemsGrid.currentPage
-        totalPages: systems._crtGridLayout ? 1 : Math.max(1, Math.ceil(Browse.SystemsModel.count / systemsGrid.pageSize))
-        totalText: systems._crtGridLayout ? "" : (Browse.SystemsModel.count > 0 ? qsTr("%1 systems").arg(Browse.SystemsModel.count) : "")
-        visible: !systems.transitioning && !systems._crtGridLayout
+        totalPages: systems._tileLayout.showBottomStatusRow ? 1 : Math.max(1, Math.ceil(Browse.SystemsModel.count / systemsGrid.pageSize))
+        totalText: systems._tileLayout.showBottomStatusRow ? "" : (Browse.SystemsModel.count > 0 ? qsTr("%1 systems").arg(Browse.SystemsModel.count) : "")
+        visible: !systems.transitioning && systems._tileLayout.showTopStrip
     }
 
     BrowseList {
@@ -233,22 +234,13 @@ Item {
         anchors.right: parent.right
         anchors.top: topStrip.bottom
         anchors.bottom: parent.bottom
-        anchors.bottomMargin: systems._crtGridLayout ? Sizing.pctH(6) + Sizing.px(4) + 8 : Sizing.pctH(15)
+        anchors.bottomMargin: Sizing.pctH(6) + systems._tileLayout.activeLabelBottomMargin + systems._tileLayout.activeLabelHeight
         focused: systems.gridFocused
         model: Browse.SystemsModel
-        leftInsetOverride: systems._crtGridLayout ? 4 : -1
-        rightInsetOverride: systems._crtGridLayout ? 0 : -1
-        gutterWidthOverride: systems._crtGridLayout ? 8 : -1
-        gutterGapOverride: systems._crtGridLayout ? 4 : -1
-        cellSpacingXOverride: systems._crtGridLayout ? 4 : -1
-        topInsetOverride: systems._crtGridLayout ? 2 : -1
-        bottomInsetOverride: systems._crtGridLayout ? 4 : -1
-        cellSpacingYOverride: systems._crtGridLayout ? 4 : -1
-        scrollThumbWidthOverride: systems._crtGridLayout ? 4 : -1
-        scrollThumbRightInsetOverride: systems._crtGridLayout ? 2 : -1
-        scrollArrowSizeOverride: systems._crtGridLayout ? 8 : -1
-        packHorizontalRemainderAfterGutter: systems._crtGridLayout
-        delegate: Tile {}
+        layoutProfile: systems._tileLayout
+        delegate: Tile {
+            layoutProfile: systems._tileLayout
+        }
         onItemHovered: index => systems._focusIndex(index)
         onItemClicked: index => {
             systems._focusIndex(index);
@@ -276,18 +268,18 @@ Item {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.bottom: parent.bottom
-        anchors.bottomMargin: systems._crtGridLayout ? Sizing.pctH(6) + Sizing.px(4) : Sizing.pctH(8)
-        height: systems._crtGridLayout ? 8 : Sizing.pctH(7)
+        anchors.bottomMargin: systems._tileLayout.activeLabelBottomMargin
+        height: systems._tileLayout.activeLabelHeight
         text: systemsGrid.itemCount > 0 ? Browse.SystemsModel.system_name_at(systemsGrid.currentIndex) : ""
         visible: !systems.transitioning && !systems._listLayout
     }
 
     Text {
-        visible: systems._crtGridLayout && !systems.transitioning && Browse.SystemsModel.count > 0
+        visible: systems._tileLayout.showBottomStatusRow && !systems.transitioning && Browse.SystemsModel.count > 0
         anchors.left: parent.left
-        anchors.leftMargin: 4
+        anchors.leftMargin: systems._tileLayout.bottomStatusLeftMargin
         anchors.verticalCenter: activeLabel.verticalCenter
-        width: Sizing.px(parent.width / 3) - 4
+        width: Sizing.px(parent.width / 3) - systems._tileLayout.bottomStatusLeftMargin
         height: Sizing.fontSize(2.9)
         elide: Text.ElideRight
         horizontalAlignment: Text.AlignLeft
@@ -300,11 +292,11 @@ Item {
     }
 
     Text {
-        visible: systems._crtGridLayout && !systems.transitioning && Math.ceil(Browse.SystemsModel.count / systemsGrid.pageSize) > 1
+        visible: systems._tileLayout.showBottomStatusRow && !systems.transitioning && Math.ceil(Browse.SystemsModel.count / systemsGrid.pageSize) > 1
         anchors.right: parent.right
-        anchors.rightMargin: Sizing.pctW(5)
+        anchors.rightMargin: systems._tileLayout.bottomStatusRightMargin
         anchors.verticalCenter: activeLabel.verticalCenter
-        width: Sizing.px(parent.width / 3) - Sizing.pctW(5)
+        width: Sizing.px(parent.width / 3) - systems._tileLayout.bottomStatusRightMargin
         height: Sizing.fontSize(2.9)
         elide: Text.ElideRight
         horizontalAlignment: Text.AlignRight

--- a/src/ui/screens/SystemsScreen.qml
+++ b/src/ui/screens/SystemsScreen.qml
@@ -37,6 +37,7 @@ Item {
     // times. The ring restores automatically when the modal pops.
     property bool gridFocused: true
     readonly property bool _listLayout: Browse.Settings.current_browse_layout === "list"
+    readonly property bool _crtGridLayout: Theme.crtNativePath && !systems._listLayout
 
     signal requestAccept(systemId: string)
     signal requestHubScreen
@@ -175,12 +176,12 @@ Item {
         anchors.right: parent.right
         anchors.top: parent.top
         anchors.topMargin: Sizing.headerBottom + Sizing.pctH(1)
-        height: Sizing.pctH(7)
-        title: Browse.SystemsModel.current_category
+        height: systems._crtGridLayout ? 0 : Sizing.pctH(7)
+        title: systems._crtGridLayout ? "" : Browse.SystemsModel.current_category
         currentPage: systemsGrid.currentPage
-        totalPages: Math.max(1, Math.ceil(Browse.SystemsModel.count / systemsGrid.pageSize))
-        totalText: Browse.SystemsModel.count > 0 ? qsTr("%1 systems").arg(Browse.SystemsModel.count) : ""
-        visible: !systems.transitioning
+        totalPages: systems._crtGridLayout ? 1 : Math.max(1, Math.ceil(Browse.SystemsModel.count / systemsGrid.pageSize))
+        totalText: systems._crtGridLayout ? "" : (Browse.SystemsModel.count > 0 ? qsTr("%1 systems").arg(Browse.SystemsModel.count) : "")
+        visible: !systems.transitioning && !systems._crtGridLayout
     }
 
     BrowseList {
@@ -232,9 +233,13 @@ Item {
         anchors.right: parent.right
         anchors.top: topStrip.bottom
         anchors.bottom: parent.bottom
-        anchors.bottomMargin: Sizing.pctH(15)
+        anchors.bottomMargin: systems._crtGridLayout ? Sizing.pctH(6) + Sizing.px(2) + Sizing.pctH(7) : Sizing.pctH(15)
         focused: systems.gridFocused
         model: Browse.SystemsModel
+        leftInsetOverride: systems._crtGridLayout ? 4 : -1
+        rightInsetOverride: systems._crtGridLayout ? 4 : -1
+        gutterWidthOverride: systems._crtGridLayout ? 4 : -1
+        gutterGapOverride: systems._crtGridLayout ? 4 : -1
         delegate: Tile {}
         onItemHovered: index => systems._focusIndex(index)
         onItemClicked: index => {
@@ -262,10 +267,45 @@ Item {
         id: activeLabel
         anchors.left: parent.left
         anchors.right: parent.right
-        anchors.top: systemsGrid.bottom
+        anchors.bottom: parent.bottom
+        anchors.bottomMargin: systems._crtGridLayout ? Sizing.pctH(6) + Sizing.px(2) : Sizing.pctH(8)
         height: Sizing.pctH(7)
         text: systemsGrid.itemCount > 0 ? Browse.SystemsModel.system_name_at(systemsGrid.currentIndex) : ""
         visible: !systems.transitioning && !systems._listLayout
+    }
+
+    Text {
+        visible: systems._crtGridLayout && !systems.transitioning && Browse.SystemsModel.count > 0
+        anchors.left: parent.left
+        anchors.leftMargin: 4
+        anchors.verticalCenter: activeLabel.verticalCenter
+        width: Sizing.px(parent.width / 3) - 4
+        height: Sizing.fontSize(2.9)
+        elide: Text.ElideRight
+        horizontalAlignment: Text.AlignLeft
+        verticalAlignment: Text.AlignVCenter
+        text: qsTr("%1 systems").arg(Browse.SystemsModel.count)
+        font.family: Theme.fontUi
+        font.pixelSize: Sizing.fontSize(2.9)
+        color: Theme.textPrimary
+        renderType: Text.NativeRendering
+    }
+
+    Text {
+        visible: systems._crtGridLayout && !systems.transitioning && Math.ceil(Browse.SystemsModel.count / systemsGrid.pageSize) > 1
+        anchors.right: parent.right
+        anchors.rightMargin: Sizing.pctW(5)
+        anchors.verticalCenter: activeLabel.verticalCenter
+        width: Sizing.px(parent.width / 3) - Sizing.pctW(5)
+        height: Sizing.fontSize(2.9)
+        elide: Text.ElideRight
+        horizontalAlignment: Text.AlignRight
+        verticalAlignment: Text.AlignVCenter
+        text: qsTr("%1 / %2").arg(systemsGrid.currentPage + 1).arg(Math.max(1, Math.ceil(Browse.SystemsModel.count / systemsGrid.pageSize)))
+        font.family: Theme.fontUi
+        font.pixelSize: Sizing.fontSize(2.9)
+        color: Theme.textPrimary
+        renderType: Text.NativeRendering
     }
 
     ScreenStateOverlay {

--- a/src/ui/theme/BrowseLayouts.qml
+++ b/src/ui/theme/BrowseLayouts.qml
@@ -1,0 +1,62 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+pragma Singleton
+import QtQuick
+
+// Shared browse-screen layout profiles. These only describe geometry and
+// slot placement; screen behavior stays in the screens/components that
+// consume them.
+QtObject {
+    readonly property QtObject defaultTile: QtObject {
+        readonly property bool showTopStrip: true
+        readonly property bool showHeaderTitleInHeader: false
+        readonly property bool showBottomStatusRow: false
+        readonly property bool headerHudBottomAligned: false
+        readonly property bool headerStatusPillPinnedTop: false
+        readonly property int gridLeftInset: Sizing.pctW(5)
+        readonly property int gridRightInset: Sizing.pctW(5)
+        readonly property int gridGutterWidth: Sizing.pctW(3)
+        readonly property int gridGutterGap: Sizing.pctW(1.5)
+        readonly property int gridColumnGap: Sizing.pctW(3)
+        readonly property int gridTopInset: Sizing.pctH(2)
+        readonly property int gridBottomInset: Sizing.pctH(2)
+        readonly property int gridRowGap: Sizing.pctH(4)
+        readonly property int scrollThumbWidth: Sizing.pctW(1.2)
+        readonly property int scrollThumbRightInset: 0
+        readonly property int scrollArrowSize: Math.min(gridGutterWidth, Sizing.pctH(4))
+        readonly property bool packHorizontalRemainderAfterGutter: false
+        readonly property int activeLabelHeight: Sizing.pctH(7)
+        readonly property int activeLabelBottomMargin: Sizing.pctH(8)
+        readonly property int bottomStatusLeftMargin: Sizing.pctW(5)
+        readonly property int bottomStatusRightMargin: Sizing.pctW(5)
+        readonly property int bottomUnsafeHeight: Sizing.pctH(6) + Sizing.pctH(2)
+        readonly property int tileCornerRadius: Sizing.cornerRadius
+    }
+
+    readonly property QtObject crtTile: QtObject {
+        readonly property bool showTopStrip: false
+        readonly property bool showHeaderTitleInHeader: true
+        readonly property bool showBottomStatusRow: true
+        readonly property bool headerHudBottomAligned: true
+        readonly property bool headerStatusPillPinnedTop: true
+        readonly property int gridLeftInset: 4
+        readonly property int gridRightInset: 0
+        readonly property int gridGutterWidth: 8
+        readonly property int gridGutterGap: 4
+        readonly property int gridColumnGap: 4
+        readonly property int gridTopInset: 2
+        readonly property int gridBottomInset: 4
+        readonly property int gridRowGap: 4
+        readonly property int scrollThumbWidth: 4
+        readonly property int scrollThumbRightInset: 2
+        readonly property int scrollArrowSize: 8
+        readonly property bool packHorizontalRemainderAfterGutter: true
+        readonly property int activeLabelHeight: 8
+        readonly property int activeLabelBottomMargin: Sizing.pctH(6) + 4
+        readonly property int bottomStatusLeftMargin: 4
+        readonly property int bottomStatusRightMargin: Sizing.pctW(5)
+        readonly property int bottomUnsafeHeight: 16
+        readonly property int tileCornerRadius: 4
+    }
+}

--- a/src/ui/theme/CMakeLists.txt
+++ b/src/ui/theme/CMakeLists.txt
@@ -5,6 +5,7 @@
 qt_add_library(zaparoo_ui_theme STATIC)
 
 set_source_files_properties(
+    BrowseLayouts.qml
     Resources.qml
     Sizing.qml
     Theme.qml
@@ -16,6 +17,7 @@ qt_add_qml_module(
     URI Zaparoo.Theme
     VERSION 1.0
     QML_FILES
+        BrowseLayouts.qml
         Resources.qml
         Sizing.qml
         Theme.qml

--- a/tests/ui/CMakeLists.txt
+++ b/tests/ui/CMakeLists.txt
@@ -9,6 +9,7 @@ qt_add_qml_module(
     URI ZaparooTest.Ui
     VERSION 1.0
     QML_FILES
+        tst_browse_layout_profiles.qml
         tst_smoke.qml
         tst_navigation.qml
         tst_sizing.qml

--- a/tests/ui/tst_browse_layout_profiles.qml
+++ b/tests/ui/tst_browse_layout_profiles.qml
@@ -1,0 +1,64 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+import QtQuick
+import QtTest
+import Zaparoo.App
+import Zaparoo.Browse as Browse
+import Zaparoo.Theme
+
+// Verifies that browse screens route geometry through the shared
+// BrowseLayouts profiles instead of inlining CRT-specific numbers in
+// each screen/component. The goal is not to snapshot every pixel, just
+// to prove the live tree picks the intended profile in the key modes.
+TestCase {
+    name: "UiBrowseLayoutProfiles"
+    when: windowShown
+
+    Main {
+        id: main
+        fullScreen: false
+        width: 1280
+        height: 720
+    }
+
+    property string _originalBrowseLayout: "grid"
+
+    Component.onCompleted: {
+        _originalBrowseLayout = Browse.Settings.current_browse_layout;
+    }
+
+    function init(): void {
+        main.bootComplete = true;
+        main.activeScreen = main.screenSystems;
+        main.crtNativePath = false;
+        Browse.Settings.current_browse_layout = "grid";
+    }
+
+    function cleanup(): void {
+        main.crtNativePath = false;
+        Browse.Settings.current_browse_layout = _originalBrowseLayout;
+    }
+
+    function test_crt_grid_uses_crt_tile_profile(): void {
+        main.crtNativePath = true;
+        Browse.Settings.current_browse_layout = "grid";
+
+        compare(main.headerBar.layoutProfile.showHeaderTitleInHeader, true);
+        compare(main.systemsScreen.systemsGrid.layoutProfile.tileCornerRadius, 4);
+        compare(main.systemsScreen.systemsGrid.leftInset, 4);
+        compare(main.systemsScreen.systemsGrid.gutterWidth, 8);
+        compare(main.systemsScreen.systemsGrid.scrollArrowSize, 8);
+    }
+
+    function test_list_mode_uses_default_tile_profile(): void {
+        main.crtNativePath = true;
+        Browse.Settings.current_browse_layout = "list";
+
+        compare(main.headerBar.layoutProfile.showHeaderTitleInHeader, false);
+        compare(main.systemsScreen.systemsGrid.layoutProfile.tileCornerRadius, Sizing.cornerRadius);
+        compare(main.systemsScreen.systemsGrid.leftInset, Sizing.pctW(5));
+        compare(main.systemsScreen.systemsGrid.gutterWidth, Sizing.pctW(3));
+    }
+}


### PR DESCRIPTION
<!-- Thanks for the pull request. Please fill this out before requesting review. -->

## Summary

Tweaked the geometry of margin/padding items and certain positions.
Tried also to put a refactor commit on top of it to make it more maintainable.

<img width="962" height="752" alt="image" src="https://github.com/user-attachments/assets/b2a7b4ed-86fe-462e-9812-402d87925ff6" />

BEFORE

<img width="1920" height="1440" alt="image" src="https://github.com/user-attachments/assets/2a40c21c-e43b-438b-9e11-d155052ea61e" />


<img width="966" height="752" alt="image" src="https://github.com/user-attachments/assets/ae869a7f-9e9f-48e4-9081-6e987143db75" />


<!-- What changed, and why? One or two sentences is usually enough. -->

## Motivation

<!-- Link the issue or discussion that led to this. Delete this section if it does not apply. -->

## Screenshots / recordings

<!-- Required for visual changes. Include the FPS counter at 720p and, if possible, 240p. -->

## Test plan

<!-- How did you verify this? Manual steps and automated tests are both fine. -->

## Checklist

- [ ] `just lint` is green (zero warnings)
- [ ] `just test` passes
- [ ] If this touches QML, the FPS counter stays green (≥ 55) at 720p+ and ≥ 30 at 240p
- [ ] If this could affect the MiSTer build, I considered ARM32 implications (see `docs/architecture.md`)
- [ ] If this adds user-visible strings, they are wrapped in `qsTr()` (QML) or `tr()` (C++)
- [ ] I have signed the [CLA](../.github/CLA.md) (first-time contributors only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced CRT support: adaptive CRT header titles, optional centered CRT title overlay, and CRT-aware status/header behavior.
  * CRT-tailored grids: adjustable spacing, insets, gutter/scroll sizing, packing, and active-row layout.
  * Active-row enhancements: visible totals and page counters in CRT grid mode; loading indicator offset adjusted.
  * Tile visuals respect per-layout corner radius and caption sizing.
* **Chores**
  * macOS launcher now starts with CRT mode enabled and preserves CRT-related environment settings.
* **New Exports**
  * Theme layouts file included in the exported UI module.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ZaparooProject/zaparoo-launcher/pull/136)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->