### PR TITLE
Refine list metadata UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ output/
 CLAUDE.md
 .claude/
 .opencode/
+.pi/
 docs/plans/
 
 # Cargo build cache

--- a/rust/launcher/build.rs
+++ b/rust/launcher/build.rs
@@ -27,6 +27,7 @@ fn main() {
         "src/models/alternate_versions.rs",
         "src/models/categories.rs",
         "src/models/systems.rs",
+        "src/models/game_info.rs",
         "src/models/games.rs",
         "src/models/favorites.rs",
         "src/models/browse.rs",

--- a/rust/launcher/src/media_image_cache.rs
+++ b/rust/launcher/src/media_image_cache.rs
@@ -643,8 +643,7 @@ impl MediaImageCache {
             let pending = guard.pending.contains(&key);
             let soft_no_image = guard.soft_no_image.contains(&key);
             let search_seen = guard.search_seen.contains(&key);
-            let blocked_by_soft_miss =
-                soft_no_image && (no_image_policy == NoImagePolicy::SoftMiss || search_seen);
+            let blocked_by_soft_miss = soft_no_image && no_image_policy == NoImagePolicy::SoftMiss;
             debug!(
                 system_id = %key.system_id,
                 path = %key.path,
@@ -2087,7 +2086,7 @@ mod tests {
     }
 
     #[test]
-    fn default_enqueue_skips_protected_soft_no_image_keys() {
+    fn default_enqueue_allows_protected_soft_no_image_keys() {
         let cache = cache_for_test();
         let k = key("SNES", "/protected-soft-missed");
         {
@@ -2095,9 +2094,16 @@ mod tests {
             guard.soft_no_image.insert(k.clone());
             guard.search_seen.insert(k.clone());
         }
-        cache.enqueue_with_media_id(k, Some(7), 15);
-        assert!(cache.queue.lock().unwrap().is_empty());
-        assert!(cache.state.read().unwrap().pending.is_empty());
+        cache.enqueue_with_media_id(k.clone(), Some(7), 15);
+        let entry = cache
+            .queue
+            .lock()
+            .unwrap()
+            .pop_back()
+            .expect("default enqueue is not blocked by protected soft miss");
+        assert_eq!(entry.key, k);
+        assert_eq!(entry.no_image_policy, NoImagePolicy::Memoize);
+        assert!(cache.state.read().unwrap().pending.contains(&k));
     }
 
     #[test]

--- a/rust/launcher/src/media_image_cache.rs
+++ b/rust/launcher/src/media_image_cache.rs
@@ -77,19 +77,14 @@ const CACHE_CAP_BYTES: usize = 64 * 1024 * 1024;
 /// memo.
 const MAX_FETCH_ATTEMPTS: u8 = 3;
 
-/// Number of parallel fetch worker tasks pulling from the shared
-/// LIFO queue. The Zaparoo Core WebSocket multiplexes JSON-RPC calls
-/// by id so concurrent `media.image` requests are safe at the wire;
-/// however, Core itself currently serializes its `media.image`
-/// handler at roughly one response per 250–400 ms. Empirically all
-/// four workers spend most of their time parked on `oneshot`
-/// receivers waiting for Core's serial output — so the *immediate*
-/// throughput floor is set by Core, not by us. Four workers is kept
-/// as an upper bound that costs nothing under the current cadence
-/// (idle workers parked on `Notify` are free) and turns into an
-/// instant win the moment Core gains concurrency in its image
-/// handler. Don't drop this back to 1.
-const FETCH_DRIVER_WORKERS: usize = 4;
+/// Number of fetch worker tasks pulling from the shared LIFO queue.
+/// Keep this single-flight against Core: fast list scrolling on `MiSTer`
+/// can otherwise stack multiple large `media.image` bulk requests on
+/// top of Core's image handler and reset the WebSocket. The queue is
+/// already LIFO and capped, so one in-flight batch is enough to keep
+/// the visible work moving without turning cover fetches into a Core
+/// `DoS` vector.
+const FETCH_DRIVER_WORKERS: usize = 1;
 
 /// Hard cap on pending enqueues in the LIFO fetch queue. New pushes
 /// spill the **oldest** entry off the front, on the assumption that
@@ -756,7 +751,11 @@ fn process_batch_outcomes(
     for (entry, outcome) in outcomes {
         let key = entry.key.clone();
         let is_transient = matches!(outcome, FetchOutcome::Transient);
+        let is_connection_down = matches!(outcome, FetchOutcome::ConnectionDown);
         let update = finish_fetch(state, cap_bytes, &key, outcome);
+        if is_connection_down {
+            continue;
+        }
         if is_transient {
             let attempts = {
                 #[allow(clippy::unwrap_used, reason = "RwLock poisoning is unrecoverable")]
@@ -862,12 +861,15 @@ enum FetchOutcome {
     /// path)` — empty payload, unsupported format. Caller memoises so
     /// page revisits do not re-issue a guaranteed-miss RPC.
     NoImage,
-    /// Local or RPC-level failure that may not repeat: socket flap,
-    /// rate-limit during fast flicking, base64 wire corruption, generic
-    /// `media.image` error from Core. Caller clears `pending` and lets
-    /// the next `enqueue` retry; never memoised, because the *next*
-    /// time the user looks at this row Core may answer cleanly.
+    /// Local or RPC-level failure that may not repeat while Core is
+    /// still connected: stale `media_id`, base64 wire corruption, or a
+    /// generic `media.image` error. Caller retries within the bounded
+    /// attempt budget.
     Transient,
+    /// Batch-level connection failure (`disconnected`, `not connected`,
+    /// reset/refused). Caller clears `pending` but does not immediately
+    /// retry every key, avoiding a retry storm while Core is down.
+    ConnectionDown,
 }
 
 /// Fetch a batch of media images in a single bulk JSON-RPC. Returns
@@ -918,15 +920,30 @@ async fn fetch_batch(
     let response = match result {
         Ok(r) => r,
         Err(e) => {
+            let connection_down = is_connection_down_error(&e.message);
             info!(
                 batch_size = batch.len(),
-                "media_image_cache: media.image (bulk) failed: {} (transient, will retry on next enqueue)",
+                "media_image_cache: media.image (bulk) failed: {} ({})",
                 e.message,
+                if connection_down {
+                    "connection down, cleared pending without immediate retry"
+                } else {
+                    "transient, will retry within attempt budget"
+                },
             );
             return batch
                 .iter()
                 .cloned()
-                .map(|entry| (entry, FetchOutcome::Transient))
+                .map(|entry| {
+                    (
+                        entry,
+                        if connection_down {
+                            FetchOutcome::ConnectionDown
+                        } else {
+                            FetchOutcome::Transient
+                        },
+                    )
+                })
                 .collect();
         }
     };
@@ -1104,12 +1121,22 @@ fn finish_fetch(
                 ext: None,
             })
         }
-        // Transient: drop the pending guard and let the next enqueue
-        // retry. No map insert, no negative memo, no broadcast — the
-        // row's `coverKey` is unchanged so subscribers have nothing to
-        // act on.
-        FetchOutcome::Transient => None,
+        // Transient: drop the pending guard and let the bounded retry
+        // path decide whether to requeue. No map insert, no negative
+        // memo, no broadcast — the row's `coverKey` is unchanged so
+        // subscribers have nothing to act on.
+        FetchOutcome::Transient | FetchOutcome::ConnectionDown => None,
     }
+}
+
+fn is_connection_down_error(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+    lower.contains("disconnected")
+        || lower.contains("not connected")
+        || lower.contains("connection reset")
+        || lower.contains("connection refused")
+        || lower.contains("broken pipe")
+        || lower.contains("channel closed")
 }
 
 static GLOBAL_MEDIA_IMAGE_CACHE: OnceLock<Arc<MediaImageCache>> = OnceLock::new();
@@ -1207,9 +1234,9 @@ mod tests {
     )]
 
     use super::{
-        drain_one_round, ext_for_content_type, ext_from_extension_field, finish_fetch, CacheState,
-        FetchOutcome, MediaImageCache, MediaImageUpdate, MediaKey, NegativeMemo, QueueEntry,
-        IMAGE_BATCH_PAGES, MAX_QUEUE_LEN, NEGATIVE_MEMO_CAP,
+        drain_one_round, ext_for_content_type, ext_from_extension_field, finish_fetch,
+        is_connection_down_error, CacheState, FetchOutcome, MediaImageCache, MediaImageUpdate,
+        MediaKey, NegativeMemo, QueueEntry, IMAGE_BATCH_PAGES, MAX_QUEUE_LEN, NEGATIVE_MEMO_CAP,
     };
     use std::collections::VecDeque;
     use std::sync::{Arc, Mutex, RwLock};
@@ -1394,6 +1421,31 @@ mod tests {
         assert!(!guard.map.contains_key(&k));
         assert!(!guard.pending.contains(&k));
         assert!(guard.negative.contains(&k));
+    }
+
+    #[test]
+    fn connection_down_outcome_only_clears_pending() {
+        let state = Arc::new(RwLock::new(CacheState::new()));
+        let k = key("SNES", "/p");
+        state.write().unwrap().pending.insert(k.clone());
+        let update = finish_fetch(&state, usize::MAX, &k, FetchOutcome::ConnectionDown);
+        assert!(update.is_none());
+        let guard = state.read().unwrap();
+        assert!(!guard.pending.contains(&k));
+        assert!(!guard.map.contains_key(&k));
+        assert!(!guard.negative.contains(&k));
+        assert!(!guard.attempts.contains_key(&k));
+    }
+
+    #[test]
+    fn connection_down_classifier_matches_client_disconnect_messages() {
+        assert!(is_connection_down_error("disconnected"));
+        assert!(is_connection_down_error("not connected"));
+        assert!(is_connection_down_error(
+            "IO error: Connection reset by peer"
+        ));
+        assert!(is_connection_down_error("IO error: Connection refused"));
+        assert!(!is_connection_down_error("base64 decode failed"));
     }
 
     fn ok_png(state: &Arc<RwLock<CacheState>>, cap: usize, k: &MediaKey, n: usize) {

--- a/rust/launcher/src/media_image_cache.rs
+++ b/rust/launcher/src/media_image_cache.rs
@@ -43,7 +43,8 @@ use tokio::sync::{broadcast, Notify};
 use tracing::{debug, info, warn};
 
 use zaparoo_core::media_types::{
-    MediaImageBulkItem, MediaImageBulkItemResult, MediaImageBulkParams, MEDIA_IMAGE_BATCH_MAX,
+    MediaImageBulkItem, MediaImageBulkItemResult, MediaImageBulkParams, MediaImageResult,
+    MEDIA_IMAGE_BATCH_MAX,
 };
 use zaparoo_core::store::Store;
 
@@ -292,6 +293,12 @@ pub struct MediaImageUpdate {
     pub ext: Option<&'static str>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum NoImagePolicy {
+    Memoize,
+    SoftMiss,
+}
+
 /// One slot in the LIFO fetch queue. Tracks the `page_size` of the
 /// caller that enqueued the key so the drain can ship one page's
 /// worth at a time (see `IMAGE_BATCH_PAGES`). `pending`/`map`/the
@@ -301,6 +308,7 @@ pub struct MediaImageUpdate {
 struct QueueEntry {
     key: MediaKey,
     page_size: u32,
+    no_image_policy: NoImagePolicy,
 }
 
 #[derive(Debug)]
@@ -342,6 +350,13 @@ impl NegativeMemo {
             }
         }
     }
+
+    fn remove(&mut self, key: &MediaKey) {
+        if !self.set.remove(key) {
+            return;
+        }
+        self.order.retain(|memo_key| memo_key != key);
+    }
 }
 
 #[derive(Debug)]
@@ -349,6 +364,8 @@ struct CacheState {
     map: HashMap<MediaKey, MediaImageEntry>,
     total_bytes: usize,
     negative: NegativeMemo,
+    soft_no_image: NegativeMemo,
+    search_seen: NegativeMemo,
     pending: HashSet<MediaKey>,
     /// Per-key retry counter for transient fetch failures. Bumped in
     /// the fetch driver before each re-enqueue; cleared on Success,
@@ -376,6 +393,8 @@ impl CacheState {
             map: HashMap::new(),
             total_bytes: 0,
             negative: NegativeMemo::default(),
+            soft_no_image: NegativeMemo::default(),
+            search_seen: NegativeMemo::default(),
             pending: HashSet::new(),
             attempts: HashMap::new(),
             media_ids: HashMap::new(),
@@ -536,6 +555,12 @@ impl MediaImageCache {
         guard.negative.contains(key)
     }
 
+    pub fn is_soft_no_image(&self, key: &MediaKey) -> bool {
+        #[allow(clippy::unwrap_used, reason = "RwLock poisoning is unrecoverable")]
+        let guard = self.state.read().unwrap();
+        guard.soft_no_image.contains(key)
+    }
+
     /// Subscribe to cache updates. Used by `GamesModel` to bridge image
     /// completions onto `dataChanged(coverKey)` on the Qt thread.
     pub fn subscribe(&self) -> broadcast::Receiver<MediaImageUpdate> {
@@ -570,6 +595,32 @@ impl MediaImageCache {
     /// callers); otherwise the page that re-enqueued it triggers its
     /// own drain round, so the value can't go stale.
     pub fn enqueue_with_media_id(&self, key: MediaKey, media_id: Option<i64>, page_size: u32) {
+        self.enqueue_with_policy(key, media_id, page_size, NoImagePolicy::Memoize);
+    }
+
+    /// Schedule a search/history cover fetch whose "no image" result
+    /// should not poison the global negative memo. Favorites and
+    /// Recents are backed by `media.search`/`media.history`; their row
+    /// paths can fail `media.image` fallback even when the same game
+    /// has a valid cover through browse/detail paths. They still need
+    /// a broadcast so QML leaves the loading state, but the miss must
+    /// remain local to this fetch attempt.
+    pub fn enqueue_search_cover_with_media_id(
+        &self,
+        key: MediaKey,
+        media_id: Option<i64>,
+        page_size: u32,
+    ) {
+        self.enqueue_with_policy(key, media_id, page_size, NoImagePolicy::SoftMiss);
+    }
+
+    fn enqueue_with_policy(
+        &self,
+        key: MediaKey,
+        media_id: Option<i64>,
+        page_size: u32,
+        no_image_policy: NoImagePolicy,
+    ) {
         if key.system_id.is_empty() || key.path.is_empty() {
             return;
         }
@@ -584,10 +635,31 @@ impl MediaImageCache {
             if let Some(id) = media_id {
                 guard.media_ids.insert(key.clone(), id);
             }
-            if guard.map.contains_key(&key)
-                || guard.negative.contains(&key)
-                || guard.pending.contains(&key)
-            {
+            if no_image_policy == NoImagePolicy::SoftMiss {
+                guard.search_seen.insert(key.clone());
+            }
+            let cached = guard.map.contains_key(&key);
+            let negative = guard.negative.contains(&key);
+            let pending = guard.pending.contains(&key);
+            let soft_no_image = guard.soft_no_image.contains(&key);
+            let search_seen = guard.search_seen.contains(&key);
+            let blocked_by_soft_miss =
+                soft_no_image && (no_image_policy == NoImagePolicy::SoftMiss || search_seen);
+            debug!(
+                system_id = %key.system_id,
+                path = %key.path,
+                media_id = ?media_id,
+                page_size,
+                policy = ?no_image_policy,
+                cached,
+                negative,
+                pending,
+                soft_no_image,
+                search_seen,
+                blocked_by_soft_miss,
+                "media_image_cache: enqueue cover request"
+            );
+            if cached || negative || pending || blocked_by_soft_miss {
                 false
             } else {
                 // Reset the retry counter — a fresh user-driven
@@ -604,7 +676,11 @@ impl MediaImageCache {
         let dropped = {
             #[allow(clippy::unwrap_used, reason = "Mutex poisoning is unrecoverable")]
             let mut q = self.queue.lock().unwrap();
-            q.push_back(QueueEntry { key, page_size });
+            q.push_back(QueueEntry {
+                key,
+                page_size,
+                no_image_policy,
+            });
             // Keep only the freshest MAX_QUEUE_LEN entries; the rest
             // (oldest enqueues at the front) get dropped. The dropped
             // keys must also leave `pending` so a later `enqueue` can
@@ -752,7 +828,7 @@ fn process_batch_outcomes(
         let key = entry.key.clone();
         let is_transient = matches!(outcome, FetchOutcome::Transient);
         let is_connection_down = matches!(outcome, FetchOutcome::ConnectionDown);
-        let update = finish_fetch(state, cap_bytes, &key, outcome);
+        let update = finish_fetch(state, cap_bytes, &key, outcome, entry.no_image_policy);
         if is_connection_down {
             continue;
         }
@@ -840,11 +916,28 @@ fn process_batch_outcomes(
                     "media_image_cache: cached image",
                 );
             } else {
-                info!(
-                    system_id = %key.system_id,
-                    path = %key.path,
-                    "media_image_cache: no image (negative memo)",
-                );
+                #[allow(clippy::unwrap_used, reason = "RwLock poisoning is unrecoverable")]
+                let guard = state.read().unwrap();
+                let negative = guard.negative.contains(&key);
+                let soft_no_image = guard.soft_no_image.contains(&key);
+                let search_seen = guard.search_seen.contains(&key);
+                if negative {
+                    info!(
+                        system_id = %key.system_id,
+                        path = %key.path,
+                        search_seen,
+                        "media_image_cache: no image (negative memo)",
+                    );
+                } else {
+                    info!(
+                        system_id = %key.system_id,
+                        path = %key.path,
+                        policy = ?entry.no_image_policy,
+                        soft_no_image,
+                        search_seen,
+                        "media_image_cache: no image (soft/protected miss)",
+                    );
+                }
             }
             let _ = updates_tx.send(update);
         }
@@ -857,9 +950,10 @@ enum FetchOutcome {
         bytes: Vec<u8>,
         ext: &'static str,
     },
-    /// Core gave a definitive "no image" answer for this `(system_id,
-    /// path)` — empty payload, unsupported format. Caller memoises so
-    /// page revisits do not re-issue a guaranteed-miss RPC.
+    /// Core gave a "no image" answer for this `(system_id, path)` —
+    /// empty payload, unsupported format, or per-item miss. The queue
+    /// entry's policy decides whether that answer is strong enough to
+    /// enter the shared negative memo.
     NoImage,
     /// Local or RPC-level failure that may not repeat while Core is
     /// still connected: stale `media_id`, base64 wire corruption, or a
@@ -912,6 +1006,19 @@ async fn fetch_batch(
             .collect()
     };
     let (items, id_hinted): (Vec<MediaImageBulkItem>, Vec<bool>) = paired.into_iter().unzip();
+    for (entry, (item, had_id_hint)) in batch.iter().zip(items.iter().zip(id_hinted.iter())) {
+        debug!(
+            system_id = %entry.key.system_id,
+            path = %entry.key.path,
+            media_id = ?item.media_id,
+            request_system = %item.system,
+            request_path = %item.path,
+            had_id_hint,
+            policy = ?entry.no_image_policy,
+            page_size = entry.page_size,
+            "media_image_cache: media.image request item"
+        );
+    }
     let params = MediaImageBulkParams {
         items,
         image_types: Vec::new(),
@@ -1015,7 +1122,7 @@ fn classify_bulk_item(
             );
             return FetchOutcome::Transient;
         }
-        info!(
+        debug!(
             system_id = %key.system_id,
             path = %key.path,
             "media_image_cache: media.image (bulk) per-item error: {err} (treating as no image)",
@@ -1033,6 +1140,10 @@ fn classify_bulk_item(
         );
         return FetchOutcome::NoImage;
     };
+    classify_media_image_result(key, &image)
+}
+
+fn classify_media_image_result(key: &MediaKey, image: &MediaImageResult) -> FetchOutcome {
     let bytes = match BASE64_STANDARD.decode(image.data.as_bytes()) {
         Ok(b) => b,
         Err(e) => {
@@ -1076,10 +1187,12 @@ fn finish_fetch(
     cap_bytes: usize,
     key: &MediaKey,
     outcome: FetchOutcome,
+    no_image_policy: NoImagePolicy,
 ) -> Option<MediaImageUpdate> {
     #[allow(clippy::unwrap_used, reason = "RwLock poisoning is unrecoverable")]
     let mut guard = state.write().unwrap();
     guard.pending.remove(key);
+    let search_seen = guard.search_seen.contains(key);
     match outcome {
         FetchOutcome::Success { bytes, ext } => {
             if bytes.len() > cap_bytes {
@@ -1090,10 +1203,16 @@ fn finish_fetch(
                     cap_bytes,
                     "media_image_cache: payload exceeds cache cap, recording as negative",
                 );
-                if let Some(prev) = guard.map.remove(key) {
-                    guard.total_bytes = guard.total_bytes.saturating_sub(prev.bytes.len());
+                if no_image_policy == NoImagePolicy::Memoize && !search_seen {
+                    if let Some(prev) = guard.map.remove(key) {
+                        guard.total_bytes = guard.total_bytes.saturating_sub(prev.bytes.len());
+                        guard.media_ids.remove(key);
+                    }
+                    guard.soft_no_image.remove(key);
+                    guard.negative.insert(key.clone());
+                } else if !guard.map.contains_key(key) {
+                    guard.soft_no_image.insert(key.clone());
                 }
-                guard.negative.insert(key.clone());
                 return Some(MediaImageUpdate {
                     key: key.clone(),
                     ext: None,
@@ -1110,6 +1229,7 @@ fn finish_fetch(
             if let Some(prev) = guard.map.insert(key.clone(), entry) {
                 guard.total_bytes = guard.total_bytes.saturating_sub(prev.bytes.len());
             }
+            guard.soft_no_image.remove(key);
             guard.total_bytes = guard.total_bytes.saturating_add(bytes_len);
             guard.evict_until_fits(cap_bytes);
             Some(MediaImageUpdate {
@@ -1118,10 +1238,16 @@ fn finish_fetch(
             })
         }
         FetchOutcome::NoImage => {
-            if let Some(prev) = guard.map.remove(key) {
-                guard.total_bytes = guard.total_bytes.saturating_sub(prev.bytes.len());
+            if no_image_policy == NoImagePolicy::Memoize && !search_seen {
+                if let Some(prev) = guard.map.remove(key) {
+                    guard.total_bytes = guard.total_bytes.saturating_sub(prev.bytes.len());
+                    guard.media_ids.remove(key);
+                }
+                guard.soft_no_image.remove(key);
+                guard.negative.insert(key.clone());
+            } else if !guard.map.contains_key(key) {
+                guard.soft_no_image.insert(key.clone());
             }
-            guard.negative.insert(key.clone());
             Some(MediaImageUpdate {
                 key: key.clone(),
                 ext: None,
@@ -1242,7 +1368,8 @@ mod tests {
     use super::{
         drain_one_round, ext_for_content_type, ext_from_extension_field, finish_fetch,
         is_connection_down_error, CacheState, FetchOutcome, MediaImageCache, MediaImageUpdate,
-        MediaKey, NegativeMemo, QueueEntry, IMAGE_BATCH_PAGES, MAX_QUEUE_LEN, NEGATIVE_MEMO_CAP,
+        MediaKey, NegativeMemo, NoImagePolicy, QueueEntry, IMAGE_BATCH_PAGES, MAX_QUEUE_LEN,
+        NEGATIVE_MEMO_CAP,
     };
     use std::collections::VecDeque;
     use std::sync::{Arc, Mutex, RwLock};
@@ -1363,7 +1490,11 @@ mod tests {
     fn finish_fetch_success_records_and_clears_pending() {
         let state = Arc::new(RwLock::new(CacheState::new()));
         let k = key("SNES", "/p");
-        state.write().unwrap().pending.insert(k.clone());
+        {
+            let mut guard = state.write().unwrap();
+            guard.pending.insert(k.clone());
+            guard.soft_no_image.insert(k.clone());
+        }
         let update = finish_fetch(
             &state,
             usize::MAX,
@@ -1372,6 +1503,7 @@ mod tests {
                 bytes: vec![1, 2, 3],
                 ext: "png",
             },
+            NoImagePolicy::Memoize,
         )
         .expect("Success returns Some(update)");
         assert_eq!(update.key, k);
@@ -1381,6 +1513,7 @@ mod tests {
         assert_eq!(guard.total_bytes, 3);
         assert!(!guard.pending.contains(&k));
         assert!(!guard.negative.contains(&k));
+        assert!(!guard.soft_no_image.contains(&k));
     }
 
     #[test]
@@ -1397,8 +1530,14 @@ mod tests {
         let state = Arc::new(RwLock::new(CacheState::new()));
         let k = key("SNES", "/empty");
         state.write().unwrap().pending.insert(k.clone());
-        let update = finish_fetch(&state, usize::MAX, &k, FetchOutcome::NoImage)
-            .expect("NoImage returns Some(update)");
+        let update = finish_fetch(
+            &state,
+            usize::MAX,
+            &k,
+            FetchOutcome::NoImage,
+            NoImagePolicy::Memoize,
+        )
+        .expect("NoImage returns Some(update)");
         assert_eq!(update.key, k);
         assert!(update.ext.is_none());
         let guard = state.read().unwrap();
@@ -1419,8 +1558,14 @@ mod tests {
         let state = Arc::new(RwLock::new(CacheState::new()));
         let k = key("SNES", "/p");
         state.write().unwrap().pending.insert(k.clone());
-        let update = finish_fetch(&state, usize::MAX, &k, FetchOutcome::NoImage)
-            .expect("NoImage returns Some(update)");
+        let update = finish_fetch(
+            &state,
+            usize::MAX,
+            &k,
+            FetchOutcome::NoImage,
+            NoImagePolicy::Memoize,
+        )
+        .expect("NoImage returns Some(update)");
         assert_eq!(update.key, k);
         assert!(update.ext.is_none());
         let guard = state.read().unwrap();
@@ -1430,11 +1575,147 @@ mod tests {
     }
 
     #[test]
+    fn memoized_no_image_removes_cached_bytes_and_media_id_hint() {
+        let state = Arc::new(RwLock::new(CacheState::new()));
+        let k = key("SNES", "/stale");
+        ok_png(&state, usize::MAX, &k, 4);
+        {
+            let mut guard = state.write().unwrap();
+            guard.media_ids.insert(k.clone(), 42);
+            guard.pending.insert(k.clone());
+        }
+        let update = finish_fetch(
+            &state,
+            usize::MAX,
+            &k,
+            FetchOutcome::NoImage,
+            NoImagePolicy::Memoize,
+        )
+        .expect("NoImage returns Some(update)");
+        assert_eq!(update.key, k);
+        assert!(update.ext.is_none());
+        let guard = state.read().unwrap();
+        assert!(!guard.map.contains_key(&k));
+        assert_eq!(guard.total_bytes, 0);
+        assert!(!guard.media_ids.contains_key(&k));
+        assert!(!guard.pending.contains(&k));
+        assert!(guard.negative.contains(&k));
+        assert!(!guard.soft_no_image.contains(&k));
+    }
+
+    #[test]
+    fn protected_memoized_no_image_records_soft_memo_without_global_negative() {
+        let state = Arc::new(RwLock::new(CacheState::new()));
+        let k = key("SNES", "/favorite-strict-miss");
+        {
+            let mut guard = state.write().unwrap();
+            guard.pending.insert(k.clone());
+            guard.search_seen.insert(k.clone());
+        }
+        let update = finish_fetch(
+            &state,
+            usize::MAX,
+            &k,
+            FetchOutcome::NoImage,
+            NoImagePolicy::Memoize,
+        )
+        .expect("protected strict NoImage returns Some(update)");
+        assert_eq!(update.key, k);
+        assert!(update.ext.is_none());
+        let guard = state.read().unwrap();
+        assert!(!guard.map.contains_key(&k));
+        assert!(!guard.pending.contains(&k));
+        assert!(!guard.negative.contains(&k));
+        assert!(guard.soft_no_image.contains(&k));
+        assert!(guard.search_seen.contains(&k));
+    }
+
+    #[test]
+    fn protected_memoized_no_image_preserves_cached_bytes() {
+        let state = Arc::new(RwLock::new(CacheState::new()));
+        let k = key("SNES", "/favorite-cached");
+        ok_png(&state, usize::MAX, &k, 4);
+        {
+            let mut guard = state.write().unwrap();
+            guard.pending.insert(k.clone());
+            guard.search_seen.insert(k.clone());
+        }
+        let update = finish_fetch(
+            &state,
+            usize::MAX,
+            &k,
+            FetchOutcome::NoImage,
+            NoImagePolicy::Memoize,
+        )
+        .expect("protected strict NoImage returns Some(update)");
+        assert_eq!(update.key, k);
+        assert!(update.ext.is_none());
+        let guard = state.read().unwrap();
+        assert!(guard.map.contains_key(&k));
+        assert_eq!(guard.total_bytes, 4);
+        assert!(!guard.pending.contains(&k));
+        assert!(!guard.negative.contains(&k));
+        assert!(!guard.soft_no_image.contains(&k));
+    }
+
+    #[test]
+    fn soft_no_image_records_soft_memo_without_global_negative() {
+        let state = Arc::new(RwLock::new(CacheState::new()));
+        let k = key("SNES", "/search-miss");
+        state.write().unwrap().pending.insert(k.clone());
+        let update = finish_fetch(
+            &state,
+            usize::MAX,
+            &k,
+            FetchOutcome::NoImage,
+            NoImagePolicy::SoftMiss,
+        )
+        .expect("soft NoImage returns Some(update)");
+        assert_eq!(update.key, k);
+        assert!(update.ext.is_none());
+        let guard = state.read().unwrap();
+        assert!(!guard.map.contains_key(&k));
+        assert!(!guard.pending.contains(&k));
+        assert!(!guard.negative.contains(&k));
+        assert!(guard.soft_no_image.contains(&k));
+    }
+
+    #[test]
+    fn soft_no_image_preserves_cached_bytes_and_skips_negative_memo() {
+        let state = Arc::new(RwLock::new(CacheState::new()));
+        let k = key("SNES", "/search-row");
+        ok_png(&state, usize::MAX, &k, 4);
+        state.write().unwrap().pending.insert(k.clone());
+        let update = finish_fetch(
+            &state,
+            usize::MAX,
+            &k,
+            FetchOutcome::NoImage,
+            NoImagePolicy::SoftMiss,
+        )
+        .expect("soft NoImage returns Some(update)");
+        assert_eq!(update.key, k);
+        assert!(update.ext.is_none());
+        let guard = state.read().unwrap();
+        assert!(guard.map.contains_key(&k));
+        assert_eq!(guard.total_bytes, 4);
+        assert!(!guard.pending.contains(&k));
+        assert!(!guard.negative.contains(&k));
+        assert!(!guard.soft_no_image.contains(&k));
+    }
+
+    #[test]
     fn connection_down_outcome_only_clears_pending() {
         let state = Arc::new(RwLock::new(CacheState::new()));
         let k = key("SNES", "/p");
         state.write().unwrap().pending.insert(k.clone());
-        let update = finish_fetch(&state, usize::MAX, &k, FetchOutcome::ConnectionDown);
+        let update = finish_fetch(
+            &state,
+            usize::MAX,
+            &k,
+            FetchOutcome::ConnectionDown,
+            NoImagePolicy::Memoize,
+        );
         assert!(update.is_none());
         let guard = state.read().unwrap();
         assert!(!guard.pending.contains(&k));
@@ -1463,6 +1744,7 @@ mod tests {
                 bytes: vec![0; n],
                 ext: "png",
             },
+            NoImagePolicy::Memoize,
         );
     }
 
@@ -1628,6 +1910,7 @@ mod tests {
                 bytes: vec![0; cap + 1],
                 ext: "png",
             },
+            NoImagePolicy::Memoize,
         )
         .expect("oversize Success returns Some(update) with ext=None");
         assert_eq!(update.key, k);
@@ -1655,7 +1938,13 @@ mod tests {
         let state = Arc::new(RwLock::new(CacheState::new()));
         let k = key("SNES", "/p");
         state.write().unwrap().pending.insert(k.clone());
-        let update = finish_fetch(&state, usize::MAX, &k, FetchOutcome::Transient);
+        let update = finish_fetch(
+            &state,
+            usize::MAX,
+            &k,
+            FetchOutcome::Transient,
+            NoImagePolicy::Memoize,
+        );
         assert!(update.is_none(), "Transient must not broadcast");
         let g = state.read().unwrap();
         assert!(!g.map.contains_key(&k), "no insert on Transient");
@@ -1678,14 +1967,17 @@ mod tests {
         q.push_back(QueueEntry {
             key: a.clone(),
             page_size: 15,
+            no_image_policy: NoImagePolicy::Memoize,
         });
         q.push_back(QueueEntry {
             key: b.clone(),
             page_size: 15,
+            no_image_policy: NoImagePolicy::Memoize,
         });
         q.push_back(QueueEntry {
             key: c.clone(),
             page_size: 15,
+            no_image_policy: NoImagePolicy::Memoize,
         });
         assert_eq!(q.pop_back().map(|e| e.key), Some(c));
         assert_eq!(q.pop_back().map(|e| e.key), Some(b));
@@ -1747,6 +2039,65 @@ mod tests {
             guard.pending.contains(&revived),
             "re-enqueued key must be pending again"
         );
+    }
+
+    #[test]
+    fn search_cover_enqueue_uses_soft_no_image_policy() {
+        let cache = cache_for_test();
+        let k = key("SNES", "/favorite");
+        cache.enqueue_search_cover_with_media_id(k.clone(), Some(7), 15);
+        let entry = cache
+            .queue
+            .lock()
+            .unwrap()
+            .pop_back()
+            .expect("search cover enqueue adds queue entry");
+        assert_eq!(entry.key, k);
+        assert_eq!(entry.no_image_policy, NoImagePolicy::SoftMiss);
+        let guard = cache.state.read().unwrap();
+        assert_eq!(guard.media_ids.get(&k), Some(&7));
+        assert!(guard.search_seen.contains(&k));
+    }
+
+    #[test]
+    fn search_cover_enqueue_skips_soft_no_image_keys() {
+        let cache = cache_for_test();
+        let k = key("SNES", "/soft-missed");
+        cache.state.write().unwrap().soft_no_image.insert(k.clone());
+        cache.enqueue_search_cover_with_media_id(k, Some(7), 15);
+        assert!(cache.queue.lock().unwrap().is_empty());
+        assert!(cache.state.read().unwrap().pending.is_empty());
+    }
+
+    #[test]
+    fn default_enqueue_allows_unprotected_soft_no_image_keys() {
+        let cache = cache_for_test();
+        let k = key("SNES", "/soft-missed");
+        cache.state.write().unwrap().soft_no_image.insert(k.clone());
+        cache.enqueue_with_media_id(k.clone(), Some(7), 15);
+        let entry = cache
+            .queue
+            .lock()
+            .unwrap()
+            .pop_back()
+            .expect("default enqueue is not blocked by unprotected soft miss");
+        assert_eq!(entry.key, k);
+        assert_eq!(entry.no_image_policy, NoImagePolicy::Memoize);
+        assert!(cache.state.read().unwrap().pending.contains(&k));
+    }
+
+    #[test]
+    fn default_enqueue_skips_protected_soft_no_image_keys() {
+        let cache = cache_for_test();
+        let k = key("SNES", "/protected-soft-missed");
+        {
+            let mut guard = cache.state.write().unwrap();
+            guard.soft_no_image.insert(k.clone());
+            guard.search_seen.insert(k.clone());
+        }
+        cache.enqueue_with_media_id(k, Some(7), 15);
+        assert!(cache.queue.lock().unwrap().is_empty());
+        assert!(cache.state.read().unwrap().pending.is_empty());
     }
 
     #[test]
@@ -1899,7 +2250,13 @@ mod tests {
             .unwrap()
             .pending
             .insert(memoised.clone());
-        let _ = finish_fetch(&cache.state, usize::MAX, &memoised, FetchOutcome::NoImage);
+        let _ = finish_fetch(
+            &cache.state,
+            usize::MAX,
+            &memoised,
+            FetchOutcome::NoImage,
+            NoImagePolicy::Memoize,
+        );
         assert!(
             cache.is_negative(&memoised),
             "NoImage outcome must populate the negative memo"

--- a/rust/launcher/src/media_image_cache.rs
+++ b/rust/launcher/src/media_image_cache.rs
@@ -1090,6 +1090,9 @@ fn finish_fetch(
                     cap_bytes,
                     "media_image_cache: payload exceeds cache cap, recording as negative",
                 );
+                if let Some(prev) = guard.map.remove(key) {
+                    guard.total_bytes = guard.total_bytes.saturating_sub(prev.bytes.len());
+                }
                 guard.negative.insert(key.clone());
                 return Some(MediaImageUpdate {
                     key: key.clone(),
@@ -1115,6 +1118,9 @@ fn finish_fetch(
             })
         }
         FetchOutcome::NoImage => {
+            if let Some(prev) = guard.map.remove(key) {
+                guard.total_bytes = guard.total_bytes.saturating_sub(prev.bytes.len());
+            }
             guard.negative.insert(key.clone());
             Some(MediaImageUpdate {
                 key: key.clone(),

--- a/rust/launcher/src/models/favorites.rs
+++ b/rust/launcher/src/models/favorites.rs
@@ -776,13 +776,15 @@ fn sync_current_detail_image_key(mut model: Pin<&mut ffi::FavoritesModel>) {
         model.as_mut().set_current_detail_image_key(QString::from(
             MediaImageCache::image_key_for(&key).as_str(),
         ));
-    } else {
-        if !cache.is_negative(&key) {
-            cache.enqueue_with_media_id(key, model.current_detail_media_id, 1);
-        }
+    } else if cache.is_negative(&key) {
         model
             .as_mut()
             .set_current_detail_image_key(QString::default());
+    } else {
+        cache.enqueue_with_media_id(key, model.current_detail_media_id, 1);
+        model
+            .as_mut()
+            .set_current_detail_image_key(QString::from("icons/Loading"));
     }
 }
 

--- a/rust/launcher/src/models/favorites.rs
+++ b/rust/launcher/src/models/favorites.rs
@@ -41,8 +41,8 @@ use zaparoo_core::endpoints::media_tags_update::MediaTagsUpdateMutation;
 use zaparoo_core::endpoints::readers_write::ReadersWriteMutation;
 use zaparoo_core::endpoints::run::RunMutation;
 use zaparoo_core::media_types::{
-    MediaItem, MediaSearchParams, MediaSearchResult, MediaTagsUpdateParams, ReadersWriteParams,
-    RunParams, TagInfo,
+    MediaItem, MediaMeta, MediaMetaParams, MediaSearchParams, MediaSearchResult,
+    MediaTagsUpdateParams, ReadersWriteParams, RunParams, TagInfo,
 };
 use zaparoo_core::remote_resource::ResourceStatus;
 
@@ -78,7 +78,13 @@ pub struct FavoritesModelRust {
     next_cursor: Option<String>,
     card_write_pending: bool,
     card_write_error: QString,
+    current_detail_loading: bool,
+    current_detail_tags: QString,
+    current_detail_image_key: QString,
+    current_detail_media_key: Option<MediaKey>,
+    current_detail_media_id: Option<i64>,
     card_write_seq: Arc<AtomicU64>,
+    detail_seq: Arc<AtomicU64>,
     // Bumped whenever the cursor chain is reset by an initial
     // `apply_state` so any in-flight `fetch_more` callback can detect
     // its append no longer belongs to the current chain.
@@ -134,6 +140,9 @@ pub mod ffi {
         #[qproperty(bool, has_next_page)]
         #[qproperty(bool, card_write_pending)]
         #[qproperty(QString, card_write_error)]
+        #[qproperty(bool, current_detail_loading)]
+        #[qproperty(QString, current_detail_tags)]
+        #[qproperty(QString, current_detail_image_key)]
         type FavoritesModel = super::FavoritesModelRust;
 
         #[qinvokable]
@@ -165,6 +174,12 @@ pub mod ffi {
 
         #[qinvokable]
         fn system_id_at(self: &FavoritesModel, index: i32) -> QString;
+
+        #[qinvokable]
+        fn load_detail_at(self: Pin<&mut FavoritesModel>, index: i32);
+
+        #[qinvokable]
+        fn clear_current_detail(self: Pin<&mut FavoritesModel>);
 
         #[qinvokable]
         fn index_for_path(self: &FavoritesModel, path: &QString) -> i32;
@@ -262,6 +277,7 @@ fn apply_state(
         model.as_mut().ensure_cover_subscription();
         enqueue_favorites_covers(&entries);
         let count = i32::try_from(entries.len()).unwrap_or(i32::MAX);
+        clear_current_detail_state(model.as_mut());
         model.as_mut().begin_reset_model();
         model.as_mut().rust_mut().entries = entries;
         model.as_mut().rust_mut().count = count;
@@ -296,6 +312,7 @@ fn apply_state(
         // Disarm the cover gate too: a stale timer firing during the
         // next Ready would clear loading prematurely.
         disarm_cover_gate(model.as_mut());
+        clear_current_detail_state(model.as_mut());
         model.as_mut().rust_mut().seq.fetch_add(1, Ordering::SeqCst);
         model.as_mut().rust_mut().next_cursor = None;
         if !model.loading {
@@ -310,6 +327,7 @@ fn apply_state(
         // Ready could otherwise append rows that don't belong to the
         // current chain.
         disarm_cover_gate(model.as_mut());
+        clear_current_detail_state(model.as_mut());
         model.as_mut().rust_mut().seq.fetch_add(1, Ordering::SeqCst);
         model.as_mut().rust_mut().next_cursor = None;
         if model.loading {
@@ -541,6 +559,57 @@ impl ffi::FavoritesModel {
         QString::from(self.entries[index as usize].system.id.as_str())
     }
 
+    fn load_detail_at(mut self: Pin<&mut Self>, index: i32) {
+        let ticket = self
+            .as_mut()
+            .rust_mut()
+            .detail_seq
+            .fetch_add(1, Ordering::SeqCst)
+            + 1;
+        if index < 0 || index >= self.count {
+            clear_current_detail_state(self.as_mut());
+            return;
+        }
+        let entry = &self.entries[index as usize];
+        let system = entry.system.id.clone();
+        let path = entry.path.clone();
+        let media_id = entry.media_id;
+        if system.trim().is_empty() || path.trim().is_empty() {
+            clear_current_detail_state(self.as_mut());
+            return;
+        }
+        let detail_key = MediaKey::new(system.clone(), path.clone());
+        self.as_mut().rust_mut().current_detail_media_key = Some(detail_key);
+        self.as_mut().rust_mut().current_detail_media_id = media_id;
+        sync_current_detail_image_key(self.as_mut());
+        self.as_mut().set_current_detail_loading(false);
+        let seq = self.rust().detail_seq.clone();
+        let qt_thread = self.qt_thread();
+        let store = global_store();
+        global_handle().spawn(async move {
+            let result = store
+                .client()
+                .media_meta(MediaMetaParams::for_media(system, path.clone()))
+                .await;
+            let _ = qt_thread.queue(move |mut model| {
+                if seq.load(Ordering::SeqCst) != ticket {
+                    return;
+                }
+                model.as_mut().set_current_detail_loading(false);
+                match result {
+                    Ok(result) => model.as_mut().set_current_detail_tags(QString::from(
+                        detail_tags_from_meta(&result.media).as_str(),
+                    )),
+                    Err(e) => warn!("favorite detail fetch failed for {path}: {}", e.message),
+                }
+            });
+        });
+    }
+
+    fn clear_current_detail(self: Pin<&mut Self>) {
+        clear_current_detail_state(self);
+    }
+
     fn index_for_path(&self, path: &QString) -> i32 {
         position_of_path(&self.entries, &path.to_string())
     }
@@ -620,6 +689,52 @@ fn favorite_role_value(tags: &[TagInfo]) -> i32 {
     i32::from(has_favorite_tag(tags))
 }
 
+fn detail_tags_from_meta(meta: &MediaMeta) -> String {
+    let source = if meta.title.tags.is_empty() {
+        meta.tags.as_slice()
+    } else {
+        meta.title.tags.as_slice()
+    };
+    let rows = [
+        (
+            "Year",
+            detail_value_for_aliases(source, &["year", "release date", "release_date"]),
+        ),
+        (
+            "Genre",
+            detail_value_for_aliases(source, &["genre", "gamegenre"]),
+        ),
+        ("Players", detail_value_for_aliases(source, &["players"])),
+        (
+            "Developer",
+            detail_value_for_aliases(source, &["developer"]),
+        ),
+        (
+            "Publisher",
+            detail_value_for_aliases(source, &["publisher"]),
+        ),
+        ("Rating", detail_value_for_aliases(source, &["rating"])),
+    ];
+    rows.into_iter()
+        .map(|(label, value)| format!("{label}\t{value}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn detail_value_for_aliases(source: &[TagInfo], aliases: &[&str]) -> String {
+    source
+        .iter()
+        .filter(|tag| {
+            aliases
+                .iter()
+                .any(|alias| tag.tag_type.eq_ignore_ascii_case(alias))
+                && !tag.tag.trim().is_empty()
+        })
+        .map(|tag| tag.tag.trim().to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 fn file_stem_or_name(path: &str, name: &str) -> String {
     let file = path
         .trim_end_matches(['/', '\\'])
@@ -631,6 +746,43 @@ fn file_stem_or_name(path: &str, name: &str) -> String {
         name.to_string()
     } else {
         stem.to_string()
+    }
+}
+
+fn clear_current_detail_state(mut model: Pin<&mut ffi::FavoritesModel>) {
+    model
+        .as_mut()
+        .rust_mut()
+        .detail_seq
+        .fetch_add(1, Ordering::SeqCst);
+    model.as_mut().rust_mut().current_detail_media_key = None;
+    model.as_mut().rust_mut().current_detail_media_id = None;
+    model.as_mut().set_current_detail_loading(false);
+    model.as_mut().set_current_detail_tags(QString::default());
+    model
+        .as_mut()
+        .set_current_detail_image_key(QString::default());
+}
+
+fn sync_current_detail_image_key(mut model: Pin<&mut ffi::FavoritesModel>) {
+    let Some(key) = model.current_detail_media_key.clone() else {
+        model
+            .as_mut()
+            .set_current_detail_image_key(QString::default());
+        return;
+    };
+    let cache = global_media_image_cache();
+    if cache.is_cached(&key) {
+        model.as_mut().set_current_detail_image_key(QString::from(
+            MediaImageCache::image_key_for(&key).as_str(),
+        ));
+    } else {
+        if !cache.is_negative(&key) {
+            cache.enqueue_with_media_id(key, model.current_detail_media_id, 1);
+        }
+        model
+            .as_mut()
+            .set_current_detail_image_key(QString::default());
     }
 }
 
@@ -749,6 +901,13 @@ fn notify_cover_update(mut model: Pin<&mut ffi::FavoritesModel>, key: &MediaKey)
             let idx = model.index(row, 0, &parent);
             model.as_mut().data_changed(&idx, &idx, &roles);
         }
+    }
+    if model
+        .current_detail_media_key
+        .as_ref()
+        .is_some_and(|current| current == key)
+    {
+        sync_current_detail_image_key(model.as_mut());
     }
     // Tick the gate's pending set down. `remove` returns false if the
     // key wasn't gated (broadcast events fire for every cache update,

--- a/rust/launcher/src/models/favorites.rs
+++ b/rust/launcher/src/models/favorites.rs
@@ -664,15 +664,18 @@ fn cover_key_for(entry: &MediaItem) -> String {
     let cache = global_media_image_cache();
     let cached = media_key.as_ref().is_some_and(|k| cache.is_cached(k));
     let negative = media_key.as_ref().is_some_and(|k| cache.is_negative(k));
-    if !cached && !negative {
+    let soft_no_image = media_key
+        .as_ref()
+        .is_some_and(|k| cache.is_soft_no_image(k));
+    if !cached && !negative && !soft_no_image {
         // Miss-driven re-enqueue, same rationale as GamesModel's
         // `cover_key_for`: tiles re-bound after LRU eviction or stale-
         // enqueue truncation will hit this branch and re-arm the fetch.
         if let Some(k) = media_key.as_ref() {
-            cache.enqueue_with_media_id(k.clone(), entry.media_id, PAGE_SIZE);
+            cache.enqueue_search_cover_with_media_id(k.clone(), entry.media_id, PAGE_SIZE);
         }
     }
-    cover_key_for_with(entry, media_key.as_ref(), cached, negative)
+    cover_key_for_with(entry, media_key.as_ref(), cached, negative || soft_no_image)
 }
 
 /// Build the canonical `(systemId, mediaPath)` identifier for a search
@@ -780,12 +783,12 @@ fn sync_current_detail_image_key(mut model: Pin<&mut ffi::FavoritesModel>) {
         model.as_mut().set_current_detail_image_key(QString::from(
             MediaImageCache::image_key_for(&key).as_str(),
         ));
-    } else if cache.is_negative(&key) {
+    } else if cache.is_negative(&key) || cache.is_soft_no_image(&key) {
         model
             .as_mut()
             .set_current_detail_image_key(QString::default());
     } else {
-        cache.enqueue_with_media_id(key, model.current_detail_media_id, 1);
+        cache.enqueue_search_cover_with_media_id(key, model.current_detail_media_id, 1);
         model
             .as_mut()
             .set_current_detail_image_key(QString::from("icons/Loading"));
@@ -865,10 +868,10 @@ fn cover_key_for_with(
 }
 
 /// Schedule a cover fetch for every search row with a non-empty
-/// `(systemId, mediaPath)`. `MediaImageCache::enqueue_with_media_id`
-/// is idempotent — already-cached, already-pending, or negatively-
-/// memoised keys are dropped — so spamming this from `apply_state` /
-/// `apply_append_page` is cheap.
+/// `(systemId, mediaPath)`. The cache enqueue is idempotent —
+/// already-cached, already-pending, or negatively-memoised keys are
+/// dropped — so spamming this from `apply_state` / `apply_append_page`
+/// is cheap.
 ///
 /// Iterates `entries` in reverse so the LIFO fetch queue drains in
 /// visual order: the last entry pushed is `entries[0]`, which the
@@ -877,7 +880,7 @@ fn enqueue_favorites_covers(results: &[MediaItem]) {
     let cache = global_media_image_cache();
     for entry in results.iter().rev() {
         if let Some(key) = media_key_for(entry) {
-            cache.enqueue_with_media_id(key, entry.media_id, PAGE_SIZE);
+            cache.enqueue_search_cover_with_media_id(key, entry.media_id, PAGE_SIZE);
         }
     }
 }
@@ -1106,5 +1109,42 @@ fn apply_append_page(
                 .set_error_message(QString::from(e.message.as_str()));
             model.as_mut().set_loading_more(false);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn favorite_entry() -> MediaItem {
+        MediaItem {
+            name: "Favorite".to_string(),
+            path: "/games/favorite.rom".to_string(),
+            system: zaparoo_core::media_types::System {
+                id: "SNES".to_string(),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn soft_missed_favorite_cover_uses_system_fallback() {
+        let entry = favorite_entry();
+        let key = MediaKey::new("SNES", "/games/favorite.rom");
+        assert_eq!(
+            cover_key_for_with(&entry, Some(&key), false, true),
+            "systems/SNES"
+        );
+    }
+
+    #[test]
+    fn pending_favorite_cover_uses_loading_icon() {
+        let entry = favorite_entry();
+        let key = MediaKey::new("SNES", "/games/favorite.rom");
+        assert_eq!(
+            cover_key_for_with(&entry, Some(&key), false, false),
+            "icons/Loading"
+        );
     }
 }

--- a/rust/launcher/src/models/favorites.rs
+++ b/rust/launcher/src/models/favorites.rs
@@ -675,7 +675,7 @@ fn cover_key_for(entry: &MediaItem) -> String {
             cache.enqueue_search_cover_with_media_id(k.clone(), entry.media_id, PAGE_SIZE);
         }
     }
-    cover_key_for_with(entry, media_key.as_ref(), cached, negative || soft_no_image)
+    cover_key_for_with(entry, media_key.as_ref(), cached, negative, soft_no_image)
 }
 
 /// Build the canonical `(systemId, mediaPath)` identifier for a search
@@ -856,13 +856,14 @@ fn cover_key_for_with(
     key: Option<&MediaKey>,
     cached: bool,
     negative: bool,
+    soft_no_image: bool,
 ) -> String {
     if entry.system.id.is_empty() {
         return "icons/File".to_string();
     }
     match key {
         Some(k) if cached => MediaImageCache::image_key_for(k),
-        Some(_) if !negative => "icons/Loading".to_string(),
+        Some(_) if !negative && !soft_no_image => "icons/Loading".to_string(),
         _ => format!("systems/{}", entry.system.id),
     }
 }
@@ -1001,7 +1002,7 @@ fn arm_cover_gate(mut model: Pin<&mut ffi::FavoritesModel>) {
     let unresolved = compute_unresolved_keys(
         &model.entries,
         |k| cache.is_cached(k),
-        |k| cache.is_negative(k),
+        |k| cache.is_negative(k) || cache.is_soft_no_image(k),
     );
     if unresolved.is_empty() {
         model.as_mut().rust_mut().pending_first_paint_keys.clear();
@@ -1133,7 +1134,7 @@ mod tests {
         let entry = favorite_entry();
         let key = MediaKey::new("SNES", "/games/favorite.rom");
         assert_eq!(
-            cover_key_for_with(&entry, Some(&key), false, true),
+            cover_key_for_with(&entry, Some(&key), false, false, true),
             "systems/SNES"
         );
     }
@@ -1143,8 +1144,28 @@ mod tests {
         let entry = favorite_entry();
         let key = MediaKey::new("SNES", "/games/favorite.rom");
         assert_eq!(
-            cover_key_for_with(&entry, Some(&key), false, false),
+            cover_key_for_with(&entry, Some(&key), false, false, false),
             "icons/Loading"
         );
+    }
+
+    #[test]
+    fn compute_unresolved_keys_excludes_soft_no_image() {
+        let soft_key = MediaKey::new("SNES", "/games/favorite.rom");
+        let mut pending_entry = favorite_entry();
+        pending_entry.path = "/games/pending.rom".to_string();
+        let entries = vec![favorite_entry(), pending_entry];
+        let unresolved = compute_unresolved_keys(
+            &entries,
+            |_| false,
+            |k| {
+                k.system_id.as_ref() == soft_key.system_id.as_ref()
+                    && k.path.as_ref() == soft_key.path.as_ref()
+            },
+        );
+        let expected: HashSet<MediaKey> = [MediaKey::new("SNES", "/games/pending.rom")]
+            .into_iter()
+            .collect();
+        assert_eq!(unresolved, expected);
     }
 }

--- a/rust/launcher/src/models/favorites.rs
+++ b/rust/launcher/src/models/favorites.rs
@@ -582,7 +582,8 @@ impl ffi::FavoritesModel {
         self.as_mut().rust_mut().current_detail_media_key = Some(detail_key);
         self.as_mut().rust_mut().current_detail_media_id = media_id;
         sync_current_detail_image_key(self.as_mut());
-        self.as_mut().set_current_detail_loading(false);
+        self.as_mut().set_current_detail_loading(true);
+        self.as_mut().set_current_detail_tags(QString::default());
         let seq = self.rust().detail_seq.clone();
         let qt_thread = self.qt_thread();
         let store = global_store();
@@ -595,13 +596,16 @@ impl ffi::FavoritesModel {
                 if seq.load(Ordering::SeqCst) != ticket {
                     return;
                 }
-                model.as_mut().set_current_detail_loading(false);
                 match result {
                     Ok(result) => model.as_mut().set_current_detail_tags(QString::from(
                         detail_tags_from_meta(&result.media).as_str(),
                     )),
-                    Err(e) => warn!("favorite detail fetch failed for {path}: {}", e.message),
+                    Err(e) => {
+                        model.as_mut().set_current_detail_tags(QString::default());
+                        warn!("favorite detail fetch failed for {path}: {}", e.message);
+                    }
                 }
+                model.as_mut().set_current_detail_loading(false);
             });
         });
     }

--- a/rust/launcher/src/models/game_info.rs
+++ b/rust/launcher/src/models/game_info.rs
@@ -1,0 +1,398 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+use crate::media_image_cache::{global_media_image_cache, MediaImageCache, MediaKey};
+use crate::models::{global_handle, global_store};
+use cxx_qt::{CxxQtType, Threading};
+use cxx_qt_lib::QString;
+use std::collections::BTreeSet;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use tokio::sync::broadcast::error::RecvError;
+use tokio::task::JoinHandle;
+use tracing::debug;
+use zaparoo_core::media_types::{MediaMeta, MediaMetaParams};
+
+#[derive(Default)]
+pub struct GameInfoRust {
+    loading: bool,
+    error_message: QString,
+    title: QString,
+    description: QString,
+    detail_tags: QString,
+    image_key: QString,
+    image_index: i32,
+    image_count: i32,
+    image_can_prev: bool,
+    image_can_next: bool,
+    detail_image_keys: Vec<MediaKey>,
+    seq: Arc<AtomicU64>,
+    cover_subscription: Option<JoinHandle<()>>,
+}
+
+#[cxx_qt::bridge]
+pub mod ffi {
+    unsafe extern "C++" {
+        include!("model_includes.h");
+
+        type QString = cxx_qt_lib::QString;
+    }
+
+    unsafe extern "RustQt" {
+        #[qobject]
+        #[qml_element]
+        #[qml_singleton]
+        #[qproperty(bool, loading)]
+        #[qproperty(QString, error_message)]
+        #[qproperty(QString, title)]
+        #[qproperty(QString, description)]
+        #[qproperty(QString, detail_tags)]
+        #[qproperty(QString, image_key)]
+        #[qproperty(i32, image_index)]
+        #[qproperty(i32, image_count)]
+        #[qproperty(bool, image_can_prev)]
+        #[qproperty(bool, image_can_next)]
+        type GameInfo = super::GameInfoRust;
+
+        #[qinvokable]
+        fn load(
+            self: Pin<&mut GameInfo>,
+            system_id: &QString,
+            path: &QString,
+            fallback_title: &QString,
+        );
+
+        #[qinvokable]
+        fn clear(self: Pin<&mut GameInfo>);
+
+        #[qinvokable]
+        fn cycle_image(self: Pin<&mut GameInfo>, delta: i32);
+    }
+
+    impl cxx_qt::Threading for GameInfo {}
+}
+
+impl ffi::GameInfo {
+    fn load(
+        mut self: Pin<&mut Self>,
+        system_id: &QString,
+        path: &QString,
+        fallback_title: &QString,
+    ) {
+        self.as_mut().ensure_cover_subscription();
+        let system = system_id.to_string();
+        let path = path.to_string();
+        let fallback_title = fallback_title.to_string();
+        self.as_mut().rust().seq.fetch_add(1, Ordering::SeqCst);
+        clear_detail_images(self.as_mut());
+        self.as_mut().set_error_message(QString::default());
+        self.as_mut()
+            .set_title(QString::from(fallback_title.trim()));
+        self.as_mut().set_description(QString::default());
+        self.as_mut().set_detail_tags(QString::default());
+        if system.trim().is_empty() || path.trim().is_empty() {
+            self.as_mut().set_loading(false);
+            return;
+        }
+        self.as_mut().set_loading(true);
+        let seq = self.rust().seq.clone();
+        let ticket = seq.load(Ordering::SeqCst);
+        let qt_thread = self.qt_thread();
+        let store = global_store();
+        global_handle().spawn(async move {
+            let result = store
+                .client()
+                .media_meta(MediaMetaParams::for_media(system.clone(), path.clone()))
+                .await;
+            let _ = qt_thread.queue(move |mut model| {
+                if seq.load(Ordering::SeqCst) != ticket {
+                    return;
+                }
+                model.as_mut().set_loading(false);
+                match result {
+                    Ok(result) => {
+                        let meta_title = result.media.title.name.trim();
+                        if !meta_title.is_empty() {
+                            model.as_mut().set_title(QString::from(meta_title));
+                        }
+                        model.as_mut().set_description(QString::from(
+                            description_from_meta(&result.media).as_str(),
+                        ));
+                        model.as_mut().set_detail_tags(QString::from(
+                            detail_tags_from_meta(&result.media, &path).as_str(),
+                        ));
+                        install_detail_images(
+                            model.as_mut(),
+                            detail_image_keys_from_meta(&result.media, &system, &path),
+                        );
+                    }
+                    Err(e) => {
+                        debug!("game info fetch failed for {path}: {}", e.message);
+                        model
+                            .as_mut()
+                            .set_error_message(QString::from(e.message.as_str()));
+                    }
+                }
+            });
+        });
+    }
+
+    fn clear(mut self: Pin<&mut Self>) {
+        self.as_mut().rust().seq.fetch_add(1, Ordering::SeqCst);
+        self.as_mut().set_loading(false);
+        self.as_mut().set_error_message(QString::default());
+        self.as_mut().set_title(QString::default());
+        self.as_mut().set_description(QString::default());
+        self.as_mut().set_detail_tags(QString::default());
+        clear_detail_images(self);
+    }
+
+    fn cycle_image(self: Pin<&mut Self>, delta: i32) {
+        if delta == 0 || self.image_count <= 1 {
+            return;
+        }
+        let current = self.image_index;
+        let next = (current + delta).clamp(0, self.image_count - 1);
+        if next == current {
+            return;
+        }
+        set_detail_image_index(self, next);
+    }
+
+    fn ensure_cover_subscription(mut self: Pin<&mut Self>) {
+        if self.cover_subscription.is_some() {
+            return;
+        }
+        let cache = global_media_image_cache();
+        let mut rx = cache.subscribe();
+        let qt_thread = self.qt_thread();
+        let handle = global_handle().spawn(async move {
+            loop {
+                match rx.recv().await {
+                    Ok(update) => {
+                        let _ = qt_thread.queue(move |model| {
+                            notify_cover_update(model, &update.key);
+                        });
+                    }
+                    Err(RecvError::Lagged(_)) => {}
+                    Err(RecvError::Closed) => break,
+                }
+            }
+        });
+        self.as_mut().rust_mut().cover_subscription = Some(handle);
+    }
+}
+
+fn description_from_meta(meta: &MediaMeta) -> String {
+    meta.title
+        .properties
+        .get("property:description")
+        .or_else(|| meta.properties.get("property:description"))
+        .map(|property| property.text.trim().to_string())
+        .filter(|text| !text.is_empty())
+        .unwrap_or_default()
+}
+
+fn detail_tags_from_meta(meta: &MediaMeta, path: &str) -> String {
+    let source = if meta.title.tags.is_empty() {
+        meta.tags.as_slice()
+    } else {
+        meta.title.tags.as_slice()
+    };
+    let mut rows: Vec<(String, String)> = Vec::new();
+    for tag_type in [
+        "system",
+        "platform",
+        "year",
+        "release date",
+        "release_date",
+        "genre",
+        "players",
+        "play mode",
+        "play_mode",
+        "cooperative",
+        "developer",
+        "publisher",
+        "rating",
+    ] {
+        rows.extend(
+            source
+                .iter()
+                .filter(|tag| {
+                    tag.tag_type.eq_ignore_ascii_case(tag_type) && !tag.tag.trim().is_empty()
+                })
+                .map(|tag| (display_label(&tag.tag_type), tag.tag.trim().to_string())),
+        );
+    }
+    rows.extend(
+        source
+            .iter()
+            .filter(|tag| {
+                !is_ordered_tag(&tag.tag_type)
+                    && !tag.tag_type.trim().is_empty()
+                    && !tag.tag.trim().is_empty()
+            })
+            .map(|tag| (display_label(&tag.tag_type), tag.tag.trim().to_string())),
+    );
+    let filename = file_stem_or_name(path);
+    if !filename.is_empty() {
+        rows.push(("Filename".to_string(), filename));
+    }
+    rows.into_iter()
+        .map(|(label, value)| format!("{label}\t{value}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn is_ordered_tag(tag_type: &str) -> bool {
+    matches!(
+        normalize_tag_type(tag_type).as_str(),
+        "system"
+            | "platform"
+            | "year"
+            | "release date"
+            | "release_date"
+            | "genre"
+            | "players"
+            | "play mode"
+            | "play_mode"
+            | "cooperative"
+            | "developer"
+            | "publisher"
+            | "rating"
+    )
+}
+
+fn normalize_tag_type(tag_type: &str) -> String {
+    tag_type.trim().to_ascii_lowercase().replace('-', " ")
+}
+
+fn display_label(tag_type: &str) -> String {
+    let normalized = normalize_tag_type(tag_type).replace('_', " ");
+    match normalized.as_str() {
+        "release date" => "Release date".to_string(),
+        "play mode" => "Play mode".to_string(),
+        other => {
+            let mut words = other.split_whitespace();
+            let Some(first) = words.next() else {
+                return String::new();
+            };
+            let mut label = first.to_string();
+            if let Some(ch) = label.get_mut(0..1) {
+                ch.make_ascii_uppercase();
+            }
+            for word in words {
+                label.push(' ');
+                label.push_str(word);
+            }
+            label
+        }
+    }
+}
+
+fn image_type_from_property_key(key: &str) -> Option<String> {
+    let suffix = key.strip_prefix("property:image")?;
+    if suffix.is_empty() {
+        return Some("image".to_string());
+    }
+    Some(suffix.trim_start_matches('-').to_string()).filter(|image_type| !image_type.is_empty())
+}
+
+fn detail_image_keys_from_meta(meta: &MediaMeta, system: &str, path: &str) -> Vec<MediaKey> {
+    let mut types = BTreeSet::<String>::new();
+    for key in meta
+        .title
+        .properties
+        .keys()
+        .chain(meta.properties.keys())
+        .filter_map(|key| image_type_from_property_key(key))
+    {
+        types.insert(key);
+    }
+    let mut ordered = Vec::new();
+    if types.remove("image") {
+        ordered.push("image".to_string());
+    }
+    ordered.extend(types);
+    ordered
+        .into_iter()
+        .map(|image_type| MediaKey::with_image_type(system, path, image_type))
+        .collect()
+}
+
+fn clear_detail_images(mut model: Pin<&mut ffi::GameInfo>) {
+    model.as_mut().rust_mut().detail_image_keys.clear();
+    model.as_mut().set_image_key(QString::default());
+    model.as_mut().set_image_index(0);
+    model.as_mut().set_image_count(0);
+    model.as_mut().set_image_can_prev(false);
+    model.as_mut().set_image_can_next(false);
+}
+
+fn install_detail_images(mut model: Pin<&mut ffi::GameInfo>, keys: Vec<MediaKey>) {
+    model.as_mut().rust_mut().detail_image_keys = keys;
+    set_detail_image_index(model, 0);
+}
+
+fn set_detail_image_index(mut model: Pin<&mut ffi::GameInfo>, index: i32) {
+    let count = i32::try_from(model.detail_image_keys.len()).unwrap_or(i32::MAX);
+    let clamped = if count <= 0 {
+        0
+    } else {
+        index.clamp(0, count - 1)
+    };
+    model.as_mut().set_image_index(clamped);
+    model.as_mut().set_image_count(count);
+    model.as_mut().set_image_can_prev(clamped > 0);
+    model
+        .as_mut()
+        .set_image_can_next(count > 0 && clamped < count - 1);
+    sync_current_image_key(model);
+}
+
+fn sync_current_image_key(mut model: Pin<&mut ffi::GameInfo>) {
+    let index = model.image_index;
+    if index < 0 {
+        model.as_mut().set_image_key(QString::default());
+        return;
+    }
+    let Some(key) = model.detail_image_keys.get(index as usize).cloned() else {
+        model.as_mut().set_image_key(QString::default());
+        return;
+    };
+    let cache = global_media_image_cache();
+    if cache.is_cached(&key) {
+        model
+            .as_mut()
+            .set_image_key(QString::from(MediaImageCache::image_key_for(&key).as_str()));
+    } else {
+        cache.enqueue_with_media_id(key, None, 1);
+        model.as_mut().set_image_key(QString::default());
+    }
+}
+
+fn notify_cover_update(mut model: Pin<&mut ffi::GameInfo>, key: &MediaKey) {
+    let current = model
+        .detail_image_keys
+        .get(model.image_index as usize)
+        .cloned();
+    if current.as_ref().is_some_and(|current| current == key) {
+        model
+            .as_mut()
+            .set_image_key(QString::from(MediaImageCache::image_key_for(key).as_str()));
+    }
+}
+
+fn file_stem_or_name(path: &str) -> String {
+    let file = path
+        .trim_end_matches(['/', '\\'])
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or_default();
+    file.rsplit_once('.')
+        .map_or(file, |(stem, _)| stem)
+        .trim()
+        .to_string()
+}

--- a/rust/launcher/src/models/game_info.rs
+++ b/rust/launcher/src/models/game_info.rs
@@ -2,7 +2,9 @@
 // Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
-use crate::media_image_cache::{global_media_image_cache, MediaImageCache, MediaKey};
+use crate::media_image_cache::{
+    global_media_image_cache, MediaImageCache, MediaImageUpdate, MediaKey,
+};
 use crate::models::{global_handle, global_store};
 use cxx_qt::{CxxQtType, Threading};
 use cxx_qt_lib::QString;
@@ -173,7 +175,7 @@ impl ffi::GameInfo {
                 match rx.recv().await {
                     Ok(update) => {
                         let _ = qt_thread.queue(move |model| {
-                            notify_cover_update(model, &update.key);
+                            notify_cover_update(model, &update);
                         });
                     }
                     Err(RecvError::Lagged(_)) => {}
@@ -373,15 +375,23 @@ fn sync_current_image_key(mut model: Pin<&mut ffi::GameInfo>) {
     }
 }
 
-fn notify_cover_update(mut model: Pin<&mut ffi::GameInfo>, key: &MediaKey) {
+fn notify_cover_update(mut model: Pin<&mut ffi::GameInfo>, update: &MediaImageUpdate) {
     let current = model
         .detail_image_keys
         .get(model.image_index as usize)
         .cloned();
-    if current.as_ref().is_some_and(|current| current == key) {
-        model
-            .as_mut()
-            .set_image_key(QString::from(MediaImageCache::image_key_for(key).as_str()));
+    if !current
+        .as_ref()
+        .is_some_and(|current| current == &update.key)
+    {
+        return;
+    }
+    if update.ext.is_some() {
+        model.as_mut().set_image_key(QString::from(
+            MediaImageCache::image_key_for(&update.key).as_str(),
+        ));
+    } else {
+        model.as_mut().set_image_key(QString::default());
     }
 }
 

--- a/rust/launcher/src/models/games.rs
+++ b/rust/launcher/src/models/games.rs
@@ -36,7 +36,7 @@ use cxx_qt::{CxxQtType, Threading};
 use cxx_qt_lib::{
     QByteArray, QHash, QHashPair_i32_QByteArray, QList, QModelIndex, QString, QVariant,
 };
-use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
+use std::collections::HashSet;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -50,8 +50,8 @@ use zaparoo_core::endpoints::media_tags_update::MediaTagsUpdateMutation;
 use zaparoo_core::endpoints::readers_write::ReadersWriteMutation;
 use zaparoo_core::endpoints::run::RunMutation;
 use zaparoo_core::media_types::{
-    BrowseEntry, MediaBrowseParams, MediaBrowseResult, MediaMeta, MediaMetaParams,
-    MediaTagsUpdateParams, ReadersWriteParams, RunParams, TagInfo,
+    BrowseEntry, MediaBrowseParams, MediaBrowseResult, MediaTagsUpdateParams, ReadersWriteParams,
+    RunParams, TagInfo,
 };
 use zaparoo_core::platform::{self, Platform};
 use zaparoo_core::remote_resource::ResourceStatus;
@@ -78,15 +78,6 @@ const FILE_STEM_ROLE: i32 = 256 + 10;
 // test harness sees this until it overrides explicitly. Server cap is
 // 1000; grid page sizes top out at ~30 so we stay well inside bounds.
 const DEFAULT_PAGE_SIZE: i32 = 15;
-const DETAIL_METADATA_CACHE_CAP: usize = 256;
-
-#[derive(Clone)]
-struct DetailMetadata {
-    description: String,
-    tags: String,
-    image_keys: Vec<MediaKey>,
-}
-
 // `media.browse` `max_results` for cursor follow-ups. Held separate
 // from `page_size` (which dictates grid layout, scroll-thumb sizing,
 // and the initial-page cover gate) so wire chunks can be larger than a
@@ -168,8 +159,6 @@ pub struct GamesModelRust {
     current_detail_image_can_prev: bool,
     current_detail_image_can_next: bool,
     detail_image_keys: Vec<MediaKey>,
-    detail_metadata_cache: HashMap<MediaKey, DetailMetadata>,
-    detail_metadata_lru: VecDeque<MediaKey>,
     // Watcher for the current initial-page subscription. Aborted on
     // every path swap so the prior watcher stops enqueuing callbacks
     // for the old `BrowseArgs`. Callbacks already in the Qt queue are
@@ -271,8 +260,6 @@ impl Default for GamesModelRust {
             current_detail_image_can_prev: false,
             current_detail_image_can_next: false,
             detail_image_keys: Vec::new(),
-            detail_metadata_cache: HashMap::new(),
-            detail_metadata_lru: VecDeque::new(),
             watcher: None,
             seq: Arc::new(AtomicU64::new(0)),
             auto_nav_eligible: false,
@@ -759,6 +746,7 @@ impl ffi::GamesModel {
             clear_detail_images(self.as_mut());
             return;
         }
+
         let entry = &self.entries[index as usize];
         if entry.is_folder() {
             self.as_mut().set_current_detail_loading(false);
@@ -767,77 +755,17 @@ impl ffi::GamesModel {
             clear_detail_images(self.as_mut());
             return;
         }
+
         let description = entry.description.clone();
-        let title = entry.name.clone();
-        let system = entry_system_id(entry);
-        let path = entry.path.clone();
-        let filename = file_stem_or_name(&path, &title);
-        if !description.is_empty() {
-            self.as_mut()
-                .set_current_description(QString::from(description.as_str()));
-        }
-        if system.is_empty() || path.is_empty() {
-            self.as_mut().set_current_detail_loading(false);
-            self.as_mut().set_current_description(QString::default());
-            self.as_mut().set_current_detail_tags(QString::default());
-            clear_detail_images(self.as_mut());
-            return;
-        }
-        let cache_key = MediaKey::new(system.clone(), path.clone());
-        if let Some(metadata) = detail_metadata_cache_hit(self.as_mut(), &cache_key) {
-            self.as_mut().set_current_detail_loading(false);
-            apply_detail_metadata(self.as_mut(), metadata);
-            return;
-        }
-        clear_detail_images(self.as_mut());
-        self.as_mut().set_current_detail_tags(QString::default());
-        if description.is_empty() {
-            self.as_mut().set_current_description(QString::default());
-        }
-        self.as_mut().set_current_detail_loading(true);
-        let fallback_description = description;
-        let seq = self.rust().description_seq.clone();
-        let ticket = seq.load(Ordering::SeqCst);
-        let store = global_store();
-        let qt_thread = self.qt_thread();
-        global_handle().spawn(async move {
-            let result = store
-                .client()
-                .media_meta(MediaMetaParams::for_media(system.clone(), path.clone()))
-                .await;
-            let _ = qt_thread.queue(move |mut model| {
-                if seq.load(Ordering::SeqCst) != ticket {
-                    return;
-                }
-                let metadata = match result {
-                    Ok(result) => {
-                        let meta_description = description_from_meta(&result.media);
-                        Some(DetailMetadata {
-                            description: if meta_description.is_empty() {
-                                fallback_description
-                            } else {
-                                meta_description
-                            },
-                            tags: detail_tags_from_meta(&result.media, &filename),
-                            image_keys: detail_image_keys_from_meta(&result.media, &system, &path),
-                        })
-                    }
-                    Err(e) => {
-                        debug!("description fetch failed for {path}: {}", e.message);
-                        None
-                    }
-                };
-                model.as_mut().set_current_detail_loading(false);
-                if let Some(metadata) = metadata {
-                    cache_detail_metadata(model.as_mut(), cache_key, metadata.clone());
-                    apply_detail_metadata(model.as_mut(), metadata);
-                } else {
-                    model.as_mut().set_current_description(QString::default());
-                    model.as_mut().set_current_detail_tags(QString::default());
-                    clear_detail_images(model.as_mut());
-                }
-            });
-        });
+        let filename = file_stem_or_name(&entry.path, &entry.name);
+        let detail_tags = detail_tags_from_entry(entry, &filename);
+
+        self.as_mut().set_current_detail_loading(false);
+        self.as_mut()
+            .set_current_description(QString::from(description.as_str()));
+        self.as_mut()
+            .set_current_detail_tags(QString::from(detail_tags.as_str()));
+        clear_detail_images(self);
     }
 
     fn clear_current_detail(mut self: Pin<&mut Self>) {
@@ -1053,114 +981,50 @@ fn entry_system_id(entry: &BrowseEntry) -> String {
     entry.system_ids.first().cloned().unwrap_or_default()
 }
 
-fn description_from_meta(meta: &MediaMeta) -> String {
-    meta.title
-        .properties
-        .get("property:description")
-        .or_else(|| meta.properties.get("property:description"))
-        .map(|property| property.text.trim().to_string())
-        .filter(|text| !text.is_empty())
-        .unwrap_or_default()
+fn detail_tags_from_entry(entry: &BrowseEntry, filename: &str) -> String {
+    detail_tags_from_tags(entry.tags.as_slice(), filename)
 }
 
-fn detail_tags_from_meta<'a>(meta: &'a MediaMeta, filename: &'a str) -> String {
-    let source = if meta.title.tags.is_empty() {
-        meta.tags.as_slice()
-    } else {
-        meta.title.tags.as_slice()
-    };
-    let mut rows: Vec<(String, String)> = Vec::new();
-    for tag_type in [
-        "system",
-        "platform",
-        "year",
-        "release date",
-        "release_date",
-        "genre",
-        "players",
-        "play mode",
-        "play_mode",
-        "cooperative",
-        "developer",
-        "publisher",
-        "rating",
-    ] {
-        rows.extend(
-            source
-                .iter()
-                .filter(|tag| {
-                    tag.tag_type.eq_ignore_ascii_case(tag_type) && !tag.tag.trim().is_empty()
-                })
-                .map(|tag| (display_tag_label(&tag.tag_type), tag.tag.trim().to_string())),
-        );
-    }
-    rows.extend(
-        source
-            .iter()
-            .filter(|tag| {
-                !is_ordered_detail_tag(&tag.tag_type)
-                    && !tag.tag_type.trim().is_empty()
-                    && !tag.tag.trim().is_empty()
-            })
-            .map(|tag| (display_tag_label(&tag.tag_type), tag.tag.trim().to_string())),
-    );
-    let filename = filename.trim();
-    if !filename.is_empty() {
-        rows.push(("Filename".to_string(), filename.to_string()));
-    }
+fn detail_tags_from_tags(source: &[TagInfo], filename: &str) -> String {
+    let rows = [
+        (
+            "Year",
+            detail_value_for_aliases(source, &["year", "release date", "release_date"]),
+        ),
+        (
+            "Genre",
+            detail_value_for_aliases(source, &["genre", "gamegenre"]),
+        ),
+        ("Players", detail_value_for_aliases(source, &["players"])),
+        (
+            "Developer",
+            detail_value_for_aliases(source, &["developer"]),
+        ),
+        (
+            "Publisher",
+            detail_value_for_aliases(source, &["publisher"]),
+        ),
+        ("Rating", detail_value_for_aliases(source, &["rating"])),
+        ("Filename", filename.trim().to_string()),
+    ];
     rows.into_iter()
         .map(|(label, value)| format!("{label}\t{value}"))
         .collect::<Vec<_>>()
         .join("\n")
 }
 
-fn is_ordered_detail_tag(tag_type: &str) -> bool {
-    matches!(
-        tag_type
-            .trim()
-            .to_ascii_lowercase()
-            .replace('-', " ")
-            .as_str(),
-        "system"
-            | "platform"
-            | "year"
-            | "release date"
-            | "release_date"
-            | "genre"
-            | "players"
-            | "play mode"
-            | "play_mode"
-            | "cooperative"
-            | "developer"
-            | "publisher"
-            | "rating"
-    )
-}
-
-fn display_tag_label(tag_type: &str) -> String {
-    let normalized = tag_type
-        .trim()
-        .to_ascii_lowercase()
-        .replace(['-', '_'], " ");
-    match normalized.as_str() {
-        "release date" => "Release date".to_string(),
-        "play mode" => "Play mode".to_string(),
-        other => {
-            let mut words = other.split_whitespace();
-            let Some(first) = words.next() else {
-                return String::new();
-            };
-            let mut label = first.to_string();
-            if let Some(ch) = label.get_mut(0..1) {
-                ch.make_ascii_uppercase();
-            }
-            for word in words {
-                label.push(' ');
-                label.push_str(word);
-            }
-            label
-        }
-    }
+fn detail_value_for_aliases(source: &[TagInfo], aliases: &[&str]) -> String {
+    source
+        .iter()
+        .filter(|tag| {
+            aliases
+                .iter()
+                .any(|alias| tag.tag_type.eq_ignore_ascii_case(alias))
+                && !tag.tag.trim().is_empty()
+        })
+        .map(|tag| tag.tag.trim().to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 fn file_stem_or_name(path: &str, name: &str) -> String {
@@ -1177,79 +1041,6 @@ fn file_stem_or_name(path: &str, name: &str) -> String {
     }
 }
 
-fn detail_metadata_cache_hit(
-    mut model: Pin<&mut ffi::GamesModel>,
-    key: &MediaKey,
-) -> Option<DetailMetadata> {
-    let mut rust = model.as_mut().rust_mut();
-    let metadata = rust.detail_metadata_cache.get(key).cloned();
-    if metadata.is_some() {
-        rust.detail_metadata_lru.retain(|cached| cached != key);
-        rust.detail_metadata_lru.push_back(key.clone());
-    }
-    metadata
-}
-
-fn cache_detail_metadata(
-    mut model: Pin<&mut ffi::GamesModel>,
-    key: MediaKey,
-    metadata: DetailMetadata,
-) {
-    let mut rust = model.as_mut().rust_mut();
-    if rust.detail_metadata_cache.contains_key(&key) {
-        rust.detail_metadata_lru.retain(|cached| cached != &key);
-        rust.detail_metadata_lru.push_back(key.clone());
-    } else {
-        rust.detail_metadata_lru.push_back(key.clone());
-    }
-    rust.detail_metadata_cache.insert(key, metadata);
-    while rust.detail_metadata_lru.len() > DETAIL_METADATA_CACHE_CAP {
-        if let Some(oldest) = rust.detail_metadata_lru.pop_front() {
-            rust.detail_metadata_cache.remove(&oldest);
-        }
-    }
-}
-
-fn apply_detail_metadata(mut model: Pin<&mut ffi::GamesModel>, metadata: DetailMetadata) {
-    model
-        .as_mut()
-        .set_current_description(QString::from(metadata.description.as_str()));
-    model
-        .as_mut()
-        .set_current_detail_tags(QString::from(metadata.tags.as_str()));
-    install_detail_images(model, metadata.image_keys);
-}
-
-fn image_type_from_property_key(key: &str) -> Option<String> {
-    let suffix = key.strip_prefix("property:image")?;
-    if suffix.is_empty() {
-        return Some("image".to_string());
-    }
-    Some(suffix.trim_start_matches('-').to_string()).filter(|image_type| !image_type.is_empty())
-}
-
-fn detail_image_keys_from_meta(meta: &MediaMeta, system: &str, path: &str) -> Vec<MediaKey> {
-    let mut types = BTreeSet::<String>::new();
-    for key in meta
-        .title
-        .properties
-        .keys()
-        .chain(meta.properties.keys())
-        .filter_map(|key| image_type_from_property_key(key))
-    {
-        types.insert(key);
-    }
-    let mut ordered = Vec::new();
-    if types.remove("image") {
-        ordered.push("image".to_string());
-    }
-    ordered.extend(types);
-    ordered
-        .into_iter()
-        .map(|image_type| MediaKey::with_image_type(system, path, image_type))
-        .collect()
-}
-
 fn clear_detail_images(mut model: Pin<&mut ffi::GamesModel>) {
     model.as_mut().rust_mut().detail_image_keys.clear();
     model
@@ -1259,11 +1050,6 @@ fn clear_detail_images(mut model: Pin<&mut ffi::GamesModel>) {
     model.as_mut().set_current_detail_image_count(0);
     model.as_mut().set_current_detail_image_can_prev(false);
     model.as_mut().set_current_detail_image_can_next(false);
-}
-
-fn install_detail_images(mut model: Pin<&mut ffi::GamesModel>, keys: Vec<MediaKey>) {
-    model.as_mut().rust_mut().detail_image_keys = keys;
-    set_detail_image_index(model, 0);
 }
 
 fn set_detail_image_index(mut model: Pin<&mut ffi::GamesModel>, index: i32) {
@@ -2300,13 +2086,13 @@ mod tests {
 
     use super::{
         chunk_for_subbatching, compute_unresolved_keys, cover_key_for_with, decide_initial,
-        dedup_roots_drop_ancestors, display_name, entry_system_id, is_strict_ancestor_path,
-        leading_dir_count, media_key_for, position_of_game_path, prefetch_around_plan,
-        project_status, transform_entries, InitialAction, Projection,
+        dedup_roots_drop_ancestors, detail_tags_from_tags, display_name, entry_system_id,
+        is_strict_ancestor_path, leading_dir_count, media_key_for, position_of_game_path,
+        prefetch_around_plan, project_status, transform_entries, InitialAction, Projection,
     };
     use crate::media_image_cache::{MediaImageCache, MediaKey};
     use std::collections::HashSet;
-    use zaparoo_core::media_types::{BrowseEntry, MediaBrowseResult, Pagination};
+    use zaparoo_core::media_types::{BrowseEntry, MediaBrowseResult, Pagination, TagInfo};
     use zaparoo_core::platform::Platform;
     use zaparoo_core::remote_resource::ResourceStatus;
 
@@ -3028,5 +2814,53 @@ mod tests {
         let mut expected: Vec<String> = (15..30).rev().map(|i| format!("/g/{i}")).collect();
         expected.extend((0..15).rev().map(|i| format!("/g/{i}")));
         assert_eq!(paths, expected);
+    }
+
+    #[test]
+    fn detail_tags_emit_fixed_rows_with_blank_values() {
+        let tags = vec![TagInfo {
+            tag_type: "genre".into(),
+            tag: "Platformer".into(),
+        }];
+        let detail = detail_tags_from_tags(&tags, "mario");
+        let rows: Vec<&str> = detail.split('\n').collect();
+        assert_eq!(
+            rows,
+            vec![
+                "Year\t",
+                "Genre\tPlatformer",
+                "Players\t",
+                "Developer\t",
+                "Publisher\t",
+                "Rating\t",
+                "Filename\tmario",
+            ]
+        );
+    }
+
+    #[test]
+    fn detail_tags_match_aliases_and_join_multiple_values() {
+        let tags = vec![
+            TagInfo {
+                tag_type: "platform".into(),
+                tag: "Arcade".into(),
+            },
+            TagInfo {
+                tag_type: "release_date".into(),
+                tag: "1984".into(),
+            },
+            TagInfo {
+                tag_type: "gamegenre".into(),
+                tag: "Action".into(),
+            },
+            TagInfo {
+                tag_type: "genre".into(),
+                tag: "Shooter".into(),
+            },
+        ];
+        let detail = detail_tags_from_tags(&tags, "game");
+        let rows: Vec<&str> = detail.split('\n').collect();
+        assert_eq!(rows[0], "Year\t1984");
+        assert_eq!(rows[1], "Genre\tAction, Shooter");
     }
 }

--- a/rust/launcher/src/models/games.rs
+++ b/rust/launcher/src/models/games.rs
@@ -768,12 +768,13 @@ impl ffi::GamesModel {
         let detail_tags = detail_tags_from_entry(entry);
         let detail_image_key = media_key_for(entry);
 
-        self.as_mut().set_current_detail_loading(false);
+        self.as_mut().set_current_detail_loading(true);
         self.as_mut()
             .set_current_description(QString::from(description.as_str()));
         self.as_mut()
             .set_current_detail_tags(QString::from(detail_tags.as_str()));
-        set_detail_image_keys(self, detail_image_key);
+        set_detail_image_keys(self.as_mut(), detail_image_key);
+        self.as_mut().set_current_detail_loading(false);
     }
 
     fn clear_current_detail(mut self: Pin<&mut Self>) {

--- a/rust/launcher/src/models/games.rs
+++ b/rust/launcher/src/models/games.rs
@@ -158,6 +158,7 @@ pub struct GamesModelRust {
     current_detail_image_count: i32,
     current_detail_image_can_prev: bool,
     current_detail_image_can_next: bool,
+    cover_key_roles_enabled: bool,
     detail_image_keys: Vec<MediaKey>,
     // Watcher for the current initial-page subscription. Aborted on
     // every path swap so the prior watcher stops enqueuing callbacks
@@ -259,6 +260,7 @@ impl Default for GamesModelRust {
             current_detail_image_count: 0,
             current_detail_image_can_prev: false,
             current_detail_image_can_next: false,
+            cover_key_roles_enabled: true,
             detail_image_keys: Vec::new(),
             watcher: None,
             seq: Arc::new(AtomicU64::new(0)),
@@ -318,6 +320,7 @@ pub mod ffi {
         #[qproperty(i32, current_detail_image_count)]
         #[qproperty(bool, current_detail_image_can_prev)]
         #[qproperty(bool, current_detail_image_can_next)]
+        #[qproperty(bool, cover_key_roles_enabled)]
         #[qproperty(i32, visible_first_row)]
         type GamesModel = super::GamesModelRust;
 
@@ -447,7 +450,12 @@ impl ffi::GamesModel {
             ZAP_SCRIPT_ROLE => QVariant::from(&QString::from(entry.zap_script.as_str())),
             SYSTEM_ID_ROLE => QVariant::from(&QString::from(entry_system_id(entry).as_str())),
             COVER_KEY_ROLE => QVariant::from(&QString::from(
-                cover_key_for(entry, u32::try_from(self.page_size.max(1)).unwrap_or(1)).as_str(),
+                if self.cover_key_roles_enabled {
+                    cover_key_for(entry, u32::try_from(self.page_size.max(1)).unwrap_or(1))
+                } else {
+                    cover_placeholder_for(entry)
+                }
+                .as_str(),
             )),
             ENTRY_TYPE_ROLE => QVariant::from(&QString::from(entry.entry_type.as_str())),
             FILE_COUNT_ROLE => QVariant::from(&i32::try_from(entry.file_count).unwrap_or(i32::MAX)),
@@ -757,15 +765,15 @@ impl ffi::GamesModel {
         }
 
         let description = entry.description.clone();
-        let filename = file_stem_or_name(&entry.path, &entry.name);
-        let detail_tags = detail_tags_from_entry(entry, &filename);
+        let detail_tags = detail_tags_from_entry(entry);
+        let detail_image_key = media_key_for(entry);
 
         self.as_mut().set_current_detail_loading(false);
         self.as_mut()
             .set_current_description(QString::from(description.as_str()));
         self.as_mut()
             .set_current_detail_tags(QString::from(detail_tags.as_str()));
-        clear_detail_images(self);
+        set_detail_image_keys(self, detail_image_key);
     }
 
     fn clear_current_detail(mut self: Pin<&mut Self>) {
@@ -981,11 +989,11 @@ fn entry_system_id(entry: &BrowseEntry) -> String {
     entry.system_ids.first().cloned().unwrap_or_default()
 }
 
-fn detail_tags_from_entry(entry: &BrowseEntry, filename: &str) -> String {
-    detail_tags_from_tags(entry.tags.as_slice(), filename)
+fn detail_tags_from_entry(entry: &BrowseEntry) -> String {
+    detail_tags_from_tags(entry.tags.as_slice())
 }
 
-fn detail_tags_from_tags(source: &[TagInfo], filename: &str) -> String {
+fn detail_tags_from_tags(source: &[TagInfo]) -> String {
     let rows = [
         (
             "Year",
@@ -1005,7 +1013,6 @@ fn detail_tags_from_tags(source: &[TagInfo], filename: &str) -> String {
             detail_value_for_aliases(source, &["publisher"]),
         ),
         ("Rating", detail_value_for_aliases(source, &["rating"])),
-        ("Filename", filename.trim().to_string()),
     ];
     rows.into_iter()
         .map(|(label, value)| format!("{label}\t{value}"))
@@ -1052,6 +1059,19 @@ fn clear_detail_images(mut model: Pin<&mut ffi::GamesModel>) {
     model.as_mut().set_current_detail_image_can_next(false);
 }
 
+fn set_detail_image_keys(mut model: Pin<&mut ffi::GamesModel>, key: Option<MediaKey>) {
+    model.as_mut().rust_mut().detail_image_keys.clear();
+    if let Some(key) = key {
+        model.as_mut().rust_mut().detail_image_keys.push(key);
+    }
+    model.as_mut().set_current_detail_image_index(0);
+    let count = i32::try_from(model.detail_image_keys.len()).unwrap_or(i32::MAX);
+    model.as_mut().set_current_detail_image_count(count);
+    model.as_mut().set_current_detail_image_can_prev(false);
+    model.as_mut().set_current_detail_image_can_next(count > 1);
+    sync_current_detail_image_key_with_page_size(model, 1);
+}
+
 fn set_detail_image_index(mut model: Pin<&mut ffi::GamesModel>, index: i32) {
     let count = i32::try_from(model.detail_image_keys.len()).unwrap_or(i32::MAX);
     let clamped = if count <= 0 {
@@ -1070,7 +1090,15 @@ fn set_detail_image_index(mut model: Pin<&mut ffi::GamesModel>, index: i32) {
     sync_current_detail_image_key(model);
 }
 
-fn sync_current_detail_image_key(mut model: Pin<&mut ffi::GamesModel>) {
+fn sync_current_detail_image_key(model: Pin<&mut ffi::GamesModel>) {
+    let page_size = u32::try_from(model.page_size.max(1)).unwrap_or(1);
+    sync_current_detail_image_key_with_page_size(model, page_size);
+}
+
+fn sync_current_detail_image_key_with_page_size(
+    mut model: Pin<&mut ffi::GamesModel>,
+    page_size: u32,
+) {
     let index = model.current_detail_image_index;
     if index < 0 {
         model
@@ -1091,15 +1119,19 @@ fn sync_current_detail_image_key(mut model: Pin<&mut ffi::GamesModel>) {
         ));
     } else {
         if !cache.is_negative(&key) {
-            cache.enqueue_with_media_id(
-                key,
-                None,
-                u32::try_from(model.page_size.max(1)).unwrap_or(1),
-            );
+            cache.enqueue_with_media_id(key, None, page_size.max(1));
         }
         model
             .as_mut()
             .set_current_detail_image_key(QString::default());
+    }
+}
+
+fn cover_placeholder_for(entry: &BrowseEntry) -> String {
+    if entry.is_folder() {
+        "icons/Folder".to_string()
+    } else {
+        "icons/File".to_string()
     }
 }
 
@@ -2085,10 +2117,11 @@ mod tests {
     )]
 
     use super::{
-        chunk_for_subbatching, compute_unresolved_keys, cover_key_for_with, decide_initial,
-        dedup_roots_drop_ancestors, detail_tags_from_tags, display_name, entry_system_id,
-        is_strict_ancestor_path, leading_dir_count, media_key_for, position_of_game_path,
-        prefetch_around_plan, project_status, transform_entries, InitialAction, Projection,
+        chunk_for_subbatching, compute_unresolved_keys, cover_key_for_with, cover_placeholder_for,
+        decide_initial, dedup_roots_drop_ancestors, detail_tags_from_tags, display_name,
+        entry_system_id, is_strict_ancestor_path, leading_dir_count, media_key_for,
+        position_of_game_path, prefetch_around_plan, project_status, transform_entries,
+        InitialAction, Projection,
     };
     use crate::media_image_cache::{MediaImageCache, MediaKey};
     use std::collections::HashSet;
@@ -2513,6 +2546,18 @@ mod tests {
     }
 
     #[test]
+    fn cover_placeholder_never_returns_loading_icon() {
+        assert_eq!(
+            cover_placeholder_for(&media("smb", "/p/smb", "NES")),
+            "icons/File"
+        );
+        assert_eq!(
+            cover_placeholder_for(&folder("Games", "/x")),
+            "icons/Folder"
+        );
+    }
+
+    #[test]
     fn cover_key_for_media_negatively_memoed_returns_file_icon() {
         let entry = media("smb", "/p/smb", "NES");
         let key = media_key_for(&entry).expect("media has key");
@@ -2822,7 +2867,7 @@ mod tests {
             tag_type: "genre".into(),
             tag: "Platformer".into(),
         }];
-        let detail = detail_tags_from_tags(&tags, "mario");
+        let detail = detail_tags_from_tags(&tags);
         let rows: Vec<&str> = detail.split('\n').collect();
         assert_eq!(
             rows,
@@ -2833,7 +2878,6 @@ mod tests {
                 "Developer\t",
                 "Publisher\t",
                 "Rating\t",
-                "Filename\tmario",
             ]
         );
     }
@@ -2858,7 +2902,7 @@ mod tests {
                 tag: "Shooter".into(),
             },
         ];
-        let detail = detail_tags_from_tags(&tags, "game");
+        let detail = detail_tags_from_tags(&tags);
         let rows: Vec<&str> = detail.split('\n').collect();
         assert_eq!(rows[0], "Year\t1984");
         assert_eq!(rows[1], "Genre\tAction, Shooter");

--- a/rust/launcher/src/models/games.rs
+++ b/rust/launcher/src/models/games.rs
@@ -161,6 +161,7 @@ pub struct GamesModelRust {
     card_write_error: QString,
     current_description: QString,
     current_detail_tags: QString,
+    current_detail_loading: bool,
     current_detail_image_key: QString,
     current_detail_image_index: i32,
     current_detail_image_count: i32,
@@ -263,6 +264,7 @@ impl Default for GamesModelRust {
             card_write_error: QString::default(),
             current_description: QString::default(),
             current_detail_tags: QString::default(),
+            current_detail_loading: false,
             current_detail_image_key: QString::default(),
             current_detail_image_index: 0,
             current_detail_image_count: 0,
@@ -323,6 +325,7 @@ pub mod ffi {
         #[qproperty(QString, card_write_error)]
         #[qproperty(QString, current_description)]
         #[qproperty(QString, current_detail_tags)]
+        #[qproperty(bool, current_detail_loading)]
         #[qproperty(QString, current_detail_image_key)]
         #[qproperty(i32, current_detail_image_index)]
         #[qproperty(i32, current_detail_image_count)]
@@ -750,6 +753,7 @@ impl ffi::GamesModel {
             .description_seq
             .fetch_add(1, Ordering::SeqCst);
         if index < 0 || index >= self.count {
+            self.as_mut().set_current_detail_loading(false);
             self.as_mut().set_current_description(QString::default());
             self.as_mut().set_current_detail_tags(QString::default());
             clear_detail_images(self.as_mut());
@@ -757,6 +761,7 @@ impl ffi::GamesModel {
         }
         let entry = &self.entries[index as usize];
         if entry.is_folder() {
+            self.as_mut().set_current_detail_loading(false);
             self.as_mut().set_current_description(QString::default());
             self.as_mut().set_current_detail_tags(QString::default());
             clear_detail_images(self.as_mut());
@@ -772,6 +777,7 @@ impl ffi::GamesModel {
                 .set_current_description(QString::from(description.as_str()));
         }
         if system.is_empty() || path.is_empty() {
+            self.as_mut().set_current_detail_loading(false);
             self.as_mut().set_current_description(QString::default());
             self.as_mut().set_current_detail_tags(QString::default());
             clear_detail_images(self.as_mut());
@@ -779,6 +785,7 @@ impl ffi::GamesModel {
         }
         let cache_key = MediaKey::new(system.clone(), path.clone());
         if let Some(metadata) = detail_metadata_cache_hit(self.as_mut(), &cache_key) {
+            self.as_mut().set_current_detail_loading(false);
             apply_detail_metadata(self.as_mut(), metadata);
             return;
         }
@@ -787,6 +794,7 @@ impl ffi::GamesModel {
         if description.is_empty() {
             self.as_mut().set_current_description(QString::default());
         }
+        self.as_mut().set_current_detail_loading(true);
         let fallback_description = description;
         let seq = self.rust().description_seq.clone();
         let ticket = seq.load(Ordering::SeqCst);
@@ -810,7 +818,7 @@ impl ffi::GamesModel {
                             } else {
                                 meta_description
                             },
-                            tags: detail_tags_from_meta(&result.media, &title, &filename),
+                            tags: detail_tags_from_meta(&result.media, &filename),
                             image_keys: detail_image_keys_from_meta(&result.media, &system, &path),
                         })
                     }
@@ -819,6 +827,7 @@ impl ffi::GamesModel {
                         None
                     }
                 };
+                model.as_mut().set_current_detail_loading(false);
                 if let Some(metadata) = metadata {
                     cache_detail_metadata(model.as_mut(), cache_key, metadata.clone());
                     apply_detail_metadata(model.as_mut(), metadata);
@@ -836,6 +845,7 @@ impl ffi::GamesModel {
             .rust_mut()
             .description_seq
             .fetch_add(1, Ordering::SeqCst);
+        self.as_mut().set_current_detail_loading(false);
         self.as_mut().set_current_description(QString::default());
         self.as_mut().set_current_detail_tags(QString::default());
         clear_detail_images(self);
@@ -936,6 +946,7 @@ impl ffi::GamesModel {
         self.as_mut().set_current_path(QString::from(path.as_str()));
         self.as_mut().set_loading(true);
         self.as_mut().set_error_message(QString::default());
+        self.as_mut().set_current_detail_loading(false);
         self.as_mut().set_current_description(QString::default());
         self.as_mut().set_current_detail_tags(QString::default());
         self.as_mut()
@@ -1052,58 +1063,104 @@ fn description_from_meta(meta: &MediaMeta) -> String {
         .unwrap_or_default()
 }
 
-fn detail_tags_from_meta<'a>(
-    meta: &'a MediaMeta,
-    fallback_title: &'a str,
-    filename: &'a str,
-) -> String {
+fn detail_tags_from_meta<'a>(meta: &'a MediaMeta, filename: &'a str) -> String {
     let source = if meta.title.tags.is_empty() {
         meta.tags.as_slice()
     } else {
         meta.title.tags.as_slice()
     };
-    let mut rows: Vec<(&str, &str)> = Vec::new();
-    let meta_title = meta.title.name.trim();
-    let title = if meta_title.is_empty() {
-        fallback_title.trim()
-    } else {
-        meta_title
-    };
-    if !title.is_empty() {
-        rows.push(("title", title));
-    }
-    let filename = filename.trim();
-    if !filename.is_empty() {
-        rows.push(("filename", filename));
-    }
-    for tag_type in ["genre", "year", "rating"] {
+    let mut rows: Vec<(String, String)> = Vec::new();
+    for tag_type in [
+        "system",
+        "platform",
+        "year",
+        "release date",
+        "release_date",
+        "genre",
+        "players",
+        "play mode",
+        "play_mode",
+        "cooperative",
+        "developer",
+        "publisher",
+        "rating",
+    ] {
         rows.extend(
             source
                 .iter()
-                .filter(|tag| tag.tag_type == tag_type && !tag.tag.trim().is_empty())
-                .map(|tag| (tag.tag_type.as_str(), tag.tag.trim())),
+                .filter(|tag| {
+                    tag.tag_type.eq_ignore_ascii_case(tag_type) && !tag.tag.trim().is_empty()
+                })
+                .map(|tag| (display_tag_label(&tag.tag_type), tag.tag.trim().to_string())),
         );
     }
     rows.extend(
         source
             .iter()
             .filter(|tag| {
-                !matches!(tag.tag_type.as_str(), "genre" | "year" | "rating")
+                !is_ordered_detail_tag(&tag.tag_type)
                     && !tag.tag_type.trim().is_empty()
                     && !tag.tag.trim().is_empty()
             })
-            .map(|tag| (tag.tag_type.as_str(), tag.tag.trim())),
+            .map(|tag| (display_tag_label(&tag.tag_type), tag.tag.trim().to_string())),
     );
+    let filename = filename.trim();
+    if !filename.is_empty() {
+        rows.push(("Filename".to_string(), filename.to_string()));
+    }
     rows.into_iter()
-        .map(|(tag_type, value)| {
-            let mut label = tag_type.to_string();
-            if let Some(first) = label.get_mut(0..1) {
-                first.make_ascii_uppercase();
-            }
-            format!("{label}\t{value}")
-        })
+        .map(|(label, value)| format!("{label}\t{value}"))
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+fn is_ordered_detail_tag(tag_type: &str) -> bool {
+    matches!(
+        tag_type
+            .trim()
+            .to_ascii_lowercase()
+            .replace('-', " ")
+            .as_str(),
+        "system"
+            | "platform"
+            | "year"
+            | "release date"
+            | "release_date"
+            | "genre"
+            | "players"
+            | "play mode"
+            | "play_mode"
+            | "cooperative"
+            | "developer"
+            | "publisher"
+            | "rating"
+    )
+}
+
+fn display_tag_label(tag_type: &str) -> String {
+    let normalized = tag_type
+        .trim()
+        .to_ascii_lowercase()
+        .replace(['-', '_'], " ");
+    match normalized.as_str() {
+        "release date" => "Release date".to_string(),
+        "play mode" => "Play mode".to_string(),
+        other => {
+            let mut words = other.split_whitespace();
+            let Some(first) = words.next() else {
+                return String::new();
+            };
+            let mut label = first.to_string();
+            if let Some(ch) = label.get_mut(0..1) {
+                ch.make_ascii_uppercase();
+            }
+            for word in words {
+                label.push(' ');
+                label.push_str(word);
+            }
+            label
+        }
+    }
 }
 
 fn file_stem_or_name(path: &str, name: &str) -> String {

--- a/rust/launcher/src/models/games.rs
+++ b/rust/launcher/src/models/games.rs
@@ -1118,7 +1118,7 @@ fn sync_current_detail_image_key_with_page_size(
         model.as_mut().set_current_detail_image_key(QString::from(
             MediaImageCache::image_key_for(&key).as_str(),
         ));
-    } else if cache.is_negative(&key) {
+    } else if cache.is_negative(&key) || cache.is_soft_no_image(&key) {
         model
             .as_mut()
             .set_current_detail_image_key(QString::default());
@@ -1146,7 +1146,10 @@ fn cover_key_for(entry: &BrowseEntry, page_size: u32) -> String {
     let cache = global_media_image_cache();
     let cached = media_key.as_ref().is_some_and(|k| cache.is_cached(k));
     let negative = media_key.as_ref().is_some_and(|k| cache.is_negative(k));
-    if !cached && !negative {
+    let soft_no_image = media_key
+        .as_ref()
+        .is_some_and(|k| cache.is_soft_no_image(k));
+    if !cached && !negative && !soft_no_image {
         // Miss-driven re-enqueue: when QML asks for the cover URL of
         // a media entry whose bytes aren't in the cache, kick a fetch
         // right here. This is the only implicit path covers reach the
@@ -1160,7 +1163,7 @@ fn cover_key_for(entry: &BrowseEntry, page_size: u32) -> String {
             cache.enqueue_with_media_id(k.clone(), entry.media_id, page_size);
         }
     }
-    cover_key_for_with(entry, media_key.as_ref(), cached, negative)
+    cover_key_for_with(entry, media_key.as_ref(), cached, negative || soft_no_image)
 }
 
 /// Build the canonical `(systemId, path)` identifier for a media
@@ -1296,14 +1299,14 @@ fn cover_key_for_with(
     entry: &BrowseEntry,
     key: Option<&MediaKey>,
     cached: bool,
-    negative: bool,
+    unavailable: bool,
 ) -> String {
     if entry.is_folder() {
         return "icons/Folder".to_string();
     }
     match key {
         Some(k) if cached => MediaImageCache::image_key_for(k),
-        Some(_) if !negative => "icons/Loading".to_string(),
+        Some(_) if !unavailable => "icons/Loading".to_string(),
         _ => "icons/File".to_string(),
     }
 }
@@ -2567,6 +2570,16 @@ mod tests {
         // Not cached, but negatively memoed → there is no image to
         // wait for, fall back to the plain file icon (no stuck
         // hourglass).
+        assert_eq!(
+            cover_key_for_with(&entry, Some(&key), false, true),
+            "icons/File"
+        );
+    }
+
+    #[test]
+    fn cover_key_for_media_soft_missed_returns_file_icon() {
+        let entry = media("smb", "/p/smb", "NES");
+        let key = media_key_for(&entry).expect("media has key");
         assert_eq!(
             cover_key_for_with(&entry, Some(&key), false, true),
             "icons/File"

--- a/rust/launcher/src/models/games.rs
+++ b/rust/launcher/src/models/games.rs
@@ -1117,13 +1117,15 @@ fn sync_current_detail_image_key_with_page_size(
         model.as_mut().set_current_detail_image_key(QString::from(
             MediaImageCache::image_key_for(&key).as_str(),
         ));
-    } else {
-        if !cache.is_negative(&key) {
-            cache.enqueue_with_media_id(key, None, page_size.max(1));
-        }
+    } else if cache.is_negative(&key) {
         model
             .as_mut()
             .set_current_detail_image_key(QString::default());
+    } else {
+        cache.enqueue_with_media_id(key, None, page_size.max(1));
+        model
+            .as_mut()
+            .set_current_detail_image_key(QString::from("icons/Loading"));
     }
 }
 

--- a/rust/launcher/src/models/mod.rs
+++ b/rust/launcher/src/models/mod.rs
@@ -31,6 +31,7 @@ pub mod build_info;
 pub mod categories;
 pub mod favorites;
 pub mod favorites_state;
+pub mod game_info;
 pub mod games;
 pub mod games_state;
 pub mod hub_state;

--- a/rust/launcher/src/models/recents.rs
+++ b/rust/launcher/src/models/recents.rs
@@ -547,7 +547,7 @@ fn cover_key_for(entry: &MediaHistoryEntry) -> String {
             cache.enqueue_search_cover_with_media_id(k.clone(), entry.media_id, PAGE_SIZE);
         }
     }
-    cover_key_for_with(entry, media_key.as_ref(), cached, negative || soft_no_image)
+    cover_key_for_with(entry, media_key.as_ref(), cached, negative, soft_no_image)
 }
 
 /// Build the canonical `(systemId, mediaPath)` identifier for a history
@@ -575,13 +575,14 @@ fn cover_key_for_with(
     key: Option<&MediaKey>,
     cached: bool,
     negative: bool,
+    soft_no_image: bool,
 ) -> String {
     if entry.system_id.is_empty() {
         return "icons/File".to_string();
     }
     match key {
         Some(k) if cached => MediaImageCache::image_key_for(k),
-        Some(_) if !negative => "icons/Loading".to_string(),
+        Some(_) if !negative && !soft_no_image => "icons/Loading".to_string(),
         _ => format!("systems/{}", entry.system_id),
     }
 }
@@ -819,7 +820,7 @@ fn arm_cover_gate(mut model: Pin<&mut ffi::RecentsModel>) {
     let unresolved = compute_unresolved_keys(
         &model.entries,
         |k| cache.is_cached(k),
-        |k| cache.is_negative(k),
+        |k| cache.is_negative(k) || cache.is_soft_no_image(k),
     );
     if unresolved.is_empty() {
         model.as_mut().rust_mut().pending_first_paint_keys.clear();
@@ -987,7 +988,7 @@ mod tests {
         // Has a key, not cached, not negative → fetch is in flight,
         // show the hourglass over the tile.
         assert_eq!(
-            cover_key_for_with(&e, Some(&key), false, false),
+            cover_key_for_with(&e, Some(&key), false, false, false),
             "icons/Loading"
         );
     }
@@ -1000,7 +1001,7 @@ mod tests {
         // for. Fall back to the system logo (friendlier than icons/File
         // for favorites/recents lists).
         assert_eq!(
-            cover_key_for_with(&e, Some(&key), false, true),
+            cover_key_for_with(&e, Some(&key), false, true, false),
             "systems/NES"
         );
     }
@@ -1010,7 +1011,7 @@ mod tests {
         let e = entry("smb", "/p/smb", "NES", "NES");
         let key = media_key_for(&e).expect("media has key");
         assert_eq!(
-            cover_key_for_with(&e, Some(&key), false, true),
+            cover_key_for_with(&e, Some(&key), false, false, true),
             "systems/NES"
         );
     }
@@ -1020,14 +1021,20 @@ mod tests {
         let e = entry("smb", "/p/smb", "NES", "NES");
         let key = media_key_for(&e).expect("media has key");
         let expected = MediaImageCache::image_key_for(&key);
-        assert_eq!(cover_key_for_with(&e, Some(&key), true, false), expected);
+        assert_eq!(
+            cover_key_for_with(&e, Some(&key), true, false, false),
+            expected
+        );
         assert!(expected.starts_with("media-image/"));
     }
 
     #[test]
     fn cover_key_falls_back_to_file_glyph_when_system_missing() {
         let e = entry("orphan", "/p/orphan", "", "");
-        assert_eq!(cover_key_for_with(&e, None, false, false), "icons/File");
+        assert_eq!(
+            cover_key_for_with(&e, None, false, false, false),
+            "icons/File"
+        );
     }
 
     #[test]
@@ -1210,6 +1217,19 @@ mod tests {
         ];
         let unresolved =
             compute_unresolved_keys(&entries, |_| false, |k| k.path.as_ref() == negative_path);
+        let expected: HashSet<MediaKey> = [MediaKey::new("NES", "/p/smb")].into_iter().collect();
+        assert_eq!(unresolved, expected);
+    }
+
+    #[test]
+    fn compute_unresolved_keys_excludes_soft_no_image() {
+        let soft_path = "/p/soft-no-image";
+        let entries = vec![
+            entry("smb", "/p/smb", "NES", "NES"),
+            entry("orphan", soft_path, "NES", "NES"),
+        ];
+        let unresolved =
+            compute_unresolved_keys(&entries, |_| false, |k| k.path.as_ref() == soft_path);
         let expected: HashSet<MediaKey> = [MediaKey::new("NES", "/p/smb")].into_iter().collect();
         assert_eq!(unresolved, expected);
     }

--- a/rust/launcher/src/models/recents.rs
+++ b/rust/launcher/src/models/recents.rs
@@ -536,15 +536,18 @@ fn cover_key_for(entry: &MediaHistoryEntry) -> String {
     let cache = global_media_image_cache();
     let cached = media_key.as_ref().is_some_and(|k| cache.is_cached(k));
     let negative = media_key.as_ref().is_some_and(|k| cache.is_negative(k));
-    if !cached && !negative {
+    let soft_no_image = media_key
+        .as_ref()
+        .is_some_and(|k| cache.is_soft_no_image(k));
+    if !cached && !negative && !soft_no_image {
         // Miss-driven re-enqueue, same rationale as GamesModel's
         // `cover_key_for`: tiles re-bound after LRU eviction or stale-
         // enqueue truncation will hit this branch and re-arm the fetch.
         if let Some(k) = media_key.as_ref() {
-            cache.enqueue_with_media_id(k.clone(), entry.media_id, PAGE_SIZE);
+            cache.enqueue_search_cover_with_media_id(k.clone(), entry.media_id, PAGE_SIZE);
         }
     }
-    cover_key_for_with(entry, media_key.as_ref(), cached, negative)
+    cover_key_for_with(entry, media_key.as_ref(), cached, negative || soft_no_image)
 }
 
 /// Build the canonical `(systemId, mediaPath)` identifier for a history
@@ -656,12 +659,12 @@ fn sync_current_detail_image_key(mut model: Pin<&mut ffi::RecentsModel>) {
         model.as_mut().set_current_detail_image_key(QString::from(
             MediaImageCache::image_key_for(&key).as_str(),
         ));
-    } else if cache.is_negative(&key) {
+    } else if cache.is_negative(&key) || cache.is_soft_no_image(&key) {
         model
             .as_mut()
             .set_current_detail_image_key(QString::default());
     } else {
-        cache.enqueue_with_media_id(key, model.current_detail_media_id, 1);
+        cache.enqueue_search_cover_with_media_id(key, model.current_detail_media_id, 1);
         model
             .as_mut()
             .set_current_detail_image_key(QString::from("icons/Loading"));
@@ -683,10 +686,10 @@ fn file_stem_or_name(path: &str, name: &str) -> String {
 }
 
 /// Schedule a cover fetch for every history row with a non-empty
-/// `(systemId, mediaPath)`. `MediaImageCache::enqueue_with_media_id`
-/// is idempotent — already-cached, already-pending, or negatively-
-/// memoised keys are dropped — so spamming this from `apply_state` /
-/// `apply_append_page` is cheap.
+/// `(systemId, mediaPath)`. The cache enqueue is idempotent —
+/// already-cached, already-pending, or negatively-memoised keys are
+/// dropped — so spamming this from `apply_state` / `apply_append_page`
+/// is cheap.
 ///
 /// Iterates `entries` in reverse so the LIFO fetch queue drains in
 /// visual order: the last entry pushed is `entries[0]`, which the
@@ -695,7 +698,7 @@ fn enqueue_recents_covers(entries: &[MediaHistoryEntry]) {
     let cache = global_media_image_cache();
     for entry in entries.iter().rev() {
         if let Some(key) = media_key_for(entry) {
-            cache.enqueue_with_media_id(key, entry.media_id, PAGE_SIZE);
+            cache.enqueue_search_cover_with_media_id(key, entry.media_id, PAGE_SIZE);
         }
     }
 }
@@ -996,6 +999,16 @@ mod tests {
         // Has a key, not cached, negatively memoed → no image to wait
         // for. Fall back to the system logo (friendlier than icons/File
         // for favorites/recents lists).
+        assert_eq!(
+            cover_key_for_with(&e, Some(&key), false, true),
+            "systems/NES"
+        );
+    }
+
+    #[test]
+    fn cover_key_falls_back_to_system_logo_when_soft_missed() {
+        let e = entry("smb", "/p/smb", "NES", "NES");
+        let key = media_key_for(&e).expect("media has key");
         assert_eq!(
             cover_key_for_with(&e, Some(&key), false, true),
             "systems/NES"

--- a/rust/launcher/src/models/recents.rs
+++ b/rust/launcher/src/models/recents.rs
@@ -40,7 +40,8 @@ use zaparoo_core::client::ClientError;
 use zaparoo_core::endpoints::media_history::{HistoryArgs, MediaHistoryEndpoint};
 use zaparoo_core::endpoints::run::RunMutation;
 use zaparoo_core::media_types::{
-    MediaHistoryEntry, MediaHistoryParams, MediaHistoryResult, RunParams,
+    MediaHistoryEntry, MediaHistoryParams, MediaHistoryResult, MediaMeta, MediaMetaParams,
+    RunParams, TagInfo,
 };
 use zaparoo_core::remote_resource::ResourceStatus;
 
@@ -60,6 +61,13 @@ const FILE_STEM_ROLE: i32 = 256 + 7;
 const PAGE_SIZE: u32 = 25;
 
 #[derive(Default)]
+#[allow(
+    clippy::struct_excessive_bools,
+    reason = "the bools are independent qproperties surfaced to QML; collapsing them \
+              into an enum would force the QML side to read a single state property \
+              and re-derive each flag locally, which is exactly the work the bridge \
+              avoids"
+)]
 pub struct RecentsModelRust {
     entries: Vec<MediaHistoryEntry>,
     count: i32,
@@ -68,6 +76,12 @@ pub struct RecentsModelRust {
     error_message: QString,
     has_next_page: bool,
     next_cursor: Option<String>,
+    current_detail_loading: bool,
+    current_detail_tags: QString,
+    current_detail_image_key: QString,
+    current_detail_media_key: Option<MediaKey>,
+    current_detail_media_id: Option<i64>,
+    detail_seq: Arc<AtomicU64>,
     // Bumped whenever the cursor chain is reset by an initial
     // `apply_state` so any in-flight `fetch_more` callback can detect
     // its append no longer belongs to the current chain.
@@ -121,6 +135,9 @@ pub mod ffi {
         #[qproperty(bool, loading_more)]
         #[qproperty(QString, error_message)]
         #[qproperty(bool, has_next_page)]
+        #[qproperty(bool, current_detail_loading)]
+        #[qproperty(QString, current_detail_tags)]
+        #[qproperty(QString, current_detail_image_key)]
         type RecentsModel = super::RecentsModelRust;
 
         #[qinvokable]
@@ -137,6 +154,12 @@ pub mod ffi {
 
         #[qinvokable]
         fn system_id_at(self: &RecentsModel, index: i32) -> QString;
+
+        #[qinvokable]
+        fn load_detail_at(self: Pin<&mut RecentsModel>, index: i32);
+
+        #[qinvokable]
+        fn clear_current_detail(self: Pin<&mut RecentsModel>);
 
         #[qinvokable]
         fn index_for_path(self: &RecentsModel, path: &QString) -> i32;
@@ -233,6 +256,7 @@ fn apply_state(
         model.as_mut().ensure_cover_subscription();
         enqueue_recents_covers(&entries);
         let count = i32::try_from(entries.len()).unwrap_or(i32::MAX);
+        clear_current_detail_state(model.as_mut());
         model.as_mut().begin_reset_model();
         model.as_mut().rust_mut().entries = entries;
         model.as_mut().rust_mut().count = count;
@@ -267,6 +291,7 @@ fn apply_state(
         // Disarm the cover gate too: a stale timer firing during the
         // next Ready would clear loading prematurely.
         disarm_cover_gate(model.as_mut());
+        clear_current_detail_state(model.as_mut());
         model.as_mut().rust_mut().seq.fetch_add(1, Ordering::SeqCst);
         model.as_mut().rust_mut().next_cursor = None;
         if !model.loading {
@@ -281,6 +306,7 @@ fn apply_state(
         // Ready could otherwise append rows that don't belong to the
         // current chain.
         disarm_cover_gate(model.as_mut());
+        clear_current_detail_state(model.as_mut());
         model.as_mut().rust_mut().seq.fetch_add(1, Ordering::SeqCst);
         model.as_mut().rust_mut().next_cursor = None;
         if model.loading {
@@ -405,6 +431,57 @@ impl ffi::RecentsModel {
         QString::from(self.entries[index as usize].system_id.as_str())
     }
 
+    fn load_detail_at(mut self: Pin<&mut Self>, index: i32) {
+        let ticket = self
+            .as_mut()
+            .rust_mut()
+            .detail_seq
+            .fetch_add(1, Ordering::SeqCst)
+            + 1;
+        if index < 0 || index >= self.count {
+            clear_current_detail_state(self.as_mut());
+            return;
+        }
+        let entry = &self.entries[index as usize];
+        let system = entry.system_id.clone();
+        let path = entry.media_path.clone();
+        let media_id = entry.media_id;
+        if system.trim().is_empty() || path.trim().is_empty() {
+            clear_current_detail_state(self.as_mut());
+            return;
+        }
+        let detail_key = MediaKey::new(system.clone(), path.clone());
+        self.as_mut().rust_mut().current_detail_media_key = Some(detail_key);
+        self.as_mut().rust_mut().current_detail_media_id = media_id;
+        sync_current_detail_image_key(self.as_mut());
+        self.as_mut().set_current_detail_loading(false);
+        let seq = self.rust().detail_seq.clone();
+        let qt_thread = self.qt_thread();
+        let store = global_store();
+        global_handle().spawn(async move {
+            let result = store
+                .client()
+                .media_meta(MediaMetaParams::for_media(system, path.clone()))
+                .await;
+            let _ = qt_thread.queue(move |mut model| {
+                if seq.load(Ordering::SeqCst) != ticket {
+                    return;
+                }
+                model.as_mut().set_current_detail_loading(false);
+                match result {
+                    Ok(result) => model.as_mut().set_current_detail_tags(QString::from(
+                        detail_tags_from_meta(&result.media).as_str(),
+                    )),
+                    Err(e) => warn!("recent detail fetch failed for {path}: {}", e.message),
+                }
+            });
+        });
+    }
+
+    fn clear_current_detail(self: Pin<&mut Self>) {
+        clear_current_detail_state(self);
+    }
+
     fn index_for_path(&self, path: &QString) -> i32 {
         position_of_path(&self.entries, &path.to_string())
     }
@@ -502,6 +579,89 @@ fn cover_key_for_with(
     }
 }
 
+fn detail_tags_from_meta(meta: &MediaMeta) -> String {
+    let source = if meta.title.tags.is_empty() {
+        meta.tags.as_slice()
+    } else {
+        meta.title.tags.as_slice()
+    };
+    let rows = [
+        (
+            "Year",
+            detail_value_for_aliases(source, &["year", "release date", "release_date"]),
+        ),
+        (
+            "Genre",
+            detail_value_for_aliases(source, &["genre", "gamegenre"]),
+        ),
+        ("Players", detail_value_for_aliases(source, &["players"])),
+        (
+            "Developer",
+            detail_value_for_aliases(source, &["developer"]),
+        ),
+        (
+            "Publisher",
+            detail_value_for_aliases(source, &["publisher"]),
+        ),
+        ("Rating", detail_value_for_aliases(source, &["rating"])),
+    ];
+    rows.into_iter()
+        .map(|(label, value)| format!("{label}\t{value}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn detail_value_for_aliases(source: &[TagInfo], aliases: &[&str]) -> String {
+    source
+        .iter()
+        .filter(|tag| {
+            aliases
+                .iter()
+                .any(|alias| tag.tag_type.eq_ignore_ascii_case(alias))
+                && !tag.tag.trim().is_empty()
+        })
+        .map(|tag| tag.tag.trim().to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn clear_current_detail_state(mut model: Pin<&mut ffi::RecentsModel>) {
+    model
+        .as_mut()
+        .rust_mut()
+        .detail_seq
+        .fetch_add(1, Ordering::SeqCst);
+    model.as_mut().rust_mut().current_detail_media_key = None;
+    model.as_mut().rust_mut().current_detail_media_id = None;
+    model.as_mut().set_current_detail_loading(false);
+    model.as_mut().set_current_detail_tags(QString::default());
+    model
+        .as_mut()
+        .set_current_detail_image_key(QString::default());
+}
+
+fn sync_current_detail_image_key(mut model: Pin<&mut ffi::RecentsModel>) {
+    let Some(key) = model.current_detail_media_key.clone() else {
+        model
+            .as_mut()
+            .set_current_detail_image_key(QString::default());
+        return;
+    };
+    let cache = global_media_image_cache();
+    if cache.is_cached(&key) {
+        model.as_mut().set_current_detail_image_key(QString::from(
+            MediaImageCache::image_key_for(&key).as_str(),
+        ));
+    } else {
+        if !cache.is_negative(&key) {
+            cache.enqueue_with_media_id(key, model.current_detail_media_id, 1);
+        }
+        model
+            .as_mut()
+            .set_current_detail_image_key(QString::default());
+    }
+}
+
 fn file_stem_or_name(path: &str, name: &str) -> String {
     let file = path
         .trim_end_matches(['/', '\\'])
@@ -559,6 +719,13 @@ fn notify_cover_update(mut model: Pin<&mut ffi::RecentsModel>, key: &MediaKey) {
             let idx = model.index(row, 0, &parent);
             model.as_mut().data_changed(&idx, &idx, &roles);
         }
+    }
+    if model
+        .current_detail_media_key
+        .as_ref()
+        .is_some_and(|current| current == key)
+    {
+        sync_current_detail_image_key(model.as_mut());
     }
     // Tick the gate's pending set down. `remove` returns false if the
     // key wasn't gated (broadcast events fire for every cache update,

--- a/rust/launcher/src/models/recents.rs
+++ b/rust/launcher/src/models/recents.rs
@@ -652,13 +652,15 @@ fn sync_current_detail_image_key(mut model: Pin<&mut ffi::RecentsModel>) {
         model.as_mut().set_current_detail_image_key(QString::from(
             MediaImageCache::image_key_for(&key).as_str(),
         ));
-    } else {
-        if !cache.is_negative(&key) {
-            cache.enqueue_with_media_id(key, model.current_detail_media_id, 1);
-        }
+    } else if cache.is_negative(&key) {
         model
             .as_mut()
             .set_current_detail_image_key(QString::default());
+    } else {
+        cache.enqueue_with_media_id(key, model.current_detail_media_id, 1);
+        model
+            .as_mut()
+            .set_current_detail_image_key(QString::from("icons/Loading"));
     }
 }
 

--- a/rust/launcher/src/models/recents.rs
+++ b/rust/launcher/src/models/recents.rs
@@ -454,7 +454,8 @@ impl ffi::RecentsModel {
         self.as_mut().rust_mut().current_detail_media_key = Some(detail_key);
         self.as_mut().rust_mut().current_detail_media_id = media_id;
         sync_current_detail_image_key(self.as_mut());
-        self.as_mut().set_current_detail_loading(false);
+        self.as_mut().set_current_detail_loading(true);
+        self.as_mut().set_current_detail_tags(QString::default());
         let seq = self.rust().detail_seq.clone();
         let qt_thread = self.qt_thread();
         let store = global_store();
@@ -467,13 +468,16 @@ impl ffi::RecentsModel {
                 if seq.load(Ordering::SeqCst) != ticket {
                     return;
                 }
-                model.as_mut().set_current_detail_loading(false);
                 match result {
                     Ok(result) => model.as_mut().set_current_detail_tags(QString::from(
                         detail_tags_from_meta(&result.media).as_str(),
                     )),
-                    Err(e) => warn!("recent detail fetch failed for {path}: {}", e.message),
+                    Err(e) => {
+                        model.as_mut().set_current_detail_tags(QString::default());
+                        warn!("recent detail fetch failed for {path}: {}", e.message);
+                    }
                 }
+                model.as_mut().set_current_detail_loading(false);
             });
         });
     }

--- a/rust/launcher/src/models/systems.rs
+++ b/rust/launcher/src/models/systems.rs
@@ -31,6 +31,8 @@ pub struct SystemInfo {
     pub id: String,
     pub name: String,
     pub category: String,
+    pub release_date: Option<String>,
+    pub manufacturer: Option<String>,
 }
 
 #[derive(Default)]
@@ -102,6 +104,9 @@ pub mod ffi {
 
         #[qinvokable]
         fn system_name_at(self: &SystemsModel, index: i32) -> QString;
+
+        #[qinvokable]
+        fn detail_tags_at(self: &SystemsModel, index: i32) -> QString;
 
         #[qinvokable]
         fn write_card_at(self: Pin<&mut SystemsModel>, index: i32);
@@ -185,6 +190,8 @@ fn rows_for_category(catalog: Option<&CatalogData>, cat: &str) -> Vec<SystemInfo
                 id: s.id,
                 name: s.name,
                 category: s.category,
+                release_date: s.release_date,
+                manufacturer: s.manufacturer,
             })
             .collect()
     })
@@ -396,6 +403,13 @@ impl ffi::SystemsModel {
         QString::from(self.systems[index as usize].name.as_str())
     }
 
+    fn detail_tags_at(&self, index: i32) -> QString {
+        if index < 0 || index >= self.count {
+            return QString::default();
+        }
+        QString::from(detail_tags_for_system(&self.systems[index as usize]).as_str())
+    }
+
     fn launch_text_at(&self, index: i32) -> QString {
         if index < 0 || index >= self.count {
             return QString::default();
@@ -486,6 +500,34 @@ impl ffi::SystemsModel {
     }
 }
 
+fn detail_tags_for_system(system: &SystemInfo) -> String {
+    let rows = [
+        ("Category", system.category.trim().to_string()),
+        (
+            "Release date",
+            system
+                .release_date
+                .as_deref()
+                .unwrap_or_default()
+                .trim()
+                .to_string(),
+        ),
+        (
+            "Manufacturer",
+            system
+                .manufacturer
+                .as_deref()
+                .unwrap_or_default()
+                .trim()
+                .to_string(),
+        ),
+    ];
+    rows.into_iter()
+        .map(|(label, value)| format!("{label}\t{value}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(
@@ -495,7 +537,9 @@ mod tests {
         reason = "tests should fail-fast on unexpected errors"
     )]
 
-    use super::{position_of_system_id, project, rows_for_category, SystemInfo};
+    use super::{
+        detail_tags_for_system, position_of_system_id, project, rows_for_category, SystemInfo,
+    };
     use zaparoo_core::media_types::SystemInfo as MediaSystemInfo;
     use zaparoo_core::remote_resource::ResourceStatus;
     use zaparoo_core::systems_catalog::CatalogData;
@@ -505,6 +549,7 @@ mod tests {
             id: id.into(),
             name: name.into(),
             category: category.into(),
+            ..MediaSystemInfo::default()
         }
     }
 
@@ -582,6 +627,29 @@ mod tests {
     }
 
     #[test]
+    fn rows_for_category_preserves_system_metadata() {
+        let mut nes = sys("nes", "Nintendo Entertainment System", "Consoles");
+        nes.release_date = Some("1983".into());
+        nes.manufacturer = Some("Nintendo".into());
+        let catalog = catalog_with(vec![nes]);
+        let rows = rows_for_category(Some(&catalog), "Consoles");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].release_date.as_deref(), Some("1983"));
+        assert_eq!(rows[0].manufacturer.as_deref(), Some("Nintendo"));
+    }
+
+    #[test]
+    fn detail_tags_for_system_emits_fixed_rows() {
+        let mut system = local_sys("NES");
+        system.release_date = Some("1983".into());
+        system.manufacturer = Some("Nintendo".into());
+        assert_eq!(
+            detail_tags_for_system(&system),
+            "Category\tConsoles\nRelease date\t1983\nManufacturer\tNintendo"
+        );
+    }
+
+    #[test]
     fn rows_for_category_unknown_returns_empty() {
         let catalog = catalog_with(vec![sys("smb", "SMB", "Consoles")]);
         let rows = rows_for_category(Some(&catalog), "DoesNotExist");
@@ -593,6 +661,8 @@ mod tests {
             id: id.into(),
             name: id.into(),
             category: "Consoles".into(),
+            release_date: None,
+            manufacturer: None,
         }
     }
 

--- a/rust/zaparoo-core/src/endpoints/catalog.rs
+++ b/rust/zaparoo-core/src/endpoints/catalog.rs
@@ -93,6 +93,7 @@ mod tests {
             id: id.into(),
             name: name.into(),
             category: category.into(),
+            ..SystemInfo::default()
         }
     }
 

--- a/rust/zaparoo-core/src/endpoints/snapshots/zaparoo_core__endpoints__catalog__tests__shape_catalog_snapshot_matches_fixture.snap
+++ b/rust/zaparoo-core/src/endpoints/snapshots/zaparoo_core__endpoints__catalog__tests__shape_catalog_snapshot_matches_fixture.snap
@@ -1,5 +1,6 @@
 ---
 source: zaparoo-core/src/endpoints/catalog.rs
+assertion_line: 140
 expression: shape_catalog(systems)
 ---
 CatalogData {
@@ -8,26 +9,36 @@ CatalogData {
             id: "Gameboy",
             name: "Game Boy",
             category: "Handhelds",
+            release_date: None,
+            manufacturer: None,
         },
         SystemInfo {
             id: "MAME",
             name: "MAME",
             category: "arcade",
+            release_date: None,
+            manufacturer: None,
         },
         SystemInfo {
             id: "NES",
             name: "Nintendo",
             category: "Consoles",
+            release_date: None,
+            manufacturer: None,
         },
         SystemInfo {
             id: "odd",
             name: "Odd One",
             category: "",
+            release_date: None,
+            manufacturer: None,
         },
         SystemInfo {
             id: "SNES",
             name: "Super Nintendo",
             category: "Consoles",
+            release_date: None,
+            manufacturer: None,
         },
     ],
     categories: [

--- a/rust/zaparoo-core/src/media_types.rs
+++ b/rust/zaparoo-core/src/media_types.rs
@@ -12,6 +12,10 @@ pub struct SystemInfo {
     pub name: String,
     #[serde(default)]
     pub category: String,
+    #[serde(default)]
+    pub release_date: Option<String>,
+    #[serde(default)]
+    pub manufacturer: Option<String>,
 }
 
 /// Parameters for `media.search`. Mirrors Core's `SearchParams`

--- a/rust/zaparoo-core/src/systems_catalog.rs
+++ b/rust/zaparoo-core/src/systems_catalog.rs
@@ -42,6 +42,7 @@ mod tests {
             id: id.into(),
             name: name.into(),
             category: category.into(),
+            ..SystemInfo::default()
         }
     }
 

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -34,6 +34,7 @@ MainLayout {
 
     readonly property string modalCardWrite: "card_write"
     readonly property string modalContextMenu: "context_menu"
+    readonly property string modalGameInfo: "game_info"
     readonly property string modalQrCode: "qr_code"
     readonly property string modalCommercialNotice: "commercial_notice"
     readonly property string modalFirstRunIndex: "first_run_index"
@@ -704,6 +705,7 @@ MainLayout {
     onActiveCardWritePendingChanged: root.handleCardWriteStatus()
     onActiveCardWriteErrorChanged: root.handleCardWriteStatus()
     onCancelCardWriteRequested: root.cancelCardWrite()
+    onCloseGameInfoRequested: root.closeGameInfoModal()
     onCloseQrCodeRequested: root.closeQrCodeModal()
     onContextMenuCloseRequested: root.handleContextMenuCloseRequested()
     onContextMenuAccepted: id => root.handleContextMenuAccepted(id)
@@ -755,6 +757,10 @@ MainLayout {
         if (owner === "recents") {
             const entries = [
                 {
+                    id: "more_info",
+                    label: qsTr("More info")
+                },
+                {
                     id: "launch_game",
                     label: qsTr("Launch game")
                 }
@@ -769,12 +775,15 @@ MainLayout {
         if (owner === "games" || owner === "favorites") {
             if (entryType === "directory" || entryType === "root")
                 return [];
-            const entries = [
-                {
-                    id: "toggle_favorite",
-                    label: isFavorite ? qsTr("Remove from favorites") : qsTr("Add to favorites")
-                }
-            ];
+            const entries = [];
+            entries.push({
+                id: "more_info",
+                label: qsTr("More info")
+            });
+            entries.push({
+                id: "toggle_favorite",
+                label: isFavorite ? qsTr("Remove from favorites") : qsTr("Add to favorites")
+            });
             if (hasNfc)
                 entries.push({
                     id: "write_card",
@@ -940,6 +949,8 @@ MainLayout {
                 Browse.GamesModel.toggle_favorite_at(targetIndex);
             else if (owner === "favorites")
                 Browse.FavoritesModel.toggle_favorite_at(targetIndex);
+        } else if (id === "more_info") {
+            root.openGameInfo(owner, targetIndex);
         } else if (id === "write_card") {
             if (owner === "systems") {
                 root.beginCardWrite("systems");
@@ -960,6 +971,38 @@ MainLayout {
         } else if (id === "discover_unavailable" || id === "discover_loading") {
             return;
         }
+    }
+
+    function openGameInfo(owner: string, index: int): void {
+        let systemId = "";
+        let path = "";
+        let title = "";
+        if (owner === "games") {
+            systemId = Browse.GamesModel.system_id_at(index);
+            path = Browse.GamesModel.path_at(index);
+            title = Browse.GamesModel.name_at(index);
+        } else if (owner === "favorites") {
+            systemId = Browse.FavoritesModel.system_id_at(index);
+            path = Browse.FavoritesModel.path_at(index);
+            title = Browse.FavoritesModel.name_at(index);
+        } else if (owner === "recents") {
+            systemId = Browse.RecentsModel.system_id_at(index);
+            path = Browse.RecentsModel.path_at(index);
+            title = Browse.RecentsModel.name_at(index);
+        }
+        if (systemId === "" || path === "")
+            return;
+        Browse.GameInfo.load(systemId, path, title);
+        root.gameInfoModalVisible = true;
+        if (ScreenManager.topModal !== root.modalGameInfo)
+            ScreenManager.pushModal(root.modalGameInfo);
+    }
+
+    function closeGameInfoModal(): void {
+        root.gameInfoModalVisible = false;
+        Browse.GameInfo.clear();
+        if (ScreenManager.topModal === root.modalGameInfo)
+            ScreenManager.popModal();
     }
 
     function openQrCodeModal(): void {
@@ -1300,6 +1343,8 @@ MainLayout {
                 root.cancelCardWrite();
             } else if (ScreenManager.topModal === root.modalQrCode && action === "cancel") {
                 root.closeQrCodeModal();
+            } else if (ScreenManager.topModal === root.modalGameInfo) {
+                root.gameInfoModal.handleAction(action);
             } else if (ScreenManager.topModal === root.modalContextMenu) {
                 root.contextMenu.handleAction(action);
             } else if (ScreenManager.topModal === root.modalFirstRunIndex) {

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -757,10 +757,6 @@ MainLayout {
         if (owner === "recents") {
             const entries = [
                 {
-                    id: "more_info",
-                    label: qsTr("View details")
-                },
-                {
                     id: "launch_game",
                     label: qsTr("Launch game")
                 }
@@ -776,10 +772,6 @@ MainLayout {
             if (entryType === "directory" || entryType === "root")
                 return [];
             const entries = [];
-            entries.push({
-                id: "more_info",
-                label: qsTr("View details")
-            });
             entries.push({
                 id: "toggle_favorite",
                 label: isFavorite ? qsTr("Remove from favorites") : qsTr("Add to favorites")

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -758,7 +758,7 @@ MainLayout {
             const entries = [
                 {
                     id: "more_info",
-                    label: qsTr("More info")
+                    label: qsTr("View details")
                 },
                 {
                     id: "launch_game",
@@ -778,7 +778,7 @@ MainLayout {
             const entries = [];
             entries.push({
                 id: "more_info",
-                label: qsTr("More info")
+                label: qsTr("View details")
             });
             entries.push({
                 id: "toggle_favorite",

--- a/src/ui/app/MainLayout.qml
+++ b/src/ui/app/MainLayout.qml
@@ -206,6 +206,7 @@ ApplicationWindow {
     property alias contextMenu: contextMenu
     property alias commercialNoticeModal: commercialNoticeModal
     property alias firstRunIndexModal: firstRunIndexModal
+    property alias gameInfoModal: gameInfoModal
     property alias logUploadModal: logUploadModal
     property alias quitConfirmModal: quitConfirmModal
     property alias settingNeedsRestartModal: settingNeedsRestartModal
@@ -224,6 +225,7 @@ ApplicationWindow {
     property bool qrCodeModalVisible: false
     property bool commercialNoticeModalVisible: false
     property bool firstRunIndexModalVisible: false
+    property bool gameInfoModalVisible: false
     property bool logUploadModalVisible: false
     property bool quitConfirmModalVisible: false
     property bool listPickerModalVisible: false
@@ -250,6 +252,7 @@ ApplicationWindow {
 
     signal contextMenuAccepted(string id)
     signal contextMenuCloseRequested
+    signal closeGameInfoRequested
 
     // Forward-transition state owned by Main.qml. "" while idle;
     // "systems" or "games" while waiting on a model fill before
@@ -574,6 +577,14 @@ ApplicationWindow {
             open: root.qrCodeModalVisible
         }
 
+        GameInfoModal {
+            id: gameInfoModal
+
+            anchors.fill: parent
+            open: root.gameInfoModalVisible
+            onCloseRequested: root.closeGameInfoRequested()
+        }
+
         // First-run mediadb index modal. Pushed by Main.qml the first time
         // we connect to a Core whose mediadb is empty. Blocks the screens
         // beneath until the initial scan completes (or the user cancels and
@@ -713,7 +724,7 @@ ApplicationWindow {
                             label: qsTr("Cancel")
                         }
                     ];
-                if (root.qrCodeModalVisible)
+                if (root.qrCodeModalVisible || root.gameInfoModalVisible)
                     return [
                         {
                             button: "ButtonB",

--- a/src/ui/components/BrowseDetailPane.qml
+++ b/src/ui/components/BrowseDetailPane.qml
@@ -17,149 +17,205 @@ Item {
     property string detailTags: ""
     property bool canPreviousImage: false
     property bool canNextImage: false
+    property bool loading: false
 
+    property int _labelColumnWidth: 0
+
+    readonly property int _cardPaddingX: Sizing.pctW(2)
+    readonly property int _cardPaddingY: Sizing.pctH(2)
     readonly property int _carouselGutter: (canPreviousImage || canNextImage) ? Sizing.pctW(4) : 0
+    readonly property int _tagLabelGap: Sizing.pctW(1.4)
+    readonly property int _tagRowCount: detailTags === "" ? 0 : detailTags.split("\n").length
+    readonly property int _tagRowSpacing: Sizing.pctH(0.8)
+    readonly property int _metadataNaturalHeight: _tagRowCount <= 0 ? 0 : (_tagRowCount * Sizing.pctH(3)) + ((_tagRowCount - 1) * _tagRowSpacing)
+    readonly property int _compactDetailHeight: loading ? Sizing.pctH(12) : Math.min(Sizing.px(content.height * 0.45), _metadataNaturalHeight)
+    readonly property bool _coverPending: coverKey === "icons/Loading"
+    readonly property url _coverSource: _coverPending ? "" : Resources.coverUrl(coverKey)
+
+    onDetailTagsChanged: root._labelColumnWidth = 0
+
+    Rectangle {
+        anchors.fill: parent
+        color: Theme.surfaceCard
+        border.width: Sizing.stroke(1)
+        border.color: Theme.borderMid
+        radius: Sizing.cornerRadius
+    }
 
     Item {
-        id: imageSlot
+        id: content
 
-        anchors.left: parent.left
-        anchors.leftMargin: root._carouselGutter
-        anchors.right: parent.right
-        anchors.rightMargin: root._carouselGutter
-        anchors.top: parent.top
-        height: Sizing.px(parent.height * 0.5)
-
-        Image {
-            id: cover
-            anchors.fill: parent
-            source: Resources.coverUrl(root.coverKey)
-            fillMode: Image.PreserveAspectFit
-            sourceSize.width: 512
-            smooth: true
-            asynchronous: true
-            visible: root.coverKey !== "" && status === Image.Ready
-        }
-    }
-
-    Image {
-        source: Resources.iconUrl("NavLeft")
-        width: Sizing.pctH(4)
-        height: width
-        anchors.left: parent.left
-        anchors.verticalCenter: imageSlot.verticalCenter
-        fillMode: Image.PreserveAspectFit
-        smooth: true
-        visible: root.canPreviousImage
-    }
-
-    Image {
-        source: Resources.iconUrl("NavRight")
-        width: Sizing.pctH(4)
-        height: width
-        anchors.right: parent.right
-        anchors.verticalCenter: imageSlot.verticalCenter
-        fillMode: Image.PreserveAspectFit
-        smooth: true
-        visible: root.canNextImage
-    }
-
-    Text {
-        id: titleText
-
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.top: imageSlot.bottom
-        anchors.topMargin: Sizing.pctH(3)
-        text: root.title
-        color: Theme.textPrimary
-        font.family: Theme.fontUi
-        font.pixelSize: Sizing.fontSize(3.2)
-        wrapMode: Text.Wrap
-        maximumLineCount: 3
-        elide: Text.ElideRight
-        horizontalAlignment: Text.AlignHCenter
-        renderType: Text.NativeRendering
-        visible: root.showTitle && root.title !== ""
-    }
-
-    Column {
-        id: tagTable
-
-        visible: root.detailTags !== ""
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.top: imageSlot.bottom
-        anchors.topMargin: Sizing.pctH(3)
-        anchors.bottom: parent.bottom
-        spacing: Sizing.pctH(0.8)
+        anchors.fill: parent
+        anchors.leftMargin: root._cardPaddingX
+        anchors.rightMargin: root._cardPaddingX
+        anchors.topMargin: root._cardPaddingY
+        anchors.bottomMargin: root._cardPaddingY
         clip: true
 
-        Repeater {
-            model: root.detailTags === "" ? [] : root.detailTags.split("\n")
+        Item {
+            id: imageSlot
 
-            delegate: Item {
-                id: tagRow
+            anchors.left: parent.left
+            anchors.leftMargin: root._carouselGutter
+            anchors.right: parent.right
+            anchors.rightMargin: root._carouselGutter
+            anchors.top: parent.top
+            height: root.showTitle ? Sizing.px(parent.height * 0.48) : Math.max(0, detailBody.y - Sizing.pctH(2))
 
-                required property string modelData
+            Image {
+                id: cover
+                anchors.fill: parent
+                source: root._coverSource
+                fillMode: Image.PreserveAspectFit
+                sourceSize.width: 512
+                smooth: true
+                asynchronous: true
+                visible: root._coverSource !== "" && status === Image.Ready
+            }
 
-                width: tagTable.width
-                height: Math.max(Sizing.pctH(3), tagValue.paintedHeight)
+            Image {
+                id: loadingGlyph
 
-                readonly property list<string> parts: modelData.split("\t")
-                readonly property bool isFilename: parts.length > 0 && parts[0] === "Filename"
+                x: Sizing.center(parent.width, width)
+                y: Sizing.center(parent.height, height)
+                width: Math.min(Sizing.pctH(10), parent.width, parent.height)
+                height: width
+                source: Resources.iconUrl("Loading")
+                sourceSize.width: Sizing.px(width)
+                sourceSize.height: Sizing.px(height)
+                fillMode: Image.PreserveAspectFit
+                smooth: true
+                asynchronous: false
+                visible: root._coverPending || cover.status === Image.Loading
+            }
+        }
 
-                Text {
-                    id: tagType
+        Image {
+            source: Resources.iconUrl("NavLeft")
+            width: Sizing.pctH(4)
+            height: width
+            anchors.left: parent.left
+            anchors.verticalCenter: imageSlot.verticalCenter
+            fillMode: Image.PreserveAspectFit
+            smooth: true
+            visible: root.canPreviousImage
+        }
 
-                    anchors.left: parent.left
-                    anchors.top: parent.top
-                    width: Sizing.pctW(9)
-                    text: tagRow.parts.length > 0 ? tagRow.parts[0] : ""
-                    color: Theme.textLabel
-                    font.family: Theme.fontUi
-                    font.pixelSize: Sizing.fontSize(2.2)
-                    elide: Text.ElideRight
-                    horizontalAlignment: Text.AlignRight
-                    renderType: Text.NativeRendering
-                }
+        Image {
+            source: Resources.iconUrl("NavRight")
+            width: Sizing.pctH(4)
+            height: width
+            anchors.right: parent.right
+            anchors.verticalCenter: imageSlot.verticalCenter
+            fillMode: Image.PreserveAspectFit
+            smooth: true
+            visible: root.canNextImage
+        }
 
-                Text {
-                    id: tagValue
+        Text {
+            id: titleText
 
-                    anchors.left: tagType.right
-                    anchors.leftMargin: Sizing.pctW(1.4)
-                    anchors.right: parent.right
-                    anchors.top: parent.top
-                    text: tagRow.parts.length > 1 ? tagRow.parts[1] : ""
-                    color: Theme.textPrimary
-                    font.family: Theme.fontUi
-                    font.pixelSize: Sizing.fontSize(2.2)
-                    wrapMode: Text.Wrap
-                    maximumLineCount: tagRow.isFilename ? 8 : 2
-                    elide: tagRow.isFilename ? Text.ElideNone : Text.ElideRight
-                    horizontalAlignment: Text.AlignLeft
-                    renderType: Text.NativeRendering
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.top: imageSlot.bottom
+            anchors.topMargin: Sizing.pctH(2)
+            text: root.title
+            color: Theme.textPrimary
+            font.family: Theme.fontUi
+            font.pixelSize: Sizing.fontSize(3.2)
+            wrapMode: Text.Wrap
+            maximumLineCount: 3
+            elide: Text.ElideRight
+            horizontalAlignment: Text.AlignLeft
+            renderType: Text.NativeRendering
+            visible: root.showTitle && root.title !== ""
+        }
+
+        Item {
+            id: detailBody
+
+            x: 0
+            y: root.showTitle ? (titleText.visible ? titleText.y + titleText.height : imageSlot.y + imageSlot.height) + Sizing.pctH(2) : parent.height - height
+            width: parent.width
+            height: root.showTitle ? Math.max(0, parent.height - y) : root._compactDetailHeight
+            clip: true
+
+            LoadingIndicator {
+                visible: root.loading
+                x: Sizing.center(parent.width, width)
+                y: Sizing.center(parent.height, height)
+                text: qsTr("Loading details…")
+            }
+
+            Column {
+                id: tagTable
+
+                visible: !root.loading && root.detailTags !== ""
+                anchors.fill: parent
+                spacing: root._tagRowSpacing
+                clip: true
+
+                Repeater {
+                    model: root.detailTags === "" ? [] : root.detailTags.split("\n")
+
+                    delegate: Item {
+                        id: tagRow
+
+                        required property string modelData
+
+                        width: tagTable.width
+                        height: Math.max(Sizing.pctH(3), tagValue.paintedHeight)
+
+                        readonly property list<string> parts: modelData.split("\t")
+                        readonly property string label: parts.length > 0 ? parts[0] : ""
+                        readonly property string value: parts.length > 1 ? parts[1] : ""
+                        readonly property bool isFilename: label === "Filename"
+
+                        TextMetrics {
+                            id: labelMetrics
+                            text: tagRow.label
+                            font.family: Theme.fontUi
+                            font.pixelSize: Sizing.fontSize(2.2)
+                            onAdvanceWidthChanged: root._labelColumnWidth = Math.max(root._labelColumnWidth, Math.ceil(advanceWidth))
+                        }
+
+                        Component.onCompleted: root._labelColumnWidth = Math.max(root._labelColumnWidth, Math.ceil(labelMetrics.advanceWidth))
+
+                        Text {
+                            id: tagType
+
+                            anchors.left: parent.left
+                            anchors.top: parent.top
+                            width: root._labelColumnWidth
+                            text: tagRow.label
+                            color: Theme.textLabel
+                            font.family: Theme.fontUi
+                            font.pixelSize: Sizing.fontSize(2.2)
+                            elide: Text.ElideRight
+                            horizontalAlignment: Text.AlignLeft
+                            renderType: Text.NativeRendering
+                        }
+
+                        Text {
+                            id: tagValue
+
+                            anchors.left: parent.left
+                            anchors.leftMargin: root._labelColumnWidth + root._tagLabelGap
+                            anchors.right: parent.right
+                            anchors.top: parent.top
+                            text: tagRow.value
+                            color: Theme.textPrimary
+                            font.family: Theme.fontUi
+                            font.pixelSize: Sizing.fontSize(2.2)
+                            wrapMode: Text.Wrap
+                            maximumLineCount: tagRow.isFilename ? 8 : 2
+                            elide: tagRow.isFilename ? Text.ElideNone : Text.ElideRight
+                            horizontalAlignment: Text.AlignLeft
+                            renderType: Text.NativeRendering
+                        }
+                    }
                 }
             }
         }
-    }
-
-    Text {
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.top: titleText.bottom
-        anchors.topMargin: Sizing.pctH(2)
-        anchors.bottom: parent.bottom
-        text: root.description
-        color: Theme.textLabel
-        font.family: Theme.fontUi
-        font.pixelSize: Sizing.fontSize(2.2)
-        wrapMode: Text.Wrap
-        elide: Text.ElideRight
-        horizontalAlignment: Text.AlignLeft
-        verticalAlignment: Text.AlignTop
-        renderType: Text.NativeRendering
-        visible: root.showDescription && root.description !== ""
     }
 }

--- a/src/ui/components/BrowseDetailPane.qml
+++ b/src/ui/components/BrowseDetailPane.qml
@@ -18,21 +18,21 @@ Item {
     property bool canPreviousImage: false
     property bool canNextImage: false
     property bool loading: false
-
-    property int _labelColumnWidth: 0
+    property bool showChrome: true
+    property string loadingText: qsTr("Loading…")
 
     readonly property int _cardPaddingX: Sizing.pctW(2)
     readonly property int _cardPaddingY: Sizing.pctH(2)
     readonly property int _carouselGutter: (canPreviousImage || canNextImage) ? Sizing.pctW(4) : 0
+    readonly property int _labelColumnWidth: Sizing.pctW(8)
     readonly property int _tagLabelGap: Sizing.pctW(1.4)
     readonly property int _tagRowCount: detailTags === "" ? 0 : detailTags.split("\n").length
     readonly property int _tagRowSpacing: Sizing.pctH(0.8)
     readonly property int _metadataNaturalHeight: _tagRowCount <= 0 ? 0 : (_tagRowCount * Sizing.pctH(3)) + ((_tagRowCount - 1) * _tagRowSpacing)
-    readonly property int _compactDetailHeight: loading ? Sizing.pctH(12) : Math.min(Sizing.px(content.height * 0.45), _metadataNaturalHeight)
+    readonly property int _compactDetailHeight: Math.min(Sizing.px(content.height * 0.45), Math.max(Sizing.pctH(12), _metadataNaturalHeight))
     readonly property bool _coverPending: coverKey === "icons/Loading"
     readonly property url _coverSource: _coverPending ? "" : Resources.coverUrl(coverKey)
-
-    onDetailTagsChanged: root._labelColumnWidth = 0
+    readonly property bool _paneLoading: root.loading
 
     Rectangle {
         anchors.fill: parent
@@ -40,6 +40,7 @@ Item {
         border.width: Sizing.stroke(1)
         border.color: Theme.borderMid
         radius: Sizing.cornerRadius
+        visible: root.showChrome
     }
 
     Item {
@@ -70,23 +71,21 @@ Item {
                 sourceSize.width: 512
                 smooth: true
                 asynchronous: true
-                visible: root._coverSource !== "" && status === Image.Ready
+                visible: !root._paneLoading && root._coverSource !== "" && status === Image.Ready
             }
 
             Image {
-                id: loadingGlyph
-
                 x: Sizing.center(parent.width, width)
                 y: Sizing.center(parent.height, height)
                 width: Math.min(Sizing.pctH(10), parent.width, parent.height)
                 height: width
-                source: Resources.iconUrl("Loading")
+                source: Resources.iconUrl(root._coverPending || cover.status === Image.Loading ? "Loading" : "File")
                 sourceSize.width: Sizing.px(width)
                 sourceSize.height: Sizing.px(height)
                 fillMode: Image.PreserveAspectFit
                 smooth: true
                 asynchronous: false
-                visible: root._coverPending || cover.status === Image.Loading
+                visible: !root._paneLoading && (root._coverPending || cover.status === Image.Loading || root._coverSource === "" || cover.status === Image.Error)
             }
         }
 
@@ -98,7 +97,7 @@ Item {
             anchors.verticalCenter: imageSlot.verticalCenter
             fillMode: Image.PreserveAspectFit
             smooth: true
-            visible: root.canPreviousImage
+            visible: !root._paneLoading && root.canPreviousImage
         }
 
         Image {
@@ -109,7 +108,7 @@ Item {
             anchors.verticalCenter: imageSlot.verticalCenter
             fillMode: Image.PreserveAspectFit
             smooth: true
-            visible: root.canNextImage
+            visible: !root._paneLoading && root.canNextImage
         }
 
         Text {
@@ -128,7 +127,7 @@ Item {
             elide: Text.ElideRight
             horizontalAlignment: Text.AlignLeft
             renderType: Text.NativeRendering
-            visible: root.showTitle && root.title !== ""
+            visible: !root._paneLoading && root.showTitle && root.title !== ""
         }
 
         Item {
@@ -140,17 +139,10 @@ Item {
             height: root.showTitle ? Math.max(0, parent.height - y) : root._compactDetailHeight
             clip: true
 
-            LoadingIndicator {
-                visible: root.loading
-                x: Sizing.center(parent.width, width)
-                y: Sizing.center(parent.height, height)
-                text: qsTr("Loading details…")
-            }
-
             Column {
                 id: tagTable
 
-                visible: !root.loading && root.detailTags !== ""
+                visible: !root._paneLoading && root.detailTags !== ""
                 anchors.fill: parent
                 spacing: root._tagRowSpacing
                 clip: true
@@ -170,16 +162,6 @@ Item {
                         readonly property string label: parts.length > 0 ? parts[0] : ""
                         readonly property string value: parts.length > 1 ? parts[1] : ""
                         readonly property bool isFilename: label === "Filename"
-
-                        TextMetrics {
-                            id: labelMetrics
-                            text: tagRow.label
-                            font.family: Theme.fontUi
-                            font.pixelSize: Sizing.fontSize(2.2)
-                            onAdvanceWidthChanged: root._labelColumnWidth = Math.max(root._labelColumnWidth, Math.ceil(advanceWidth))
-                        }
-
-                        Component.onCompleted: root._labelColumnWidth = Math.max(root._labelColumnWidth, Math.ceil(labelMetrics.advanceWidth))
 
                         Text {
                             id: tagType
@@ -216,6 +198,13 @@ Item {
                     }
                 }
             }
+        }
+
+        LoadingIndicator {
+            visible: root._paneLoading
+            x: Sizing.center(parent.width, width)
+            y: Sizing.center(parent.height, height)
+            text: root.loadingText
         }
     }
 }

--- a/src/ui/components/BrowseDetailPane.qml
+++ b/src/ui/components/BrowseDetailPane.qml
@@ -52,6 +52,12 @@ Item {
             return qsTr("Publisher");
         if (label === "Rating")
             return qsTr("Rating");
+        if (label === "Category")
+            return qsTr("Category");
+        if (label === "Release date")
+            return qsTr("Release date");
+        if (label === "Manufacturer")
+            return qsTr("Manufacturer");
         return label;
     }
 

--- a/src/ui/components/BrowseDetailPane.qml
+++ b/src/ui/components/BrowseDetailPane.qml
@@ -24,15 +24,50 @@ Item {
     readonly property int _cardPaddingX: Sizing.pctW(2)
     readonly property int _cardPaddingY: Sizing.pctH(2)
     readonly property int _carouselGutter: (canPreviousImage || canNextImage) ? Sizing.pctW(4) : 0
-    readonly property int _labelColumnWidth: Sizing.pctW(8)
+    property int _labelColumnWidth: 0
+    readonly property int _tagTextSize: Sizing.fontSize(2.2)
     readonly property int _tagLabelGap: Sizing.pctW(1.4)
-    readonly property int _tagRowCount: detailTags === "" ? 0 : detailTags.split("\n").length
-    readonly property int _tagRowSpacing: Sizing.pctH(0.8)
-    readonly property int _metadataNaturalHeight: _tagRowCount <= 0 ? 0 : (_tagRowCount * Sizing.pctH(3)) + ((_tagRowCount - 1) * _tagRowSpacing)
-    readonly property int _compactDetailHeight: Math.min(Sizing.px(content.height * 0.45), Math.max(Sizing.pctH(12), _metadataNaturalHeight))
+    readonly property var _detailRows: _parseDetailTags(detailTags)
+    readonly property int _tagRowCount: _detailRows.length
+    readonly property int _tagRowHeight: Sizing.pctH(3)
+    readonly property int _tagRowSpacing: Sizing.pctH(0.55)
+    readonly property int _metadataNaturalHeight: _tagRowCount <= 0 ? 0 : (_tagRowCount * _tagRowHeight) + ((_tagRowCount - 1) * _tagRowSpacing)
+    readonly property int _compactDetailHeight: Math.min(Sizing.px(content.height * 0.38), _metadataNaturalHeight)
     readonly property bool _coverPending: coverKey === "icons/Loading"
     readonly property url _coverSource: _coverPending ? "" : Resources.coverUrl(coverKey)
     readonly property bool _paneLoading: root.loading
+
+    onDetailTagsChanged: root._labelColumnWidth = 0
+
+    function _localizedTagLabel(label: string): string {
+        if (label === "Year")
+            return qsTr("Year");
+        if (label === "Genre")
+            return qsTr("Genre");
+        if (label === "Players")
+            return qsTr("Players");
+        if (label === "Developer")
+            return qsTr("Developer");
+        if (label === "Publisher")
+            return qsTr("Publisher");
+        if (label === "Rating")
+            return qsTr("Rating");
+        return label;
+    }
+
+    function _parseDetailTags(tags: string): var {
+        if (tags === "")
+            return [];
+        return tags.split("\n").map(row => {
+            const parts = row.split("\t");
+            const rawLabel = parts.length > 0 ? parts[0] : "";
+            return {
+                "rawLabel": rawLabel,
+                "label": root._localizedTagLabel(rawLabel),
+                "value": parts.length > 1 ? parts[1] : ""
+            };
+        });
+    }
 
     Rectangle {
         anchors.fill: parent
@@ -56,12 +91,14 @@ Item {
         Item {
             id: imageSlot
 
-            anchors.left: parent.left
-            anchors.leftMargin: root._carouselGutter
-            anchors.right: parent.right
-            anchors.rightMargin: root._carouselGutter
+            readonly property int availableWidth: Math.max(0, parent.width - (2 * root._carouselGutter))
+            readonly property int availableHeight: Math.max(0, root.showTitle ? Sizing.px(parent.height * 0.48) : detailBody.y - Sizing.pctH(1))
+            readonly property int slotSize: Math.min(availableWidth, availableHeight)
+
+            x: root._carouselGutter + Sizing.center(availableWidth, width)
             anchors.top: parent.top
-            height: root.showTitle ? Sizing.px(parent.height * 0.48) : Math.max(0, detailBody.y - Sizing.pctH(2))
+            width: slotSize
+            height: slotSize
 
             Image {
                 id: cover
@@ -142,26 +179,36 @@ Item {
             Column {
                 id: tagTable
 
-                visible: !root._paneLoading && root.detailTags !== ""
+                visible: !root._paneLoading && root._detailRows.length > 0
                 anchors.fill: parent
                 spacing: root._tagRowSpacing
                 clip: true
 
                 Repeater {
-                    model: root.detailTags === "" ? [] : root.detailTags.split("\n")
+                    model: root._detailRows
 
                     delegate: Item {
                         id: tagRow
 
-                        required property string modelData
+                        required property var modelData
 
                         width: tagTable.width
-                        height: Math.max(Sizing.pctH(3), tagValue.paintedHeight)
+                        height: root._tagRowHeight
 
-                        readonly property list<string> parts: modelData.split("\t")
-                        readonly property string label: parts.length > 0 ? parts[0] : ""
-                        readonly property string value: parts.length > 1 ? parts[1] : ""
-                        readonly property bool isFilename: label === "Filename"
+                        readonly property string rawLabel: modelData.rawLabel ?? ""
+                        readonly property string label: modelData.label ?? ""
+                        readonly property string value: modelData.value ?? ""
+
+                        TextMetrics {
+                            id: labelMetrics
+
+                            text: tagRow.label
+                            font.family: Theme.fontUi
+                            font.pixelSize: root._tagTextSize
+                            onAdvanceWidthChanged: root._labelColumnWidth = Math.max(root._labelColumnWidth, Math.ceil(advanceWidth))
+                        }
+
+                        Component.onCompleted: root._labelColumnWidth = Math.max(root._labelColumnWidth, Math.ceil(labelMetrics.advanceWidth))
 
                         Text {
                             id: tagType
@@ -172,9 +219,9 @@ Item {
                             text: tagRow.label
                             color: Theme.textLabel
                             font.family: Theme.fontUi
-                            font.pixelSize: Sizing.fontSize(2.2)
+                            font.pixelSize: root._tagTextSize
                             elide: Text.ElideRight
-                            horizontalAlignment: Text.AlignLeft
+                            horizontalAlignment: Text.AlignRight
                             renderType: Text.NativeRendering
                         }
 
@@ -188,10 +235,10 @@ Item {
                             text: tagRow.value
                             color: Theme.textPrimary
                             font.family: Theme.fontUi
-                            font.pixelSize: Sizing.fontSize(2.2)
-                            wrapMode: Text.Wrap
-                            maximumLineCount: tagRow.isFilename ? 8 : 2
-                            elide: tagRow.isFilename ? Text.ElideNone : Text.ElideRight
+                            font.pixelSize: root._tagTextSize
+                            wrapMode: Text.NoWrap
+                            maximumLineCount: 1
+                            elide: Text.ElideRight
                             horizontalAlignment: Text.AlignLeft
                             renderType: Text.NativeRendering
                         }

--- a/src/ui/components/BrowseDetailPane.qml
+++ b/src/ui/components/BrowseDetailPane.qml
@@ -176,10 +176,12 @@ Item {
         Item {
             id: detailBody
 
+            readonly property int _bodyY: Math.round(root.showTitle ? (titleText.visible ? titleText.y + titleText.height : imageSlot.y + imageSlot.height) + Sizing.pctH(2) : parent.height - height)
+
             x: 0
-            y: root.showTitle ? (titleText.visible ? titleText.y + titleText.height : imageSlot.y + imageSlot.height) + Sizing.pctH(2) : parent.height - height
+            y: _bodyY
             width: parent.width
-            height: root.showTitle ? Math.max(0, parent.height - y) : root._compactDetailHeight
+            height: root.showTitle ? Math.round(Math.max(0, parent.height - _bodyY)) : root._compactDetailHeight
             clip: true
 
             Column {

--- a/src/ui/components/BrowseList.qml
+++ b/src/ui/components/BrowseList.qml
@@ -16,6 +16,7 @@ Item {
     property int totalItemsOverride: -1
     property int targetVisibleRowCount: 0
     property bool showFileStem: false
+    property bool showChrome: true
     readonly property int itemCount: listView.count
     readonly property int totalItems: totalItemsOverride >= 0 ? totalItemsOverride : itemCount
     readonly property int cardPaddingX: Sizing.pctW(2)
@@ -65,6 +66,7 @@ Item {
         border.width: Sizing.stroke(1)
         border.color: Theme.borderMid
         radius: Sizing.cornerRadius
+        visible: root.showChrome
     }
 
     onItemCountChanged: {

--- a/src/ui/components/BrowseList.qml
+++ b/src/ui/components/BrowseList.qml
@@ -18,10 +18,13 @@ Item {
     property bool showFileStem: false
     readonly property int itemCount: listView.count
     readonly property int totalItems: totalItemsOverride >= 0 ? totalItemsOverride : itemCount
+    readonly property int cardPaddingX: Sizing.pctW(2)
+    readonly property int cardPaddingY: Sizing.pctH(2)
     readonly property int rowSpacing: Sizing.pctH(0.7)
-    readonly property int rowHeight: targetVisibleRowCount > 0 ? Math.max(Sizing.pctH(3), Math.floor((height - (rowSpacing * (targetVisibleRowCount - 1))) / targetVisibleRowCount)) : Sizing.pctH(6)
+    readonly property int contentHeight: Math.max(0, height - (2 * cardPaddingY))
+    readonly property int rowHeight: targetVisibleRowCount > 0 ? Math.max(Sizing.pctH(3), Math.floor((contentHeight - (rowSpacing * (targetVisibleRowCount - 1))) / targetVisibleRowCount)) : Sizing.pctH(6)
     readonly property int rowStride: rowHeight + rowSpacing
-    readonly property int visibleRowCount: targetVisibleRowCount > 0 ? targetVisibleRowCount : Math.max(1, Math.floor((height + rowSpacing) / rowStride))
+    readonly property int visibleRowCount: targetVisibleRowCount > 0 ? targetVisibleRowCount : Math.max(1, Math.floor((contentHeight + rowSpacing) / rowStride))
     readonly property int _centerSlot: Math.max(0, Math.floor((visibleRowCount - 1) / 2))
     readonly property int _maxViewTopIndex: Math.max(0, itemCount - visibleRowCount)
     readonly property int _viewTopIndex: Math.max(0, Math.min(_maxViewTopIndex, currentIndex - _centerSlot))
@@ -56,6 +59,14 @@ Item {
 
     clip: true
 
+    Rectangle {
+        anchors.fill: parent
+        color: Theme.surfaceCard
+        border.width: Sizing.stroke(1)
+        border.color: Theme.borderMid
+        radius: Sizing.cornerRadius
+    }
+
     onItemCountChanged: {
         if (root.itemCount === 0) {
             root.currentName = "";
@@ -74,10 +85,13 @@ Item {
         id: listView
 
         anchors.left: parent.left
+        anchors.leftMargin: root.cardPaddingX
         anchors.top: parent.top
+        anchors.topMargin: root.cardPaddingY
         anchors.bottom: parent.bottom
+        anchors.bottomMargin: root.cardPaddingY
         anchors.right: parent.right
-        anchors.rightMargin: root.totalItems > root.visibleRowCount ? root._gutterWidth + root._gutterGap : 0
+        anchors.rightMargin: root.totalItems > root.visibleRowCount ? root._gutterWidth + root._gutterGap + root.cardPaddingX : root.cardPaddingX
         model: root.model
         currentIndex: root.currentIndex
         contentY: Math.min(root._targetContentY, Math.max(0, contentHeight - height))
@@ -117,17 +131,11 @@ Item {
             }
 
             Rectangle {
-                anchors.fill: parent
-                color: row.selected ? Theme.surfaceCard : "transparent"
-                radius: Math.max(0, Sizing.px(Sizing.cornerRadius / 3))
-            }
-
-            Rectangle {
                 anchors.left: parent.left
                 anchors.top: parent.top
                 anchors.bottom: parent.bottom
                 width: Sizing.pctW(0.45)
-                color: Theme.textPrimary
+                color: Theme.accent
                 visible: row.selected
                 radius: Math.max(0, Sizing.px(width / 3))
             }
@@ -185,8 +193,11 @@ Item {
         id: scrollGutter
 
         anchors.right: parent.right
+        anchors.rightMargin: root.cardPaddingX
         anchors.top: parent.top
+        anchors.topMargin: root.cardPaddingY
         anchors.bottom: parent.bottom
+        anchors.bottomMargin: root.cardPaddingY
         width: root._gutterWidth
         visible: root.totalItems > root.visibleRowCount
 

--- a/src/ui/components/BrowseList.qml
+++ b/src/ui/components/BrowseList.qml
@@ -132,6 +132,25 @@ Item {
                 restoreMode: Binding.RestoreNone
             }
 
+            Item {
+                anchors.fill: parent
+                visible: row.selected
+
+                Rectangle {
+                    anchors.fill: parent
+                    color: Theme.selectionSurface
+                    radius: Sizing.cornerRadius
+                }
+
+                Rectangle {
+                    anchors.left: parent.left
+                    anchors.top: parent.top
+                    anchors.bottom: parent.bottom
+                    width: Sizing.cornerRadius
+                    color: Theme.selectionSurface
+                }
+            }
+
             Rectangle {
                 anchors.left: parent.left
                 anchors.top: parent.top

--- a/src/ui/components/BrowseListDetailView.qml
+++ b/src/ui/components/BrowseListDetailView.qml
@@ -1,0 +1,81 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+import QtQuick
+import Zaparoo.Theme
+
+Item {
+    id: root
+
+    property alias model: browseList.model
+    property alias currentIndex: browseList.currentIndex
+    property alias totalItemsOverride: browseList.totalItemsOverride
+    property alias targetVisibleRowCount: browseList.targetVisibleRowCount
+    property alias showFileStem: browseList.showFileStem
+    property alias currentName: browseList.currentName
+    property alias currentCoverKey: browseList.currentCoverKey
+    property alias itemCount: browseList.itemCount
+
+    property alias detailTitle: detailPane.title
+    property alias detailCoverKey: detailPane.coverKey
+    property alias detailDescription: detailPane.description
+    property alias detailShowDescription: detailPane.showDescription
+    property alias detailShowTitle: detailPane.showTitle
+    property alias detailTags: detailPane.detailTags
+    property alias detailLoading: detailPane.loading
+    property alias detailLoadingText: detailPane.loadingText
+    property alias detailCanPreviousImage: detailPane.canPreviousImage
+    property alias detailCanNextImage: detailPane.canNextImage
+
+    signal itemHovered(int index)
+    signal itemClicked(int index)
+    signal itemRightClicked(int index)
+    signal emptyRightClicked
+    signal pageWheelRequested(int delta)
+
+    function currentCellRectIn(target: Item): rect {
+        return browseList.currentCellRectIn(target);
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        color: Theme.surfaceCard
+        border.width: Sizing.stroke(1)
+        border.color: Theme.borderMid
+        radius: Sizing.cornerRadius
+    }
+
+    CardDivider {
+        id: listDivider
+
+        x: Sizing.px(parent.width * 2 / 3)
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+    }
+
+    BrowseList {
+        id: browseList
+
+        anchors.left: parent.left
+        anchors.right: listDivider.left
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        showChrome: false
+        onItemHovered: index => root.itemHovered(index)
+        onItemClicked: index => root.itemClicked(index)
+        onItemRightClicked: index => root.itemRightClicked(index)
+        onEmptyRightClicked: root.emptyRightClicked()
+        onPageWheelRequested: delta => root.pageWheelRequested(delta)
+    }
+
+    BrowseDetailPane {
+        id: detailPane
+
+        anchors.left: listDivider.right
+        anchors.right: parent.right
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        showChrome: false
+    }
+}

--- a/src/ui/components/BrowseListDetailView.qml
+++ b/src/ui/components/BrowseListDetailView.qml
@@ -16,6 +16,7 @@ Item {
     property alias currentName: browseList.currentName
     property alias currentCoverKey: browseList.currentCoverKey
     property alias itemCount: browseList.itemCount
+    property alias visibleRowCount: browseList.visibleRowCount
 
     property alias detailTitle: detailPane.title
     property alias detailCoverKey: detailPane.coverKey

--- a/src/ui/components/CMakeLists.txt
+++ b/src/ui/components/CMakeLists.txt
@@ -13,6 +13,7 @@ qt_add_qml_module(
         BootOverlay.qml
         BrowseDetailPane.qml
         BrowseList.qml
+        CardDivider.qml
         CommercialNoticeModal.qml
         ContextMenu.qml
         CoreStatusPill.qml

--- a/src/ui/components/CMakeLists.txt
+++ b/src/ui/components/CMakeLists.txt
@@ -17,6 +17,7 @@ qt_add_qml_module(
         ContextMenu.qml
         CoreStatusPill.qml
         FirstRunIndexModal.qml
+        GameInfoModal.qml
         HeaderBar.qml
         LoadingIndicator.qml
         ListPickerModal.qml

--- a/src/ui/components/CMakeLists.txt
+++ b/src/ui/components/CMakeLists.txt
@@ -13,6 +13,7 @@ qt_add_qml_module(
         BootOverlay.qml
         BrowseDetailPane.qml
         BrowseList.qml
+        BrowseListDetailView.qml
         CardDivider.qml
         CommercialNoticeModal.qml
         ContextMenu.qml

--- a/src/ui/components/CardDivider.qml
+++ b/src/ui/components/CardDivider.qml
@@ -1,0 +1,19 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+import QtQuick
+import Zaparoo.Theme
+
+Item {
+    id: root
+
+    property color lineColor: Theme.borderMid
+
+    width: Sizing.stroke(1)
+
+    Rectangle {
+        anchors.fill: parent
+        color: root.lineColor
+    }
+}

--- a/src/ui/components/ContextMenu.qml
+++ b/src/ui/components/ContextMenu.qml
@@ -46,9 +46,12 @@ Item {
     // rounded corners — see the panel `Rectangle` below.
     readonly property int panelRadius: Sizing.half(Sizing.cornerRadius)
     readonly property int panelHeight: Math.min(entries.length * rowHeight + Math.max(0, entries.length - 1) * rowSpacing + 2 * panelRadius, Math.max(0, _usableBottom - menu.margin))
-    readonly property bool preferRight: anchorRect.x + anchorRect.width + gap + panelWidth <= width - margin
-    readonly property int preferredX: preferRight ? Sizing.px(anchorRect.x + anchorRect.width + gap) : Sizing.px(anchorRect.x - gap - panelWidth)
-    readonly property int preferredY: Sizing.px(anchorRect.y + Sizing.center(anchorRect.height, panelHeight))
+    readonly property bool _fitsRight: anchorRect.x + anchorRect.width + gap + panelWidth <= width - margin
+    readonly property bool _fitsLeft: anchorRect.x - gap - panelWidth >= margin
+    readonly property bool _placeBesideAnchor: _fitsRight || _fitsLeft
+    readonly property bool _fitsBelow: anchorRect.y + anchorRect.height + gap + panelHeight <= _usableBottom
+    readonly property int preferredX: _placeBesideAnchor ? (_fitsRight ? Sizing.px(anchorRect.x + anchorRect.width + gap) : Sizing.px(anchorRect.x - gap - panelWidth)) : Sizing.px(anchorRect.x + Sizing.center(anchorRect.width, panelWidth))
+    readonly property int preferredY: _placeBesideAnchor ? Sizing.px(anchorRect.y + Sizing.center(anchorRect.height, panelHeight)) : (_fitsBelow ? Sizing.px(anchorRect.y + anchorRect.height + gap) : Sizing.px(anchorRect.y - gap - panelHeight))
 
     visible: open
     enabled: visible

--- a/src/ui/components/GameInfoModal.qml
+++ b/src/ui/components/GameInfoModal.qml
@@ -1,0 +1,270 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Zaparoo.Browse as Browse
+import Zaparoo.Theme
+
+Item {
+    id: root
+
+    property bool open: false
+    property int _labelColumnWidth: 0
+
+    signal closeRequested
+
+    visible: open
+    enabled: visible
+    anchors.fill: parent
+    z: 300
+
+    onOpenChanged: root._labelColumnWidth = 0
+
+    function handleAction(action: string): void {
+        if (action === "cancel" || action === "accept")
+            root.closeRequested();
+        else if (action === "left")
+            Browse.GameInfo.cycle_image(-1);
+        else if (action === "right")
+            Browse.GameInfo.cycle_image(1);
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        color: Theme.scrim
+
+        MouseArea {
+            anchors.fill: parent
+            hoverEnabled: true
+            acceptedButtons: Qt.AllButtons
+            onClicked: root.closeRequested()
+        }
+
+        Rectangle {
+            id: panel
+
+            x: Sizing.center(parent.width, width)
+            y: Sizing.center(parent.height, height)
+            width: Sizing.px(Math.min(parent.width * 0.84, Sizing.pctH(118)))
+            height: Sizing.px(Math.min(parent.height - Sizing.pctH(14), Sizing.pctH(78)))
+            color: Theme.bgPanel
+            radius: Sizing.cornerRadius
+
+            MouseArea {
+                anchors.fill: parent
+                hoverEnabled: true
+                acceptedButtons: Qt.AllButtons
+            }
+
+            Text {
+                id: titleText
+
+                anchors.left: parent.left
+                anchors.leftMargin: Sizing.pctW(4)
+                anchors.right: closeText.left
+                anchors.rightMargin: Sizing.pctW(2)
+                anchors.top: parent.top
+                anchors.topMargin: Sizing.pctH(4)
+                text: Browse.GameInfo.title
+                color: Theme.textPrimary
+                font.family: Theme.fontUi
+                font.pixelSize: Sizing.fontSize(3.2)
+                font.weight: Font.Medium
+                elide: Text.ElideRight
+                horizontalAlignment: Text.AlignLeft
+                renderType: Text.NativeRendering
+            }
+
+            Text {
+                id: closeText
+
+                anchors.right: parent.right
+                anchors.rightMargin: Sizing.pctW(4)
+                anchors.verticalCenter: titleText.verticalCenter
+                text: qsTr("Back to close")
+                color: Theme.textLabel
+                font.family: Theme.fontUi
+                font.pixelSize: Sizing.fontSize(2.2)
+                horizontalAlignment: Text.AlignRight
+                renderType: Text.NativeRendering
+            }
+
+            Rectangle {
+                id: contentCard
+
+                anchors.left: parent.left
+                anchors.leftMargin: Sizing.pctW(4)
+                anchors.right: parent.right
+                anchors.rightMargin: Sizing.pctW(4)
+                anchors.top: titleText.bottom
+                anchors.topMargin: Sizing.pctH(3)
+                anchors.bottom: parent.bottom
+                anchors.bottomMargin: Sizing.pctH(4)
+                color: Theme.surfaceCard
+                border.width: Sizing.stroke(1)
+                border.color: Theme.borderMid
+                radius: Sizing.cornerRadius
+
+                LoadingIndicator {
+                    visible: Browse.GameInfo.loading
+                    x: Sizing.center(parent.width, width)
+                    y: Sizing.center(parent.height, height)
+                    text: qsTr("Loading details…")
+                }
+
+                Text {
+                    visible: !Browse.GameInfo.loading && Browse.GameInfo.error_message !== ""
+                    anchors.left: parent.left
+                    anchors.leftMargin: Sizing.pctW(3)
+                    anchors.right: parent.right
+                    anchors.rightMargin: Sizing.pctW(3)
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: Browse.GameInfo.error_message
+                    color: Theme.textPrimary
+                    font.family: Theme.fontUi
+                    font.pixelSize: Sizing.fontSize(2.6)
+                    wrapMode: Text.WordWrap
+                    horizontalAlignment: Text.AlignHCenter
+                    renderType: Text.NativeRendering
+                }
+
+                Flickable {
+                    id: flick
+
+                    visible: !Browse.GameInfo.loading && Browse.GameInfo.error_message === ""
+                    anchors.fill: parent
+                    anchors.leftMargin: Sizing.pctW(3)
+                    anchors.rightMargin: Sizing.pctW(3)
+                    anchors.topMargin: Sizing.pctH(3)
+                    anchors.bottomMargin: Sizing.pctH(3)
+                    contentWidth: width
+                    contentHeight: contentColumn.height
+                    boundsBehavior: Flickable.StopAtBounds
+                    clip: true
+
+                    Column {
+                        id: contentColumn
+
+                        width: flick.width
+                        spacing: Sizing.pctH(2.2)
+
+                        Item {
+                            width: parent.width
+                            height: Browse.GameInfo.image_key !== "" ? Sizing.pctH(26) : 0
+                            visible: height > 0
+
+                            Image {
+                                anchors.fill: parent
+                                source: Resources.coverUrl(Browse.GameInfo.image_key)
+                                sourceSize.width: 512
+                                fillMode: Image.PreserveAspectFit
+                                smooth: true
+                                asynchronous: true
+                            }
+
+                            Image {
+                                source: Resources.iconUrl("NavLeft")
+                                width: Sizing.pctH(4)
+                                height: width
+                                anchors.left: parent.left
+                                anchors.verticalCenter: parent.verticalCenter
+                                fillMode: Image.PreserveAspectFit
+                                smooth: true
+                                visible: Browse.GameInfo.image_can_prev
+                            }
+
+                            Image {
+                                source: Resources.iconUrl("NavRight")
+                                width: Sizing.pctH(4)
+                                height: width
+                                anchors.right: parent.right
+                                anchors.verticalCenter: parent.verticalCenter
+                                fillMode: Image.PreserveAspectFit
+                                smooth: true
+                                visible: Browse.GameInfo.image_can_next
+                            }
+                        }
+
+                        Column {
+                            id: tagTable
+
+                            width: parent.width
+                            spacing: Sizing.pctH(0.8)
+                            visible: Browse.GameInfo.detail_tags !== ""
+
+                            Repeater {
+                                model: Browse.GameInfo.detail_tags === "" ? [] : Browse.GameInfo.detail_tags.split("\n")
+
+                                delegate: Item {
+                                    id: tagRow
+
+                                    required property string modelData
+
+                                    width: tagTable.width
+                                    height: Math.max(Sizing.pctH(3), tagValue.paintedHeight)
+
+                                    readonly property list<string> parts: modelData.split("\t")
+                                    readonly property string label: parts.length > 0 ? parts[0] : ""
+                                    readonly property string value: parts.length > 1 ? parts[1] : ""
+
+                                    TextMetrics {
+                                        id: labelMetrics
+                                        text: tagRow.label
+                                        font.family: Theme.fontUi
+                                        font.pixelSize: Sizing.fontSize(2.4)
+                                        onAdvanceWidthChanged: root._labelColumnWidth = Math.max(root._labelColumnWidth, Math.ceil(advanceWidth))
+                                    }
+
+                                    Component.onCompleted: root._labelColumnWidth = Math.max(root._labelColumnWidth, Math.ceil(labelMetrics.advanceWidth))
+
+                                    Text {
+                                        anchors.left: parent.left
+                                        anchors.top: parent.top
+                                        width: root._labelColumnWidth
+                                        text: tagRow.label
+                                        color: Theme.textLabel
+                                        font.family: Theme.fontUi
+                                        font.pixelSize: Sizing.fontSize(2.4)
+                                        elide: Text.ElideRight
+                                        horizontalAlignment: Text.AlignLeft
+                                        renderType: Text.NativeRendering
+                                    }
+
+                                    Text {
+                                        id: tagValue
+
+                                        anchors.left: parent.left
+                                        anchors.leftMargin: root._labelColumnWidth + Sizing.pctW(1.4)
+                                        anchors.right: parent.right
+                                        anchors.top: parent.top
+                                        text: tagRow.value
+                                        color: Theme.textPrimary
+                                        font.family: Theme.fontUi
+                                        font.pixelSize: Sizing.fontSize(2.4)
+                                        wrapMode: Text.Wrap
+                                        horizontalAlignment: Text.AlignLeft
+                                        renderType: Text.NativeRendering
+                                    }
+                                }
+                            }
+                        }
+
+                        Text {
+                            width: parent.width
+                            visible: Browse.GameInfo.description !== ""
+                            text: Browse.GameInfo.description
+                            color: Theme.textPrimary
+                            font.family: Theme.fontUi
+                            font.pixelSize: Sizing.fontSize(2.6)
+                            wrapMode: Text.WordWrap
+                            horizontalAlignment: Text.AlignLeft
+                            renderType: Text.NativeRendering
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/ui/components/GameInfoModal.qml
+++ b/src/ui/components/GameInfoModal.qml
@@ -12,6 +12,8 @@ Item {
 
     property bool open: false
     property int _labelColumnWidth: 0
+    readonly property bool _hasContentAbove: flick.contentY > 1
+    readonly property bool _hasContentBelow: flick.contentY + flick.height < flick.contentHeight - 1
 
     signal closeRequested
 
@@ -20,15 +22,34 @@ Item {
     anchors.fill: parent
     z: 300
 
-    onOpenChanged: root._labelColumnWidth = 0
+    onOpenChanged: {
+        root._labelColumnWidth = 0;
+        if (root.open)
+            flick.contentY = 0;
+    }
+
+    function _scrollBody(delta: int): void {
+        if (!flick.visible)
+            return;
+        const maxY = Math.max(0, flick.contentHeight - flick.height);
+        flick.contentY = Math.max(0, Math.min(maxY, flick.contentY + delta));
+    }
 
     function handleAction(action: string): void {
         if (action === "cancel" || action === "accept")
             root.closeRequested();
-        else if (action === "left")
+        else if (action === "left" && Browse.GameInfo.image_count > 1)
             Browse.GameInfo.cycle_image(-1);
-        else if (action === "right")
+        else if (action === "right" && Browse.GameInfo.image_count > 1)
             Browse.GameInfo.cycle_image(1);
+        else if (action === "up")
+            root._scrollBody(-Sizing.pctH(8));
+        else if (action === "down")
+            root._scrollBody(Sizing.pctH(8));
+        else if (action === "page_prev")
+            root._scrollBody(-Math.max(Sizing.pctH(12), flick.height - Sizing.pctH(8)));
+        else if (action === "page_next")
+            root._scrollBody(Math.max(Sizing.pctH(12), flick.height - Sizing.pctH(8)));
     }
 
     Rectangle {
@@ -47,8 +68,8 @@ Item {
 
             x: Sizing.center(parent.width, width)
             y: Sizing.center(parent.height, height)
-            width: Sizing.px(Math.min(parent.width * 0.84, Sizing.pctH(118)))
-            height: Sizing.px(Math.min(parent.height - Sizing.pctH(14), Sizing.pctH(78)))
+            width: Sizing.px(Math.min(parent.width - Sizing.pctW(6), Sizing.pctH(150)))
+            height: Sizing.px(parent.height - Sizing.pctH(16))
             color: Theme.bgPanel
             radius: Sizing.cornerRadius
 
@@ -63,37 +84,49 @@ Item {
 
                 anchors.left: parent.left
                 anchors.leftMargin: Sizing.pctW(4)
-                anchors.right: closeText.left
-                anchors.rightMargin: Sizing.pctW(2)
+                anchors.right: parent.right
+                anchors.rightMargin: Sizing.pctW(4)
                 anchors.top: parent.top
                 anchors.topMargin: Sizing.pctH(4)
                 text: Browse.GameInfo.title
                 color: Theme.textPrimary
                 font.family: Theme.fontUi
-                font.pixelSize: Sizing.fontSize(3.2)
+                font.pixelSize: Sizing.fontSize(3.4)
                 font.weight: Font.Medium
                 elide: Text.ElideRight
+                maximumLineCount: 1
                 horizontalAlignment: Text.AlignLeft
                 renderType: Text.NativeRendering
             }
 
-            Text {
-                id: closeText
+            LoadingIndicator {
+                visible: Browse.GameInfo.loading
+                x: Sizing.center(parent.width, width)
+                y: Sizing.center(parent.height, height)
+                text: qsTr("Loading details…")
+            }
 
+            Text {
+                visible: !Browse.GameInfo.loading && Browse.GameInfo.error_message !== ""
+                anchors.left: parent.left
+                anchors.leftMargin: Sizing.pctW(4)
                 anchors.right: parent.right
                 anchors.rightMargin: Sizing.pctW(4)
-                anchors.verticalCenter: titleText.verticalCenter
-                text: qsTr("Back to close")
-                color: Theme.textLabel
+                anchors.top: titleText.bottom
+                anchors.topMargin: Sizing.pctH(4)
+                text: Browse.GameInfo.error_message
+                color: Theme.textPrimary
                 font.family: Theme.fontUi
-                font.pixelSize: Sizing.fontSize(2.2)
-                horizontalAlignment: Text.AlignRight
+                font.pixelSize: Sizing.fontSize(2.6)
+                wrapMode: Text.WordWrap
+                horizontalAlignment: Text.AlignLeft
                 renderType: Text.NativeRendering
             }
 
-            Rectangle {
-                id: contentCard
+            Flickable {
+                id: flick
 
+                visible: !Browse.GameInfo.loading && Browse.GameInfo.error_message === ""
                 anchors.left: parent.left
                 anchors.leftMargin: Sizing.pctW(4)
                 anchors.right: parent.right
@@ -102,168 +135,162 @@ Item {
                 anchors.topMargin: Sizing.pctH(3)
                 anchors.bottom: parent.bottom
                 anchors.bottomMargin: Sizing.pctH(4)
-                color: Theme.surfaceCard
-                border.width: Sizing.stroke(1)
-                border.color: Theme.borderMid
-                radius: Sizing.cornerRadius
+                contentWidth: width
+                contentHeight: contentColumn.height
+                boundsBehavior: Flickable.StopAtBounds
+                clip: true
 
-                LoadingIndicator {
-                    visible: Browse.GameInfo.loading
-                    x: Sizing.center(parent.width, width)
-                    y: Sizing.center(parent.height, height)
-                    text: qsTr("Loading details…")
-                }
+                Column {
+                    id: contentColumn
 
-                Text {
-                    visible: !Browse.GameInfo.loading && Browse.GameInfo.error_message !== ""
-                    anchors.left: parent.left
-                    anchors.leftMargin: Sizing.pctW(3)
-                    anchors.right: parent.right
-                    anchors.rightMargin: Sizing.pctW(3)
-                    anchors.verticalCenter: parent.verticalCenter
-                    text: Browse.GameInfo.error_message
-                    color: Theme.textPrimary
-                    font.family: Theme.fontUi
-                    font.pixelSize: Sizing.fontSize(2.6)
-                    wrapMode: Text.WordWrap
-                    horizontalAlignment: Text.AlignHCenter
-                    renderType: Text.NativeRendering
-                }
+                    width: flick.width
+                    spacing: Sizing.pctH(2.4)
 
-                Flickable {
-                    id: flick
+                    Item {
+                        width: parent.width
+                        height: Browse.GameInfo.image_count > 0 ? Sizing.pctH(32) : 0
+                        visible: height > 0
 
-                    visible: !Browse.GameInfo.loading && Browse.GameInfo.error_message === ""
-                    anchors.fill: parent
-                    anchors.leftMargin: Sizing.pctW(3)
-                    anchors.rightMargin: Sizing.pctW(3)
-                    anchors.topMargin: Sizing.pctH(3)
-                    anchors.bottomMargin: Sizing.pctH(3)
-                    contentWidth: width
-                    contentHeight: contentColumn.height
-                    boundsBehavior: Flickable.StopAtBounds
-                    clip: true
-
-                    Column {
-                        id: contentColumn
-
-                        width: flick.width
-                        spacing: Sizing.pctH(2.2)
-
-                        Item {
-                            width: parent.width
-                            height: Browse.GameInfo.image_key !== "" ? Sizing.pctH(26) : 0
-                            visible: height > 0
-
-                            Image {
-                                anchors.fill: parent
-                                source: Resources.coverUrl(Browse.GameInfo.image_key)
-                                sourceSize.width: 512
-                                fillMode: Image.PreserveAspectFit
-                                smooth: true
-                                asynchronous: true
-                            }
-
-                            Image {
-                                source: Resources.iconUrl("NavLeft")
-                                width: Sizing.pctH(4)
-                                height: width
-                                anchors.left: parent.left
-                                anchors.verticalCenter: parent.verticalCenter
-                                fillMode: Image.PreserveAspectFit
-                                smooth: true
-                                visible: Browse.GameInfo.image_can_prev
-                            }
-
-                            Image {
-                                source: Resources.iconUrl("NavRight")
-                                width: Sizing.pctH(4)
-                                height: width
-                                anchors.right: parent.right
-                                anchors.verticalCenter: parent.verticalCenter
-                                fillMode: Image.PreserveAspectFit
-                                smooth: true
-                                visible: Browse.GameInfo.image_can_next
-                            }
+                        Image {
+                            anchors.fill: parent
+                            source: Browse.GameInfo.image_key !== "" ? Resources.coverUrl(Browse.GameInfo.image_key) : ""
+                            sourceSize.width: 768
+                            fillMode: Image.PreserveAspectFit
+                            smooth: true
+                            asynchronous: true
                         }
 
-                        Column {
-                            id: tagTable
+                        LoadingIndicator {
+                            visible: Browse.GameInfo.image_key === ""
+                            x: Sizing.center(parent.width, width)
+                            y: Sizing.center(parent.height, height)
+                            text: qsTr("Loading image…")
+                            glyphSize: Sizing.fontSize(2.4)
+                        }
 
-                            width: parent.width
-                            spacing: Sizing.pctH(0.8)
-                            visible: Browse.GameInfo.detail_tags !== ""
+                        Image {
+                            source: Resources.iconUrl("NavLeft")
+                            width: Sizing.pctH(4)
+                            height: width
+                            anchors.left: parent.left
+                            anchors.verticalCenter: parent.verticalCenter
+                            fillMode: Image.PreserveAspectFit
+                            smooth: true
+                            visible: Browse.GameInfo.image_count > 1 && Browse.GameInfo.image_can_prev
+                        }
 
-                            Repeater {
-                                model: Browse.GameInfo.detail_tags === "" ? [] : Browse.GameInfo.detail_tags.split("\n")
+                        Image {
+                            source: Resources.iconUrl("NavRight")
+                            width: Sizing.pctH(4)
+                            height: width
+                            anchors.right: parent.right
+                            anchors.verticalCenter: parent.verticalCenter
+                            fillMode: Image.PreserveAspectFit
+                            smooth: true
+                            visible: Browse.GameInfo.image_count > 1 && Browse.GameInfo.image_can_next
+                        }
+                    }
 
-                                delegate: Item {
-                                    id: tagRow
+                    Column {
+                        id: tagTable
 
-                                    required property string modelData
+                        width: parent.width
+                        spacing: Sizing.pctH(0.8)
+                        visible: Browse.GameInfo.detail_tags !== ""
 
-                                    width: tagTable.width
-                                    height: Math.max(Sizing.pctH(3), tagValue.paintedHeight)
+                        Repeater {
+                            model: Browse.GameInfo.detail_tags === "" ? [] : Browse.GameInfo.detail_tags.split("\n")
 
-                                    readonly property list<string> parts: modelData.split("\t")
-                                    readonly property string label: parts.length > 0 ? parts[0] : ""
-                                    readonly property string value: parts.length > 1 ? parts[1] : ""
+                            delegate: Item {
+                                id: tagRow
 
-                                    TextMetrics {
-                                        id: labelMetrics
-                                        text: tagRow.label
-                                        font.family: Theme.fontUi
-                                        font.pixelSize: Sizing.fontSize(2.4)
-                                        onAdvanceWidthChanged: root._labelColumnWidth = Math.max(root._labelColumnWidth, Math.ceil(advanceWidth))
-                                    }
+                                required property string modelData
 
-                                    Component.onCompleted: root._labelColumnWidth = Math.max(root._labelColumnWidth, Math.ceil(labelMetrics.advanceWidth))
+                                width: tagTable.width
+                                height: Math.max(Sizing.pctH(3), tagValue.paintedHeight)
 
-                                    Text {
-                                        anchors.left: parent.left
-                                        anchors.top: parent.top
-                                        width: root._labelColumnWidth
-                                        text: tagRow.label
-                                        color: Theme.textLabel
-                                        font.family: Theme.fontUi
-                                        font.pixelSize: Sizing.fontSize(2.4)
-                                        elide: Text.ElideRight
-                                        horizontalAlignment: Text.AlignLeft
-                                        renderType: Text.NativeRendering
-                                    }
+                                readonly property list<string> parts: modelData.split("\t")
+                                readonly property string label: parts.length > 0 ? parts[0] : ""
+                                readonly property string value: parts.length > 1 ? parts[1] : ""
 
-                                    Text {
-                                        id: tagValue
+                                TextMetrics {
+                                    id: labelMetrics
+                                    text: tagRow.label
+                                    font.family: Theme.fontUi
+                                    font.pixelSize: Sizing.fontSize(2.4)
+                                    onAdvanceWidthChanged: root._labelColumnWidth = Math.max(root._labelColumnWidth, Math.ceil(advanceWidth))
+                                }
 
-                                        anchors.left: parent.left
-                                        anchors.leftMargin: root._labelColumnWidth + Sizing.pctW(1.4)
-                                        anchors.right: parent.right
-                                        anchors.top: parent.top
-                                        text: tagRow.value
-                                        color: Theme.textPrimary
-                                        font.family: Theme.fontUi
-                                        font.pixelSize: Sizing.fontSize(2.4)
-                                        wrapMode: Text.Wrap
-                                        horizontalAlignment: Text.AlignLeft
-                                        renderType: Text.NativeRendering
-                                    }
+                                Component.onCompleted: root._labelColumnWidth = Math.max(root._labelColumnWidth, Math.ceil(labelMetrics.advanceWidth))
+
+                                Text {
+                                    anchors.left: parent.left
+                                    anchors.top: parent.top
+                                    width: root._labelColumnWidth
+                                    text: tagRow.label
+                                    color: Theme.textLabel
+                                    font.family: Theme.fontUi
+                                    font.pixelSize: Sizing.fontSize(2.4)
+                                    elide: Text.ElideRight
+                                    horizontalAlignment: Text.AlignLeft
+                                    renderType: Text.NativeRendering
+                                }
+
+                                Text {
+                                    id: tagValue
+
+                                    anchors.left: parent.left
+                                    anchors.leftMargin: root._labelColumnWidth + Sizing.pctW(1.4)
+                                    anchors.right: parent.right
+                                    anchors.top: parent.top
+                                    text: tagRow.value
+                                    color: Theme.textPrimary
+                                    font.family: Theme.fontUi
+                                    font.pixelSize: Sizing.fontSize(2.4)
+                                    wrapMode: Text.Wrap
+                                    horizontalAlignment: Text.AlignLeft
+                                    renderType: Text.NativeRendering
                                 }
                             }
                         }
+                    }
 
-                        Text {
-                            width: parent.width
-                            visible: Browse.GameInfo.description !== ""
-                            text: Browse.GameInfo.description
-                            color: Theme.textPrimary
-                            font.family: Theme.fontUi
-                            font.pixelSize: Sizing.fontSize(2.6)
-                            wrapMode: Text.WordWrap
-                            horizontalAlignment: Text.AlignLeft
-                            renderType: Text.NativeRendering
-                        }
+                    Text {
+                        width: parent.width
+                        visible: Browse.GameInfo.description !== ""
+                        text: Browse.GameInfo.description
+                        color: Theme.textPrimary
+                        font.family: Theme.fontUi
+                        font.pixelSize: Sizing.fontSize(2.6)
+                        wrapMode: Text.WordWrap
+                        horizontalAlignment: Text.AlignLeft
+                        renderType: Text.NativeRendering
                     }
                 }
+            }
+
+            Image {
+                source: Resources.iconUrl("ScrollUp")
+                width: Sizing.pctH(3)
+                height: width
+                anchors.bottom: flick.top
+                anchors.bottomMargin: Sizing.pctH(0.5)
+                anchors.horizontalCenter: flick.horizontalCenter
+                fillMode: Image.PreserveAspectFit
+                smooth: true
+                visible: flick.visible && root._hasContentAbove
+            }
+
+            Image {
+                source: Resources.iconUrl("ScrollDown")
+                width: Sizing.pctH(3)
+                height: width
+                anchors.top: flick.bottom
+                anchors.topMargin: Sizing.pctH(0.5)
+                anchors.horizontalCenter: flick.horizontalCenter
+                fillMode: Image.PreserveAspectFit
+                smooth: true
+                visible: flick.visible && root._hasContentBelow
             }
         }
     }

--- a/src/ui/components/GameInfoModal.qml
+++ b/src/ui/components/GameInfoModal.qml
@@ -154,9 +154,8 @@ Item {
                         Image {
                             anchors.fill: parent
                             source: Browse.GameInfo.image_key !== "" ? Resources.coverUrl(Browse.GameInfo.image_key) : ""
-                            sourceSize.width: 768
+                            sourceSize.width: Sizing.px(parent.width)
                             fillMode: Image.PreserveAspectFit
-                            smooth: true
                             asynchronous: true
                         }
 

--- a/src/ui/components/LoadingIndicator.qml
+++ b/src/ui/components/LoadingIndicator.qml
@@ -29,6 +29,7 @@ Row {
     // and total-files badges in TopStatusStrip.
     property real glyphSize: Sizing.fontSize(3)
 
+    width: Sizing.px(implicitWidth)
     height: indicator.glyphSize
     spacing: Sizing.pctW(0.6)
 

--- a/src/ui/components/TopStatusStrip.qml
+++ b/src/ui/components/TopStatusStrip.qml
@@ -23,6 +23,7 @@ Item {
     property int currentPage: 0 // 0-indexed; displayed as N+1
     property int totalPages: 1
     property string totalText: "" // formatted; empty hides the slot
+    property string rightTextOverride: "" // formatted; non-empty replaces Page N / M
     readonly property int _slotWidth: Sizing.px(status.width / 3)
     readonly property int _slotMargin: Sizing.pctW(5)
     readonly property int _textMeasureSlack: Theme.crtNativePath ? 0 : 2
@@ -80,14 +81,14 @@ Item {
     Text {
         id: pageCounter
 
-        visible: status.totalPages > 1
+        visible: status.rightTextOverride !== "" || status.totalPages > 1
         anchors.right: parent.right
         anchors.rightMargin: status._slotMargin
         anchors.bottom: titleText.bottom
         width: status._slotWidth - status._slotMargin
         elide: Text.ElideRight
         horizontalAlignment: Text.AlignRight
-        text: qsTr("Page %1 / %2").arg(status.currentPage + 1).arg(status.totalPages)
+        text: status.rightTextOverride !== "" ? status.rightTextOverride : qsTr("Page %1 / %2").arg(status.currentPage + 1).arg(status.totalPages)
         font.family: Theme.fontUi
         font.pixelSize: Sizing.fontSize(2.9)
         color: Theme.textPrimary

--- a/src/ui/screens/FavoritesScreen.qml
+++ b/src/ui/screens/FavoritesScreen.qml
@@ -47,6 +47,7 @@ Item {
     // during cold-launch / model-reset, matching `GamesScreen.qml`.
     // Pagination uses a separate `loading_more` flag and is unaffected.
     readonly property bool _gateHide: favorites.transitioning || Browse.FavoritesModel.loading
+    property string _detailRequestKey: ""
 
     signal requestHubScreen
     signal requestContextMenu(int index, var anchorRect)
@@ -86,6 +87,31 @@ Item {
             return;
         favorites.favoritesGrid.currentIndex = index;
         favorites._persistFocus();
+    }
+
+    function _selectedDetailKey(): string {
+        if (favorites.favoritesGrid.itemCount <= 0)
+            return "";
+        const idx = favoritesGrid.currentIndex;
+        const systemId = Browse.FavoritesModel.system_id_at(idx);
+        const path = Browse.FavoritesModel.path_at(idx);
+        return systemId !== "" && path !== "" ? systemId + "\n" + path : "";
+    }
+
+    function _scheduleDetailLoad(): void {
+        if (!favorites._listLayout)
+            return;
+        const key = favorites._selectedDetailKey();
+        if (key === "" || key === favorites._detailRequestKey)
+            return;
+        favorites._detailRequestKey = key;
+        detailLoadDebounce.restart();
+    }
+
+    function _loadSelectedDetail(): void {
+        if (!favorites._listLayout || favorites.favoritesGrid.itemCount <= 0)
+            return;
+        Browse.FavoritesModel.load_detail_at(favoritesGrid.currentIndex);
     }
 
     function _performLinearMove(delta: int): void {
@@ -158,7 +184,7 @@ Item {
             if (favorites.favoritesGrid.itemCount > 0) {
                 const idx = favorites.favoritesGrid.currentIndex;
                 favorites._persistFocus();
-                const rect = favorites._listLayout ? favoritesList.currentCellRectIn(favorites) : favorites.favoritesGrid.currentCellRectIn(favorites);
+                const rect = favorites._listLayout ? listCard.currentCellRectIn(favorites) : favorites.favoritesGrid.currentCellRectIn(favorites);
                 favorites.requestContextMenu(idx, rect);
             }
         } else if (action === "cancel") {
@@ -167,6 +193,22 @@ Item {
     }
 
     // ── Visual tree ───────────────────────────────────────────────────────────
+
+    Timer {
+        id: detailLoadDebounce
+        interval: 220
+        repeat: false
+        onTriggered: favorites._loadSelectedDetail()
+    }
+
+    Connections {
+        target: Browse.FavoritesModel
+        function onCountChanged(): void {
+            if (Browse.FavoritesModel.current_detail_tags === "")
+                favorites._detailRequestKey = "";
+            favorites._scheduleDetailLoad();
+        }
+    }
 
     // Top status strip — page counter, screen title, total entries.
     // The total badge reads `count` directly: favorites is a flat list,
@@ -183,10 +225,15 @@ Item {
         title: qsTr("Favorites")
         currentPage: favoritesGrid.currentPage
         totalPages: Math.max(1, Math.ceil(Browse.FavoritesModel.count / favoritesGrid.pageSize))
-        totalText: Browse.FavoritesModel.count > 0 ? qsTr("%1 entries").arg(Browse.FavoritesModel.count) : ""
+        totalText: favorites._listLayout ? "" : (Browse.FavoritesModel.count > 0 ? qsTr("%1 entries").arg(Browse.FavoritesModel.count) : "")
+        rightTextOverride: {
+            if (!favorites._listLayout || favoritesGrid.itemCount <= 0)
+                return "";
+            return qsTr("%1 / %2").arg(favoritesGrid.currentIndex + 1).arg(Math.max(1, Browse.FavoritesModel.count));
+        }
     }
 
-    Item {
+    BrowseListDetailView {
         id: listCard
 
         visible: !favorites._gateHide && favorites._listLayout
@@ -198,54 +245,29 @@ Item {
         anchors.topMargin: Sizing.pctH(2)
         anchors.bottom: parent.bottom
         anchors.bottomMargin: Sizing.pctH(8)
-
-        Rectangle {
-            anchors.fill: parent
-            color: Theme.surfaceCard
-            border.width: Sizing.stroke(1)
-            border.color: Theme.borderMid
-            radius: Sizing.cornerRadius
+        model: Browse.FavoritesModel
+        currentIndex: favoritesGrid.currentIndex
+        detailTitle: listCard.currentName
+        detailCoverKey: Browse.FavoritesModel.current_detail_image_key !== "" ? Browse.FavoritesModel.current_detail_image_key : listCard.currentCoverKey
+        detailTags: Browse.FavoritesModel.current_detail_tags
+        onItemHovered: index => favorites._focusIndex(index)
+        onItemClicked: index => {
+            favorites._focusIndex(index);
+            favorites.handleAction("accept");
         }
-
-        CardDivider {
-            id: listDivider
-
-            x: Sizing.center(parent.width, width)
-            anchors.top: parent.top
-            anchors.bottom: parent.bottom
+        onItemRightClicked: index => {
+            favorites._focusIndex(index);
+            favorites.handleAction("write_card");
         }
-
-        BrowseList {
-            id: favoritesList
-
-            anchors.left: parent.left
-            anchors.right: listDivider.left
-            anchors.top: parent.top
-            anchors.bottom: parent.bottom
-            showChrome: false
-            model: Browse.FavoritesModel
-            currentIndex: favoritesGrid.currentIndex
-            onItemHovered: index => favorites._focusIndex(index)
-            onItemClicked: index => {
-                favorites._focusIndex(index);
-                favorites.handleAction("accept");
+        onEmptyRightClicked: favorites.handleAction("cancel")
+        onPageWheelRequested: delta => favorites.handleAction(delta > 0 ? "page_next" : "page_prev")
+        onVisibleChanged: {
+            if (visible)
+                favorites._scheduleDetailLoad();
+            else {
+                favorites._detailRequestKey = "";
+                Browse.FavoritesModel.clear_current_detail();
             }
-            onItemRightClicked: index => {
-                favorites._focusIndex(index);
-                favorites.handleAction("write_card");
-            }
-            onEmptyRightClicked: favorites.handleAction("cancel")
-            onPageWheelRequested: delta => favorites.handleAction(delta > 0 ? "page_next" : "page_prev")
-        }
-
-        BrowseDetailPane {
-            anchors.left: listDivider.right
-            anchors.right: parent.right
-            anchors.top: parent.top
-            anchors.bottom: parent.bottom
-            showChrome: false
-            title: favoritesList.currentName
-            coverKey: favoritesList.currentCoverKey
         }
     }
 
@@ -271,7 +293,10 @@ Item {
         columnsOverride: Sizing.gamesGridColumns
         rowsOverride: Sizing.gamesGridRows
         onLoadMoreRequested: Browse.FavoritesModel.fetch_more()
-        onCurrentIndexChanged: favorites._persistFocus()
+        onCurrentIndexChanged: {
+            favorites._persistFocus();
+            favorites._scheduleDetailLoad();
+        }
         onItemHovered: index => favorites._focusIndex(index)
         onItemClicked: index => {
             favorites._focusIndex(index);
@@ -300,9 +325,9 @@ Item {
 
     ScreenStateOverlay {
         x: favorites._listLayout ? 0 : favoritesGrid.x
-        y: favorites._listLayout ? favoritesList.y : favoritesGrid.y
+        y: favorites._listLayout ? listCard.y : favoritesGrid.y
         width: favorites._listLayout ? favorites.width : favoritesGrid.width
-        height: favorites._listLayout ? Math.max(0, favorites.height - favoritesList.y - favorites._listOverlayBottomMargin) : favoritesGrid.height
+        height: favorites._listLayout ? Math.max(0, favorites.height - listCard.y - favorites._listOverlayBottomMargin) : favoritesGrid.height
         loading: Browse.FavoritesModel.loading
         errorMessage: Browse.FavoritesModel.error_message ?? ""
         count: Browse.FavoritesModel.count

--- a/src/ui/screens/FavoritesScreen.qml
+++ b/src/ui/screens/FavoritesScreen.qml
@@ -186,42 +186,67 @@ Item {
         totalText: Browse.FavoritesModel.count > 0 ? qsTr("%1 entries").arg(Browse.FavoritesModel.count) : ""
     }
 
-    BrowseList {
-        id: favoritesList
+    Item {
+        id: listCard
 
         visible: !favorites._gateHide && favorites._listLayout
         anchors.left: parent.left
         anchors.leftMargin: Sizing.pctW(5)
+        anchors.right: parent.right
+        anchors.rightMargin: Sizing.pctW(5)
         anchors.top: topStrip.bottom
         anchors.topMargin: Sizing.pctH(2)
         anchors.bottom: parent.bottom
         anchors.bottomMargin: Sizing.pctH(8)
-        width: Sizing.pctW(45)
-        model: Browse.FavoritesModel
-        currentIndex: favoritesGrid.currentIndex
-        onItemHovered: index => favorites._focusIndex(index)
-        onItemClicked: index => {
-            favorites._focusIndex(index);
-            favorites.handleAction("accept");
-        }
-        onItemRightClicked: index => {
-            favorites._focusIndex(index);
-            favorites.handleAction("write_card");
-        }
-        onEmptyRightClicked: favorites.handleAction("cancel")
-        onPageWheelRequested: delta => favorites.handleAction(delta > 0 ? "page_next" : "page_prev")
-    }
 
-    BrowseDetailPane {
-        visible: !favorites._gateHide && favorites._listLayout
-        anchors.left: favoritesList.right
-        anchors.leftMargin: Sizing.pctW(5)
-        anchors.right: parent.right
-        anchors.rightMargin: Sizing.pctW(5)
-        anchors.top: favoritesList.top
-        anchors.bottom: favoritesList.bottom
-        title: favoritesList.currentName
-        coverKey: favoritesList.currentCoverKey
+        Rectangle {
+            anchors.fill: parent
+            color: Theme.surfaceCard
+            border.width: Sizing.stroke(1)
+            border.color: Theme.borderMid
+            radius: Sizing.cornerRadius
+        }
+
+        CardDivider {
+            id: listDivider
+
+            x: Sizing.center(parent.width, width)
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+        }
+
+        BrowseList {
+            id: favoritesList
+
+            anchors.left: parent.left
+            anchors.right: listDivider.left
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            showChrome: false
+            model: Browse.FavoritesModel
+            currentIndex: favoritesGrid.currentIndex
+            onItemHovered: index => favorites._focusIndex(index)
+            onItemClicked: index => {
+                favorites._focusIndex(index);
+                favorites.handleAction("accept");
+            }
+            onItemRightClicked: index => {
+                favorites._focusIndex(index);
+                favorites.handleAction("write_card");
+            }
+            onEmptyRightClicked: favorites.handleAction("cancel")
+            onPageWheelRequested: delta => favorites.handleAction(delta > 0 ? "page_next" : "page_prev")
+        }
+
+        BrowseDetailPane {
+            anchors.left: listDivider.right
+            anchors.right: parent.right
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            showChrome: false
+            title: favoritesList.currentName
+            coverKey: favoritesList.currentCoverKey
+        }
     }
 
     PagedGrid {

--- a/src/ui/screens/FavoritesScreen.qml
+++ b/src/ui/screens/FavoritesScreen.qml
@@ -38,6 +38,7 @@ Item {
     // hides while a modal (the context menu) is on top of the stack.
     property bool gridFocused: true
     readonly property bool _listLayout: Browse.Settings.current_browse_layout === "list"
+    readonly property int _listOverlayBottomMargin: Sizing.pctH(15)
 
     // True while either the cross-screen router is mid-flip
     // (`transitioning`) or the in-screen cover gate is holding
@@ -177,7 +178,7 @@ Item {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: parent.top
-        anchors.topMargin: Sizing.pctH(11)
+        anchors.topMargin: Sizing.headerBottom + Sizing.pctH(1)
         height: Sizing.pctH(7)
         title: qsTr("Favorites")
         currentPage: favoritesGrid.currentPage
@@ -273,10 +274,10 @@ Item {
     }
 
     ScreenStateOverlay {
-        x: (favorites._listLayout ? favoritesList.x : favoritesGrid.x) + Sizing.center(favorites._listLayout ? favoritesList.width : favoritesGrid.width, width)
-        y: (favorites._listLayout ? favoritesList.y : favoritesGrid.y) + Sizing.center(favorites._listLayout ? favoritesList.height : favoritesGrid.height, height)
-        width: favorites._listLayout ? favoritesList.width : favoritesGrid.width
-        height: favorites._listLayout ? favoritesList.height : favoritesGrid.height
+        x: favorites._listLayout ? 0 : favoritesGrid.x
+        y: favorites._listLayout ? favoritesList.y : favoritesGrid.y
+        width: favorites._listLayout ? favorites.width : favoritesGrid.width
+        height: favorites._listLayout ? Math.max(0, favorites.height - favoritesList.y - favorites._listOverlayBottomMargin) : favoritesGrid.height
         loading: Browse.FavoritesModel.loading
         errorMessage: Browse.FavoritesModel.error_message ?? ""
         count: Browse.FavoritesModel.count

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -401,7 +401,7 @@ Item {
         showFileStem: true
         currentIndex: gamesGrid.currentIndex
         detailTitle: listCard.currentName
-        detailCoverKey: Browse.GamesModel.current_detail_image_key !== "" ? Browse.GamesModel.current_detail_image_key : listCard.currentCoverKey
+        detailCoverKey: Browse.GamesModel.current_detail_image_key
         detailShowDescription: false
         detailShowTitle: false
         detailTags: Browse.GamesModel.current_detail_tags

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -401,7 +401,7 @@ Item {
         showFileStem: true
         currentIndex: gamesGrid.currentIndex
         detailTitle: listCard.currentName
-        detailCoverKey: Browse.GamesModel.current_detail_image_key
+        detailCoverKey: Browse.GamesModel.current_detail_image_key !== "" ? Browse.GamesModel.current_detail_image_key : listCard.currentCoverKey
         detailShowDescription: false
         detailShowTitle: false
         detailTags: Browse.GamesModel.current_detail_tags

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -368,63 +368,79 @@ Item {
     }
 
     Item {
-        id: listBand
+        id: listCard
 
         visible: !games.transitioning && !games.coverGateLoading && games._listLayout
         anchors.left: parent.left
+        anchors.leftMargin: Sizing.pctW(5)
         anchors.right: parent.right
+        anchors.rightMargin: Sizing.pctW(5)
         anchors.top: topStrip.bottom
         anchors.topMargin: Sizing.pctH(2)
         anchors.bottom: parent.bottom
         anchors.bottomMargin: Sizing.pctH(8)
-    }
 
-    BrowseList {
-        id: gamesList
-
-        visible: !games.transitioning && !games.coverGateLoading && games._listLayout
-        anchors.left: listBand.left
-        anchors.leftMargin: Sizing.pctW(5)
-        anchors.top: listBand.top
-        anchors.bottom: listBand.bottom
-        width: Sizing.pctW(45)
-        model: Browse.GamesModel
-        totalItemsOverride: Browse.GamesModel.dir_count + Browse.GamesModel.total_files
-        targetVisibleRowCount: games._listPageSize
-        showFileStem: true
-        currentIndex: gamesGrid.currentIndex
-        onItemHovered: index => games._focusIndex(index)
-        onItemClicked: index => {
-            games._focusIndex(index);
-            games.handleAction("accept");
+        Rectangle {
+            anchors.fill: parent
+            color: Theme.surfaceCard
+            border.width: Sizing.stroke(1)
+            border.color: Theme.borderMid
+            radius: Sizing.cornerRadius
         }
-        onItemRightClicked: index => {
-            games._focusIndex(index);
-            games.handleAction("write_card");
-        }
-        onEmptyRightClicked: games.handleAction("cancel")
-        onPageWheelRequested: delta => games.handleAction(delta > 0 ? "page_next" : "page_prev")
-    }
 
-    BrowseDetailPane {
-        visible: !games.transitioning && !games.coverGateLoading && games._listLayout
-        anchors.left: gamesList.right
-        anchors.leftMargin: Sizing.pctW(5)
-        anchors.right: parent.right
-        anchors.rightMargin: Sizing.pctW(5)
-        anchors.top: listBand.top
-        anchors.bottom: listBand.bottom
-        title: gamesList.currentName
-        coverKey: Browse.GamesModel.current_detail_image_key !== "" ? Browse.GamesModel.current_detail_image_key : gamesList.currentCoverKey
-        showDescription: false
-        showTitle: false
-        detailTags: Browse.GamesModel.current_detail_tags
-        loading: Browse.GamesModel.current_detail_loading
-        canPreviousImage: Browse.GamesModel.current_detail_image_can_prev
-        canNextImage: Browse.GamesModel.current_detail_image_can_next
-        onVisibleChanged: {
-            if (visible)
-                Browse.GamesModel.load_description_at(gamesGrid.currentIndex);
+        CardDivider {
+            id: listDivider
+
+            x: Sizing.center(parent.width, width)
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+        }
+
+        BrowseList {
+            id: gamesList
+
+            anchors.left: parent.left
+            anchors.right: listDivider.left
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            showChrome: false
+            model: Browse.GamesModel
+            totalItemsOverride: Browse.GamesModel.dir_count + Browse.GamesModel.total_files
+            targetVisibleRowCount: games._listPageSize
+            showFileStem: true
+            currentIndex: gamesGrid.currentIndex
+            onItemHovered: index => games._focusIndex(index)
+            onItemClicked: index => {
+                games._focusIndex(index);
+                games.handleAction("accept");
+            }
+            onItemRightClicked: index => {
+                games._focusIndex(index);
+                games.handleAction("write_card");
+            }
+            onEmptyRightClicked: games.handleAction("cancel")
+            onPageWheelRequested: delta => games.handleAction(delta > 0 ? "page_next" : "page_prev")
+        }
+
+        BrowseDetailPane {
+            anchors.left: listDivider.right
+            anchors.right: parent.right
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            showChrome: false
+            title: gamesList.currentName
+            coverKey: Browse.GamesModel.current_detail_image_key !== "" ? Browse.GamesModel.current_detail_image_key : gamesList.currentCoverKey
+            showDescription: false
+            showTitle: false
+            detailTags: Browse.GamesModel.current_detail_tags
+            loading: Browse.GamesModel.current_detail_loading
+            loadingText: qsTr("Loading game…")
+            canPreviousImage: Browse.GamesModel.current_detail_image_can_prev
+            canNextImage: Browse.GamesModel.current_detail_image_can_next
+            onVisibleChanged: {
+                if (visible)
+                    Browse.GamesModel.load_description_at(gamesGrid.currentIndex);
+            }
         }
     }
 
@@ -544,9 +560,9 @@ Item {
 
     ScreenStateOverlay {
         x: games._listLayout ? 0 : gamesGrid.x
-        y: games._listLayout ? listBand.y : gamesGrid.y
+        y: games._listLayout ? listCard.y : gamesGrid.y
         width: games._listLayout ? games.width : gamesGrid.width
-        height: games._listLayout ? Math.max(0, games.height - listBand.y - games._listOverlayBottomMargin) : gamesGrid.height
+        height: games._listLayout ? Math.max(0, games.height - listCard.y - games._listOverlayBottomMargin) : gamesGrid.height
         loading: Browse.GamesModel.loading
         errorMessage: Browse.GamesModel.error_message ?? ""
         count: Browse.GamesModel.count

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -35,8 +35,8 @@ Item {
     // and the anchored tile both light up.
     property bool gridFocused: true
     readonly property bool _listLayout: Browse.Settings.current_browse_layout === "list"
-    readonly property real _listBandScale: 0.85
     readonly property int _listPageSize: 10
+    readonly property int _listOverlayBottomMargin: Sizing.pctH(6) + games._tileLayout.activeLabelBottomMargin + games._tileLayout.activeLabelHeight
     readonly property int _browsePageSize: games._listLayout ? games._listPageSize : gamesGrid.pageSize
     readonly property bool _crtGridLayout: Theme.crtNativePath && !games._listLayout
     readonly property var _tileLayout: games._crtGridLayout ? BrowseLayouts.crtTile : BrowseLayouts.defaultTile
@@ -375,7 +375,8 @@ Item {
         anchors.right: parent.right
         anchors.top: topStrip.bottom
         anchors.topMargin: Sizing.pctH(2)
-        height: Math.round(Math.max(0, games.height - (topStrip.y + topStrip.height + Sizing.pctH(2)) - Sizing.pctH(8)) * games._listBandScale)
+        anchors.bottom: parent.bottom
+        anchors.bottomMargin: Sizing.pctH(8)
     }
 
     BrowseList {
@@ -415,39 +416,16 @@ Item {
         anchors.bottom: listBand.bottom
         title: gamesList.currentName
         coverKey: Browse.GamesModel.current_detail_image_key !== "" ? Browse.GamesModel.current_detail_image_key : gamesList.currentCoverKey
-        description: Browse.GamesModel.current_description
         showDescription: false
         showTitle: false
         detailTags: Browse.GamesModel.current_detail_tags
+        loading: Browse.GamesModel.current_detail_loading
         canPreviousImage: Browse.GamesModel.current_detail_image_can_prev
         canNextImage: Browse.GamesModel.current_detail_image_can_next
         onVisibleChanged: {
             if (visible)
                 Browse.GamesModel.load_description_at(gamesGrid.currentIndex);
         }
-    }
-
-    Text {
-        id: listDescription
-
-        visible: listBand.visible && text !== ""
-        anchors.left: parent.left
-        anchors.leftMargin: Sizing.pctW(5)
-        anchors.right: parent.right
-        anchors.rightMargin: Sizing.pctW(5)
-        anchors.top: listBand.bottom
-        anchors.topMargin: Sizing.pctH(2)
-        anchors.bottom: parent.bottom
-        anchors.bottomMargin: Sizing.pctH(8)
-        text: Browse.GamesModel.current_description
-        color: Theme.textLabel
-        font.family: Theme.fontUi
-        font.pixelSize: Sizing.fontSize(2.2)
-        wrapMode: Text.Wrap
-        elide: Text.ElideRight
-        horizontalAlignment: Text.AlignLeft
-        verticalAlignment: Text.AlignTop
-        renderType: Text.NativeRendering
     }
 
     // Grid fills the safe zone between the top strip and the active
@@ -565,10 +543,10 @@ Item {
     }
 
     ScreenStateOverlay {
-        x: (games._listLayout ? gamesList.x : gamesGrid.x) + Sizing.center(games._listLayout ? gamesList.width : gamesGrid.width, width)
-        y: (games._listLayout ? gamesList.y : gamesGrid.y) + Sizing.center(games._listLayout ? gamesList.height : gamesGrid.height, height)
-        width: games._listLayout ? gamesList.width : gamesGrid.width
-        height: games._listLayout ? gamesList.height : gamesGrid.height
+        x: games._listLayout ? 0 : gamesGrid.x
+        y: games._listLayout ? listBand.y : gamesGrid.y
+        width: games._listLayout ? games.width : gamesGrid.width
+        height: games._listLayout ? Math.max(0, games.height - listBand.y - games._listOverlayBottomMargin) : gamesGrid.height
         loading: Browse.GamesModel.loading
         errorMessage: Browse.GamesModel.error_message ?? ""
         count: Browse.GamesModel.count

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -542,9 +542,9 @@ Item {
     }
 
     ScreenStateOverlay {
-        x: games._listLayout ? 0 : gamesGrid.x
+        x: games._listLayout ? listCard.x : gamesGrid.x
         y: games._listLayout ? listCard.y : gamesGrid.y
-        width: games._listLayout ? games.width : gamesGrid.width
+        width: games._listLayout ? listCard.width : gamesGrid.width
         height: games._listLayout ? Math.max(0, games.height - listCard.y - games._listOverlayBottomMargin) : gamesGrid.height
         loading: Browse.GamesModel.loading
         errorMessage: Browse.GamesModel.error_message ?? ""

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -36,8 +36,7 @@ Item {
     property bool gridFocused: true
     readonly property bool _listLayout: Browse.Settings.current_browse_layout === "list"
     readonly property int _listPageSize: 10
-    readonly property int _listOverlayBottomMargin: Sizing.pctH(6) + games._tileLayout.activeLabelBottomMargin + games._tileLayout.activeLabelHeight
-    readonly property int _browsePageSize: games._listLayout ? games._listPageSize : gamesGrid.pageSize
+    readonly property int _browsePageSize: games._listLayout ? Math.max(1, listCard.visibleRowCount) : gamesGrid.pageSize
     readonly property bool _crtGridLayout: Theme.crtNativePath && !games._listLayout
     readonly property var _tileLayout: games._crtGridLayout ? BrowseLayouts.crtTile : BrowseLayouts.defaultTile
     property bool _currentMoveIsRepeat: false
@@ -545,7 +544,7 @@ Item {
         x: games._listLayout ? listCard.x : gamesGrid.x
         y: games._listLayout ? listCard.y : gamesGrid.y
         width: games._listLayout ? listCard.width : gamesGrid.width
-        height: games._listLayout ? Math.max(0, games.height - listCard.y - games._listOverlayBottomMargin) : gamesGrid.height
+        height: games._listLayout ? listCard.height : gamesGrid.height
         loading: Browse.GamesModel.loading
         errorMessage: Browse.GamesModel.error_message ?? ""
         count: Browse.GamesModel.count

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -49,6 +49,12 @@ Item {
     // `ScreenStateOverlay` paints alone in both cases.
     readonly property bool coverGateLoading: Browse.GamesModel.loading
 
+    Binding {
+        target: Browse.GamesModel
+        property: "cover_key_roles_enabled"
+        value: !games._listLayout
+    }
+
     on_ListLayoutChanged: {
         if (games._listLayout) {
             games._fillListPage();
@@ -364,7 +370,17 @@ Item {
         }
         currentPage: Math.floor(gamesGrid.currentIndex / games._browsePageSize)
         totalPages: games._tileLayout.showBottomStatusRow ? 1 : Math.max(1, Math.ceil((Browse.GamesModel.dir_count + Browse.GamesModel.total_files) / games._browsePageSize))
-        totalText: games._tileLayout.showBottomStatusRow ? "" : (Browse.GamesModel.total_files > 0 ? qsTr("%1 files").arg(Browse.GamesModel.total_files) : "")
+        totalText: games._listLayout || games._tileLayout.showBottomStatusRow ? "" : (Browse.GamesModel.total_files > 0 ? qsTr("%1 files").arg(Browse.GamesModel.total_files) : "")
+        rightTextOverride: {
+            if (!games._listLayout)
+                return "";
+            if (Browse.GamesModel.loading_more)
+                return qsTr("Loading more…");
+            if (gamesGrid.itemCount <= 0)
+                return "";
+            const total = Math.max(1, Browse.GamesModel.dir_count + Browse.GamesModel.total_files);
+            return qsTr("%1 / %2").arg(gamesGrid.currentIndex + 1).arg(total);
+        }
     }
 
     Item {
@@ -391,7 +407,7 @@ Item {
         CardDivider {
             id: listDivider
 
-            x: Sizing.center(parent.width, width)
+            x: Sizing.px(parent.width * 2 / 3)
             anchors.top: parent.top
             anchors.bottom: parent.bottom
         }
@@ -493,7 +509,8 @@ Item {
         onCurrentPageChanged: {
             const first = currentPage * pageSize;
             Browse.GamesModel.visible_first_row = first;
-            Browse.GamesModel.prefetch_around(first);
+            if (!games._listLayout)
+                Browse.GamesModel.prefetch_around(first);
         }
         onItemHovered: index => games._focusIndex(index)
         onItemClicked: index => {
@@ -585,7 +602,7 @@ Item {
     // over the global "Loading..." overlay.
     LoadingIndicator {
         id: pageLoadingCue
-        visible: !games.transitioning && !games.coverGateLoading && Browse.GamesModel.loading_more && gamesGrid.hasPendingTarget
+        visible: !games.transitioning && !games.coverGateLoading && !games._listLayout && Browse.GamesModel.loading_more && gamesGrid.hasPendingTarget
         anchors.left: activeLabel.left
         anchors.leftMargin: games._tileLayout.showBottomStatusRow && bottomTotalText.visible ? bottomTotalText.x + bottomTotalText.width + games._tileLayout.bottomStatusLeftMargin : gamesGrid.leftInset
         anchors.verticalCenter: activeLabel.verticalCenter

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -317,7 +317,7 @@ Item {
                     return;
                 games._scheduleSelectedPersist(Browse.GamesModel.path_at(idx));
                 games.flushSelectedPersist();
-                const rect = games._listLayout ? gamesList.currentCellRectIn(games) : games.gamesGrid.currentCellRectIn(games);
+                const rect = games._listLayout ? listCard.currentCellRectIn(games) : games.gamesGrid.currentCellRectIn(games);
                 games.requestContextMenu(idx, rect);
             }
         } else if (action === "cancel") {
@@ -383,7 +383,7 @@ Item {
         }
     }
 
-    Item {
+    BrowseListDetailView {
         id: listCard
 
         visible: !games.transitioning && !games.coverGateLoading && games._listLayout
@@ -395,68 +395,34 @@ Item {
         anchors.topMargin: Sizing.pctH(2)
         anchors.bottom: parent.bottom
         anchors.bottomMargin: Sizing.pctH(8)
-
-        Rectangle {
-            anchors.fill: parent
-            color: Theme.surfaceCard
-            border.width: Sizing.stroke(1)
-            border.color: Theme.borderMid
-            radius: Sizing.cornerRadius
+        model: Browse.GamesModel
+        totalItemsOverride: Browse.GamesModel.dir_count + Browse.GamesModel.total_files
+        targetVisibleRowCount: games._listPageSize
+        showFileStem: true
+        currentIndex: gamesGrid.currentIndex
+        detailTitle: listCard.currentName
+        detailCoverKey: Browse.GamesModel.current_detail_image_key !== "" ? Browse.GamesModel.current_detail_image_key : listCard.currentCoverKey
+        detailShowDescription: false
+        detailShowTitle: false
+        detailTags: Browse.GamesModel.current_detail_tags
+        detailLoading: Browse.GamesModel.current_detail_loading
+        detailLoadingText: qsTr("Loading game…")
+        detailCanPreviousImage: Browse.GamesModel.current_detail_image_can_prev
+        detailCanNextImage: Browse.GamesModel.current_detail_image_can_next
+        onItemHovered: index => games._focusIndex(index)
+        onItemClicked: index => {
+            games._focusIndex(index);
+            games.handleAction("accept");
         }
-
-        CardDivider {
-            id: listDivider
-
-            x: Sizing.px(parent.width * 2 / 3)
-            anchors.top: parent.top
-            anchors.bottom: parent.bottom
+        onItemRightClicked: index => {
+            games._focusIndex(index);
+            games.handleAction("write_card");
         }
-
-        BrowseList {
-            id: gamesList
-
-            anchors.left: parent.left
-            anchors.right: listDivider.left
-            anchors.top: parent.top
-            anchors.bottom: parent.bottom
-            showChrome: false
-            model: Browse.GamesModel
-            totalItemsOverride: Browse.GamesModel.dir_count + Browse.GamesModel.total_files
-            targetVisibleRowCount: games._listPageSize
-            showFileStem: true
-            currentIndex: gamesGrid.currentIndex
-            onItemHovered: index => games._focusIndex(index)
-            onItemClicked: index => {
-                games._focusIndex(index);
-                games.handleAction("accept");
-            }
-            onItemRightClicked: index => {
-                games._focusIndex(index);
-                games.handleAction("write_card");
-            }
-            onEmptyRightClicked: games.handleAction("cancel")
-            onPageWheelRequested: delta => games.handleAction(delta > 0 ? "page_next" : "page_prev")
-        }
-
-        BrowseDetailPane {
-            anchors.left: listDivider.right
-            anchors.right: parent.right
-            anchors.top: parent.top
-            anchors.bottom: parent.bottom
-            showChrome: false
-            title: gamesList.currentName
-            coverKey: Browse.GamesModel.current_detail_image_key !== "" ? Browse.GamesModel.current_detail_image_key : gamesList.currentCoverKey
-            showDescription: false
-            showTitle: false
-            detailTags: Browse.GamesModel.current_detail_tags
-            loading: Browse.GamesModel.current_detail_loading
-            loadingText: qsTr("Loading game…")
-            canPreviousImage: Browse.GamesModel.current_detail_image_can_prev
-            canNextImage: Browse.GamesModel.current_detail_image_can_next
-            onVisibleChanged: {
-                if (visible)
-                    Browse.GamesModel.load_description_at(gamesGrid.currentIndex);
-            }
+        onEmptyRightClicked: games.handleAction("cancel")
+        onPageWheelRequested: delta => games.handleAction(delta > 0 ? "page_next" : "page_prev")
+        onVisibleChanged: {
+            if (visible)
+                Browse.GamesModel.load_description_at(gamesGrid.currentIndex);
         }
     }
 

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -200,6 +200,10 @@ Item {
     // post-move state-commit path as _performMove so the saved entry
     // tracks whichever item the user lands on.
     function _performPage(delta: int): void {
+        if (games._listLayout) {
+            games._performLinearMove(delta * games._browsePageSize, false);
+            return;
+        }
         if (games.gamesGrid.pageBy(delta))
             games._scheduleSelectedPersist(Browse.GamesModel.path_at(games.gamesGrid.currentIndex));
     }

--- a/src/ui/screens/RecentsScreen.qml
+++ b/src/ui/screens/RecentsScreen.qml
@@ -38,6 +38,7 @@ Item {
     // hides while a modal (the context menu) is on top of the stack.
     property bool gridFocused: true
     readonly property bool _listLayout: Browse.Settings.current_browse_layout === "list"
+    readonly property int _listOverlayBottomMargin: Sizing.pctH(15)
 
     // True while either the cross-screen router is mid-flip
     // (`transitioning`) or the in-screen cover gate is holding
@@ -204,6 +205,10 @@ Item {
             recents._focusIndex(index);
             recents.handleAction("accept");
         }
+        onItemRightClicked: index => {
+            recents._focusIndex(index);
+            recents.handleAction("write_card");
+        }
         onEmptyRightClicked: recents.handleAction("cancel")
         onPageWheelRequested: delta => recents.handleAction(delta > 0 ? "page_next" : "page_prev")
     }
@@ -271,10 +276,10 @@ Item {
     }
 
     ScreenStateOverlay {
-        x: (recents._listLayout ? recentsList.x : recentsGrid.x) + Sizing.center(recents._listLayout ? recentsList.width : recentsGrid.width, width)
-        y: (recents._listLayout ? recentsList.y : recentsGrid.y) + Sizing.center(recents._listLayout ? recentsList.height : recentsGrid.height, height)
-        width: recents._listLayout ? recentsList.width : recentsGrid.width
-        height: recents._listLayout ? recentsList.height : recentsGrid.height
+        x: recents._listLayout ? 0 : recentsGrid.x
+        y: recents._listLayout ? recentsList.y : recentsGrid.y
+        width: recents._listLayout ? recents.width : recentsGrid.width
+        height: recents._listLayout ? Math.max(0, recents.height - recentsList.y - recents._listOverlayBottomMargin) : recentsGrid.height
         loading: Browse.RecentsModel.loading
         errorMessage: Browse.RecentsModel.error_message ?? ""
         count: Browse.RecentsModel.count

--- a/src/ui/screens/RecentsScreen.qml
+++ b/src/ui/screens/RecentsScreen.qml
@@ -187,42 +187,67 @@ Item {
         totalText: Browse.RecentsModel.count > 0 ? qsTr("%1 entries").arg(Browse.RecentsModel.count) : ""
     }
 
-    BrowseList {
-        id: recentsList
+    Item {
+        id: listCard
 
         visible: !recents._gateHide && recents._listLayout
         anchors.left: parent.left
         anchors.leftMargin: Sizing.pctW(5)
+        anchors.right: parent.right
+        anchors.rightMargin: Sizing.pctW(5)
         anchors.top: topStrip.bottom
         anchors.topMargin: Sizing.pctH(2)
         anchors.bottom: parent.bottom
         anchors.bottomMargin: Sizing.pctH(8)
-        width: Sizing.pctW(45)
-        model: Browse.RecentsModel
-        currentIndex: recentsGrid.currentIndex
-        onItemHovered: index => recents._focusIndex(index)
-        onItemClicked: index => {
-            recents._focusIndex(index);
-            recents.handleAction("accept");
-        }
-        onItemRightClicked: index => {
-            recents._focusIndex(index);
-            recents.handleAction("write_card");
-        }
-        onEmptyRightClicked: recents.handleAction("cancel")
-        onPageWheelRequested: delta => recents.handleAction(delta > 0 ? "page_next" : "page_prev")
-    }
 
-    BrowseDetailPane {
-        visible: !recents._gateHide && recents._listLayout
-        anchors.left: recentsList.right
-        anchors.leftMargin: Sizing.pctW(5)
-        anchors.right: parent.right
-        anchors.rightMargin: Sizing.pctW(5)
-        anchors.top: recentsList.top
-        anchors.bottom: recentsList.bottom
-        title: recentsList.currentName
-        coverKey: recentsList.currentCoverKey
+        Rectangle {
+            anchors.fill: parent
+            color: Theme.surfaceCard
+            border.width: Sizing.stroke(1)
+            border.color: Theme.borderMid
+            radius: Sizing.cornerRadius
+        }
+
+        CardDivider {
+            id: listDivider
+
+            x: Sizing.center(parent.width, width)
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+        }
+
+        BrowseList {
+            id: recentsList
+
+            anchors.left: parent.left
+            anchors.right: listDivider.left
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            showChrome: false
+            model: Browse.RecentsModel
+            currentIndex: recentsGrid.currentIndex
+            onItemHovered: index => recents._focusIndex(index)
+            onItemClicked: index => {
+                recents._focusIndex(index);
+                recents.handleAction("accept");
+            }
+            onItemRightClicked: index => {
+                recents._focusIndex(index);
+                recents.handleAction("write_card");
+            }
+            onEmptyRightClicked: recents.handleAction("cancel")
+            onPageWheelRequested: delta => recents.handleAction(delta > 0 ? "page_next" : "page_prev")
+        }
+
+        BrowseDetailPane {
+            anchors.left: listDivider.right
+            anchors.right: parent.right
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            showChrome: false
+            title: recentsList.currentName
+            coverKey: recentsList.currentCoverKey
+        }
     }
 
     PagedGrid {

--- a/src/ui/screens/RecentsScreen.qml
+++ b/src/ui/screens/RecentsScreen.qml
@@ -47,6 +47,7 @@ Item {
     // during cold-launch / model-reset, matching `GamesScreen.qml`.
     // Pagination uses a separate `loading_more` flag and is unaffected.
     readonly property bool _gateHide: recents.transitioning || Browse.RecentsModel.loading
+    property string _detailRequestKey: ""
 
     signal requestHubScreen
     signal requestContextMenu(int index, var anchorRect)
@@ -87,6 +88,31 @@ Item {
             return;
         recents.recentsGrid.currentIndex = index;
         recents._persistFocus();
+    }
+
+    function _selectedDetailKey(): string {
+        if (recents.recentsGrid.itemCount <= 0)
+            return "";
+        const idx = recentsGrid.currentIndex;
+        const systemId = Browse.RecentsModel.system_id_at(idx);
+        const path = Browse.RecentsModel.path_at(idx);
+        return systemId !== "" && path !== "" ? systemId + "\n" + path : "";
+    }
+
+    function _scheduleDetailLoad(): void {
+        if (!recents._listLayout)
+            return;
+        const key = recents._selectedDetailKey();
+        if (key === "" || key === recents._detailRequestKey)
+            return;
+        recents._detailRequestKey = key;
+        detailLoadDebounce.restart();
+    }
+
+    function _loadSelectedDetail(): void {
+        if (!recents._listLayout || recents.recentsGrid.itemCount <= 0)
+            return;
+        Browse.RecentsModel.load_detail_at(recentsGrid.currentIndex);
     }
 
     function _performLinearMove(delta: int): void {
@@ -159,7 +185,7 @@ Item {
             if (recents.recentsGrid.itemCount > 0) {
                 const idx = recents.recentsGrid.currentIndex;
                 recents._persistFocus();
-                const rect = recents._listLayout ? recentsList.currentCellRectIn(recents) : recents.recentsGrid.currentCellRectIn(recents);
+                const rect = recents._listLayout ? listCard.currentCellRectIn(recents) : recents.recentsGrid.currentCellRectIn(recents);
                 recents.requestContextMenu(idx, rect);
             }
         } else if (action === "cancel") {
@@ -168,6 +194,22 @@ Item {
     }
 
     // ── Visual tree ───────────────────────────────────────────────────────────
+
+    Timer {
+        id: detailLoadDebounce
+        interval: 220
+        repeat: false
+        onTriggered: recents._loadSelectedDetail()
+    }
+
+    Connections {
+        target: Browse.RecentsModel
+        function onCountChanged(): void {
+            if (Browse.RecentsModel.current_detail_tags === "")
+                recents._detailRequestKey = "";
+            recents._scheduleDetailLoad();
+        }
+    }
 
     // Top status strip — page counter, screen title, total entries.
     // The total badge reads `count` directly: history is a flat list,
@@ -184,10 +226,15 @@ Item {
         title: qsTr("Recently Played")
         currentPage: recentsGrid.currentPage
         totalPages: Math.max(1, Math.ceil(Browse.RecentsModel.count / recentsGrid.pageSize))
-        totalText: Browse.RecentsModel.count > 0 ? qsTr("%1 entries").arg(Browse.RecentsModel.count) : ""
+        totalText: recents._listLayout ? "" : (Browse.RecentsModel.count > 0 ? qsTr("%1 entries").arg(Browse.RecentsModel.count) : "")
+        rightTextOverride: {
+            if (!recents._listLayout || recentsGrid.itemCount <= 0)
+                return "";
+            return qsTr("%1 / %2").arg(recentsGrid.currentIndex + 1).arg(Math.max(1, Browse.RecentsModel.count));
+        }
     }
 
-    Item {
+    BrowseListDetailView {
         id: listCard
 
         visible: !recents._gateHide && recents._listLayout
@@ -199,54 +246,29 @@ Item {
         anchors.topMargin: Sizing.pctH(2)
         anchors.bottom: parent.bottom
         anchors.bottomMargin: Sizing.pctH(8)
-
-        Rectangle {
-            anchors.fill: parent
-            color: Theme.surfaceCard
-            border.width: Sizing.stroke(1)
-            border.color: Theme.borderMid
-            radius: Sizing.cornerRadius
+        model: Browse.RecentsModel
+        currentIndex: recentsGrid.currentIndex
+        detailTitle: listCard.currentName
+        detailCoverKey: Browse.RecentsModel.current_detail_image_key !== "" ? Browse.RecentsModel.current_detail_image_key : listCard.currentCoverKey
+        detailTags: Browse.RecentsModel.current_detail_tags
+        onItemHovered: index => recents._focusIndex(index)
+        onItemClicked: index => {
+            recents._focusIndex(index);
+            recents.handleAction("accept");
         }
-
-        CardDivider {
-            id: listDivider
-
-            x: Sizing.center(parent.width, width)
-            anchors.top: parent.top
-            anchors.bottom: parent.bottom
+        onItemRightClicked: index => {
+            recents._focusIndex(index);
+            recents.handleAction("write_card");
         }
-
-        BrowseList {
-            id: recentsList
-
-            anchors.left: parent.left
-            anchors.right: listDivider.left
-            anchors.top: parent.top
-            anchors.bottom: parent.bottom
-            showChrome: false
-            model: Browse.RecentsModel
-            currentIndex: recentsGrid.currentIndex
-            onItemHovered: index => recents._focusIndex(index)
-            onItemClicked: index => {
-                recents._focusIndex(index);
-                recents.handleAction("accept");
+        onEmptyRightClicked: recents.handleAction("cancel")
+        onPageWheelRequested: delta => recents.handleAction(delta > 0 ? "page_next" : "page_prev")
+        onVisibleChanged: {
+            if (visible)
+                recents._scheduleDetailLoad();
+            else {
+                recents._detailRequestKey = "";
+                Browse.RecentsModel.clear_current_detail();
             }
-            onItemRightClicked: index => {
-                recents._focusIndex(index);
-                recents.handleAction("write_card");
-            }
-            onEmptyRightClicked: recents.handleAction("cancel")
-            onPageWheelRequested: delta => recents.handleAction(delta > 0 ? "page_next" : "page_prev")
-        }
-
-        BrowseDetailPane {
-            anchors.left: listDivider.right
-            anchors.right: parent.right
-            anchors.top: parent.top
-            anchors.bottom: parent.bottom
-            showChrome: false
-            title: recentsList.currentName
-            coverKey: recentsList.currentCoverKey
         }
     }
 
@@ -272,7 +294,10 @@ Item {
         columnsOverride: Sizing.gamesGridColumns
         rowsOverride: Sizing.gamesGridRows
         onLoadMoreRequested: Browse.RecentsModel.fetch_more()
-        onCurrentIndexChanged: recents._persistFocus()
+        onCurrentIndexChanged: {
+            recents._persistFocus();
+            recents._scheduleDetailLoad();
+        }
         onItemHovered: index => recents._focusIndex(index)
         onItemClicked: index => {
             recents._focusIndex(index);
@@ -302,9 +327,9 @@ Item {
 
     ScreenStateOverlay {
         x: recents._listLayout ? 0 : recentsGrid.x
-        y: recents._listLayout ? recentsList.y : recentsGrid.y
+        y: recents._listLayout ? listCard.y : recentsGrid.y
         width: recents._listLayout ? recents.width : recentsGrid.width
-        height: recents._listLayout ? Math.max(0, recents.height - recentsList.y - recents._listOverlayBottomMargin) : recentsGrid.height
+        height: recents._listLayout ? Math.max(0, recents.height - listCard.y - recents._listOverlayBottomMargin) : recentsGrid.height
         loading: Browse.RecentsModel.loading
         errorMessage: Browse.RecentsModel.error_message ?? ""
         count: Browse.RecentsModel.count

--- a/src/ui/screens/SystemsScreen.qml
+++ b/src/ui/screens/SystemsScreen.qml
@@ -186,42 +186,67 @@ Item {
         visible: !systems.transitioning && systems._tileLayout.showTopStrip
     }
 
-    BrowseList {
-        id: systemsList
+    Item {
+        id: listCard
 
         visible: !systems.transitioning && systems._listLayout
         anchors.left: parent.left
         anchors.leftMargin: Sizing.pctW(5)
+        anchors.right: parent.right
+        anchors.rightMargin: Sizing.pctW(5)
         anchors.top: topStrip.bottom
         anchors.topMargin: Sizing.pctH(2)
         anchors.bottom: parent.bottom
         anchors.bottomMargin: Sizing.pctH(8)
-        width: Sizing.pctW(45)
-        model: Browse.SystemsModel
-        currentIndex: systemsGrid.currentIndex
-        onItemHovered: index => systems._focusIndex(index)
-        onItemClicked: index => {
-            systems._focusIndex(index);
-            systems.handleAction("accept");
-        }
-        onItemRightClicked: index => {
-            systems._focusIndex(index);
-            systems.handleAction("write_card");
-        }
-        onEmptyRightClicked: systems.handleAction("cancel")
-        onPageWheelRequested: delta => systems.handleAction(delta > 0 ? "page_next" : "page_prev")
-    }
 
-    BrowseDetailPane {
-        visible: !systems.transitioning && systems._listLayout
-        anchors.left: systemsList.right
-        anchors.leftMargin: Sizing.pctW(5)
-        anchors.right: parent.right
-        anchors.rightMargin: Sizing.pctW(5)
-        anchors.top: systemsList.top
-        anchors.bottom: systemsList.bottom
-        title: systemsList.currentName
-        coverKey: systemsList.currentCoverKey
+        Rectangle {
+            anchors.fill: parent
+            color: Theme.surfaceCard
+            border.width: Sizing.stroke(1)
+            border.color: Theme.borderMid
+            radius: Sizing.cornerRadius
+        }
+
+        CardDivider {
+            id: listDivider
+
+            x: Sizing.center(parent.width, width)
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+        }
+
+        BrowseList {
+            id: systemsList
+
+            anchors.left: parent.left
+            anchors.right: listDivider.left
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            showChrome: false
+            model: Browse.SystemsModel
+            currentIndex: systemsGrid.currentIndex
+            onItemHovered: index => systems._focusIndex(index)
+            onItemClicked: index => {
+                systems._focusIndex(index);
+                systems.handleAction("accept");
+            }
+            onItemRightClicked: index => {
+                systems._focusIndex(index);
+                systems.handleAction("write_card");
+            }
+            onEmptyRightClicked: systems.handleAction("cancel")
+            onPageWheelRequested: delta => systems.handleAction(delta > 0 ? "page_next" : "page_prev")
+        }
+
+        BrowseDetailPane {
+            anchors.left: listDivider.right
+            anchors.right: parent.right
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            showChrome: false
+            title: systemsList.currentName
+            coverKey: systemsList.currentCoverKey
+        }
     }
 
     // Grid fills the safe zone between the top strip and the active

--- a/src/ui/screens/SystemsScreen.qml
+++ b/src/ui/screens/SystemsScreen.qml
@@ -39,6 +39,7 @@ Item {
     readonly property bool _listLayout: Browse.Settings.current_browse_layout === "list"
     readonly property bool _crtGridLayout: Theme.crtNativePath && !systems._listLayout
     readonly property var _tileLayout: systems._crtGridLayout ? BrowseLayouts.crtTile : BrowseLayouts.defaultTile
+    readonly property int _listOverlayBottomMargin: Sizing.pctH(6) + systems._tileLayout.activeLabelBottomMargin + systems._tileLayout.activeLabelHeight
 
     signal requestAccept(systemId: string)
     signal requestHubScreen
@@ -309,10 +310,10 @@ Item {
     }
 
     ScreenStateOverlay {
-        x: (systems._listLayout ? systemsList.x : systemsGrid.x) + Sizing.center(systems._listLayout ? systemsList.width : systemsGrid.width, width)
-        y: (systems._listLayout ? systemsList.y : systemsGrid.y) + Sizing.center(systems._listLayout ? systemsList.height : systemsGrid.height, height)
-        width: systems._listLayout ? systemsList.width : systemsGrid.width
-        height: systems._listLayout ? systemsList.height : systemsGrid.height
+        x: systems._listLayout ? 0 : systemsGrid.x
+        y: systems._listLayout ? systemsList.y : systemsGrid.y
+        width: systems._listLayout ? systems.width : systemsGrid.width
+        height: systems._listLayout ? Math.max(0, systems.height - systemsList.y - systems._listOverlayBottomMargin) : systemsGrid.height
         loading: Browse.SystemsModel.loading
         errorMessage: Browse.SystemsModel.error_message ?? ""
         count: Browse.SystemsModel.count

--- a/src/ui/screens/SystemsScreen.qml
+++ b/src/ui/screens/SystemsScreen.qml
@@ -149,7 +149,7 @@ Item {
             if (systems.systemsGrid.itemCount > 0) {
                 const idx = systems.systemsGrid.currentIndex;
                 Browse.SystemsState.system_id = Browse.SystemsModel.system_id_at(idx);
-                systems.requestContextMenu(idx, systems._listLayout ? systemsList.currentCellRectIn(systems) : systems.systemsGrid.currentCellRectIn(systems));
+                systems.requestContextMenu(idx, systems._listLayout ? listCard.currentCellRectIn(systems) : systems.systemsGrid.currentCellRectIn(systems));
             }
         } else if (action === "cancel") {
             systems.requestHubScreen();
@@ -182,11 +182,16 @@ Item {
         title: systems._tileLayout.showHeaderTitleInHeader ? "" : Browse.SystemsModel.current_category
         currentPage: systemsGrid.currentPage
         totalPages: systems._tileLayout.showBottomStatusRow ? 1 : Math.max(1, Math.ceil(Browse.SystemsModel.count / systemsGrid.pageSize))
-        totalText: systems._tileLayout.showBottomStatusRow ? "" : (Browse.SystemsModel.count > 0 ? qsTr("%1 systems").arg(Browse.SystemsModel.count) : "")
+        totalText: systems._listLayout || systems._tileLayout.showBottomStatusRow ? "" : (Browse.SystemsModel.count > 0 ? qsTr("%1 systems").arg(Browse.SystemsModel.count) : "")
+        rightTextOverride: {
+            if (!systems._listLayout || systemsGrid.itemCount <= 0)
+                return "";
+            return qsTr("%1 / %2").arg(systemsGrid.currentIndex + 1).arg(Math.max(1, Browse.SystemsModel.count));
+        }
         visible: !systems.transitioning && systems._tileLayout.showTopStrip
     }
 
-    Item {
+    BrowseListDetailView {
         id: listCard
 
         visible: !systems.transitioning && systems._listLayout
@@ -198,55 +203,22 @@ Item {
         anchors.topMargin: Sizing.pctH(2)
         anchors.bottom: parent.bottom
         anchors.bottomMargin: Sizing.pctH(8)
-
-        Rectangle {
-            anchors.fill: parent
-            color: Theme.surfaceCard
-            border.width: Sizing.stroke(1)
-            border.color: Theme.borderMid
-            radius: Sizing.cornerRadius
+        model: Browse.SystemsModel
+        currentIndex: systemsGrid.currentIndex
+        detailTitle: listCard.currentName
+        detailCoverKey: listCard.currentCoverKey
+        detailTags: Browse.SystemsModel.count > 0 ? Browse.SystemsModel.detail_tags_at(systemsGrid.currentIndex) : ""
+        onItemHovered: index => systems._focusIndex(index)
+        onItemClicked: index => {
+            systems._focusIndex(index);
+            systems.handleAction("accept");
         }
-
-        CardDivider {
-            id: listDivider
-
-            x: Sizing.center(parent.width, width)
-            anchors.top: parent.top
-            anchors.bottom: parent.bottom
+        onItemRightClicked: index => {
+            systems._focusIndex(index);
+            systems.handleAction("write_card");
         }
-
-        BrowseList {
-            id: systemsList
-
-            anchors.left: parent.left
-            anchors.right: listDivider.left
-            anchors.top: parent.top
-            anchors.bottom: parent.bottom
-            showChrome: false
-            model: Browse.SystemsModel
-            currentIndex: systemsGrid.currentIndex
-            onItemHovered: index => systems._focusIndex(index)
-            onItemClicked: index => {
-                systems._focusIndex(index);
-                systems.handleAction("accept");
-            }
-            onItemRightClicked: index => {
-                systems._focusIndex(index);
-                systems.handleAction("write_card");
-            }
-            onEmptyRightClicked: systems.handleAction("cancel")
-            onPageWheelRequested: delta => systems.handleAction(delta > 0 ? "page_next" : "page_prev")
-        }
-
-        BrowseDetailPane {
-            anchors.left: listDivider.right
-            anchors.right: parent.right
-            anchors.top: parent.top
-            anchors.bottom: parent.bottom
-            showChrome: false
-            title: systemsList.currentName
-            coverKey: systemsList.currentCoverKey
-        }
+        onEmptyRightClicked: systems.handleAction("cancel")
+        onPageWheelRequested: delta => systems.handleAction(delta > 0 ? "page_next" : "page_prev")
     }
 
     // Grid fills the safe zone between the top strip and the active
@@ -336,9 +308,9 @@ Item {
 
     ScreenStateOverlay {
         x: systems._listLayout ? 0 : systemsGrid.x
-        y: systems._listLayout ? systemsList.y : systemsGrid.y
+        y: systems._listLayout ? listCard.y : systemsGrid.y
         width: systems._listLayout ? systems.width : systemsGrid.width
-        height: systems._listLayout ? Math.max(0, systems.height - systemsList.y - systems._listOverlayBottomMargin) : systemsGrid.height
+        height: systems._listLayout ? Math.max(0, systems.height - listCard.y - systems._listOverlayBottomMargin) : systemsGrid.height
         loading: Browse.SystemsModel.loading
         errorMessage: Browse.SystemsModel.error_message ?? ""
         count: Browse.SystemsModel.count

--- a/src/ui/theme/Theme.qml
+++ b/src/ui/theme/Theme.qml
@@ -18,6 +18,10 @@ QtObject {
     // contrast — the page bg pattern stays visible in the gaps between
     // tiles, and each tile reads as a self-contained chip.
     readonly property color surfaceCard: "#2a2a45"
+    // Selected row fill. Cooler and darker than the amber accent so
+    // text stays high-contrast while the accent bar remains the focus
+    // cue layered on top.
+    readonly property color selectionSurface: "#3a3a66"
     // Modal scrim — translucent black so the screen behind a modal
     // dims uniformly without a blur or shader pass.
     readonly property color scrim: "#cc000000"

--- a/src/ui/translations/launcher_ar.ts
+++ b/src/ui/translations/launcher_ar.ts
@@ -1,59 +1,60 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
 <TS version="2.1" language="ar" sourcelanguage="en">
 <context>
     <name>AboutScreen</name>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="72" />
+        <location filename="../screens/AboutScreen.qml" line="71"/>
         <source>About / License</source>
         <translation>حول / الترخيص</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="154" />
+        <location filename="../screens/AboutScreen.qml" line="153"/>
         <source>Zaparoo Launcher</source>
         <translation>مشغّل Zaparoo</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="165" />
+        <location filename="../screens/AboutScreen.qml" line="164"/>
         <source>Version %1 · %2 · %3</source>
         <translation>الإصدار %1 · %2 · %3</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="178" />
+        <location filename="../screens/AboutScreen.qml" line="174"/>
         <source>Built %1</source>
         <translation>تم البناء %1</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="189" />
+        <location filename="../screens/AboutScreen.qml" line="185"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>حقوق النشر 2026 لشركة Wizzo Pty Ltd والمساهمين في مشروع Zaparoo.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="200" />
+        <location filename="../screens/AboutScreen.qml" line="196"/>
         <source>Source available under the PolyForm Noncommercial License 1.0.0. Free for personal, non-commercial use. Commercial use or redistribution requires a separate license.</source>
         <translation>المصدر متاح بموجب ترخيص PolyForm Noncommercial 1.0.0. مجاني للاستخدام الشخصي وغير التجاري. يتطلب الاستخدام التجاري أو إعادة التوزيع ترخيصًا منفصلًا.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="211" />
+        <location filename="../screens/AboutScreen.qml" line="207"/>
         <source>Commercial licensing: legal@zaparoo.org</source>
         <translation>الترخيص التجاري: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="222" />
+        <location filename="../screens/AboutScreen.qml" line="218"/>
         <source>Project: https://zaparoo.org</source>
         <translation>المشروع: https://zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="232" />
+        <location filename="../screens/AboutScreen.qml" line="228"/>
         <source>Created by</source>
         <translation>أنشأه</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="256" />
+        <location filename="../screens/AboutScreen.qml" line="252"/>
         <source>Translations</source>
         <translation>الترجمات</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="280" />
+        <location filename="../screens/AboutScreen.qml" line="276"/>
         <source>Full license text in COPYING.</source>
         <translation>نص الترخيص الكامل موجود في COPYING.</translation>
     </message>
@@ -61,60 +62,103 @@
 <context>
     <name>BootOverlay</name>
     <message>
-        <location filename="../components/BootOverlay.qml" line="76" />
-        <source>Can't reach Zaparoo Core. Check your connection.</source>
+        <location filename="../components/BootOverlay.qml" line="76"/>
+        <source>Can&apos;t reach Zaparoo Core. Check your connection.</source>
         <translation>تعذر الوصول إلى Zaparoo Core. تحقق من الاتصال.</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="78" />
+        <location filename="../components/BootOverlay.qml" line="78"/>
         <source>Reconnecting…</source>
         <translation>جارٍ إعادة الاتصال…</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="80" />
+        <location filename="../components/BootOverlay.qml" line="80"/>
         <source>Loading library…</source>
         <translation>جارٍ تحميل المكتبة…</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="85" />
+        <location filename="../components/BootOverlay.qml" line="85"/>
         <source>Connecting to Zaparoo Core…</source>
         <translation>جارٍ الاتصال بـ Zaparoo Core…</translation>
     </message>
 </context>
 <context>
+    <name>BrowseDetailPane</name>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="22"/>
+        <source>Loading…</source>
+        <translation type="unfinished">جارٍ التحميل…</translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="43"/>
+        <source>Year</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="45"/>
+        <source>Genre</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <source>Players</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <source>Developer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <source>Publisher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <source>Rating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="55"/>
+        <source>Filename</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommercialNoticeModal</name>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="59" />
+        <location filename="../components/CommercialNoticeModal.qml" line="59"/>
         <source>Welcome to Zaparoo Launcher</source>
         <translation>مرحبًا بك في مشغّل Zaparoo</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="68" />
+        <location filename="../components/CommercialNoticeModal.qml" line="68"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>حقوق النشر 2026 لشركة Wizzo Pty Ltd والمساهمين في مشروع Zaparoo.</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="79" />
+        <location filename="../components/CommercialNoticeModal.qml" line="79"/>
         <source>This free source-available build is for personal and non-commercial use only. Commercial use or redistribution requires a license.</source>
         <translation>هذه النسخة المجانية ذات المصدر المتاح مخصصة للاستخدام الشخصي وغير التجاري فقط. يتطلب الاستخدام التجاري أو إعادة التوزيع ترخيصًا.</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="90" />
+        <location filename="../components/CommercialNoticeModal.qml" line="90"/>
         <source>Contact: legal@zaparoo.org</source>
         <translation>للتواصل: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="101" />
+        <location filename="../components/CommercialNoticeModal.qml" line="101"/>
         <source>Full details available any time under Settings &gt; About / License.</source>
         <translation>التفاصيل الكاملة متاحة في أي وقت ضمن الإعدادات &gt; حول / الترخيص.</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="119" />
+        <location filename="../components/CommercialNoticeModal.qml" line="119"/>
         <source>Created by</source>
         <translation>أنشأه</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="162" />
+        <location filename="../components/CommercialNoticeModal.qml" line="162"/>
         <source>I understand</source>
         <translation>أفهم</translation>
     </message>
@@ -122,68 +166,68 @@
 <context>
     <name>CoreStatusPill</name>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="44" />
-        <location filename="../components/CoreStatusPill.qml" line="50" />
+        <location filename="../components/CoreStatusPill.qml" line="44"/>
+        <location filename="../components/CoreStatusPill.qml" line="50"/>
         <source>Disconnected</source>
         <translation>غير متصل</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="47" />
+        <location filename="../components/CoreStatusPill.qml" line="47"/>
         <source>Reconnecting…</source>
         <translation>جارٍ إعادة الاتصال…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="53" />
+        <location filename="../components/CoreStatusPill.qml" line="53"/>
         <source>Connecting…</source>
         <translation>جارٍ الاتصال…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="56" />
+        <location filename="../components/CoreStatusPill.qml" line="56"/>
         <source>Core error</source>
         <translation>خطأ في النواة</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="60" />
+        <location filename="../components/CoreStatusPill.qml" line="60"/>
         <source>Optimizing database</source>
         <translation>جارٍ تحسين قاعدة البيانات</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="67" />
+        <location filename="../components/CoreStatusPill.qml" line="67"/>
         <source>Indexing paused</source>
         <translation>تم إيقاف الفهرسة مؤقتًا</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="70" />
+        <location filename="../components/CoreStatusPill.qml" line="70"/>
         <source>Indexing %1/%2 - %3</source>
         <translation>فهرسة %1/%2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="73" />
+        <location filename="../components/CoreStatusPill.qml" line="73"/>
         <source>Indexing %1/%2</source>
         <translation>فهرسة %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="75" />
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
         <source>Indexing…</source>
         <translation>جارٍ الفهرسة…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="83" />
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Scrape paused</source>
         <translation>تم إيقاف الاستخراج مؤقتًا</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="86" />
+        <location filename="../components/CoreStatusPill.qml" line="86"/>
         <source>Scraping %1/%2 - %3</source>
         <translation>استخراج %1/%2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="89" />
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
         <source>Scraping %1/%2</source>
         <translation>استخراج %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="91" />
+        <location filename="../components/CoreStatusPill.qml" line="91"/>
         <source>Scraping…</source>
         <translation>جارٍ الاستخراج…</translation>
     </message>
@@ -191,22 +235,22 @@
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="182" />
+        <location filename="../screens/FavoritesScreen.qml" line="183"/>
         <source>Favorites</source>
         <translation>المفضلة</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="185" />
+        <location filename="../screens/FavoritesScreen.qml" line="186"/>
         <source>%1 entries</source>
         <translation>%1 عناصر</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="283" />
+        <location filename="../screens/FavoritesScreen.qml" line="309"/>
         <source>No favorites yet</source>
         <translation>لا توجد مفضلات بعد</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="284" />
+        <location filename="../screens/FavoritesScreen.qml" line="310"/>
         <source>Loading favorites…</source>
         <translation>جارٍ تحميل المفضلة…</translation>
     </message>
@@ -214,75 +258,99 @@
 <context>
     <name>FirstRunIndexModal</name>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="127" />
+        <location filename="../components/FirstRunIndexModal.qml" line="127"/>
         <source>First-time setup</source>
         <translation>إعداد أول مرة</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="136" />
+        <location filename="../components/FirstRunIndexModal.qml" line="136"/>
         <source>Zaparoo needs to scan your games before you can use the launcher. This usually takes a few minutes.</source>
         <translation>يحتاج Zaparoo إلى فحص ألعابك قبل أن تتمكن من استخدام المشغّل. يستغرق هذا عادة بضع دقائق.</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="158" />
+        <location filename="../components/FirstRunIndexModal.qml" line="158"/>
         <source>Optimizing database - almost done</source>
         <translation>جارٍ تحسين قاعدة البيانات - أوشك على الانتهاء</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="211" />
+        <location filename="../components/FirstRunIndexModal.qml" line="211"/>
         <source>Indexing paused</source>
         <translation>تم إيقاف الفهرسة مؤقتًا</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="213" />
+        <location filename="../components/FirstRunIndexModal.qml" line="213"/>
         <source>Step %1 of %2 - %3</source>
         <translation>الخطوة %1 من %2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="215" />
+        <location filename="../components/FirstRunIndexModal.qml" line="215"/>
         <source>Step %1 of %2</source>
         <translation>الخطوة %1 من %2</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="216" />
+        <location filename="../components/FirstRunIndexModal.qml" line="216"/>
         <source>Preparing…</source>
         <translation>جارٍ التحضير…</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="233" />
+        <location filename="../components/FirstRunIndexModal.qml" line="233"/>
         <source>Done. %1 files indexed.</source>
         <translation>تم. تمت فهرسة %1 ملفات.</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="263" />
+        <location filename="../components/FirstRunIndexModal.qml" line="263"/>
         <source>Cancel</source>
         <translation>إلغاء</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="263" />
+        <location filename="../components/FirstRunIndexModal.qml" line="263"/>
         <source>Start scan</source>
         <translation>ابدأ الفحص</translation>
     </message>
 </context>
 <context>
+    <name>GameInfoModal</name>
+    <message>
+        <location filename="../components/GameInfoModal.qml" line="86"/>
+        <source>Back to close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/GameInfoModal.qml" line="114"/>
+        <source>Loading details…</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="363" />
+        <location filename="../screens/GamesScreen.qml" line="367"/>
+        <location filename="../screens/GamesScreen.qml" line="537"/>
         <source>%1 files</source>
         <translation>%1 ملفات</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="533" />
+        <location filename="../screens/GamesScreen.qml" line="437"/>
+        <source>Loading game…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/GamesScreen.qml" line="554"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/GamesScreen.qml" line="569"/>
         <source>No games in this system</source>
         <translation>لا توجد ألعاب في هذا النظام</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="534" />
+        <location filename="../screens/GamesScreen.qml" line="570"/>
         <source>Loading games…</source>
         <translation>جارٍ تحميل الألعاب…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="556" />
+        <location filename="../screens/GamesScreen.qml" line="592"/>
         <source>Loading more…</source>
         <translation>جارٍ تحميل المزيد…</translation>
     </message>
@@ -290,22 +358,22 @@
 <context>
     <name>HubScreen</name>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91" />
+        <location filename="../screens/HubScreen.qml" line="91"/>
         <source>Favorites</source>
         <translation>المفضلة</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="96" />
+        <location filename="../screens/HubScreen.qml" line="96"/>
         <source>Recently Played</source>
         <translation>تم لعبها مؤخرًا</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="101" />
+        <location filename="../screens/HubScreen.qml" line="101"/>
         <source>Settings</source>
         <translation>الإعدادات</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="537" />
+        <location filename="../screens/HubScreen.qml" line="537"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>لا توجد أنظمة متاحة. شغّل تحديث قاعدة بيانات الوسائط من الإعدادات.</translation>
     </message>
@@ -313,7 +381,7 @@
 <context>
     <name>LoadingIndicator</name>
     <message>
-        <location filename="../components/LoadingIndicator.qml" line="26" />
+        <location filename="../components/LoadingIndicator.qml" line="26"/>
         <source>Loading…</source>
         <translation>جارٍ التحميل…</translation>
     </message>
@@ -321,32 +389,32 @@
 <context>
     <name>LogUploadModal</name>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="87" />
+        <location filename="../components/LogUploadModal.qml" line="87"/>
         <source>Upload log file</source>
         <translation>رفع ملف السجل</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="97" />
+        <location filename="../components/LogUploadModal.qml" line="97"/>
         <source>Uploading log file - this may take a moment.</source>
         <translation>جارٍ رفع ملف السجل - قد يستغرق هذا لحظة.</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197" />
+        <location filename="../components/LogUploadModal.qml" line="197"/>
         <source>Upload failed: %1</source>
         <translation>فشل الرفع: %1</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197" />
+        <location filename="../components/LogUploadModal.qml" line="197"/>
         <source>Upload failed.</source>
         <translation>فشل الرفع.</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="227" />
+        <location filename="../components/LogUploadModal.qml" line="227"/>
         <source>Retry</source>
         <translation>إعادة المحاولة</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="227" />
+        <location filename="../components/LogUploadModal.qml" line="227"/>
         <source>Done</source>
         <translation>تم</translation>
     </message>
@@ -354,58 +422,64 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="723" />
+        <location filename="../app/Main.qml" line="753"/>
         <source>Launch core</source>
         <translation>تشغيل النواة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="731" />
-        <location filename="../app/Main.qml" line="755" />
+        <location filename="../app/Main.qml" line="761"/>
+        <location filename="../app/Main.qml" line="781"/>
+        <source>More info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="765"/>
+        <location filename="../app/Main.qml" line="804"/>
         <source>Launch game</source>
         <translation>تشغيل اللعبة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="741" />
+        <location filename="../app/Main.qml" line="785"/>
         <source>Remove from favorites</source>
         <translation>إزالة من المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="741" />
+        <location filename="../app/Main.qml" line="785"/>
         <source>Add to favorites</source>
         <translation>أضف إلى المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="747" />
+        <location filename="../app/Main.qml" line="790"/>
         <source>Write to NFC token</source>
         <translation>الكتابة إلى رمز NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="751" />
+        <location filename="../app/Main.qml" line="794"/>
         <source>QR code</source>
         <translation>رمز QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1437" />
+        <location filename="../app/Main.qml" line="1652"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1439" />
+        <location filename="../app/Main.qml" line="1654"/>
         <source>Loading games…</source>
         <translation>جارٍ تحميل الألعاب…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1441" />
+        <location filename="../app/Main.qml" line="1656"/>
         <source>Loading favorites…</source>
         <translation>جارٍ تحميل المفضلة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1443" />
+        <location filename="../app/Main.qml" line="1658"/>
         <source>Loading recently played…</source>
         <translation>جارٍ تحميل آخر ما تم لعبه…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1445" />
+        <location filename="../app/Main.qml" line="1660"/>
         <source>Loading…</source>
         <translation>جارٍ التحميل…</translation>
     </message>
@@ -413,144 +487,151 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="127" />
+        <location filename="../app/MainLayout.qml" line="141"/>
         <source>Zaparoo Launcher</source>
         <translation>مشغّل Zaparoo</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="475" />
+        <location filename="../app/MainLayout.qml" line="545"/>
         <source>Writing failed</source>
         <translation>فشلت الكتابة</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="475" />
+        <location filename="../app/MainLayout.qml" line="545"/>
         <source>Put a writable card near the reader</source>
         <translation>ضع بطاقة قابلة للكتابة بالقرب من القارئ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="540" />
+        <location filename="../app/MainLayout.qml" line="556"/>
+        <source>Quit and restart Zaparoo Launcher?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="557"/>
+        <source>In order to apply this setting we need to restart the launcher.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="632"/>
         <source>Quit Zaparoo Launcher?</source>
         <translation>هل تريد إنهاء مشغّل Zaparoo؟</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="541" />
+        <location filename="../app/MainLayout.qml" line="633"/>
         <source>Are you sure you want to exit?</source>
         <translation>هل أنت متأكد أنك تريد الخروج؟</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="613" />
-        <location filename="../app/MainLayout.qml" line="685" />
-        <location filename="../app/MainLayout.qml" line="700" />
-        <location filename="../app/MainLayout.qml" line="743" />
-        <location filename="../app/MainLayout.qml" line="772" />
-        <location filename="../app/MainLayout.qml" line="819" />
-        <location filename="../app/MainLayout.qml" line="860" />
-        <location filename="../app/MainLayout.qml" line="924" />
+        <location filename="../app/MainLayout.qml" line="705"/>
+        <location filename="../app/MainLayout.qml" line="777"/>
+        <location filename="../app/MainLayout.qml" line="820"/>
+        <location filename="../app/MainLayout.qml" line="849"/>
+        <location filename="../app/MainLayout.qml" line="896"/>
+        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="1001"/>
         <source>Move</source>
         <translation>تحريك</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="617" />
-        <location filename="../app/MainLayout.qml" line="689" />
-        <location filename="../app/MainLayout.qml" line="704" />
+        <location filename="../app/MainLayout.qml" line="709"/>
+        <location filename="../app/MainLayout.qml" line="781"/>
         <source>Select</source>
         <translation>تحديد</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="621" />
-        <location filename="../app/MainLayout.qml" line="625" />
-        <location filename="../app/MainLayout.qml" line="639" />
-        <location filename="../app/MainLayout.qml" line="652" />
-        <location filename="../app/MainLayout.qml" line="663" />
+        <location filename="../app/MainLayout.qml" line="713"/>
+        <location filename="../app/MainLayout.qml" line="717"/>
+        <location filename="../app/MainLayout.qml" line="731"/>
+        <location filename="../app/MainLayout.qml" line="744"/>
+        <location filename="../app/MainLayout.qml" line="755"/>
         <source>Close</source>
         <translation>إغلاق</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="632" />
-        <location filename="../app/MainLayout.qml" line="670" />
-        <location filename="../app/MainLayout.qml" line="693" />
-        <location filename="../app/MainLayout.qml" line="708" />
-        <location filename="../app/MainLayout.qml" line="719" />
+        <location filename="../app/MainLayout.qml" line="724"/>
+        <location filename="../app/MainLayout.qml" line="762"/>
+        <location filename="../app/MainLayout.qml" line="785"/>
+        <location filename="../app/MainLayout.qml" line="796"/>
         <source>Cancel</source>
         <translation>إلغاء</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="648" />
+        <location filename="../app/MainLayout.qml" line="740"/>
         <source>Done</source>
         <translation>تم</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="659" />
-        <location filename="../app/MainLayout.qml" line="795" />
-        <location filename="../app/MainLayout.qml" line="845" />
-        <location filename="../app/MainLayout.qml" line="950" />
+        <location filename="../app/MainLayout.qml" line="751"/>
+        <location filename="../app/MainLayout.qml" line="872"/>
+        <location filename="../app/MainLayout.qml" line="922"/>
+        <location filename="../app/MainLayout.qml" line="1027"/>
         <source>Retry</source>
         <translation>إعادة المحاولة</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="678" />
+        <location filename="../app/MainLayout.qml" line="770"/>
         <source>I understand</source>
         <translation>أفهم</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="727" />
+        <location filename="../app/MainLayout.qml" line="804"/>
         <source>Start</source>
         <translation>ابدأ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="747" />
-        <location filename="../app/MainLayout.qml" line="782" />
-        <location filename="../app/MainLayout.qml" line="829" />
-        <location filename="../app/MainLayout.qml" line="934" />
+        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="859"/>
+        <location filename="../app/MainLayout.qml" line="906"/>
+        <location filename="../app/MainLayout.qml" line="1011"/>
         <source>Open</source>
         <translation>فتح</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="751" />
+        <location filename="../app/MainLayout.qml" line="828"/>
         <source>Quit</source>
         <translation>إنهاء</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="760" />
-        <location filename="../app/MainLayout.qml" line="788" />
-        <location filename="../app/MainLayout.qml" line="799" />
-        <location filename="../app/MainLayout.qml" line="811" />
-        <location filename="../app/MainLayout.qml" line="838" />
-        <location filename="../app/MainLayout.qml" line="849" />
-        <location filename="../app/MainLayout.qml" line="884" />
-        <location filename="../app/MainLayout.qml" line="900" />
-        <location filename="../app/MainLayout.qml" line="909" />
-        <location filename="../app/MainLayout.qml" line="943" />
-        <location filename="../app/MainLayout.qml" line="954" />
+        <location filename="../app/MainLayout.qml" line="837"/>
+        <location filename="../app/MainLayout.qml" line="865"/>
+        <location filename="../app/MainLayout.qml" line="876"/>
+        <location filename="../app/MainLayout.qml" line="888"/>
+        <location filename="../app/MainLayout.qml" line="915"/>
+        <location filename="../app/MainLayout.qml" line="926"/>
+        <location filename="../app/MainLayout.qml" line="961"/>
+        <location filename="../app/MainLayout.qml" line="977"/>
+        <location filename="../app/MainLayout.qml" line="986"/>
+        <location filename="../app/MainLayout.qml" line="1020"/>
+        <location filename="../app/MainLayout.qml" line="1031"/>
         <source>Back</source>
         <translation>رجوع</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="778" />
-        <location filename="../app/MainLayout.qml" line="825" />
-        <location filename="../app/MainLayout.qml" line="930" />
+        <location filename="../app/MainLayout.qml" line="855"/>
+        <location filename="../app/MainLayout.qml" line="902"/>
+        <location filename="../app/MainLayout.qml" line="1007"/>
         <source>Page</source>
         <translation>صفحة</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="785" />
-        <location filename="../app/MainLayout.qml" line="834" />
-        <location filename="../app/MainLayout.qml" line="939" />
+        <location filename="../app/MainLayout.qml" line="862"/>
+        <location filename="../app/MainLayout.qml" line="911"/>
+        <location filename="../app/MainLayout.qml" line="1016"/>
         <source>Options</source>
         <translation>الخيارات</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="869" />
+        <location filename="../app/MainLayout.qml" line="946"/>
         <source>Change</source>
         <translation>تغيير</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="875" />
+        <location filename="../app/MainLayout.qml" line="952"/>
         <source>Toggle</source>
         <translation>تبديل</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="896" />
+        <location filename="../app/MainLayout.qml" line="973"/>
         <source>Scroll</source>
         <translation>تمرير</translation>
     </message>
@@ -558,22 +639,22 @@
 <context>
     <name>Modal</name>
     <message>
-        <location filename="../components/Modal.qml" line="49" />
+        <location filename="../components/Modal.qml" line="49"/>
         <source>OK</source>
         <translation>حسنًا</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="50" />
+        <location filename="../components/Modal.qml" line="50"/>
         <source>Yes</source>
         <translation>نعم</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="51" />
+        <location filename="../components/Modal.qml" line="51"/>
         <source>No</source>
         <translation>لا</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="198" />
+        <location filename="../components/Modal.qml" line="198"/>
         <source>Cancel</source>
         <translation>إلغاء</translation>
     </message>
@@ -581,22 +662,22 @@
 <context>
     <name>RecentsScreen</name>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="183" />
+        <location filename="../screens/RecentsScreen.qml" line="184"/>
         <source>Recently Played</source>
         <translation>تم لعبها مؤخرًا</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="186" />
+        <location filename="../screens/RecentsScreen.qml" line="187"/>
         <source>%1 entries</source>
         <translation>%1 عناصر</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="281" />
+        <location filename="../screens/RecentsScreen.qml" line="311"/>
         <source>Nothing played yet</source>
         <translation>لم يتم لعب أي شيء بعد</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="282" />
+        <location filename="../screens/RecentsScreen.qml" line="312"/>
         <source>Loading recently played…</source>
         <translation>جارٍ تحميل آخر ما تم لعبه…</translation>
     </message>
@@ -604,17 +685,17 @@
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="26" />
+        <location filename="../components/ScreenStateOverlay.qml" line="26"/>
         <source>Nothing here</source>
         <translation>لا يوجد شيء هنا</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27" />
+        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
         <source>Loading…</source>
         <translation>جارٍ التحميل…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="57" />
+        <location filename="../components/ScreenStateOverlay.qml" line="57"/>
         <source>Failed to load</source>
         <translation>فشل التحميل</translation>
     </message>
@@ -622,288 +703,294 @@
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="61" />
+        <location filename="../screens/SettingsScreen.qml" line="61"/>
         <source>General</source>
         <translation>عام</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78" />
-        <location filename="../screens/SettingsScreen.qml" line="436" />
+        <location filename="../screens/SettingsScreen.qml" line="73"/>
+        <location filename="../screens/SettingsScreen.qml" line="432"/>
         <source>Language</source>
         <translation>اللغة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83" />
-        <location filename="../screens/SettingsScreen.qml" line="445" />
+        <location filename="../screens/SettingsScreen.qml" line="78"/>
+        <location filename="../screens/SettingsScreen.qml" line="441"/>
         <source>Browsing layout</source>
         <translation>تخطيط التصفح</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88" />
-        <location filename="../screens/SettingsScreen.qml" line="454" />
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="450"/>
         <source>Button style</source>
         <translation>نمط الأزرار</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="93" />
-        <location filename="../screens/SettingsScreen.qml" line="463" />
+        <location filename="../screens/SettingsScreen.qml" line="88"/>
+        <location filename="../screens/SettingsScreen.qml" line="459"/>
         <source>Screensaver</source>
         <translation>شاشة التوقف</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97" />
+        <location filename="../screens/SettingsScreen.qml" line="92"/>
         <source>Library</source>
         <translation>المكتبة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102" />
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <source>Discover arcade alternate versions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
         <source>Update media database</source>
         <translation>تحديث قاعدة بيانات الوسائط</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="107" />
+        <location filename="../screens/SettingsScreen.qml" line="107"/>
         <source>Scrape metadata</source>
         <translation>استخراج البيانات الوصفية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111" />
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
         <source>Advanced</source>
         <translation>متقدم</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116" />
+        <location filename="../screens/SettingsScreen.qml" line="116"/>
         <source>Mouse support</source>
         <translation>دعم الفأرة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121" />
+        <location filename="../screens/SettingsScreen.qml" line="121"/>
         <source>Debug logging</source>
         <translation>تسجيل التصحيح</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126" />
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Upload log file</source>
         <translation>رفع ملف السجل</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131" />
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
         <source>About / License</source>
         <translation>حول / الترخيص</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147" />
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
         <source>Optimizing</source>
         <translation>جارٍ التحسين</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149" />
-        <location filename="../screens/SettingsScreen.qml" line="158" />
+        <location filename="../screens/SettingsScreen.qml" line="149"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
         <source>Paused</source>
         <translation>متوقف مؤقتًا</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149" />
-        <location filename="../screens/SettingsScreen.qml" line="158" />
+        <location filename="../screens/SettingsScreen.qml" line="149"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
         <source>In progress</source>
         <translation>قيد التنفيذ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152" />
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>%1 indexed</source>
         <translation>تمت فهرسة %1</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="161" />
+        <location filename="../screens/SettingsScreen.qml" line="161"/>
         <source>%1 scraped</source>
         <translation>تم استخراج %1</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270" />
+        <location filename="../screens/SettingsScreen.qml" line="266"/>
         <source>Cancel</source>
         <translation>إلغاء</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270" />
+        <location filename="../screens/SettingsScreen.qml" line="266"/>
         <source>Start</source>
         <translation>ابدأ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="272" />
+        <location filename="../screens/SettingsScreen.qml" line="268"/>
         <source>Upload</source>
         <translation>رفع</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="274" />
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
         <source>Open</source>
         <translation>فتح</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="326" />
+        <location filename="../screens/SettingsScreen.qml" line="322"/>
         <source>Default</source>
         <translation>افتراضي</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="346" />
+        <location filename="../screens/SettingsScreen.qml" line="342"/>
         <source>English</source>
         <translation>الإنجليزية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="348" />
+        <location filename="../screens/SettingsScreen.qml" line="344"/>
         <source>Italian</source>
         <translation>الإيطالية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="350" />
+        <location filename="../screens/SettingsScreen.qml" line="346"/>
         <source>German</source>
         <translation>الألمانية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="352" />
+        <location filename="../screens/SettingsScreen.qml" line="348"/>
         <source>Greek</source>
         <translation>اليونانية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="354" />
+        <location filename="../screens/SettingsScreen.qml" line="350"/>
         <source>Japanese</source>
         <translation>اليابانية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="356" />
+        <location filename="../screens/SettingsScreen.qml" line="352"/>
         <source>Korean</source>
         <translation>الكورية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="358" />
+        <location filename="../screens/SettingsScreen.qml" line="354"/>
         <source>Dutch</source>
         <translation>الهولندية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="360" />
+        <location filename="../screens/SettingsScreen.qml" line="356"/>
         <source>Romanian</source>
         <translation>الرومانية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="362" />
+        <location filename="../screens/SettingsScreen.qml" line="358"/>
         <source>Slovak</source>
         <translation>السلوفاكية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="364" />
+        <location filename="../screens/SettingsScreen.qml" line="360"/>
         <source>Ukrainian</source>
         <translation>الأوكرانية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="366" />
+        <location filename="../screens/SettingsScreen.qml" line="362"/>
         <source>Chinese (Simplified)</source>
         <translation>الصينية المبسطة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="368" />
+        <location filename="../screens/SettingsScreen.qml" line="364"/>
         <source>Hebrew</source>
         <translation>العبرية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="370" />
+        <location filename="../screens/SettingsScreen.qml" line="366"/>
         <source>Arabic</source>
         <translation>العربية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="372" />
+        <location filename="../screens/SettingsScreen.qml" line="368"/>
         <source>Hindi</source>
         <translation>الهندية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="373" />
+        <location filename="../screens/SettingsScreen.qml" line="369"/>
         <source>Auto</source>
         <translation>تلقائي</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="378" />
+        <location filename="../screens/SettingsScreen.qml" line="374"/>
         <source>Detailed list view</source>
         <translation>عرض قائمة مفصلة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="379" />
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Grid view</source>
         <translation>عرض الشبكة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="384" />
+        <location filename="../screens/SettingsScreen.qml" line="380"/>
         <source>Style B</source>
         <translation>النمط B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="386" />
+        <location filename="../screens/SettingsScreen.qml" line="382"/>
         <source>Style C</source>
         <translation>النمط C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="388" />
+        <location filename="../screens/SettingsScreen.qml" line="384"/>
         <source>Style D</source>
         <translation>النمط D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="389" />
+        <location filename="../screens/SettingsScreen.qml" line="385"/>
         <source>Style A</source>
         <translation>النمط A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399" />
+        <location filename="../screens/SettingsScreen.qml" line="395"/>
         <source>Off</source>
         <translation>إيقاف</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="401" />
+        <location filename="../screens/SettingsScreen.qml" line="397"/>
         <source>1 second (testing)</source>
         <translation>ثانية واحدة (اختبار)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="403" />
+        <location filename="../screens/SettingsScreen.qml" line="399"/>
         <source>1 minute</source>
         <translation>دقيقة واحدة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405" />
+        <location filename="../screens/SettingsScreen.qml" line="401"/>
         <source>2 minutes</source>
         <translation>دقيقتان</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="407" />
+        <location filename="../screens/SettingsScreen.qml" line="403"/>
         <source>5 minutes</source>
         <translation>5 دقائق</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="409" />
+        <location filename="../screens/SettingsScreen.qml" line="405"/>
         <source>10 minutes</source>
         <translation>10 دقائق</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="411" />
+        <location filename="../screens/SettingsScreen.qml" line="407"/>
         <source>15 minutes</source>
         <translation>15 دقيقة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="413" />
+        <location filename="../screens/SettingsScreen.qml" line="409"/>
         <source>30 minutes</source>
         <translation>30 دقيقة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="414" />
+        <location filename="../screens/SettingsScreen.qml" line="410"/>
         <source>%1 seconds</source>
         <translation>%1 ثوانٍ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="427" />
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="423"/>
         <source>Resolution</source>
         <translation>الدقة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="555" />
+        <location filename="../screens/SettingsScreen.qml" line="563"/>
         <source>Settings</source>
         <translation>الإعدادات</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="745" />
+        <location filename="../screens/SettingsScreen.qml" line="755"/>
         <source>No settings available on this platform</source>
         <translation>لا توجد إعدادات متاحة على هذه المنصة</translation>
     </message>
@@ -911,17 +998,23 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="182" />
+        <location filename="../screens/SystemsScreen.qml" line="185"/>
+        <location filename="../screens/SystemsScreen.qml" line="313"/>
         <source>%1 systems</source>
         <translation>%1 أنظمة</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="279" />
+        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SystemsScreen.qml" line="345"/>
         <source>No systems in this category</source>
         <translation>لا توجد أنظمة في هذه الفئة</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="280" />
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>
@@ -929,7 +1022,7 @@
 <context>
     <name>TopStatusStrip</name>
     <message>
-        <location filename="../components/TopStatusStrip.qml" line="88" />
+        <location filename="../components/TopStatusStrip.qml" line="90"/>
         <source>Page %1 / %2</source>
         <translation>الصفحة %1 / %2</translation>
     </message>

--- a/src/ui/translations/launcher_ar.ts
+++ b/src/ui/translations/launcher_ar.ts
@@ -245,27 +245,27 @@
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="183"/>
+        <location filename="../screens/FavoritesScreen.qml" line="225"/>
         <source>Favorites</source>
         <translation>المفضلة</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="186"/>
+        <location filename="../screens/FavoritesScreen.qml" line="228"/>
         <source>%1 entries</source>
         <translation>%1 عناصر</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="190"/>
+        <location filename="../screens/FavoritesScreen.qml" line="232"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="280"/>
+        <location filename="../screens/FavoritesScreen.qml" line="334"/>
         <source>No favorites yet</source>
         <translation>لا توجد مفضلات بعد</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="281"/>
+        <location filename="../screens/FavoritesScreen.qml" line="335"/>
         <source>Loading favorites…</source>
         <translation>جارٍ تحميل المفضلة…</translation>
     </message>
@@ -326,13 +326,13 @@
 <context>
     <name>GameInfoModal</name>
     <message>
-        <location filename="../components/GameInfoModal.qml" line="86"/>
-        <source>Back to close</source>
+        <location filename="../components/GameInfoModal.qml" line="104"/>
+        <source>Loading details…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/GameInfoModal.qml" line="114"/>
-        <source>Loading details…</source>
+        <location filename="../components/GameInfoModal.qml" line="174"/>
+        <source>Loading image…</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -446,7 +446,7 @@
     <message>
         <location filename="../app/Main.qml" line="761"/>
         <location filename="../app/Main.qml" line="781"/>
-        <source>More info</source>
+        <source>View details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -679,27 +679,27 @@
 <context>
     <name>RecentsScreen</name>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="184"/>
+        <location filename="../screens/RecentsScreen.qml" line="226"/>
         <source>Recently Played</source>
         <translation>تم لعبها مؤخرًا</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="187"/>
+        <location filename="../screens/RecentsScreen.qml" line="229"/>
         <source>%1 entries</source>
         <translation>%1 عناصر</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="191"/>
+        <location filename="../screens/RecentsScreen.qml" line="233"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="282"/>
+        <location filename="../screens/RecentsScreen.qml" line="336"/>
         <source>Nothing played yet</source>
         <translation>لم يتم لعب أي شيء بعد</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="283"/>
+        <location filename="../screens/RecentsScreen.qml" line="337"/>
         <source>Loading recently played…</source>
         <translation>جارٍ تحميل آخر ما تم لعبه…</translation>
     </message>

--- a/src/ui/translations/launcher_ar.ts
+++ b/src/ui/translations/launcher_ar.ts
@@ -90,38 +90,48 @@
         <translation type="unfinished">جارٍ التحميل…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="43"/>
+        <location filename="../components/BrowseDetailPane.qml" line="44"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="45"/>
+        <location filename="../components/BrowseDetailPane.qml" line="46"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <location filename="../components/BrowseDetailPane.qml" line="48"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <location filename="../components/BrowseDetailPane.qml" line="50"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <location filename="../components/BrowseDetailPane.qml" line="52"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <location filename="../components/BrowseDetailPane.qml" line="54"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="55"/>
-        <source>Filename</source>
+        <location filename="../components/BrowseDetailPane.qml" line="56"/>
+        <source>Category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="58"/>
+        <source>Release date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="60"/>
+        <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -245,12 +255,17 @@
         <translation>%1 عناصر</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="309"/>
+        <location filename="../screens/FavoritesScreen.qml" line="190"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/FavoritesScreen.qml" line="280"/>
         <source>No favorites yet</source>
         <translation>لا توجد مفضلات بعد</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="310"/>
+        <location filename="../screens/FavoritesScreen.qml" line="281"/>
         <source>Loading favorites…</source>
         <translation>جارٍ تحميل المفضلة…</translation>
     </message>
@@ -324,33 +339,35 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="367"/>
-        <location filename="../screens/GamesScreen.qml" line="537"/>
+        <location filename="../screens/GamesScreen.qml" line="373"/>
+        <location filename="../screens/GamesScreen.qml" line="520"/>
         <source>%1 files</source>
         <translation>%1 ملفات</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="437"/>
+        <location filename="../screens/GamesScreen.qml" line="409"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="554"/>
+        <location filename="../screens/GamesScreen.qml" line="382"/>
+        <location filename="../screens/GamesScreen.qml" line="537"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="569"/>
+        <location filename="../screens/GamesScreen.qml" line="552"/>
         <source>No games in this system</source>
         <translation>لا توجد ألعاب في هذا النظام</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="570"/>
+        <location filename="../screens/GamesScreen.qml" line="553"/>
         <source>Loading games…</source>
         <translation>جارٍ تحميل الألعاب…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="592"/>
+        <location filename="../screens/GamesScreen.qml" line="378"/>
+        <location filename="../screens/GamesScreen.qml" line="575"/>
         <source>Loading more…</source>
         <translation>جارٍ تحميل المزيد…</translation>
     </message>
@@ -672,12 +689,17 @@
         <translation>%1 عناصر</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="311"/>
+        <location filename="../screens/RecentsScreen.qml" line="191"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/RecentsScreen.qml" line="282"/>
         <source>Nothing played yet</source>
         <translation>لم يتم لعب أي شيء بعد</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="312"/>
+        <location filename="../screens/RecentsScreen.qml" line="283"/>
         <source>Loading recently played…</source>
         <translation>جارٍ تحميل آخر ما تم لعبه…</translation>
     </message>
@@ -999,22 +1021,23 @@
     <name>SystemsScreen</name>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="185"/>
-        <location filename="../screens/SystemsScreen.qml" line="313"/>
+        <location filename="../screens/SystemsScreen.qml" line="285"/>
         <source>%1 systems</source>
         <translation>%1 أنظمة</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <location filename="../screens/SystemsScreen.qml" line="189"/>
+        <location filename="../screens/SystemsScreen.qml" line="302"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="345"/>
+        <location filename="../screens/SystemsScreen.qml" line="317"/>
         <source>No systems in this category</source>
         <translation>لا توجد أنظمة في هذه الفئة</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="318"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>
@@ -1022,7 +1045,7 @@
 <context>
     <name>TopStatusStrip</name>
     <message>
-        <location filename="../components/TopStatusStrip.qml" line="90"/>
+        <location filename="../components/TopStatusStrip.qml" line="91"/>
         <source>Page %1 / %2</source>
         <translation>الصفحة %1 / %2</translation>
     </message>

--- a/src/ui/translations/launcher_de.ts
+++ b/src/ui/translations/launcher_de.ts
@@ -245,27 +245,27 @@
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="183"/>
+        <location filename="../screens/FavoritesScreen.qml" line="225"/>
         <source>Favorites</source>
         <translation>Favoriten</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="186"/>
+        <location filename="../screens/FavoritesScreen.qml" line="228"/>
         <source>%1 entries</source>
         <translation>%1 Einträge</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="190"/>
+        <location filename="../screens/FavoritesScreen.qml" line="232"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="280"/>
+        <location filename="../screens/FavoritesScreen.qml" line="334"/>
         <source>No favorites yet</source>
         <translation>Noch keine Favoriten</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="281"/>
+        <location filename="../screens/FavoritesScreen.qml" line="335"/>
         <source>Loading favorites…</source>
         <translation>Favoriten werden geladen…</translation>
     </message>
@@ -326,13 +326,13 @@
 <context>
     <name>GameInfoModal</name>
     <message>
-        <location filename="../components/GameInfoModal.qml" line="86"/>
-        <source>Back to close</source>
+        <location filename="../components/GameInfoModal.qml" line="104"/>
+        <source>Loading details…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/GameInfoModal.qml" line="114"/>
-        <source>Loading details…</source>
+        <location filename="../components/GameInfoModal.qml" line="174"/>
+        <source>Loading image…</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -444,12 +444,6 @@
         <translation>Core starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="781"/>
-        <source>More info</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../app/Main.qml" line="785"/>
         <source>Remove from favorites</source>
         <translation>Aus Favoriten entfernen</translation>
@@ -474,6 +468,12 @@
         <location filename="../app/Main.qml" line="804"/>
         <source>Launch game</source>
         <translation>Spiel starten</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="761"/>
+        <location filename="../app/Main.qml" line="781"/>
+        <source>View details</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1652"/>
@@ -679,27 +679,27 @@
 <context>
     <name>RecentsScreen</name>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="184"/>
+        <location filename="../screens/RecentsScreen.qml" line="226"/>
         <source>Recently Played</source>
         <translation>Zuletzt gespielt</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="187"/>
+        <location filename="../screens/RecentsScreen.qml" line="229"/>
         <source>%1 entries</source>
         <translation>%1 Einträge</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="191"/>
+        <location filename="../screens/RecentsScreen.qml" line="233"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="283"/>
+        <location filename="../screens/RecentsScreen.qml" line="337"/>
         <source>Loading recently played…</source>
         <translation>Zuletzt gespielte werden geladen…</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="282"/>
+        <location filename="../screens/RecentsScreen.qml" line="336"/>
         <source>Nothing played yet</source>
         <translation>Noch nichts gespielt</translation>
     </message>

--- a/src/ui/translations/launcher_de.ts
+++ b/src/ui/translations/launcher_de.ts
@@ -90,38 +90,48 @@
         <translation type="unfinished">Wird geladen…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="43"/>
+        <location filename="../components/BrowseDetailPane.qml" line="44"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="45"/>
+        <location filename="../components/BrowseDetailPane.qml" line="46"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <location filename="../components/BrowseDetailPane.qml" line="48"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <location filename="../components/BrowseDetailPane.qml" line="50"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <location filename="../components/BrowseDetailPane.qml" line="52"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <location filename="../components/BrowseDetailPane.qml" line="54"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="55"/>
-        <source>Filename</source>
+        <location filename="../components/BrowseDetailPane.qml" line="56"/>
+        <source>Category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="58"/>
+        <source>Release date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="60"/>
+        <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -245,12 +255,17 @@
         <translation>%1 Einträge</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="309"/>
+        <location filename="../screens/FavoritesScreen.qml" line="190"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/FavoritesScreen.qml" line="280"/>
         <source>No favorites yet</source>
         <translation>Noch keine Favoriten</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="310"/>
+        <location filename="../screens/FavoritesScreen.qml" line="281"/>
         <source>Loading favorites…</source>
         <translation>Favoriten werden geladen…</translation>
     </message>
@@ -324,33 +339,35 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="367"/>
-        <location filename="../screens/GamesScreen.qml" line="537"/>
+        <location filename="../screens/GamesScreen.qml" line="373"/>
+        <location filename="../screens/GamesScreen.qml" line="520"/>
         <source>%1 files</source>
         <translation>%1 Dateien</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="437"/>
+        <location filename="../screens/GamesScreen.qml" line="409"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="554"/>
+        <location filename="../screens/GamesScreen.qml" line="382"/>
+        <location filename="../screens/GamesScreen.qml" line="537"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="570"/>
+        <location filename="../screens/GamesScreen.qml" line="553"/>
         <source>Loading games…</source>
         <translation>Spiele werden geladen…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="592"/>
+        <location filename="../screens/GamesScreen.qml" line="378"/>
+        <location filename="../screens/GamesScreen.qml" line="575"/>
         <source>Loading more…</source>
         <translation>Mehr laden…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="569"/>
+        <location filename="../screens/GamesScreen.qml" line="552"/>
         <source>No games in this system</source>
         <translation>Keine Spiele in diesem System</translation>
     </message>
@@ -672,12 +689,17 @@
         <translation>%1 Einträge</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="312"/>
+        <location filename="../screens/RecentsScreen.qml" line="191"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/RecentsScreen.qml" line="283"/>
         <source>Loading recently played…</source>
         <translation>Zuletzt gespielte werden geladen…</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="311"/>
+        <location filename="../screens/RecentsScreen.qml" line="282"/>
         <source>Nothing played yet</source>
         <translation>Noch nichts gespielt</translation>
     </message>
@@ -999,22 +1021,23 @@
     <name>SystemsScreen</name>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="185"/>
-        <location filename="../screens/SystemsScreen.qml" line="313"/>
+        <location filename="../screens/SystemsScreen.qml" line="285"/>
         <source>%1 systems</source>
         <translation>%1 Systeme</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <location filename="../screens/SystemsScreen.qml" line="189"/>
+        <location filename="../screens/SystemsScreen.qml" line="302"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="345"/>
+        <location filename="../screens/SystemsScreen.qml" line="317"/>
         <source>No systems in this category</source>
         <translation>Keine Systeme in dieser Kategorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="318"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>
@@ -1022,7 +1045,7 @@
 <context>
     <name>TopStatusStrip</name>
     <message>
-        <location filename="../components/TopStatusStrip.qml" line="90"/>
+        <location filename="../components/TopStatusStrip.qml" line="91"/>
         <source>Page %1 / %2</source>
         <translation>Seite %1 / %2</translation>
     </message>

--- a/src/ui/translations/launcher_de.ts
+++ b/src/ui/translations/launcher_de.ts
@@ -1,59 +1,60 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
 <TS version="2.1" language="de_DE" sourcelanguage="en">
 <context>
     <name>AboutScreen</name>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="72" />
+        <location filename="../screens/AboutScreen.qml" line="71"/>
         <source>About / License</source>
         <translation>Über / Lizenz</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="154" />
+        <location filename="../screens/AboutScreen.qml" line="153"/>
         <source>Zaparoo Launcher</source>
         <translation>Zaparoo-Launcher</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="165" />
+        <location filename="../screens/AboutScreen.qml" line="164"/>
         <source>Version %1 · %2 · %3</source>
         <translation>Fassung %1 · %2 · %3</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="178" />
+        <location filename="../screens/AboutScreen.qml" line="174"/>
         <source>Built %1</source>
         <translation>Erstellt am %1</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="189" />
+        <location filename="../screens/AboutScreen.qml" line="185"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>Copyright 2026 Wizzo Pty Ltd und die Mitwirkenden des Zaparoo-Projekts.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="200" />
+        <location filename="../screens/AboutScreen.qml" line="196"/>
         <source>Source available under the PolyForm Noncommercial License 1.0.0. Free for personal, non-commercial use. Commercial use or redistribution requires a separate license.</source>
         <translation>Quellcode verfügbar unter der PolyForm Noncommercial License 1.0.0. Kostenlos für den persönlichen, nicht kommerziellen Gebrauch. Kommerzielle Nutzung oder Weiterverbreitung erfordert eine separate Lizenz.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="211" />
+        <location filename="../screens/AboutScreen.qml" line="207"/>
         <source>Commercial licensing: legal@zaparoo.org</source>
         <translation>Kommerzielle Lizenzierung: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="222" />
+        <location filename="../screens/AboutScreen.qml" line="218"/>
         <source>Project: https://zaparoo.org</source>
         <translation>Projekt: https://zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="232" />
+        <location filename="../screens/AboutScreen.qml" line="228"/>
         <source>Created by</source>
         <translation>Erstellt von</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="256" />
+        <location filename="../screens/AboutScreen.qml" line="252"/>
         <source>Translations</source>
         <translation>Übersetzungen</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="280" />
+        <location filename="../screens/AboutScreen.qml" line="276"/>
         <source>Full license text in COPYING.</source>
         <translation>Vollständiger Lizenztext in COPYING.</translation>
     </message>
@@ -61,60 +62,103 @@
 <context>
     <name>BootOverlay</name>
     <message>
-        <location filename="../components/BootOverlay.qml" line="76" />
-        <source>Can't reach Zaparoo Core. Check your connection.</source>
+        <location filename="../components/BootOverlay.qml" line="76"/>
+        <source>Can&apos;t reach Zaparoo Core. Check your connection.</source>
         <translation>Zaparoo Core nicht erreichbar. Bitte Verbindung prüfen.</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="78" />
+        <location filename="../components/BootOverlay.qml" line="78"/>
         <source>Reconnecting…</source>
         <translation>Verbindung wird wiederhergestellt…</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="80" />
+        <location filename="../components/BootOverlay.qml" line="80"/>
         <source>Loading library…</source>
         <translation>Bibliothek wird geladen…</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="85" />
+        <location filename="../components/BootOverlay.qml" line="85"/>
         <source>Connecting to Zaparoo Core…</source>
         <translation>Verbindung zu Zaparoo Core…</translation>
     </message>
 </context>
 <context>
+    <name>BrowseDetailPane</name>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="22"/>
+        <source>Loading…</source>
+        <translation type="unfinished">Wird geladen…</translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="43"/>
+        <source>Year</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="45"/>
+        <source>Genre</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <source>Players</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <source>Developer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <source>Publisher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <source>Rating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="55"/>
+        <source>Filename</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommercialNoticeModal</name>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="59" />
+        <location filename="../components/CommercialNoticeModal.qml" line="59"/>
         <source>Welcome to Zaparoo Launcher</source>
         <translation>Willkommen beim Zaparoo Launcher</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="68" />
+        <location filename="../components/CommercialNoticeModal.qml" line="68"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>Copyright 2026 Wizzo Pty Ltd und die Mitwirkenden des Zaparoo-Projekts.</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="79" />
+        <location filename="../components/CommercialNoticeModal.qml" line="79"/>
         <source>This free source-available build is for personal and non-commercial use only. Commercial use or redistribution requires a license.</source>
         <translation>Diese kostenlose, quelloffene Version ist nur für den persönlichen und nicht-kommerziellen Gebrauch. Kommerzielle Nutzung oder Weitergabe erfordert eine Lizenz.</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="90" />
+        <location filename="../components/CommercialNoticeModal.qml" line="90"/>
         <source>Contact: legal@zaparoo.org</source>
         <translation>Kontakt: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="101" />
+        <location filename="../components/CommercialNoticeModal.qml" line="101"/>
         <source>Full details available any time under Settings &gt; About / License.</source>
         <translation>Vollständige Details jederzeit unter Einstellungen &gt; Über / Lizenz.</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="119" />
+        <location filename="../components/CommercialNoticeModal.qml" line="119"/>
         <source>Created by</source>
         <translation>Erstellt von</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="162" />
+        <location filename="../components/CommercialNoticeModal.qml" line="162"/>
         <source>I understand</source>
         <translation>Ich verstehe</translation>
     </message>
@@ -122,68 +166,68 @@
 <context>
     <name>CoreStatusPill</name>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="44" />
-        <location filename="../components/CoreStatusPill.qml" line="50" />
+        <location filename="../components/CoreStatusPill.qml" line="44"/>
+        <location filename="../components/CoreStatusPill.qml" line="50"/>
         <source>Disconnected</source>
         <translation>Getrennt</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="47" />
+        <location filename="../components/CoreStatusPill.qml" line="47"/>
         <source>Reconnecting…</source>
         <translation>Verbindung wird wiederhergestellt…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="53" />
+        <location filename="../components/CoreStatusPill.qml" line="53"/>
         <source>Connecting…</source>
         <translation>Verbindung wird aufgebaut…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="56" />
+        <location filename="../components/CoreStatusPill.qml" line="56"/>
         <source>Core error</source>
         <translation>Core-Fehler</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="60" />
+        <location filename="../components/CoreStatusPill.qml" line="60"/>
         <source>Optimizing database</source>
         <translation>Datenbank wird optimiert</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="67" />
+        <location filename="../components/CoreStatusPill.qml" line="67"/>
         <source>Indexing paused</source>
         <translation>Indizierung pausiert</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="70" />
+        <location filename="../components/CoreStatusPill.qml" line="70"/>
         <source>Indexing %1/%2 - %3</source>
         <translation>Indizierung %1/%2 – %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="86" />
+        <location filename="../components/CoreStatusPill.qml" line="86"/>
         <source>Scraping %1/%2 - %3</source>
         <translation>Scraping %1/%2 – %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="73" />
+        <location filename="../components/CoreStatusPill.qml" line="73"/>
         <source>Indexing %1/%2</source>
         <translation>Indizierung %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="75" />
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
         <source>Indexing…</source>
         <translation>Indizierung…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="83" />
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Scrape paused</source>
         <translation>Scraping pausiert</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="89" />
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
         <source>Scraping %1/%2</source>
         <translation>Metadatenabruf %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="91" />
+        <location filename="../components/CoreStatusPill.qml" line="91"/>
         <source>Scraping…</source>
         <translation>Metadaten werden abgerufen…</translation>
     </message>
@@ -191,22 +235,22 @@
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="182" />
+        <location filename="../screens/FavoritesScreen.qml" line="183"/>
         <source>Favorites</source>
         <translation>Favoriten</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="185" />
+        <location filename="../screens/FavoritesScreen.qml" line="186"/>
         <source>%1 entries</source>
         <translation>%1 Einträge</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="283" />
+        <location filename="../screens/FavoritesScreen.qml" line="309"/>
         <source>No favorites yet</source>
         <translation>Noch keine Favoriten</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="284" />
+        <location filename="../screens/FavoritesScreen.qml" line="310"/>
         <source>Loading favorites…</source>
         <translation>Favoriten werden geladen…</translation>
     </message>
@@ -214,75 +258,99 @@
 <context>
     <name>FirstRunIndexModal</name>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="127" />
+        <location filename="../components/FirstRunIndexModal.qml" line="127"/>
         <source>First-time setup</source>
         <translation>Ersteinrichtung</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="136" />
+        <location filename="../components/FirstRunIndexModal.qml" line="136"/>
         <source>Zaparoo needs to scan your games before you can use the launcher. This usually takes a few minutes.</source>
         <translation>Zaparoo muss deine Spiele scannen, bevor du den Launcher nutzen kannst. Dies dauert normalerweise ein paar Minuten.</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="211" />
+        <location filename="../components/FirstRunIndexModal.qml" line="211"/>
         <source>Indexing paused</source>
         <translation>Indizierung pausiert</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="158" />
+        <location filename="../components/FirstRunIndexModal.qml" line="158"/>
         <source>Optimizing database - almost done</source>
         <translation>Datenbank wird optimiert – fast fertig</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="213" />
+        <location filename="../components/FirstRunIndexModal.qml" line="213"/>
         <source>Step %1 of %2 - %3</source>
         <translation>Schritt %1 von %2 – %3</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="215" />
+        <location filename="../components/FirstRunIndexModal.qml" line="215"/>
         <source>Step %1 of %2</source>
         <translation>Schritt %1 von %2</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="216" />
+        <location filename="../components/FirstRunIndexModal.qml" line="216"/>
         <source>Preparing…</source>
         <translation>Vorbereitung…</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="233" />
+        <location filename="../components/FirstRunIndexModal.qml" line="233"/>
         <source>Done. %1 files indexed.</source>
         <translation>Fertig. %1 Dateien indiziert.</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="263" />
+        <location filename="../components/FirstRunIndexModal.qml" line="263"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="263" />
+        <location filename="../components/FirstRunIndexModal.qml" line="263"/>
         <source>Start scan</source>
         <translation>Scan starten</translation>
     </message>
 </context>
 <context>
+    <name>GameInfoModal</name>
+    <message>
+        <location filename="../components/GameInfoModal.qml" line="86"/>
+        <source>Back to close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/GameInfoModal.qml" line="114"/>
+        <source>Loading details…</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="363" />
+        <location filename="../screens/GamesScreen.qml" line="367"/>
+        <location filename="../screens/GamesScreen.qml" line="537"/>
         <source>%1 files</source>
         <translation>%1 Dateien</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="534" />
+        <location filename="../screens/GamesScreen.qml" line="437"/>
+        <source>Loading game…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/GamesScreen.qml" line="554"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/GamesScreen.qml" line="570"/>
         <source>Loading games…</source>
         <translation>Spiele werden geladen…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="556" />
+        <location filename="../screens/GamesScreen.qml" line="592"/>
         <source>Loading more…</source>
         <translation>Mehr laden…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="533" />
+        <location filename="../screens/GamesScreen.qml" line="569"/>
         <source>No games in this system</source>
         <translation>Keine Spiele in diesem System</translation>
     </message>
@@ -290,22 +358,22 @@
 <context>
     <name>HubScreen</name>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91" />
+        <location filename="../screens/HubScreen.qml" line="91"/>
         <source>Favorites</source>
         <translation>Favoriten</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="96" />
+        <location filename="../screens/HubScreen.qml" line="96"/>
         <source>Recently Played</source>
         <translation>Zuletzt gespielt</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="101" />
+        <location filename="../screens/HubScreen.qml" line="101"/>
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="537" />
+        <location filename="../screens/HubScreen.qml" line="537"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Keine Systeme verfügbar. Bitte Mediendatenbank unter Einstellungen aktualisieren.</translation>
     </message>
@@ -313,7 +381,7 @@
 <context>
     <name>LoadingIndicator</name>
     <message>
-        <location filename="../components/LoadingIndicator.qml" line="26" />
+        <location filename="../components/LoadingIndicator.qml" line="26"/>
         <source>Loading…</source>
         <translation>Wird geladen…</translation>
     </message>
@@ -321,32 +389,32 @@
 <context>
     <name>LogUploadModal</name>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="87" />
+        <location filename="../components/LogUploadModal.qml" line="87"/>
         <source>Upload log file</source>
         <translation>Protokolldatei hochladen</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="97" />
+        <location filename="../components/LogUploadModal.qml" line="97"/>
         <source>Uploading log file - this may take a moment.</source>
         <translation>Protokolldatei wird hochgeladen – dies kann einen Moment dauern.</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197" />
+        <location filename="../components/LogUploadModal.qml" line="197"/>
         <source>Upload failed: %1</source>
         <translation>Upload fehlgeschlagen: %1</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197" />
+        <location filename="../components/LogUploadModal.qml" line="197"/>
         <source>Upload failed.</source>
         <translation>Upload fehlgeschlagen.</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="227" />
+        <location filename="../components/LogUploadModal.qml" line="227"/>
         <source>Retry</source>
         <translation>Wiederholen</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="227" />
+        <location filename="../components/LogUploadModal.qml" line="227"/>
         <source>Done</source>
         <translation>Fertig</translation>
     </message>
@@ -354,58 +422,64 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="723" />
+        <location filename="../app/Main.qml" line="753"/>
         <source>Launch core</source>
         <translation>Core starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="741" />
+        <location filename="../app/Main.qml" line="761"/>
+        <location filename="../app/Main.qml" line="781"/>
+        <source>More info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="785"/>
         <source>Remove from favorites</source>
         <translation>Aus Favoriten entfernen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="741" />
+        <location filename="../app/Main.qml" line="785"/>
         <source>Add to favorites</source>
         <translation>Zu Favoriten hinzufügen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="747" />
+        <location filename="../app/Main.qml" line="790"/>
         <source>Write to NFC token</source>
         <translation>Auf NFC-Token schreiben</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="751" />
+        <location filename="../app/Main.qml" line="794"/>
         <source>QR code</source>
         <translation>QR-Code</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="731" />
-        <location filename="../app/Main.qml" line="755" />
+        <location filename="../app/Main.qml" line="765"/>
+        <location filename="../app/Main.qml" line="804"/>
         <source>Launch game</source>
         <translation>Spiel starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1437" />
+        <location filename="../app/Main.qml" line="1652"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1441" />
+        <location filename="../app/Main.qml" line="1656"/>
         <source>Loading favorites…</source>
         <translation>Favoriten werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1439" />
+        <location filename="../app/Main.qml" line="1654"/>
         <source>Loading games…</source>
         <translation>Spiele werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1443" />
+        <location filename="../app/Main.qml" line="1658"/>
         <source>Loading recently played…</source>
         <translation>Zuletzt gespielte werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1445" />
+        <location filename="../app/Main.qml" line="1660"/>
         <source>Loading…</source>
         <translation>Wird geladen…</translation>
     </message>
@@ -413,144 +487,151 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="127" />
+        <location filename="../app/MainLayout.qml" line="141"/>
         <source>Zaparoo Launcher</source>
         <translation>Zaparoo-Launcher</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="475" />
+        <location filename="../app/MainLayout.qml" line="545"/>
         <source>Writing failed</source>
         <translation>Schreiben fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="475" />
+        <location filename="../app/MainLayout.qml" line="545"/>
         <source>Put a writable card near the reader</source>
         <translation>Beschreibbare Karte an den Leser halten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="540" />
+        <location filename="../app/MainLayout.qml" line="556"/>
+        <source>Quit and restart Zaparoo Launcher?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="557"/>
+        <source>In order to apply this setting we need to restart the launcher.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="632"/>
         <source>Quit Zaparoo Launcher?</source>
         <translation>Zaparoo Launcher beenden?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="541" />
+        <location filename="../app/MainLayout.qml" line="633"/>
         <source>Are you sure you want to exit?</source>
         <translation>Wirklich beenden?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="617" />
-        <location filename="../app/MainLayout.qml" line="689" />
-        <location filename="../app/MainLayout.qml" line="704" />
+        <location filename="../app/MainLayout.qml" line="709"/>
+        <location filename="../app/MainLayout.qml" line="781"/>
         <source>Select</source>
         <translation>Auswählen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="621" />
-        <location filename="../app/MainLayout.qml" line="625" />
-        <location filename="../app/MainLayout.qml" line="639" />
-        <location filename="../app/MainLayout.qml" line="652" />
-        <location filename="../app/MainLayout.qml" line="663" />
+        <location filename="../app/MainLayout.qml" line="713"/>
+        <location filename="../app/MainLayout.qml" line="717"/>
+        <location filename="../app/MainLayout.qml" line="731"/>
+        <location filename="../app/MainLayout.qml" line="744"/>
+        <location filename="../app/MainLayout.qml" line="755"/>
         <source>Close</source>
         <translation>Schließen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="632" />
-        <location filename="../app/MainLayout.qml" line="670" />
-        <location filename="../app/MainLayout.qml" line="693" />
-        <location filename="../app/MainLayout.qml" line="708" />
-        <location filename="../app/MainLayout.qml" line="719" />
+        <location filename="../app/MainLayout.qml" line="724"/>
+        <location filename="../app/MainLayout.qml" line="762"/>
+        <location filename="../app/MainLayout.qml" line="785"/>
+        <location filename="../app/MainLayout.qml" line="796"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="648" />
+        <location filename="../app/MainLayout.qml" line="740"/>
         <source>Done</source>
         <translation>Fertig</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="678" />
+        <location filename="../app/MainLayout.qml" line="770"/>
         <source>I understand</source>
         <translation>Ich verstehe</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="727" />
+        <location filename="../app/MainLayout.qml" line="804"/>
         <source>Start</source>
         <translation>Starten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="896" />
+        <location filename="../app/MainLayout.qml" line="973"/>
         <source>Scroll</source>
         <translation>Scrollen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="613" />
-        <location filename="../app/MainLayout.qml" line="685" />
-        <location filename="../app/MainLayout.qml" line="700" />
-        <location filename="../app/MainLayout.qml" line="743" />
-        <location filename="../app/MainLayout.qml" line="772" />
-        <location filename="../app/MainLayout.qml" line="819" />
-        <location filename="../app/MainLayout.qml" line="860" />
-        <location filename="../app/MainLayout.qml" line="924" />
+        <location filename="../app/MainLayout.qml" line="705"/>
+        <location filename="../app/MainLayout.qml" line="777"/>
+        <location filename="../app/MainLayout.qml" line="820"/>
+        <location filename="../app/MainLayout.qml" line="849"/>
+        <location filename="../app/MainLayout.qml" line="896"/>
+        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="1001"/>
         <source>Move</source>
         <translation>Bewegen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="747" />
-        <location filename="../app/MainLayout.qml" line="782" />
-        <location filename="../app/MainLayout.qml" line="829" />
-        <location filename="../app/MainLayout.qml" line="934" />
+        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="859"/>
+        <location filename="../app/MainLayout.qml" line="906"/>
+        <location filename="../app/MainLayout.qml" line="1011"/>
         <source>Open</source>
         <translation>Öffnen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="751" />
+        <location filename="../app/MainLayout.qml" line="828"/>
         <source>Quit</source>
         <translation>Beenden</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="760" />
-        <location filename="../app/MainLayout.qml" line="788" />
-        <location filename="../app/MainLayout.qml" line="799" />
-        <location filename="../app/MainLayout.qml" line="811" />
-        <location filename="../app/MainLayout.qml" line="838" />
-        <location filename="../app/MainLayout.qml" line="849" />
-        <location filename="../app/MainLayout.qml" line="884" />
-        <location filename="../app/MainLayout.qml" line="900" />
-        <location filename="../app/MainLayout.qml" line="909" />
-        <location filename="../app/MainLayout.qml" line="943" />
-        <location filename="../app/MainLayout.qml" line="954" />
+        <location filename="../app/MainLayout.qml" line="837"/>
+        <location filename="../app/MainLayout.qml" line="865"/>
+        <location filename="../app/MainLayout.qml" line="876"/>
+        <location filename="../app/MainLayout.qml" line="888"/>
+        <location filename="../app/MainLayout.qml" line="915"/>
+        <location filename="../app/MainLayout.qml" line="926"/>
+        <location filename="../app/MainLayout.qml" line="961"/>
+        <location filename="../app/MainLayout.qml" line="977"/>
+        <location filename="../app/MainLayout.qml" line="986"/>
+        <location filename="../app/MainLayout.qml" line="1020"/>
+        <location filename="../app/MainLayout.qml" line="1031"/>
         <source>Back</source>
         <translation>Zurück</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="778" />
-        <location filename="../app/MainLayout.qml" line="825" />
-        <location filename="../app/MainLayout.qml" line="930" />
+        <location filename="../app/MainLayout.qml" line="855"/>
+        <location filename="../app/MainLayout.qml" line="902"/>
+        <location filename="../app/MainLayout.qml" line="1007"/>
         <source>Page</source>
         <translation>Seite</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="785" />
-        <location filename="../app/MainLayout.qml" line="834" />
-        <location filename="../app/MainLayout.qml" line="939" />
+        <location filename="../app/MainLayout.qml" line="862"/>
+        <location filename="../app/MainLayout.qml" line="911"/>
+        <location filename="../app/MainLayout.qml" line="1016"/>
         <source>Options</source>
         <translation>Optionen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="659" />
-        <location filename="../app/MainLayout.qml" line="795" />
-        <location filename="../app/MainLayout.qml" line="845" />
-        <location filename="../app/MainLayout.qml" line="950" />
+        <location filename="../app/MainLayout.qml" line="751"/>
+        <location filename="../app/MainLayout.qml" line="872"/>
+        <location filename="../app/MainLayout.qml" line="922"/>
+        <location filename="../app/MainLayout.qml" line="1027"/>
         <source>Retry</source>
         <translation>Wiederholen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="869" />
+        <location filename="../app/MainLayout.qml" line="946"/>
         <source>Change</source>
         <translation>Ändern</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="875" />
+        <location filename="../app/MainLayout.qml" line="952"/>
         <source>Toggle</source>
         <translation>Umschalten</translation>
     </message>
@@ -558,22 +639,22 @@
 <context>
     <name>Modal</name>
     <message>
-        <location filename="../components/Modal.qml" line="49" />
+        <location filename="../components/Modal.qml" line="49"/>
         <source>OK</source>
         <translation>In Ordnung</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="50" />
+        <location filename="../components/Modal.qml" line="50"/>
         <source>Yes</source>
         <translation>Ja</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="51" />
+        <location filename="../components/Modal.qml" line="51"/>
         <source>No</source>
         <translation>Nein</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="198" />
+        <location filename="../components/Modal.qml" line="198"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
@@ -581,22 +662,22 @@
 <context>
     <name>RecentsScreen</name>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="183" />
+        <location filename="../screens/RecentsScreen.qml" line="184"/>
         <source>Recently Played</source>
         <translation>Zuletzt gespielt</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="186" />
+        <location filename="../screens/RecentsScreen.qml" line="187"/>
         <source>%1 entries</source>
         <translation>%1 Einträge</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="282" />
+        <location filename="../screens/RecentsScreen.qml" line="312"/>
         <source>Loading recently played…</source>
         <translation>Zuletzt gespielte werden geladen…</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="281" />
+        <location filename="../screens/RecentsScreen.qml" line="311"/>
         <source>Nothing played yet</source>
         <translation>Noch nichts gespielt</translation>
     </message>
@@ -604,17 +685,17 @@
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="26" />
+        <location filename="../components/ScreenStateOverlay.qml" line="26"/>
         <source>Nothing here</source>
         <translation>Nichts hier</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27" />
+        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
         <source>Loading…</source>
         <translation>Wird geladen…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="57" />
+        <location filename="../components/ScreenStateOverlay.qml" line="57"/>
         <source>Failed to load</source>
         <translation>Laden fehlgeschlagen</translation>
     </message>
@@ -622,288 +703,294 @@
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78" />
-        <location filename="../screens/SettingsScreen.qml" line="436" />
+        <location filename="../screens/SettingsScreen.qml" line="73"/>
+        <location filename="../screens/SettingsScreen.qml" line="432"/>
         <source>Language</source>
         <translation>Sprache</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83" />
-        <location filename="../screens/SettingsScreen.qml" line="445" />
+        <location filename="../screens/SettingsScreen.qml" line="78"/>
+        <location filename="../screens/SettingsScreen.qml" line="441"/>
         <source>Browsing layout</source>
         <translation>Darstellungsmodus</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116" />
+        <location filename="../screens/SettingsScreen.qml" line="116"/>
         <source>Mouse support</source>
         <translation>Mausunterstützung</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102" />
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
         <source>Update media database</source>
         <translation>Mediendatenbank aktualisieren</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="61" />
+        <location filename="../screens/SettingsScreen.qml" line="61"/>
         <source>General</source>
         <translation>Allgemein</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88" />
-        <location filename="../screens/SettingsScreen.qml" line="454" />
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="450"/>
         <source>Button style</source>
         <translation>Schaltflächenstil</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="93" />
-        <location filename="../screens/SettingsScreen.qml" line="463" />
+        <location filename="../screens/SettingsScreen.qml" line="88"/>
+        <location filename="../screens/SettingsScreen.qml" line="459"/>
         <source>Screensaver</source>
         <translation>Bildschirmschoner</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97" />
+        <location filename="../screens/SettingsScreen.qml" line="92"/>
         <source>Library</source>
         <translation>Bibliothek</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="107" />
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <source>Discover arcade alternate versions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="107"/>
         <source>Scrape metadata</source>
         <translation>Metadaten abrufen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111" />
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
         <source>Advanced</source>
         <translation>Erweitert</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121" />
+        <location filename="../screens/SettingsScreen.qml" line="121"/>
         <source>Debug logging</source>
         <translation>Debug-Protokollierung</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126" />
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Upload log file</source>
         <translation>Protokolldatei hochladen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131" />
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
         <source>About / License</source>
         <translation>Über / Lizenz</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147" />
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
         <source>Optimizing</source>
         <translation>Wird optimiert</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149" />
-        <location filename="../screens/SettingsScreen.qml" line="158" />
+        <location filename="../screens/SettingsScreen.qml" line="149"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
         <source>Paused</source>
         <translation>Pausiert</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149" />
-        <location filename="../screens/SettingsScreen.qml" line="158" />
+        <location filename="../screens/SettingsScreen.qml" line="149"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
         <source>In progress</source>
         <translation>In Bearbeitung</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152" />
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>%1 indexed</source>
         <translation>%1 indiziert</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="161" />
+        <location filename="../screens/SettingsScreen.qml" line="161"/>
         <source>%1 scraped</source>
         <translation>%1 erfasst</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270" />
+        <location filename="../screens/SettingsScreen.qml" line="266"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270" />
+        <location filename="../screens/SettingsScreen.qml" line="266"/>
         <source>Start</source>
         <translation>Starten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="272" />
+        <location filename="../screens/SettingsScreen.qml" line="268"/>
         <source>Upload</source>
         <translation>Hochladen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="274" />
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
         <source>Open</source>
         <translation>Öffnen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="346" />
+        <location filename="../screens/SettingsScreen.qml" line="342"/>
         <source>English</source>
         <translation>Englisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="348" />
+        <location filename="../screens/SettingsScreen.qml" line="344"/>
         <source>Italian</source>
         <translation>Italienisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="350" />
+        <location filename="../screens/SettingsScreen.qml" line="346"/>
         <source>German</source>
         <translation>Deutsch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="352" />
+        <location filename="../screens/SettingsScreen.qml" line="348"/>
         <source>Greek</source>
         <translation>Griechisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="354" />
+        <location filename="../screens/SettingsScreen.qml" line="350"/>
         <source>Japanese</source>
         <translation>Japanisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="356" />
+        <location filename="../screens/SettingsScreen.qml" line="352"/>
         <source>Korean</source>
         <translation>Koreanisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="358" />
+        <location filename="../screens/SettingsScreen.qml" line="354"/>
         <source>Dutch</source>
         <translation>Niederländisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="360" />
+        <location filename="../screens/SettingsScreen.qml" line="356"/>
         <source>Romanian</source>
         <translation>Rumänisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="362" />
+        <location filename="../screens/SettingsScreen.qml" line="358"/>
         <source>Slovak</source>
         <translation>Slowakisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="364" />
+        <location filename="../screens/SettingsScreen.qml" line="360"/>
         <source>Ukrainian</source>
         <translation>Ukrainisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="366" />
+        <location filename="../screens/SettingsScreen.qml" line="362"/>
         <source>Chinese (Simplified)</source>
         <translation>Chinesisch (vereinfacht)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="368" />
+        <location filename="../screens/SettingsScreen.qml" line="364"/>
         <source>Hebrew</source>
         <translation>Hebräisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="370" />
+        <location filename="../screens/SettingsScreen.qml" line="366"/>
         <source>Arabic</source>
-        <translation type="unfinished" />
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="372" />
+        <location filename="../screens/SettingsScreen.qml" line="368"/>
         <source>Hindi</source>
-        <translation type="unfinished" />
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="373" />
+        <location filename="../screens/SettingsScreen.qml" line="369"/>
         <source>Auto</source>
         <translation>Automatisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="378" />
+        <location filename="../screens/SettingsScreen.qml" line="374"/>
         <source>Detailed list view</source>
         <translation>Detaillierte Listenansicht</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="379" />
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Grid view</source>
         <translation>Rasteransicht</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="384" />
+        <location filename="../screens/SettingsScreen.qml" line="380"/>
         <source>Style B</source>
         <translation>Stil B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="386" />
+        <location filename="../screens/SettingsScreen.qml" line="382"/>
         <source>Style C</source>
         <translation>Stil C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="388" />
+        <location filename="../screens/SettingsScreen.qml" line="384"/>
         <source>Style D</source>
         <translation>Stil D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="389" />
+        <location filename="../screens/SettingsScreen.qml" line="385"/>
         <source>Style A</source>
         <translation>Stil A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="326" />
+        <location filename="../screens/SettingsScreen.qml" line="322"/>
         <source>Default</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399" />
+        <location filename="../screens/SettingsScreen.qml" line="395"/>
         <source>Off</source>
         <translation>Aus</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="401" />
+        <location filename="../screens/SettingsScreen.qml" line="397"/>
         <source>1 second (testing)</source>
         <translation>1 Sekunde (Test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="403" />
+        <location filename="../screens/SettingsScreen.qml" line="399"/>
         <source>1 minute</source>
         <translation>1 Minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405" />
+        <location filename="../screens/SettingsScreen.qml" line="401"/>
         <source>2 minutes</source>
         <translation>2 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="407" />
+        <location filename="../screens/SettingsScreen.qml" line="403"/>
         <source>5 minutes</source>
         <translation>5 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="409" />
+        <location filename="../screens/SettingsScreen.qml" line="405"/>
         <source>10 minutes</source>
         <translation>10 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="411" />
+        <location filename="../screens/SettingsScreen.qml" line="407"/>
         <source>15 minutes</source>
         <translation>15 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="413" />
+        <location filename="../screens/SettingsScreen.qml" line="409"/>
         <source>30 minutes</source>
         <translation>30 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="414" />
+        <location filename="../screens/SettingsScreen.qml" line="410"/>
         <source>%1 seconds</source>
         <translation>%1 Sekunden</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="427" />
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="423"/>
         <source>Resolution</source>
         <translation>Auflösung</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="555" />
+        <location filename="../screens/SettingsScreen.qml" line="563"/>
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="745" />
+        <location filename="../screens/SettingsScreen.qml" line="755"/>
         <source>No settings available on this platform</source>
         <translation>Keine Einstellungen für diese Plattform verfügbar</translation>
     </message>
@@ -911,17 +998,23 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="182" />
+        <location filename="../screens/SystemsScreen.qml" line="185"/>
+        <location filename="../screens/SystemsScreen.qml" line="313"/>
         <source>%1 systems</source>
         <translation>%1 Systeme</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="279" />
+        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SystemsScreen.qml" line="345"/>
         <source>No systems in this category</source>
         <translation>Keine Systeme in dieser Kategorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="280" />
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>
@@ -929,7 +1022,7 @@
 <context>
     <name>TopStatusStrip</name>
     <message>
-        <location filename="../components/TopStatusStrip.qml" line="88" />
+        <location filename="../components/TopStatusStrip.qml" line="90"/>
         <source>Page %1 / %2</source>
         <translation>Seite %1 / %2</translation>
     </message>

--- a/src/ui/translations/launcher_el.ts
+++ b/src/ui/translations/launcher_el.ts
@@ -245,27 +245,27 @@
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="183"/>
+        <location filename="../screens/FavoritesScreen.qml" line="225"/>
         <source>Favorites</source>
         <translation>Αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="186"/>
+        <location filename="../screens/FavoritesScreen.qml" line="228"/>
         <source>%1 entries</source>
         <translation>%1 εγγραφές</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="190"/>
+        <location filename="../screens/FavoritesScreen.qml" line="232"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="280"/>
+        <location filename="../screens/FavoritesScreen.qml" line="334"/>
         <source>No favorites yet</source>
         <translation>Δεν υπάρχουν αγαπημένα ακόμα</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="281"/>
+        <location filename="../screens/FavoritesScreen.qml" line="335"/>
         <source>Loading favorites…</source>
         <translation>Φόρτωση αγαπημένων…</translation>
     </message>
@@ -326,13 +326,13 @@
 <context>
     <name>GameInfoModal</name>
     <message>
-        <location filename="../components/GameInfoModal.qml" line="86"/>
-        <source>Back to close</source>
+        <location filename="../components/GameInfoModal.qml" line="104"/>
+        <source>Loading details…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/GameInfoModal.qml" line="114"/>
-        <source>Loading details…</source>
+        <location filename="../components/GameInfoModal.qml" line="174"/>
+        <source>Loading image…</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -444,12 +444,6 @@
         <translation>Εκκίνηση Core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="781"/>
-        <source>More info</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../app/Main.qml" line="785"/>
         <source>Remove from favorites</source>
         <translation>Αφαίρεση από αγαπημένα</translation>
@@ -474,6 +468,12 @@
         <location filename="../app/Main.qml" line="804"/>
         <source>Launch game</source>
         <translation>Εκκίνηση παιχνιδιού</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="761"/>
+        <location filename="../app/Main.qml" line="781"/>
+        <source>View details</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1652"/>
@@ -679,27 +679,27 @@
 <context>
     <name>RecentsScreen</name>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="184"/>
+        <location filename="../screens/RecentsScreen.qml" line="226"/>
         <source>Recently Played</source>
         <translation>Πρόσφατα Παιγμένα</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="187"/>
+        <location filename="../screens/RecentsScreen.qml" line="229"/>
         <source>%1 entries</source>
         <translation>%1 εγγραφές</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="191"/>
+        <location filename="../screens/RecentsScreen.qml" line="233"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="283"/>
+        <location filename="../screens/RecentsScreen.qml" line="337"/>
         <source>Loading recently played…</source>
         <translation>Φόρτωση πρόσφατα παιγμένων…</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="282"/>
+        <location filename="../screens/RecentsScreen.qml" line="336"/>
         <source>Nothing played yet</source>
         <translation>Δεν παίχτηκε τίποτα ακόμα</translation>
     </message>

--- a/src/ui/translations/launcher_el.ts
+++ b/src/ui/translations/launcher_el.ts
@@ -90,38 +90,48 @@
         <translation type="unfinished">Φόρτωση…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="43"/>
+        <location filename="../components/BrowseDetailPane.qml" line="44"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="45"/>
+        <location filename="../components/BrowseDetailPane.qml" line="46"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <location filename="../components/BrowseDetailPane.qml" line="48"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <location filename="../components/BrowseDetailPane.qml" line="50"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <location filename="../components/BrowseDetailPane.qml" line="52"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <location filename="../components/BrowseDetailPane.qml" line="54"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="55"/>
-        <source>Filename</source>
+        <location filename="../components/BrowseDetailPane.qml" line="56"/>
+        <source>Category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="58"/>
+        <source>Release date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="60"/>
+        <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -245,12 +255,17 @@
         <translation>%1 εγγραφές</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="309"/>
+        <location filename="../screens/FavoritesScreen.qml" line="190"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/FavoritesScreen.qml" line="280"/>
         <source>No favorites yet</source>
         <translation>Δεν υπάρχουν αγαπημένα ακόμα</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="310"/>
+        <location filename="../screens/FavoritesScreen.qml" line="281"/>
         <source>Loading favorites…</source>
         <translation>Φόρτωση αγαπημένων…</translation>
     </message>
@@ -324,33 +339,35 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="367"/>
-        <location filename="../screens/GamesScreen.qml" line="537"/>
+        <location filename="../screens/GamesScreen.qml" line="373"/>
+        <location filename="../screens/GamesScreen.qml" line="520"/>
         <source>%1 files</source>
         <translation>%1 αρχεία</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="437"/>
+        <location filename="../screens/GamesScreen.qml" line="409"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="554"/>
+        <location filename="../screens/GamesScreen.qml" line="382"/>
+        <location filename="../screens/GamesScreen.qml" line="537"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="570"/>
+        <location filename="../screens/GamesScreen.qml" line="553"/>
         <source>Loading games…</source>
         <translation>Φόρτωση παιχνιδιών…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="592"/>
+        <location filename="../screens/GamesScreen.qml" line="378"/>
+        <location filename="../screens/GamesScreen.qml" line="575"/>
         <source>Loading more…</source>
         <translation>Φόρτωση περισσότερων…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="569"/>
+        <location filename="../screens/GamesScreen.qml" line="552"/>
         <source>No games in this system</source>
         <translation>Δεν υπάρχουν παιχνίδια σε αυτό το σύστημα</translation>
     </message>
@@ -672,12 +689,17 @@
         <translation>%1 εγγραφές</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="312"/>
+        <location filename="../screens/RecentsScreen.qml" line="191"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/RecentsScreen.qml" line="283"/>
         <source>Loading recently played…</source>
         <translation>Φόρτωση πρόσφατα παιγμένων…</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="311"/>
+        <location filename="../screens/RecentsScreen.qml" line="282"/>
         <source>Nothing played yet</source>
         <translation>Δεν παίχτηκε τίποτα ακόμα</translation>
     </message>
@@ -999,22 +1021,23 @@
     <name>SystemsScreen</name>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="185"/>
-        <location filename="../screens/SystemsScreen.qml" line="313"/>
+        <location filename="../screens/SystemsScreen.qml" line="285"/>
         <source>%1 systems</source>
         <translation>%1 συστήματα</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <location filename="../screens/SystemsScreen.qml" line="189"/>
+        <location filename="../screens/SystemsScreen.qml" line="302"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="345"/>
+        <location filename="../screens/SystemsScreen.qml" line="317"/>
         <source>No systems in this category</source>
         <translation>Δεν υπάρχουν συστήματα σε αυτή την κατηγορία</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="318"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>
@@ -1022,7 +1045,7 @@
 <context>
     <name>TopStatusStrip</name>
     <message>
-        <location filename="../components/TopStatusStrip.qml" line="90"/>
+        <location filename="../components/TopStatusStrip.qml" line="91"/>
         <source>Page %1 / %2</source>
         <translation>Σελίδα %1 / %2</translation>
     </message>

--- a/src/ui/translations/launcher_el.ts
+++ b/src/ui/translations/launcher_el.ts
@@ -1,59 +1,60 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
 <TS version="2.1" language="el" sourcelanguage="en">
 <context>
     <name>AboutScreen</name>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="72" />
+        <location filename="../screens/AboutScreen.qml" line="71"/>
         <source>About / License</source>
         <translation>Σχετικά / Άδεια</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="154" />
+        <location filename="../screens/AboutScreen.qml" line="153"/>
         <source>Zaparoo Launcher</source>
         <translation>Εκκινητής Zaparoo</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="165" />
+        <location filename="../screens/AboutScreen.qml" line="164"/>
         <source>Version %1 · %2 · %3</source>
         <translation>Έκδοση %1 · %2 · %3</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="178" />
+        <location filename="../screens/AboutScreen.qml" line="174"/>
         <source>Built %1</source>
         <translation>Κατασκευάστηκε %1</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="189" />
+        <location filename="../screens/AboutScreen.qml" line="185"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>Πνευματικά δικαιώματα 2026 Wizzo Pty Ltd και οι συντελεστές του έργου Zaparoo.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="200" />
+        <location filename="../screens/AboutScreen.qml" line="196"/>
         <source>Source available under the PolyForm Noncommercial License 1.0.0. Free for personal, non-commercial use. Commercial use or redistribution requires a separate license.</source>
         <translation>Ο πηγαίος κώδικας διατίθεται με την άδεια PolyForm Noncommercial License 1.0.0. Δωρεάν για προσωπική, μη εμπορική χρήση. Η εμπορική χρήση ή αναδιανομή απαιτεί ξεχωριστή άδεια.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="211" />
+        <location filename="../screens/AboutScreen.qml" line="207"/>
         <source>Commercial licensing: legal@zaparoo.org</source>
         <translation>Εμπορική αδειοδότηση: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="222" />
+        <location filename="../screens/AboutScreen.qml" line="218"/>
         <source>Project: https://zaparoo.org</source>
         <translation>Έργο: https://zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="232" />
+        <location filename="../screens/AboutScreen.qml" line="228"/>
         <source>Created by</source>
         <translation>Δημιουργήθηκε από</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="256" />
+        <location filename="../screens/AboutScreen.qml" line="252"/>
         <source>Translations</source>
         <translation>Μεταφράσεις</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="280" />
+        <location filename="../screens/AboutScreen.qml" line="276"/>
         <source>Full license text in COPYING.</source>
         <translation>Πλήρες κείμενο άδειας στο COPYING.</translation>
     </message>
@@ -61,60 +62,103 @@
 <context>
     <name>BootOverlay</name>
     <message>
-        <location filename="../components/BootOverlay.qml" line="76" />
-        <source>Can't reach Zaparoo Core. Check your connection.</source>
+        <location filename="../components/BootOverlay.qml" line="76"/>
+        <source>Can&apos;t reach Zaparoo Core. Check your connection.</source>
         <translation>Δεν είναι δυνατή η σύνδεση με το Zaparoo Core. Ελέγξτε τη σύνδεσή σας.</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="78" />
+        <location filename="../components/BootOverlay.qml" line="78"/>
         <source>Reconnecting…</source>
         <translation>Επανασύνδεση…</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="80" />
+        <location filename="../components/BootOverlay.qml" line="80"/>
         <source>Loading library…</source>
         <translation>Φόρτωση βιβλιοθήκης…</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="85" />
+        <location filename="../components/BootOverlay.qml" line="85"/>
         <source>Connecting to Zaparoo Core…</source>
         <translation>Σύνδεση στο Zaparoo Core…</translation>
     </message>
 </context>
 <context>
+    <name>BrowseDetailPane</name>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="22"/>
+        <source>Loading…</source>
+        <translation type="unfinished">Φόρτωση…</translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="43"/>
+        <source>Year</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="45"/>
+        <source>Genre</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <source>Players</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <source>Developer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <source>Publisher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <source>Rating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="55"/>
+        <source>Filename</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommercialNoticeModal</name>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="59" />
+        <location filename="../components/CommercialNoticeModal.qml" line="59"/>
         <source>Welcome to Zaparoo Launcher</source>
         <translation>Καλώς ήρθατε στο Zaparoo Launcher</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="68" />
+        <location filename="../components/CommercialNoticeModal.qml" line="68"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>Πνευματικά δικαιώματα 2026 Wizzo Pty Ltd και οι συντελεστές του έργου Zaparoo.</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="79" />
+        <location filename="../components/CommercialNoticeModal.qml" line="79"/>
         <source>This free source-available build is for personal and non-commercial use only. Commercial use or redistribution requires a license.</source>
         <translation>Αυτή η δωρεάν έκδοση προορίζεται μόνο για προσωπική και μη εμπορική χρήση. Η εμπορική χρήση ή αναδιανομή απαιτεί άδεια.</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="90" />
+        <location filename="../components/CommercialNoticeModal.qml" line="90"/>
         <source>Contact: legal@zaparoo.org</source>
         <translation>Επικοινωνία: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="101" />
+        <location filename="../components/CommercialNoticeModal.qml" line="101"/>
         <source>Full details available any time under Settings &gt; About / License.</source>
         <translation>Πλήρεις λεπτομέρειες ανά πάσα στιγμή στις Ρυθμίσεις &gt; Σχετικά / Άδεια.</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="119" />
+        <location filename="../components/CommercialNoticeModal.qml" line="119"/>
         <source>Created by</source>
         <translation>Δημιουργήθηκε από</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="162" />
+        <location filename="../components/CommercialNoticeModal.qml" line="162"/>
         <source>I understand</source>
         <translation>Κατανοώ</translation>
     </message>
@@ -122,68 +166,68 @@
 <context>
     <name>CoreStatusPill</name>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="44" />
-        <location filename="../components/CoreStatusPill.qml" line="50" />
+        <location filename="../components/CoreStatusPill.qml" line="44"/>
+        <location filename="../components/CoreStatusPill.qml" line="50"/>
         <source>Disconnected</source>
         <translation>Αποσυνδεδεμένο</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="47" />
+        <location filename="../components/CoreStatusPill.qml" line="47"/>
         <source>Reconnecting…</source>
         <translation>Επανασύνδεση…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="53" />
+        <location filename="../components/CoreStatusPill.qml" line="53"/>
         <source>Connecting…</source>
         <translation>Σύνδεση…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="56" />
+        <location filename="../components/CoreStatusPill.qml" line="56"/>
         <source>Core error</source>
         <translation>Σφάλμα Core</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="60" />
+        <location filename="../components/CoreStatusPill.qml" line="60"/>
         <source>Optimizing database</source>
         <translation>Βελτιστοποίηση βάσης δεδομένων</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="67" />
+        <location filename="../components/CoreStatusPill.qml" line="67"/>
         <source>Indexing paused</source>
         <translation>Ευρετηρίαση σε παύση</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="70" />
+        <location filename="../components/CoreStatusPill.qml" line="70"/>
         <source>Indexing %1/%2 - %3</source>
         <translation>Ευρετηρίαση %1/%2 – %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="86" />
+        <location filename="../components/CoreStatusPill.qml" line="86"/>
         <source>Scraping %1/%2 - %3</source>
         <translation>Scraping %1/%2 – %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="73" />
+        <location filename="../components/CoreStatusPill.qml" line="73"/>
         <source>Indexing %1/%2</source>
         <translation>Ευρετηρίαση %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="75" />
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
         <source>Indexing…</source>
         <translation>Ευρετηρίαση…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="83" />
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Scrape paused</source>
         <translation>Scraping σε παύση</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="89" />
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
         <source>Scraping %1/%2</source>
         <translation>Συλλογή %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="91" />
+        <location filename="../components/CoreStatusPill.qml" line="91"/>
         <source>Scraping…</source>
         <translation>Γίνεται συλλογή…</translation>
     </message>
@@ -191,22 +235,22 @@
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="182" />
+        <location filename="../screens/FavoritesScreen.qml" line="183"/>
         <source>Favorites</source>
         <translation>Αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="185" />
+        <location filename="../screens/FavoritesScreen.qml" line="186"/>
         <source>%1 entries</source>
         <translation>%1 εγγραφές</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="283" />
+        <location filename="../screens/FavoritesScreen.qml" line="309"/>
         <source>No favorites yet</source>
         <translation>Δεν υπάρχουν αγαπημένα ακόμα</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="284" />
+        <location filename="../screens/FavoritesScreen.qml" line="310"/>
         <source>Loading favorites…</source>
         <translation>Φόρτωση αγαπημένων…</translation>
     </message>
@@ -214,75 +258,99 @@
 <context>
     <name>FirstRunIndexModal</name>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="127" />
+        <location filename="../components/FirstRunIndexModal.qml" line="127"/>
         <source>First-time setup</source>
         <translation>Αρχική ρύθμιση</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="136" />
+        <location filename="../components/FirstRunIndexModal.qml" line="136"/>
         <source>Zaparoo needs to scan your games before you can use the launcher. This usually takes a few minutes.</source>
         <translation>Το Zaparoo πρέπει να σαρώσει τα παιχνίδια σας πριν χρησιμοποιήσετε το launcher. Αυτό συνήθως διαρκεί μερικά λεπτά.</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="211" />
+        <location filename="../components/FirstRunIndexModal.qml" line="211"/>
         <source>Indexing paused</source>
         <translation>Ευρετηρίαση σε παύση</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="158" />
+        <location filename="../components/FirstRunIndexModal.qml" line="158"/>
         <source>Optimizing database - almost done</source>
         <translation>Βελτιστοποίηση βάσης δεδομένων – σχεδόν έτοιμο</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="213" />
+        <location filename="../components/FirstRunIndexModal.qml" line="213"/>
         <source>Step %1 of %2 - %3</source>
         <translation>Βήμα %1 από %2 – %3</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="215" />
+        <location filename="../components/FirstRunIndexModal.qml" line="215"/>
         <source>Step %1 of %2</source>
         <translation>Βήμα %1 από %2</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="216" />
+        <location filename="../components/FirstRunIndexModal.qml" line="216"/>
         <source>Preparing…</source>
         <translation>Προετοιμασία…</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="233" />
+        <location filename="../components/FirstRunIndexModal.qml" line="233"/>
         <source>Done. %1 files indexed.</source>
         <translation>Ολοκληρώθηκε. %1 αρχεία ευρετηριάστηκαν.</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="263" />
+        <location filename="../components/FirstRunIndexModal.qml" line="263"/>
         <source>Cancel</source>
         <translation>Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="263" />
+        <location filename="../components/FirstRunIndexModal.qml" line="263"/>
         <source>Start scan</source>
         <translation>Έναρξη σάρωσης</translation>
     </message>
 </context>
 <context>
+    <name>GameInfoModal</name>
+    <message>
+        <location filename="../components/GameInfoModal.qml" line="86"/>
+        <source>Back to close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/GameInfoModal.qml" line="114"/>
+        <source>Loading details…</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="363" />
+        <location filename="../screens/GamesScreen.qml" line="367"/>
+        <location filename="../screens/GamesScreen.qml" line="537"/>
         <source>%1 files</source>
         <translation>%1 αρχεία</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="534" />
+        <location filename="../screens/GamesScreen.qml" line="437"/>
+        <source>Loading game…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/GamesScreen.qml" line="554"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/GamesScreen.qml" line="570"/>
         <source>Loading games…</source>
         <translation>Φόρτωση παιχνιδιών…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="556" />
+        <location filename="../screens/GamesScreen.qml" line="592"/>
         <source>Loading more…</source>
         <translation>Φόρτωση περισσότερων…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="533" />
+        <location filename="../screens/GamesScreen.qml" line="569"/>
         <source>No games in this system</source>
         <translation>Δεν υπάρχουν παιχνίδια σε αυτό το σύστημα</translation>
     </message>
@@ -290,22 +358,22 @@
 <context>
     <name>HubScreen</name>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91" />
+        <location filename="../screens/HubScreen.qml" line="91"/>
         <source>Favorites</source>
         <translation>Αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="96" />
+        <location filename="../screens/HubScreen.qml" line="96"/>
         <source>Recently Played</source>
         <translation>Πρόσφατα Παιγμένα</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="101" />
+        <location filename="../screens/HubScreen.qml" line="101"/>
         <source>Settings</source>
         <translation>Ρυθμίσεις</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="537" />
+        <location filename="../screens/HubScreen.qml" line="537"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Δεν υπάρχουν διαθέσιμα συστήματα. Εκτελέστε Ενημέρωση βάσης δεδομένων από τις Ρυθμίσεις.</translation>
     </message>
@@ -313,7 +381,7 @@
 <context>
     <name>LoadingIndicator</name>
     <message>
-        <location filename="../components/LoadingIndicator.qml" line="26" />
+        <location filename="../components/LoadingIndicator.qml" line="26"/>
         <source>Loading…</source>
         <translation>Φόρτωση…</translation>
     </message>
@@ -321,32 +389,32 @@
 <context>
     <name>LogUploadModal</name>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="87" />
+        <location filename="../components/LogUploadModal.qml" line="87"/>
         <source>Upload log file</source>
         <translation>Αποστολή αρχείου καταγραφής</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="97" />
+        <location filename="../components/LogUploadModal.qml" line="97"/>
         <source>Uploading log file - this may take a moment.</source>
         <translation>Αποστολή αρχείου καταγραφής – αυτό μπορεί να χρειαστεί λίγο.</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197" />
+        <location filename="../components/LogUploadModal.qml" line="197"/>
         <source>Upload failed: %1</source>
         <translation>Αποτυχία αποστολής: %1</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197" />
+        <location filename="../components/LogUploadModal.qml" line="197"/>
         <source>Upload failed.</source>
         <translation>Αποτυχία αποστολής.</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="227" />
+        <location filename="../components/LogUploadModal.qml" line="227"/>
         <source>Retry</source>
         <translation>Επανάληψη</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="227" />
+        <location filename="../components/LogUploadModal.qml" line="227"/>
         <source>Done</source>
         <translation>Ολοκληρώθηκε</translation>
     </message>
@@ -354,58 +422,64 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="723" />
+        <location filename="../app/Main.qml" line="753"/>
         <source>Launch core</source>
         <translation>Εκκίνηση Core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="741" />
+        <location filename="../app/Main.qml" line="761"/>
+        <location filename="../app/Main.qml" line="781"/>
+        <source>More info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="785"/>
         <source>Remove from favorites</source>
         <translation>Αφαίρεση από αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="741" />
+        <location filename="../app/Main.qml" line="785"/>
         <source>Add to favorites</source>
         <translation>Προσθήκη στα αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="747" />
+        <location filename="../app/Main.qml" line="790"/>
         <source>Write to NFC token</source>
         <translation>Εγγραφή σε NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="751" />
+        <location filename="../app/Main.qml" line="794"/>
         <source>QR code</source>
         <translation>Κωδικός QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="731" />
-        <location filename="../app/Main.qml" line="755" />
+        <location filename="../app/Main.qml" line="765"/>
+        <location filename="../app/Main.qml" line="804"/>
         <source>Launch game</source>
         <translation>Εκκίνηση παιχνιδιού</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1437" />
+        <location filename="../app/Main.qml" line="1652"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1441" />
+        <location filename="../app/Main.qml" line="1656"/>
         <source>Loading favorites…</source>
         <translation>Φόρτωση αγαπημένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1439" />
+        <location filename="../app/Main.qml" line="1654"/>
         <source>Loading games…</source>
         <translation>Φόρτωση παιχνιδιών…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1443" />
+        <location filename="../app/Main.qml" line="1658"/>
         <source>Loading recently played…</source>
         <translation>Φόρτωση πρόσφατα παιγμένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1445" />
+        <location filename="../app/Main.qml" line="1660"/>
         <source>Loading…</source>
         <translation>Φόρτωση…</translation>
     </message>
@@ -413,144 +487,151 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="127" />
+        <location filename="../app/MainLayout.qml" line="141"/>
         <source>Zaparoo Launcher</source>
         <translation>Εκκινητής Zaparoo</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="475" />
+        <location filename="../app/MainLayout.qml" line="545"/>
         <source>Writing failed</source>
         <translation>Αποτυχία εγγραφής</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="475" />
+        <location filename="../app/MainLayout.qml" line="545"/>
         <source>Put a writable card near the reader</source>
         <translation>Τοποθετήστε μια εγγράψιμη κάρτα κοντά στον αναγνώστη</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="540" />
+        <location filename="../app/MainLayout.qml" line="556"/>
+        <source>Quit and restart Zaparoo Launcher?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="557"/>
+        <source>In order to apply this setting we need to restart the launcher.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="632"/>
         <source>Quit Zaparoo Launcher?</source>
         <translation>Έξοδος από το Zaparoo Launcher;</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="541" />
+        <location filename="../app/MainLayout.qml" line="633"/>
         <source>Are you sure you want to exit?</source>
         <translation>Είστε σίγουροι ότι θέλετε να βγείτε;</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="617" />
-        <location filename="../app/MainLayout.qml" line="689" />
-        <location filename="../app/MainLayout.qml" line="704" />
+        <location filename="../app/MainLayout.qml" line="709"/>
+        <location filename="../app/MainLayout.qml" line="781"/>
         <source>Select</source>
         <translation>Επιλογή</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="621" />
-        <location filename="../app/MainLayout.qml" line="625" />
-        <location filename="../app/MainLayout.qml" line="639" />
-        <location filename="../app/MainLayout.qml" line="652" />
-        <location filename="../app/MainLayout.qml" line="663" />
+        <location filename="../app/MainLayout.qml" line="713"/>
+        <location filename="../app/MainLayout.qml" line="717"/>
+        <location filename="../app/MainLayout.qml" line="731"/>
+        <location filename="../app/MainLayout.qml" line="744"/>
+        <location filename="../app/MainLayout.qml" line="755"/>
         <source>Close</source>
         <translation>Κλείσιμο</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="632" />
-        <location filename="../app/MainLayout.qml" line="670" />
-        <location filename="../app/MainLayout.qml" line="693" />
-        <location filename="../app/MainLayout.qml" line="708" />
-        <location filename="../app/MainLayout.qml" line="719" />
+        <location filename="../app/MainLayout.qml" line="724"/>
+        <location filename="../app/MainLayout.qml" line="762"/>
+        <location filename="../app/MainLayout.qml" line="785"/>
+        <location filename="../app/MainLayout.qml" line="796"/>
         <source>Cancel</source>
         <translation>Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="648" />
+        <location filename="../app/MainLayout.qml" line="740"/>
         <source>Done</source>
         <translation>Ολοκληρώθηκε</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="678" />
+        <location filename="../app/MainLayout.qml" line="770"/>
         <source>I understand</source>
         <translation>Κατανοώ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="727" />
+        <location filename="../app/MainLayout.qml" line="804"/>
         <source>Start</source>
         <translation>Έναρξη</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="896" />
+        <location filename="../app/MainLayout.qml" line="973"/>
         <source>Scroll</source>
         <translation>Κύλιση</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="613" />
-        <location filename="../app/MainLayout.qml" line="685" />
-        <location filename="../app/MainLayout.qml" line="700" />
-        <location filename="../app/MainLayout.qml" line="743" />
-        <location filename="../app/MainLayout.qml" line="772" />
-        <location filename="../app/MainLayout.qml" line="819" />
-        <location filename="../app/MainLayout.qml" line="860" />
-        <location filename="../app/MainLayout.qml" line="924" />
+        <location filename="../app/MainLayout.qml" line="705"/>
+        <location filename="../app/MainLayout.qml" line="777"/>
+        <location filename="../app/MainLayout.qml" line="820"/>
+        <location filename="../app/MainLayout.qml" line="849"/>
+        <location filename="../app/MainLayout.qml" line="896"/>
+        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="1001"/>
         <source>Move</source>
         <translation>Μετακίνηση</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="747" />
-        <location filename="../app/MainLayout.qml" line="782" />
-        <location filename="../app/MainLayout.qml" line="829" />
-        <location filename="../app/MainLayout.qml" line="934" />
+        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="859"/>
+        <location filename="../app/MainLayout.qml" line="906"/>
+        <location filename="../app/MainLayout.qml" line="1011"/>
         <source>Open</source>
         <translation>Άνοιγμα</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="751" />
+        <location filename="../app/MainLayout.qml" line="828"/>
         <source>Quit</source>
         <translation>Έξοδος</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="760" />
-        <location filename="../app/MainLayout.qml" line="788" />
-        <location filename="../app/MainLayout.qml" line="799" />
-        <location filename="../app/MainLayout.qml" line="811" />
-        <location filename="../app/MainLayout.qml" line="838" />
-        <location filename="../app/MainLayout.qml" line="849" />
-        <location filename="../app/MainLayout.qml" line="884" />
-        <location filename="../app/MainLayout.qml" line="900" />
-        <location filename="../app/MainLayout.qml" line="909" />
-        <location filename="../app/MainLayout.qml" line="943" />
-        <location filename="../app/MainLayout.qml" line="954" />
+        <location filename="../app/MainLayout.qml" line="837"/>
+        <location filename="../app/MainLayout.qml" line="865"/>
+        <location filename="../app/MainLayout.qml" line="876"/>
+        <location filename="../app/MainLayout.qml" line="888"/>
+        <location filename="../app/MainLayout.qml" line="915"/>
+        <location filename="../app/MainLayout.qml" line="926"/>
+        <location filename="../app/MainLayout.qml" line="961"/>
+        <location filename="../app/MainLayout.qml" line="977"/>
+        <location filename="../app/MainLayout.qml" line="986"/>
+        <location filename="../app/MainLayout.qml" line="1020"/>
+        <location filename="../app/MainLayout.qml" line="1031"/>
         <source>Back</source>
         <translation>Πίσω</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="778" />
-        <location filename="../app/MainLayout.qml" line="825" />
-        <location filename="../app/MainLayout.qml" line="930" />
+        <location filename="../app/MainLayout.qml" line="855"/>
+        <location filename="../app/MainLayout.qml" line="902"/>
+        <location filename="../app/MainLayout.qml" line="1007"/>
         <source>Page</source>
         <translation>Σελίδα</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="785" />
-        <location filename="../app/MainLayout.qml" line="834" />
-        <location filename="../app/MainLayout.qml" line="939" />
+        <location filename="../app/MainLayout.qml" line="862"/>
+        <location filename="../app/MainLayout.qml" line="911"/>
+        <location filename="../app/MainLayout.qml" line="1016"/>
         <source>Options</source>
         <translation>Επιλογές</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="659" />
-        <location filename="../app/MainLayout.qml" line="795" />
-        <location filename="../app/MainLayout.qml" line="845" />
-        <location filename="../app/MainLayout.qml" line="950" />
+        <location filename="../app/MainLayout.qml" line="751"/>
+        <location filename="../app/MainLayout.qml" line="872"/>
+        <location filename="../app/MainLayout.qml" line="922"/>
+        <location filename="../app/MainLayout.qml" line="1027"/>
         <source>Retry</source>
         <translation>Επανάληψη</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="869" />
+        <location filename="../app/MainLayout.qml" line="946"/>
         <source>Change</source>
         <translation>Αλλαγή</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="875" />
+        <location filename="../app/MainLayout.qml" line="952"/>
         <source>Toggle</source>
         <translation>Εναλλαγή</translation>
     </message>
@@ -558,22 +639,22 @@
 <context>
     <name>Modal</name>
     <message>
-        <location filename="../components/Modal.qml" line="49" />
+        <location filename="../components/Modal.qml" line="49"/>
         <source>OK</source>
         <translation>Εντάξει</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="50" />
+        <location filename="../components/Modal.qml" line="50"/>
         <source>Yes</source>
         <translation>Ναι</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="51" />
+        <location filename="../components/Modal.qml" line="51"/>
         <source>No</source>
         <translation>Όχι</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="198" />
+        <location filename="../components/Modal.qml" line="198"/>
         <source>Cancel</source>
         <translation>Ακύρωση</translation>
     </message>
@@ -581,22 +662,22 @@
 <context>
     <name>RecentsScreen</name>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="183" />
+        <location filename="../screens/RecentsScreen.qml" line="184"/>
         <source>Recently Played</source>
         <translation>Πρόσφατα Παιγμένα</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="186" />
+        <location filename="../screens/RecentsScreen.qml" line="187"/>
         <source>%1 entries</source>
         <translation>%1 εγγραφές</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="282" />
+        <location filename="../screens/RecentsScreen.qml" line="312"/>
         <source>Loading recently played…</source>
         <translation>Φόρτωση πρόσφατα παιγμένων…</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="281" />
+        <location filename="../screens/RecentsScreen.qml" line="311"/>
         <source>Nothing played yet</source>
         <translation>Δεν παίχτηκε τίποτα ακόμα</translation>
     </message>
@@ -604,17 +685,17 @@
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="26" />
+        <location filename="../components/ScreenStateOverlay.qml" line="26"/>
         <source>Nothing here</source>
         <translation>Τίποτα εδώ</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27" />
+        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
         <source>Loading…</source>
         <translation>Φόρτωση…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="57" />
+        <location filename="../components/ScreenStateOverlay.qml" line="57"/>
         <source>Failed to load</source>
         <translation>Αποτυχία φόρτωσης</translation>
     </message>
@@ -622,288 +703,294 @@
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78" />
-        <location filename="../screens/SettingsScreen.qml" line="436" />
+        <location filename="../screens/SettingsScreen.qml" line="73"/>
+        <location filename="../screens/SettingsScreen.qml" line="432"/>
         <source>Language</source>
         <translation>Γλώσσα</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83" />
-        <location filename="../screens/SettingsScreen.qml" line="445" />
+        <location filename="../screens/SettingsScreen.qml" line="78"/>
+        <location filename="../screens/SettingsScreen.qml" line="441"/>
         <source>Browsing layout</source>
         <translation>Διάταξη περιήγησης</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116" />
+        <location filename="../screens/SettingsScreen.qml" line="116"/>
         <source>Mouse support</source>
         <translation>Υποστήριξη ποντικιού</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102" />
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
         <source>Update media database</source>
         <translation>Ενημέρωση βάσης δεδομένων</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="61" />
+        <location filename="../screens/SettingsScreen.qml" line="61"/>
         <source>General</source>
         <translation>Γενικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88" />
-        <location filename="../screens/SettingsScreen.qml" line="454" />
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="450"/>
         <source>Button style</source>
         <translation>Στυλ κουμπιών</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="93" />
-        <location filename="../screens/SettingsScreen.qml" line="463" />
+        <location filename="../screens/SettingsScreen.qml" line="88"/>
+        <location filename="../screens/SettingsScreen.qml" line="459"/>
         <source>Screensaver</source>
         <translation>Προφύλαξη οθόνης</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97" />
+        <location filename="../screens/SettingsScreen.qml" line="92"/>
         <source>Library</source>
         <translation>Βιβλιοθήκη</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="107" />
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <source>Discover arcade alternate versions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="107"/>
         <source>Scrape metadata</source>
         <translation>Ανάκτηση μεταδεδομένων</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111" />
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
         <source>Advanced</source>
         <translation>Για προχωρημένους</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121" />
+        <location filename="../screens/SettingsScreen.qml" line="121"/>
         <source>Debug logging</source>
         <translation>Καταγραφή εντοπισμού σφαλμάτων</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126" />
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Upload log file</source>
         <translation>Αποστολή αρχείου καταγραφής</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131" />
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
         <source>About / License</source>
         <translation>Σχετικά / Άδεια</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147" />
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
         <source>Optimizing</source>
         <translation>Βελτιστοποίηση</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149" />
-        <location filename="../screens/SettingsScreen.qml" line="158" />
+        <location filename="../screens/SettingsScreen.qml" line="149"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
         <source>Paused</source>
         <translation>Σε παύση</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149" />
-        <location filename="../screens/SettingsScreen.qml" line="158" />
+        <location filename="../screens/SettingsScreen.qml" line="149"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
         <source>In progress</source>
         <translation>Σε εξέλιξη</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152" />
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>%1 indexed</source>
         <translation>%1 ευρετηριάστηκαν</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="161" />
+        <location filename="../screens/SettingsScreen.qml" line="161"/>
         <source>%1 scraped</source>
         <translation>%1 συλλέχθηκαν</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270" />
+        <location filename="../screens/SettingsScreen.qml" line="266"/>
         <source>Cancel</source>
         <translation>Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270" />
+        <location filename="../screens/SettingsScreen.qml" line="266"/>
         <source>Start</source>
         <translation>Έναρξη</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="272" />
+        <location filename="../screens/SettingsScreen.qml" line="268"/>
         <source>Upload</source>
         <translation>Μεταφόρτωση</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="274" />
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
         <source>Open</source>
         <translation>Άνοιγμα</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="346" />
+        <location filename="../screens/SettingsScreen.qml" line="342"/>
         <source>English</source>
         <translation>Αγγλικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="348" />
+        <location filename="../screens/SettingsScreen.qml" line="344"/>
         <source>Italian</source>
         <translation>Ιταλικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="350" />
+        <location filename="../screens/SettingsScreen.qml" line="346"/>
         <source>German</source>
         <translation>Γερμανικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="352" />
+        <location filename="../screens/SettingsScreen.qml" line="348"/>
         <source>Greek</source>
         <translation>Ελληνικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="354" />
+        <location filename="../screens/SettingsScreen.qml" line="350"/>
         <source>Japanese</source>
         <translation>Ιαπωνικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="356" />
+        <location filename="../screens/SettingsScreen.qml" line="352"/>
         <source>Korean</source>
         <translation>Κορεατικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="358" />
+        <location filename="../screens/SettingsScreen.qml" line="354"/>
         <source>Dutch</source>
         <translation>Ολλανδικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="360" />
+        <location filename="../screens/SettingsScreen.qml" line="356"/>
         <source>Romanian</source>
         <translation>Ρουμανικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="362" />
+        <location filename="../screens/SettingsScreen.qml" line="358"/>
         <source>Slovak</source>
         <translation>Σλοβακικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="364" />
+        <location filename="../screens/SettingsScreen.qml" line="360"/>
         <source>Ukrainian</source>
         <translation>Ουκρανικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="366" />
+        <location filename="../screens/SettingsScreen.qml" line="362"/>
         <source>Chinese (Simplified)</source>
         <translation>Κινεζικά (Απλοποιημένα)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="368" />
+        <location filename="../screens/SettingsScreen.qml" line="364"/>
         <source>Hebrew</source>
         <translation>Εβραϊκά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="370" />
+        <location filename="../screens/SettingsScreen.qml" line="366"/>
         <source>Arabic</source>
-        <translation type="unfinished" />
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="372" />
+        <location filename="../screens/SettingsScreen.qml" line="368"/>
         <source>Hindi</source>
-        <translation type="unfinished" />
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="373" />
+        <location filename="../screens/SettingsScreen.qml" line="369"/>
         <source>Auto</source>
         <translation>Αυτόματο</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="378" />
+        <location filename="../screens/SettingsScreen.qml" line="374"/>
         <source>Detailed list view</source>
         <translation>Λεπτομερής προβολή λίστας</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="379" />
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Grid view</source>
         <translation>Προβολή πλέγματος</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="384" />
+        <location filename="../screens/SettingsScreen.qml" line="380"/>
         <source>Style B</source>
         <translation>Στυλ B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="386" />
+        <location filename="../screens/SettingsScreen.qml" line="382"/>
         <source>Style C</source>
         <translation>Στυλ C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="388" />
+        <location filename="../screens/SettingsScreen.qml" line="384"/>
         <source>Style D</source>
         <translation>Στυλ D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="389" />
+        <location filename="../screens/SettingsScreen.qml" line="385"/>
         <source>Style A</source>
         <translation>Στυλ A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="326" />
+        <location filename="../screens/SettingsScreen.qml" line="322"/>
         <source>Default</source>
         <translation>Προεπιλογή</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399" />
+        <location filename="../screens/SettingsScreen.qml" line="395"/>
         <source>Off</source>
         <translation>Απενεργοποιημένο</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="401" />
+        <location filename="../screens/SettingsScreen.qml" line="397"/>
         <source>1 second (testing)</source>
         <translation>1 δευτερόλεπτο (δοκιμή)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="403" />
+        <location filename="../screens/SettingsScreen.qml" line="399"/>
         <source>1 minute</source>
         <translation>1 λεπτό</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405" />
+        <location filename="../screens/SettingsScreen.qml" line="401"/>
         <source>2 minutes</source>
         <translation>2 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="407" />
+        <location filename="../screens/SettingsScreen.qml" line="403"/>
         <source>5 minutes</source>
         <translation>5 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="409" />
+        <location filename="../screens/SettingsScreen.qml" line="405"/>
         <source>10 minutes</source>
         <translation>10 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="411" />
+        <location filename="../screens/SettingsScreen.qml" line="407"/>
         <source>15 minutes</source>
         <translation>15 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="413" />
+        <location filename="../screens/SettingsScreen.qml" line="409"/>
         <source>30 minutes</source>
         <translation>30 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="414" />
+        <location filename="../screens/SettingsScreen.qml" line="410"/>
         <source>%1 seconds</source>
         <translation>%1 δευτερόλεπτα</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="427" />
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="423"/>
         <source>Resolution</source>
         <translation>Ανάλυση</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="555" />
+        <location filename="../screens/SettingsScreen.qml" line="563"/>
         <source>Settings</source>
         <translation>Ρυθμίσεις</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="745" />
+        <location filename="../screens/SettingsScreen.qml" line="755"/>
         <source>No settings available on this platform</source>
         <translation>Δεν υπάρχουν διαθέσιμες ρυθμίσεις για αυτή την πλατφόρμα</translation>
     </message>
@@ -911,17 +998,23 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="182" />
+        <location filename="../screens/SystemsScreen.qml" line="185"/>
+        <location filename="../screens/SystemsScreen.qml" line="313"/>
         <source>%1 systems</source>
         <translation>%1 συστήματα</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="279" />
+        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SystemsScreen.qml" line="345"/>
         <source>No systems in this category</source>
         <translation>Δεν υπάρχουν συστήματα σε αυτή την κατηγορία</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="280" />
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>
@@ -929,7 +1022,7 @@
 <context>
     <name>TopStatusStrip</name>
     <message>
-        <location filename="../components/TopStatusStrip.qml" line="88" />
+        <location filename="../components/TopStatusStrip.qml" line="90"/>
         <source>Page %1 / %2</source>
         <translation>Σελίδα %1 / %2</translation>
     </message>

--- a/src/ui/translations/launcher_en.ts
+++ b/src/ui/translations/launcher_en.ts
@@ -4,57 +4,57 @@
 <context>
     <name>AboutScreen</name>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="72"/>
+        <location filename="../screens/AboutScreen.qml" line="71"/>
         <source>About / License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="154"/>
+        <location filename="../screens/AboutScreen.qml" line="153"/>
         <source>Zaparoo Launcher</source>
         <translation type="unfinished">Zaparoo Launcher</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="165"/>
+        <location filename="../screens/AboutScreen.qml" line="164"/>
         <source>Version %1 · %2 · %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="178"/>
+        <location filename="../screens/AboutScreen.qml" line="174"/>
         <source>Built %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="189"/>
+        <location filename="../screens/AboutScreen.qml" line="185"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="200"/>
+        <location filename="../screens/AboutScreen.qml" line="196"/>
         <source>Source available under the PolyForm Noncommercial License 1.0.0. Free for personal, non-commercial use. Commercial use or redistribution requires a separate license.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="211"/>
+        <location filename="../screens/AboutScreen.qml" line="207"/>
         <source>Commercial licensing: legal@zaparoo.org</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="222"/>
+        <location filename="../screens/AboutScreen.qml" line="218"/>
         <source>Project: https://zaparoo.org</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="232"/>
+        <location filename="../screens/AboutScreen.qml" line="228"/>
         <source>Created by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="256"/>
+        <location filename="../screens/AboutScreen.qml" line="252"/>
         <source>Translations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="280"/>
+        <location filename="../screens/AboutScreen.qml" line="276"/>
         <source>Full license text in COPYING.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -80,6 +80,49 @@
         <location filename="../components/BootOverlay.qml" line="85"/>
         <source>Connecting to Zaparoo Core…</source>
         <translation type="unfinished">Connecting to Zaparoo Core…</translation>
+    </message>
+</context>
+<context>
+    <name>BrowseDetailPane</name>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="22"/>
+        <source>Loading…</source>
+        <translation type="unfinished">Loading…</translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="43"/>
+        <source>Year</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="45"/>
+        <source>Genre</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <source>Players</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <source>Developer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <source>Publisher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <source>Rating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="55"/>
+        <source>Filename</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -192,22 +235,22 @@
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="182"/>
+        <location filename="../screens/FavoritesScreen.qml" line="183"/>
         <source>Favorites</source>
         <translation>Favorites</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="185"/>
+        <location filename="../screens/FavoritesScreen.qml" line="186"/>
         <source>%1 entries</source>
         <translation>%1 entries</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="283"/>
+        <location filename="../screens/FavoritesScreen.qml" line="309"/>
         <source>No favorites yet</source>
         <translation>No favorites yet</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="284"/>
+        <location filename="../screens/FavoritesScreen.qml" line="310"/>
         <source>Loading favorites…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -266,24 +309,48 @@
     </message>
 </context>
 <context>
+    <name>GameInfoModal</name>
+    <message>
+        <location filename="../components/GameInfoModal.qml" line="86"/>
+        <source>Back to close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/GameInfoModal.qml" line="114"/>
+        <source>Loading details…</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="363"/>
+        <location filename="../screens/GamesScreen.qml" line="367"/>
+        <location filename="../screens/GamesScreen.qml" line="537"/>
         <source>%1 files</source>
         <translation>%1 files</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="534"/>
+        <location filename="../screens/GamesScreen.qml" line="437"/>
+        <source>Loading game…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/GamesScreen.qml" line="554"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/GamesScreen.qml" line="570"/>
         <source>Loading games…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="556"/>
+        <location filename="../screens/GamesScreen.qml" line="592"/>
         <source>Loading more…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="533"/>
+        <location filename="../screens/GamesScreen.qml" line="569"/>
         <source>No games in this system</source>
         <translation>No games in this system</translation>
     </message>
@@ -355,58 +422,64 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="723"/>
+        <location filename="../app/Main.qml" line="753"/>
         <source>Launch core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="741"/>
+        <location filename="../app/Main.qml" line="761"/>
+        <location filename="../app/Main.qml" line="781"/>
+        <source>More info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="785"/>
         <source>Remove from favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="741"/>
+        <location filename="../app/Main.qml" line="785"/>
         <source>Add to favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="747"/>
+        <location filename="../app/Main.qml" line="790"/>
         <source>Write to NFC token</source>
         <translation type="unfinished">Write to NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="751"/>
+        <location filename="../app/Main.qml" line="794"/>
         <source>QR code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="731"/>
-        <location filename="../app/Main.qml" line="755"/>
+        <location filename="../app/Main.qml" line="765"/>
+        <location filename="../app/Main.qml" line="804"/>
         <source>Launch game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1437"/>
+        <location filename="../app/Main.qml" line="1652"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1441"/>
+        <location filename="../app/Main.qml" line="1656"/>
         <source>Loading favorites…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1439"/>
+        <location filename="../app/Main.qml" line="1654"/>
         <source>Loading games…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1443"/>
+        <location filename="../app/Main.qml" line="1658"/>
         <source>Loading recently played…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1445"/>
+        <location filename="../app/Main.qml" line="1660"/>
         <source>Loading…</source>
         <translation type="unfinished">Loading…</translation>
     </message>
@@ -414,144 +487,151 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="127"/>
+        <location filename="../app/MainLayout.qml" line="141"/>
         <source>Zaparoo Launcher</source>
         <translation>Zaparoo Launcher</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="475"/>
+        <location filename="../app/MainLayout.qml" line="545"/>
         <source>Writing failed</source>
         <translation>Writing failed</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="475"/>
+        <location filename="../app/MainLayout.qml" line="545"/>
         <source>Put a writable card near the reader</source>
         <translation>Put a writable card near the reader</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="540"/>
+        <location filename="../app/MainLayout.qml" line="556"/>
+        <source>Quit and restart Zaparoo Launcher?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="557"/>
+        <source>In order to apply this setting we need to restart the launcher.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="632"/>
         <source>Quit Zaparoo Launcher?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="541"/>
+        <location filename="../app/MainLayout.qml" line="633"/>
         <source>Are you sure you want to exit?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="617"/>
-        <location filename="../app/MainLayout.qml" line="689"/>
-        <location filename="../app/MainLayout.qml" line="704"/>
+        <location filename="../app/MainLayout.qml" line="709"/>
+        <location filename="../app/MainLayout.qml" line="781"/>
         <source>Select</source>
         <translation>Select</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="621"/>
-        <location filename="../app/MainLayout.qml" line="625"/>
-        <location filename="../app/MainLayout.qml" line="639"/>
-        <location filename="../app/MainLayout.qml" line="652"/>
-        <location filename="../app/MainLayout.qml" line="663"/>
+        <location filename="../app/MainLayout.qml" line="713"/>
+        <location filename="../app/MainLayout.qml" line="717"/>
+        <location filename="../app/MainLayout.qml" line="731"/>
+        <location filename="../app/MainLayout.qml" line="744"/>
+        <location filename="../app/MainLayout.qml" line="755"/>
         <source>Close</source>
         <translation>Close</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="632"/>
-        <location filename="../app/MainLayout.qml" line="670"/>
-        <location filename="../app/MainLayout.qml" line="693"/>
-        <location filename="../app/MainLayout.qml" line="708"/>
-        <location filename="../app/MainLayout.qml" line="719"/>
+        <location filename="../app/MainLayout.qml" line="724"/>
+        <location filename="../app/MainLayout.qml" line="762"/>
+        <location filename="../app/MainLayout.qml" line="785"/>
+        <location filename="../app/MainLayout.qml" line="796"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="648"/>
+        <location filename="../app/MainLayout.qml" line="740"/>
         <source>Done</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="678"/>
+        <location filename="../app/MainLayout.qml" line="770"/>
         <source>I understand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="727"/>
+        <location filename="../app/MainLayout.qml" line="804"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="896"/>
+        <location filename="../app/MainLayout.qml" line="973"/>
         <source>Scroll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="613"/>
-        <location filename="../app/MainLayout.qml" line="685"/>
-        <location filename="../app/MainLayout.qml" line="700"/>
-        <location filename="../app/MainLayout.qml" line="743"/>
-        <location filename="../app/MainLayout.qml" line="772"/>
-        <location filename="../app/MainLayout.qml" line="819"/>
-        <location filename="../app/MainLayout.qml" line="860"/>
-        <location filename="../app/MainLayout.qml" line="924"/>
+        <location filename="../app/MainLayout.qml" line="705"/>
+        <location filename="../app/MainLayout.qml" line="777"/>
+        <location filename="../app/MainLayout.qml" line="820"/>
+        <location filename="../app/MainLayout.qml" line="849"/>
+        <location filename="../app/MainLayout.qml" line="896"/>
+        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="1001"/>
         <source>Move</source>
         <translation>Move</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="747"/>
-        <location filename="../app/MainLayout.qml" line="782"/>
-        <location filename="../app/MainLayout.qml" line="829"/>
-        <location filename="../app/MainLayout.qml" line="934"/>
+        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="859"/>
+        <location filename="../app/MainLayout.qml" line="906"/>
+        <location filename="../app/MainLayout.qml" line="1011"/>
         <source>Open</source>
         <translation>Open</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="751"/>
+        <location filename="../app/MainLayout.qml" line="828"/>
         <source>Quit</source>
         <translation>Quit</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="760"/>
-        <location filename="../app/MainLayout.qml" line="788"/>
-        <location filename="../app/MainLayout.qml" line="799"/>
-        <location filename="../app/MainLayout.qml" line="811"/>
-        <location filename="../app/MainLayout.qml" line="838"/>
-        <location filename="../app/MainLayout.qml" line="849"/>
-        <location filename="../app/MainLayout.qml" line="884"/>
-        <location filename="../app/MainLayout.qml" line="900"/>
-        <location filename="../app/MainLayout.qml" line="909"/>
-        <location filename="../app/MainLayout.qml" line="943"/>
-        <location filename="../app/MainLayout.qml" line="954"/>
+        <location filename="../app/MainLayout.qml" line="837"/>
+        <location filename="../app/MainLayout.qml" line="865"/>
+        <location filename="../app/MainLayout.qml" line="876"/>
+        <location filename="../app/MainLayout.qml" line="888"/>
+        <location filename="../app/MainLayout.qml" line="915"/>
+        <location filename="../app/MainLayout.qml" line="926"/>
+        <location filename="../app/MainLayout.qml" line="961"/>
+        <location filename="../app/MainLayout.qml" line="977"/>
+        <location filename="../app/MainLayout.qml" line="986"/>
+        <location filename="../app/MainLayout.qml" line="1020"/>
+        <location filename="../app/MainLayout.qml" line="1031"/>
         <source>Back</source>
         <translation>Back</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="778"/>
-        <location filename="../app/MainLayout.qml" line="825"/>
-        <location filename="../app/MainLayout.qml" line="930"/>
+        <location filename="../app/MainLayout.qml" line="855"/>
+        <location filename="../app/MainLayout.qml" line="902"/>
+        <location filename="../app/MainLayout.qml" line="1007"/>
         <source>Page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="785"/>
-        <location filename="../app/MainLayout.qml" line="834"/>
-        <location filename="../app/MainLayout.qml" line="939"/>
+        <location filename="../app/MainLayout.qml" line="862"/>
+        <location filename="../app/MainLayout.qml" line="911"/>
+        <location filename="../app/MainLayout.qml" line="1016"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="659"/>
-        <location filename="../app/MainLayout.qml" line="795"/>
-        <location filename="../app/MainLayout.qml" line="845"/>
-        <location filename="../app/MainLayout.qml" line="950"/>
+        <location filename="../app/MainLayout.qml" line="751"/>
+        <location filename="../app/MainLayout.qml" line="872"/>
+        <location filename="../app/MainLayout.qml" line="922"/>
+        <location filename="../app/MainLayout.qml" line="1027"/>
         <source>Retry</source>
         <translation>Retry</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="869"/>
+        <location filename="../app/MainLayout.qml" line="946"/>
         <source>Change</source>
         <translation>Change</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="875"/>
+        <location filename="../app/MainLayout.qml" line="952"/>
         <source>Toggle</source>
         <translation>Toggle</translation>
     </message>
@@ -582,22 +662,22 @@
 <context>
     <name>RecentsScreen</name>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="183"/>
+        <location filename="../screens/RecentsScreen.qml" line="184"/>
         <source>Recently Played</source>
         <translation>Recently Played</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="186"/>
+        <location filename="../screens/RecentsScreen.qml" line="187"/>
         <source>%1 entries</source>
         <translation>%1 entries</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="282"/>
+        <location filename="../screens/RecentsScreen.qml" line="312"/>
         <source>Loading recently played…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="281"/>
+        <location filename="../screens/RecentsScreen.qml" line="311"/>
         <source>Nothing played yet</source>
         <translation>Nothing played yet</translation>
     </message>
@@ -623,14 +703,14 @@
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78"/>
-        <location filename="../screens/SettingsScreen.qml" line="436"/>
+        <location filename="../screens/SettingsScreen.qml" line="73"/>
+        <location filename="../screens/SettingsScreen.qml" line="432"/>
         <source>Language</source>
         <translation>Language</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="445"/>
+        <location filename="../screens/SettingsScreen.qml" line="78"/>
+        <location filename="../screens/SettingsScreen.qml" line="441"/>
         <source>Browsing layout</source>
         <translation>Browsing layout</translation>
     </message>
@@ -650,20 +730,25 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88"/>
-        <location filename="../screens/SettingsScreen.qml" line="454"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="450"/>
         <source>Button style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="93"/>
-        <location filename="../screens/SettingsScreen.qml" line="463"/>
+        <location filename="../screens/SettingsScreen.qml" line="88"/>
+        <location filename="../screens/SettingsScreen.qml" line="459"/>
         <source>Screensaver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <location filename="../screens/SettingsScreen.qml" line="92"/>
         <source>Library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -719,192 +804,193 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <location filename="../screens/SettingsScreen.qml" line="266"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <location filename="../screens/SettingsScreen.qml" line="266"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="272"/>
+        <location filename="../screens/SettingsScreen.qml" line="268"/>
         <source>Upload</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="274"/>
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
         <source>Open</source>
         <translation type="unfinished">Open</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="346"/>
+        <location filename="../screens/SettingsScreen.qml" line="342"/>
         <source>English</source>
         <translation>English</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="348"/>
+        <location filename="../screens/SettingsScreen.qml" line="344"/>
         <source>Italian</source>
         <translation>Italian</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="350"/>
+        <location filename="../screens/SettingsScreen.qml" line="346"/>
         <source>German</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="352"/>
+        <location filename="../screens/SettingsScreen.qml" line="348"/>
         <source>Greek</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="350"/>
         <source>Japanese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="356"/>
+        <location filename="../screens/SettingsScreen.qml" line="352"/>
         <source>Korean</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="358"/>
+        <location filename="../screens/SettingsScreen.qml" line="354"/>
         <source>Dutch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="360"/>
+        <location filename="../screens/SettingsScreen.qml" line="356"/>
         <source>Romanian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="362"/>
+        <location filename="../screens/SettingsScreen.qml" line="358"/>
         <source>Slovak</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="364"/>
+        <location filename="../screens/SettingsScreen.qml" line="360"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="366"/>
+        <location filename="../screens/SettingsScreen.qml" line="362"/>
         <source>Chinese (Simplified)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="368"/>
+        <location filename="../screens/SettingsScreen.qml" line="364"/>
         <source>Hebrew</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="370"/>
+        <location filename="../screens/SettingsScreen.qml" line="366"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="372"/>
+        <location filename="../screens/SettingsScreen.qml" line="368"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="373"/>
+        <location filename="../screens/SettingsScreen.qml" line="369"/>
         <source>Auto</source>
         <translation>Auto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="378"/>
+        <location filename="../screens/SettingsScreen.qml" line="374"/>
         <source>Detailed list view</source>
         <translation>Detailed list view</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="379"/>
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Grid view</source>
         <translation>Grid view</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="384"/>
+        <location filename="../screens/SettingsScreen.qml" line="380"/>
         <source>Style B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="386"/>
+        <location filename="../screens/SettingsScreen.qml" line="382"/>
         <source>Style C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="388"/>
+        <location filename="../screens/SettingsScreen.qml" line="384"/>
         <source>Style D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="389"/>
+        <location filename="../screens/SettingsScreen.qml" line="385"/>
         <source>Style A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="326"/>
+        <location filename="../screens/SettingsScreen.qml" line="322"/>
         <source>Default</source>
         <translation>Default</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <location filename="../screens/SettingsScreen.qml" line="395"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="401"/>
+        <location filename="../screens/SettingsScreen.qml" line="397"/>
         <source>1 second (testing)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="403"/>
+        <location filename="../screens/SettingsScreen.qml" line="399"/>
         <source>1 minute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405"/>
+        <location filename="../screens/SettingsScreen.qml" line="401"/>
         <source>2 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="407"/>
+        <location filename="../screens/SettingsScreen.qml" line="403"/>
         <source>5 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="409"/>
+        <location filename="../screens/SettingsScreen.qml" line="405"/>
         <source>10 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="411"/>
+        <location filename="../screens/SettingsScreen.qml" line="407"/>
         <source>15 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="413"/>
+        <location filename="../screens/SettingsScreen.qml" line="409"/>
         <source>30 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="414"/>
+        <location filename="../screens/SettingsScreen.qml" line="410"/>
         <source>%1 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="427"/>
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="423"/>
         <source>Resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="555"/>
+        <location filename="../screens/SettingsScreen.qml" line="563"/>
         <source>Settings</source>
         <translation>Settings</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="745"/>
+        <location filename="../screens/SettingsScreen.qml" line="755"/>
         <source>No settings available on this platform</source>
         <translation>No settings available on this platform</translation>
     </message>
@@ -912,17 +998,23 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="182"/>
+        <location filename="../screens/SystemsScreen.qml" line="185"/>
+        <location filename="../screens/SystemsScreen.qml" line="313"/>
         <source>%1 systems</source>
         <translation>%1 systems</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="279"/>
+        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SystemsScreen.qml" line="345"/>
         <source>No systems in this category</source>
         <translation>No systems in this category</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="280"/>
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -930,7 +1022,7 @@
 <context>
     <name>TopStatusStrip</name>
     <message>
-        <location filename="../components/TopStatusStrip.qml" line="88"/>
+        <location filename="../components/TopStatusStrip.qml" line="90"/>
         <source>Page %1 / %2</source>
         <translation>Page %1 / %2</translation>
     </message>

--- a/src/ui/translations/launcher_en.ts
+++ b/src/ui/translations/launcher_en.ts
@@ -245,27 +245,27 @@
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="183"/>
+        <location filename="../screens/FavoritesScreen.qml" line="225"/>
         <source>Favorites</source>
         <translation>Favorites</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="186"/>
+        <location filename="../screens/FavoritesScreen.qml" line="228"/>
         <source>%1 entries</source>
         <translation>%1 entries</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="190"/>
+        <location filename="../screens/FavoritesScreen.qml" line="232"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="280"/>
+        <location filename="../screens/FavoritesScreen.qml" line="334"/>
         <source>No favorites yet</source>
         <translation>No favorites yet</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="281"/>
+        <location filename="../screens/FavoritesScreen.qml" line="335"/>
         <source>Loading favorites…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -326,13 +326,13 @@
 <context>
     <name>GameInfoModal</name>
     <message>
-        <location filename="../components/GameInfoModal.qml" line="86"/>
-        <source>Back to close</source>
+        <location filename="../components/GameInfoModal.qml" line="104"/>
+        <source>Loading details…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/GameInfoModal.qml" line="114"/>
-        <source>Loading details…</source>
+        <location filename="../components/GameInfoModal.qml" line="174"/>
+        <source>Loading image…</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -444,12 +444,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="781"/>
-        <source>More info</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../app/Main.qml" line="785"/>
         <source>Remove from favorites</source>
         <translation type="unfinished"></translation>
@@ -473,6 +467,12 @@
         <location filename="../app/Main.qml" line="765"/>
         <location filename="../app/Main.qml" line="804"/>
         <source>Launch game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="761"/>
+        <location filename="../app/Main.qml" line="781"/>
+        <source>View details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -679,27 +679,27 @@
 <context>
     <name>RecentsScreen</name>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="184"/>
+        <location filename="../screens/RecentsScreen.qml" line="226"/>
         <source>Recently Played</source>
         <translation>Recently Played</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="187"/>
+        <location filename="../screens/RecentsScreen.qml" line="229"/>
         <source>%1 entries</source>
         <translation>%1 entries</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="191"/>
+        <location filename="../screens/RecentsScreen.qml" line="233"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="283"/>
+        <location filename="../screens/RecentsScreen.qml" line="337"/>
         <source>Loading recently played…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="282"/>
+        <location filename="../screens/RecentsScreen.qml" line="336"/>
         <source>Nothing played yet</source>
         <translation>Nothing played yet</translation>
     </message>

--- a/src/ui/translations/launcher_en.ts
+++ b/src/ui/translations/launcher_en.ts
@@ -90,38 +90,48 @@
         <translation type="unfinished">Loading…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="43"/>
+        <location filename="../components/BrowseDetailPane.qml" line="44"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="45"/>
+        <location filename="../components/BrowseDetailPane.qml" line="46"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <location filename="../components/BrowseDetailPane.qml" line="48"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <location filename="../components/BrowseDetailPane.qml" line="50"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <location filename="../components/BrowseDetailPane.qml" line="52"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <location filename="../components/BrowseDetailPane.qml" line="54"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="55"/>
-        <source>Filename</source>
+        <location filename="../components/BrowseDetailPane.qml" line="56"/>
+        <source>Category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="58"/>
+        <source>Release date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="60"/>
+        <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -245,12 +255,17 @@
         <translation>%1 entries</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="309"/>
+        <location filename="../screens/FavoritesScreen.qml" line="190"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/FavoritesScreen.qml" line="280"/>
         <source>No favorites yet</source>
         <translation>No favorites yet</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="310"/>
+        <location filename="../screens/FavoritesScreen.qml" line="281"/>
         <source>Loading favorites…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -324,33 +339,35 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="367"/>
-        <location filename="../screens/GamesScreen.qml" line="537"/>
+        <location filename="../screens/GamesScreen.qml" line="373"/>
+        <location filename="../screens/GamesScreen.qml" line="520"/>
         <source>%1 files</source>
         <translation>%1 files</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="437"/>
+        <location filename="../screens/GamesScreen.qml" line="409"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="554"/>
+        <location filename="../screens/GamesScreen.qml" line="382"/>
+        <location filename="../screens/GamesScreen.qml" line="537"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="570"/>
+        <location filename="../screens/GamesScreen.qml" line="553"/>
         <source>Loading games…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="592"/>
+        <location filename="../screens/GamesScreen.qml" line="378"/>
+        <location filename="../screens/GamesScreen.qml" line="575"/>
         <source>Loading more…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="569"/>
+        <location filename="../screens/GamesScreen.qml" line="552"/>
         <source>No games in this system</source>
         <translation>No games in this system</translation>
     </message>
@@ -672,12 +689,17 @@
         <translation>%1 entries</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="312"/>
+        <location filename="../screens/RecentsScreen.qml" line="191"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/RecentsScreen.qml" line="283"/>
         <source>Loading recently played…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="311"/>
+        <location filename="../screens/RecentsScreen.qml" line="282"/>
         <source>Nothing played yet</source>
         <translation>Nothing played yet</translation>
     </message>
@@ -999,22 +1021,23 @@
     <name>SystemsScreen</name>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="185"/>
-        <location filename="../screens/SystemsScreen.qml" line="313"/>
+        <location filename="../screens/SystemsScreen.qml" line="285"/>
         <source>%1 systems</source>
         <translation>%1 systems</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <location filename="../screens/SystemsScreen.qml" line="189"/>
+        <location filename="../screens/SystemsScreen.qml" line="302"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="345"/>
+        <location filename="../screens/SystemsScreen.qml" line="317"/>
         <source>No systems in this category</source>
         <translation>No systems in this category</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="318"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1022,7 +1045,7 @@
 <context>
     <name>TopStatusStrip</name>
     <message>
-        <location filename="../components/TopStatusStrip.qml" line="90"/>
+        <location filename="../components/TopStatusStrip.qml" line="91"/>
         <source>Page %1 / %2</source>
         <translation>Page %1 / %2</translation>
     </message>

--- a/src/ui/translations/launcher_es.ts
+++ b/src/ui/translations/launcher_es.ts
@@ -1,59 +1,60 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
 <TS version="2.1" language="es_ES" sourcelanguage="en">
 <context>
     <name>AboutScreen</name>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="72" />
+        <location filename="../screens/AboutScreen.qml" line="71"/>
         <source>About / License</source>
         <translation>Acerca de / Licencia</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="154" />
+        <location filename="../screens/AboutScreen.qml" line="153"/>
         <source>Zaparoo Launcher</source>
         <translation>Lanzador Zaparoo</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="165" />
+        <location filename="../screens/AboutScreen.qml" line="164"/>
         <source>Version %1 · %2 · %3</source>
         <translation>Versión %1 · %2 · %3</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="178" />
+        <location filename="../screens/AboutScreen.qml" line="174"/>
         <source>Built %1</source>
         <translation>Compilado %1</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="189" />
+        <location filename="../screens/AboutScreen.qml" line="185"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>Copyright 2026 Wizzo Pty Ltd y los colaboradores del proyecto Zaparoo.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="200" />
+        <location filename="../screens/AboutScreen.qml" line="196"/>
         <source>Source available under the PolyForm Noncommercial License 1.0.0. Free for personal, non-commercial use. Commercial use or redistribution requires a separate license.</source>
         <translation>Código fuente disponible bajo la Licencia PolyForm Noncommercial 1.0.0. Gratis para uso personal y no comercial. El uso comercial o la redistribución requieren una licencia independiente.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="211" />
+        <location filename="../screens/AboutScreen.qml" line="207"/>
         <source>Commercial licensing: legal@zaparoo.org</source>
         <translation>Licencia comercial: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="222" />
+        <location filename="../screens/AboutScreen.qml" line="218"/>
         <source>Project: https://zaparoo.org</source>
         <translation>Proyecto: https://zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="232" />
+        <location filename="../screens/AboutScreen.qml" line="228"/>
         <source>Created by</source>
         <translation>Creado por</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="256" />
+        <location filename="../screens/AboutScreen.qml" line="252"/>
         <source>Translations</source>
         <translation>Traducciones</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="280" />
+        <location filename="../screens/AboutScreen.qml" line="276"/>
         <source>Full license text in COPYING.</source>
         <translation>Texto completo de la licencia en COPYING.</translation>
     </message>
@@ -61,60 +62,103 @@
 <context>
     <name>BootOverlay</name>
     <message>
-        <location filename="../components/BootOverlay.qml" line="76" />
-        <source>Can't reach Zaparoo Core. Check your connection.</source>
+        <location filename="../components/BootOverlay.qml" line="76"/>
+        <source>Can&apos;t reach Zaparoo Core. Check your connection.</source>
         <translation>No se puede acceder a Zaparoo Core. Comprueba tu conexión.</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="78" />
+        <location filename="../components/BootOverlay.qml" line="78"/>
         <source>Reconnecting…</source>
         <translation>Reconectando…</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="80" />
+        <location filename="../components/BootOverlay.qml" line="80"/>
         <source>Loading library…</source>
         <translation>Cargando biblioteca…</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="85" />
+        <location filename="../components/BootOverlay.qml" line="85"/>
         <source>Connecting to Zaparoo Core…</source>
         <translation>Conectando al Core de Zaparoo…</translation>
     </message>
 </context>
 <context>
+    <name>BrowseDetailPane</name>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="22"/>
+        <source>Loading…</source>
+        <translation type="unfinished">Cargando…</translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="43"/>
+        <source>Year</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="45"/>
+        <source>Genre</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <source>Players</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <source>Developer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <source>Publisher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <source>Rating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="55"/>
+        <source>Filename</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommercialNoticeModal</name>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="59" />
+        <location filename="../components/CommercialNoticeModal.qml" line="59"/>
         <source>Welcome to Zaparoo Launcher</source>
         <translation>Bienvenido a Zaparoo Launcher</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="68" />
+        <location filename="../components/CommercialNoticeModal.qml" line="68"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>Copyright 2026 Wizzo Pty Ltd y los colaboradores del proyecto Zaparoo.</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="79" />
+        <location filename="../components/CommercialNoticeModal.qml" line="79"/>
         <source>This free source-available build is for personal and non-commercial use only. Commercial use or redistribution requires a license.</source>
         <translation>Esta compilación gratuita con código fuente disponible es solo para uso personal y no comercial. El uso comercial o la redistribución requieren una licencia.</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="90" />
+        <location filename="../components/CommercialNoticeModal.qml" line="90"/>
         <source>Contact: legal@zaparoo.org</source>
         <translation>Contacto: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="101" />
+        <location filename="../components/CommercialNoticeModal.qml" line="101"/>
         <source>Full details available any time under Settings &gt; About / License.</source>
         <translation>Todos los detalles están disponibles en cualquier momento en Ajustes &gt; Acerca de / Licencia.</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="119" />
+        <location filename="../components/CommercialNoticeModal.qml" line="119"/>
         <source>Created by</source>
         <translation>Creado por</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="162" />
+        <location filename="../components/CommercialNoticeModal.qml" line="162"/>
         <source>I understand</source>
         <translation>Entendido</translation>
     </message>
@@ -122,43 +166,43 @@
 <context>
     <name>CoreStatusPill</name>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="44" />
-        <location filename="../components/CoreStatusPill.qml" line="50" />
+        <location filename="../components/CoreStatusPill.qml" line="44"/>
+        <location filename="../components/CoreStatusPill.qml" line="50"/>
         <source>Disconnected</source>
         <translation>Desconectado</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="47" />
+        <location filename="../components/CoreStatusPill.qml" line="47"/>
         <source>Reconnecting…</source>
         <translation>Reconectando…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="53" />
+        <location filename="../components/CoreStatusPill.qml" line="53"/>
         <source>Connecting…</source>
         <translation>Conectando…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="56" />
+        <location filename="../components/CoreStatusPill.qml" line="56"/>
         <source>Core error</source>
         <translation>Error del Core</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="60" />
+        <location filename="../components/CoreStatusPill.qml" line="60"/>
         <source>Optimizing database</source>
         <translation>Optimizando base de datos</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="67" />
+        <location filename="../components/CoreStatusPill.qml" line="67"/>
         <source>Indexing paused</source>
         <translation>Indexación en pausa</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="70" />
+        <location filename="../components/CoreStatusPill.qml" line="70"/>
         <source>Indexing %1/%2 - %3</source>
         <translation>Indexando %1/%2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="86" />
+        <location filename="../components/CoreStatusPill.qml" line="86"/>
         <source>Scraping %1/%2 - %3</source>
         <translation>Extrayendo %1/%2 - %3</translation>
     </message>
@@ -167,17 +211,17 @@
         <translation type="vanished">Indexando %1/%2 — %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="73" />
+        <location filename="../components/CoreStatusPill.qml" line="73"/>
         <source>Indexing %1/%2</source>
         <translation>Indexando %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="75" />
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
         <source>Indexing…</source>
         <translation>Indexando…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="83" />
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Scrape paused</source>
         <translation>Scraping en pausa</translation>
     </message>
@@ -186,12 +230,12 @@
         <translation type="vanished">Extrayendo %1/%2 — %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="89" />
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
         <source>Scraping %1/%2</source>
         <translation>Extrayendo %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="91" />
+        <location filename="../components/CoreStatusPill.qml" line="91"/>
         <source>Scraping…</source>
         <translation>Extrayendo…</translation>
     </message>
@@ -199,22 +243,22 @@
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="182" />
+        <location filename="../screens/FavoritesScreen.qml" line="183"/>
         <source>Favorites</source>
         <translation>Favoritos</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="185" />
+        <location filename="../screens/FavoritesScreen.qml" line="186"/>
         <source>%1 entries</source>
         <translation>%1 entradas</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="283" />
+        <location filename="../screens/FavoritesScreen.qml" line="309"/>
         <source>No favorites yet</source>
         <translation>Aún no hay favoritos</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="284" />
+        <location filename="../screens/FavoritesScreen.qml" line="310"/>
         <source>Loading favorites…</source>
         <translation>Cargando favoritos…</translation>
     </message>
@@ -222,12 +266,12 @@
 <context>
     <name>FirstRunIndexModal</name>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="127" />
+        <location filename="../components/FirstRunIndexModal.qml" line="127"/>
         <source>First-time setup</source>
         <translation>Configuración inicial</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="136" />
+        <location filename="../components/FirstRunIndexModal.qml" line="136"/>
         <source>Zaparoo needs to scan your games before you can use the launcher. This usually takes a few minutes.</source>
         <translation>Zaparoo necesita escanear tus juegos antes de que puedas usar el lanzador. Esto suele tardar unos minutos.</translation>
     </message>
@@ -236,7 +280,7 @@
         <translation type="vanished">Optimizando la base de datos — ya casi hemos terminado</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="211" />
+        <location filename="../components/FirstRunIndexModal.qml" line="211"/>
         <source>Indexing paused</source>
         <translation>Indexación en pausa</translation>
     </message>
@@ -245,60 +289,84 @@
         <translation type="vanished">Paso %1 de %2 — %3</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="158" />
+        <location filename="../components/FirstRunIndexModal.qml" line="158"/>
         <source>Optimizing database - almost done</source>
         <translation>Optimizando la base de datos: casi listo</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="213" />
+        <location filename="../components/FirstRunIndexModal.qml" line="213"/>
         <source>Step %1 of %2 - %3</source>
         <translation>Paso %1 de %2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="215" />
+        <location filename="../components/FirstRunIndexModal.qml" line="215"/>
         <source>Step %1 of %2</source>
         <translation>Paso %1 de %2</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="216" />
+        <location filename="../components/FirstRunIndexModal.qml" line="216"/>
         <source>Preparing…</source>
         <translation>Preparando…</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="233" />
+        <location filename="../components/FirstRunIndexModal.qml" line="233"/>
         <source>Done. %1 files indexed.</source>
         <translation>Hecho. %1 archivos indexados.</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="263" />
+        <location filename="../components/FirstRunIndexModal.qml" line="263"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="263" />
+        <location filename="../components/FirstRunIndexModal.qml" line="263"/>
         <source>Start scan</source>
         <translation>Iniciar escaneo</translation>
     </message>
 </context>
 <context>
+    <name>GameInfoModal</name>
+    <message>
+        <location filename="../components/GameInfoModal.qml" line="86"/>
+        <source>Back to close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/GameInfoModal.qml" line="114"/>
+        <source>Loading details…</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="363" />
+        <location filename="../screens/GamesScreen.qml" line="367"/>
+        <location filename="../screens/GamesScreen.qml" line="537"/>
         <source>%1 files</source>
         <translation>%1 archivos</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="534" />
+        <location filename="../screens/GamesScreen.qml" line="437"/>
+        <source>Loading game…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/GamesScreen.qml" line="554"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/GamesScreen.qml" line="570"/>
         <source>Loading games…</source>
         <translation>Cargando juegos…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="556" />
+        <location filename="../screens/GamesScreen.qml" line="592"/>
         <source>Loading more…</source>
         <translation>Cargando más…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="533" />
+        <location filename="../screens/GamesScreen.qml" line="569"/>
         <source>No games in this system</source>
         <translation>No hay juegos en este sistema</translation>
     </message>
@@ -306,22 +374,22 @@
 <context>
     <name>HubScreen</name>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91" />
+        <location filename="../screens/HubScreen.qml" line="91"/>
         <source>Favorites</source>
         <translation>Favoritos</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="96" />
+        <location filename="../screens/HubScreen.qml" line="96"/>
         <source>Recently Played</source>
         <translation>Recientemente Jugados</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="101" />
+        <location filename="../screens/HubScreen.qml" line="101"/>
         <source>Settings</source>
         <translation>Ajustes</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="537" />
+        <location filename="../screens/HubScreen.qml" line="537"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>No hay sistemas disponibles. Ejecuta Actualizar la base de datos de medios desde Ajustes.</translation>
     </message>
@@ -329,7 +397,7 @@
 <context>
     <name>LoadingIndicator</name>
     <message>
-        <location filename="../components/LoadingIndicator.qml" line="26" />
+        <location filename="../components/LoadingIndicator.qml" line="26"/>
         <source>Loading…</source>
         <translation>Cargando…</translation>
     </message>
@@ -337,32 +405,32 @@
 <context>
     <name>LogUploadModal</name>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="87" />
+        <location filename="../components/LogUploadModal.qml" line="87"/>
         <source>Upload log file</source>
         <translation>Subir archivo de registro</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="97" />
+        <location filename="../components/LogUploadModal.qml" line="97"/>
         <source>Uploading log file - this may take a moment.</source>
         <translation>Subiendo archivo de registro; esto puede tardar un momento.</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197" />
+        <location filename="../components/LogUploadModal.qml" line="197"/>
         <source>Upload failed: %1</source>
         <translation>Error de subida: %1</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197" />
+        <location filename="../components/LogUploadModal.qml" line="197"/>
         <source>Upload failed.</source>
         <translation>La subida falló.</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="227" />
+        <location filename="../components/LogUploadModal.qml" line="227"/>
         <source>Retry</source>
         <translation>Reintentar</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="227" />
+        <location filename="../components/LogUploadModal.qml" line="227"/>
         <source>Done</source>
         <translation>Hecho</translation>
     </message>
@@ -370,58 +438,64 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="723" />
+        <location filename="../app/Main.qml" line="753"/>
         <source>Launch core</source>
         <translation>Lanzar core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="741" />
+        <location filename="../app/Main.qml" line="761"/>
+        <location filename="../app/Main.qml" line="781"/>
+        <source>More info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="785"/>
         <source>Remove from favorites</source>
         <translation>Eliminar de favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="741" />
+        <location filename="../app/Main.qml" line="785"/>
         <source>Add to favorites</source>
         <translation>Agregar a favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="747" />
+        <location filename="../app/Main.qml" line="790"/>
         <source>Write to NFC token</source>
         <translation>Escribir en token NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="751" />
+        <location filename="../app/Main.qml" line="794"/>
         <source>QR code</source>
         <translation>Código QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="731" />
-        <location filename="../app/Main.qml" line="755" />
+        <location filename="../app/Main.qml" line="765"/>
+        <location filename="../app/Main.qml" line="804"/>
         <source>Launch game</source>
         <translation>Iniciar juego</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1437" />
+        <location filename="../app/Main.qml" line="1652"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1441" />
+        <location filename="../app/Main.qml" line="1656"/>
         <source>Loading favorites…</source>
         <translation>Cargando favoritos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1439" />
+        <location filename="../app/Main.qml" line="1654"/>
         <source>Loading games…</source>
         <translation>Cargando juegos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1443" />
+        <location filename="../app/Main.qml" line="1658"/>
         <source>Loading recently played…</source>
         <translation>Cargando jugados recientemente…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1445" />
+        <location filename="../app/Main.qml" line="1660"/>
         <source>Loading…</source>
         <translation>Cargando…</translation>
     </message>
@@ -429,144 +503,151 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="127" />
+        <location filename="../app/MainLayout.qml" line="141"/>
         <source>Zaparoo Launcher</source>
         <translation>Cargador de Zaparoo</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="475" />
+        <location filename="../app/MainLayout.qml" line="545"/>
         <source>Writing failed</source>
         <translation>Error de escritura</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="475" />
+        <location filename="../app/MainLayout.qml" line="545"/>
         <source>Put a writable card near the reader</source>
         <translation>Pon una tarjeta escribible junto al lector</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="540" />
+        <location filename="../app/MainLayout.qml" line="556"/>
+        <source>Quit and restart Zaparoo Launcher?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="557"/>
+        <source>In order to apply this setting we need to restart the launcher.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="632"/>
         <source>Quit Zaparoo Launcher?</source>
         <translation>¿Salir de Zaparoo Launcher?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="541" />
+        <location filename="../app/MainLayout.qml" line="633"/>
         <source>Are you sure you want to exit?</source>
         <translation>¿Seguro que quieres salir?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="617" />
-        <location filename="../app/MainLayout.qml" line="689" />
-        <location filename="../app/MainLayout.qml" line="704" />
+        <location filename="../app/MainLayout.qml" line="709"/>
+        <location filename="../app/MainLayout.qml" line="781"/>
         <source>Select</source>
         <translation>Seleccionar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="621" />
-        <location filename="../app/MainLayout.qml" line="625" />
-        <location filename="../app/MainLayout.qml" line="639" />
-        <location filename="../app/MainLayout.qml" line="652" />
-        <location filename="../app/MainLayout.qml" line="663" />
+        <location filename="../app/MainLayout.qml" line="713"/>
+        <location filename="../app/MainLayout.qml" line="717"/>
+        <location filename="../app/MainLayout.qml" line="731"/>
+        <location filename="../app/MainLayout.qml" line="744"/>
+        <location filename="../app/MainLayout.qml" line="755"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="632" />
-        <location filename="../app/MainLayout.qml" line="670" />
-        <location filename="../app/MainLayout.qml" line="693" />
-        <location filename="../app/MainLayout.qml" line="708" />
-        <location filename="../app/MainLayout.qml" line="719" />
+        <location filename="../app/MainLayout.qml" line="724"/>
+        <location filename="../app/MainLayout.qml" line="762"/>
+        <location filename="../app/MainLayout.qml" line="785"/>
+        <location filename="../app/MainLayout.qml" line="796"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="648" />
+        <location filename="../app/MainLayout.qml" line="740"/>
         <source>Done</source>
         <translation>Hecho</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="678" />
+        <location filename="../app/MainLayout.qml" line="770"/>
         <source>I understand</source>
         <translation>Entendido</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="727" />
+        <location filename="../app/MainLayout.qml" line="804"/>
         <source>Start</source>
         <translation>Iniciar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="896" />
+        <location filename="../app/MainLayout.qml" line="973"/>
         <source>Scroll</source>
         <translation>Desplazar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="613" />
-        <location filename="../app/MainLayout.qml" line="685" />
-        <location filename="../app/MainLayout.qml" line="700" />
-        <location filename="../app/MainLayout.qml" line="743" />
-        <location filename="../app/MainLayout.qml" line="772" />
-        <location filename="../app/MainLayout.qml" line="819" />
-        <location filename="../app/MainLayout.qml" line="860" />
-        <location filename="../app/MainLayout.qml" line="924" />
+        <location filename="../app/MainLayout.qml" line="705"/>
+        <location filename="../app/MainLayout.qml" line="777"/>
+        <location filename="../app/MainLayout.qml" line="820"/>
+        <location filename="../app/MainLayout.qml" line="849"/>
+        <location filename="../app/MainLayout.qml" line="896"/>
+        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="1001"/>
         <source>Move</source>
         <translation>Mover</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="747" />
-        <location filename="../app/MainLayout.qml" line="782" />
-        <location filename="../app/MainLayout.qml" line="829" />
-        <location filename="../app/MainLayout.qml" line="934" />
+        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="859"/>
+        <location filename="../app/MainLayout.qml" line="906"/>
+        <location filename="../app/MainLayout.qml" line="1011"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="751" />
+        <location filename="../app/MainLayout.qml" line="828"/>
         <source>Quit</source>
         <translation>Salir</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="760" />
-        <location filename="../app/MainLayout.qml" line="788" />
-        <location filename="../app/MainLayout.qml" line="799" />
-        <location filename="../app/MainLayout.qml" line="811" />
-        <location filename="../app/MainLayout.qml" line="838" />
-        <location filename="../app/MainLayout.qml" line="849" />
-        <location filename="../app/MainLayout.qml" line="884" />
-        <location filename="../app/MainLayout.qml" line="900" />
-        <location filename="../app/MainLayout.qml" line="909" />
-        <location filename="../app/MainLayout.qml" line="943" />
-        <location filename="../app/MainLayout.qml" line="954" />
+        <location filename="../app/MainLayout.qml" line="837"/>
+        <location filename="../app/MainLayout.qml" line="865"/>
+        <location filename="../app/MainLayout.qml" line="876"/>
+        <location filename="../app/MainLayout.qml" line="888"/>
+        <location filename="../app/MainLayout.qml" line="915"/>
+        <location filename="../app/MainLayout.qml" line="926"/>
+        <location filename="../app/MainLayout.qml" line="961"/>
+        <location filename="../app/MainLayout.qml" line="977"/>
+        <location filename="../app/MainLayout.qml" line="986"/>
+        <location filename="../app/MainLayout.qml" line="1020"/>
+        <location filename="../app/MainLayout.qml" line="1031"/>
         <source>Back</source>
         <translation>Atrás</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="778" />
-        <location filename="../app/MainLayout.qml" line="825" />
-        <location filename="../app/MainLayout.qml" line="930" />
+        <location filename="../app/MainLayout.qml" line="855"/>
+        <location filename="../app/MainLayout.qml" line="902"/>
+        <location filename="../app/MainLayout.qml" line="1007"/>
         <source>Page</source>
         <translation>Página</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="785" />
-        <location filename="../app/MainLayout.qml" line="834" />
-        <location filename="../app/MainLayout.qml" line="939" />
+        <location filename="../app/MainLayout.qml" line="862"/>
+        <location filename="../app/MainLayout.qml" line="911"/>
+        <location filename="../app/MainLayout.qml" line="1016"/>
         <source>Options</source>
         <translation>Opciones</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="659" />
-        <location filename="../app/MainLayout.qml" line="795" />
-        <location filename="../app/MainLayout.qml" line="845" />
-        <location filename="../app/MainLayout.qml" line="950" />
+        <location filename="../app/MainLayout.qml" line="751"/>
+        <location filename="../app/MainLayout.qml" line="872"/>
+        <location filename="../app/MainLayout.qml" line="922"/>
+        <location filename="../app/MainLayout.qml" line="1027"/>
         <source>Retry</source>
         <translation>Reintentar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="869" />
+        <location filename="../app/MainLayout.qml" line="946"/>
         <source>Change</source>
         <translation>Cambiar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="875" />
+        <location filename="../app/MainLayout.qml" line="952"/>
         <source>Toggle</source>
         <translation>Alternar</translation>
     </message>
@@ -574,22 +655,22 @@
 <context>
     <name>Modal</name>
     <message>
-        <location filename="../components/Modal.qml" line="49" />
+        <location filename="../components/Modal.qml" line="49"/>
         <source>OK</source>
         <translation>Aceptar</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="50" />
+        <location filename="../components/Modal.qml" line="50"/>
         <source>Yes</source>
         <translation>Sí</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="51" />
+        <location filename="../components/Modal.qml" line="51"/>
         <source>No</source>
         <translation>No</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="198" />
+        <location filename="../components/Modal.qml" line="198"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
@@ -597,22 +678,22 @@
 <context>
     <name>RecentsScreen</name>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="183" />
+        <location filename="../screens/RecentsScreen.qml" line="184"/>
         <source>Recently Played</source>
         <translation>Jugados Recientemente</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="186" />
+        <location filename="../screens/RecentsScreen.qml" line="187"/>
         <source>%1 entries</source>
         <translation>%1 entradas</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="282" />
+        <location filename="../screens/RecentsScreen.qml" line="312"/>
         <source>Loading recently played…</source>
         <translation>Cargando jugados recientemente…</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="281" />
+        <location filename="../screens/RecentsScreen.qml" line="311"/>
         <source>Nothing played yet</source>
         <translation>No se ha jugado a nada todavía</translation>
     </message>
@@ -620,17 +701,17 @@
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="26" />
+        <location filename="../components/ScreenStateOverlay.qml" line="26"/>
         <source>Nothing here</source>
         <translation>Nada aquí</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27" />
+        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
         <source>Loading…</source>
         <translation>Cargando…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="57" />
+        <location filename="../components/ScreenStateOverlay.qml" line="57"/>
         <source>Failed to load</source>
         <translation>Fallo al cargar</translation>
     </message>
@@ -638,288 +719,294 @@
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78" />
-        <location filename="../screens/SettingsScreen.qml" line="436" />
+        <location filename="../screens/SettingsScreen.qml" line="73"/>
+        <location filename="../screens/SettingsScreen.qml" line="432"/>
         <source>Language</source>
         <translation>Idioma</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116" />
+        <location filename="../screens/SettingsScreen.qml" line="116"/>
         <source>Mouse support</source>
         <translation>Soporte a ratón</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102" />
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
         <source>Update media database</source>
         <translation>Actualizar base de datos de medios</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="61" />
+        <location filename="../screens/SettingsScreen.qml" line="61"/>
         <source>General</source>
         <translation>Ajustes generales</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83" />
-        <location filename="../screens/SettingsScreen.qml" line="445" />
+        <location filename="../screens/SettingsScreen.qml" line="78"/>
+        <location filename="../screens/SettingsScreen.qml" line="441"/>
         <source>Browsing layout</source>
         <translation>Diseño de exploración</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88" />
-        <location filename="../screens/SettingsScreen.qml" line="454" />
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="450"/>
         <source>Button style</source>
         <translation>Estilo de botón</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="93" />
-        <location filename="../screens/SettingsScreen.qml" line="463" />
+        <location filename="../screens/SettingsScreen.qml" line="88"/>
+        <location filename="../screens/SettingsScreen.qml" line="459"/>
         <source>Screensaver</source>
         <translation>Salvapantallas</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97" />
+        <location filename="../screens/SettingsScreen.qml" line="92"/>
         <source>Library</source>
         <translation>Biblioteca</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="107" />
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <source>Discover arcade alternate versions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="107"/>
         <source>Scrape metadata</source>
         <translation>Extraer metadatos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111" />
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
         <source>Advanced</source>
         <translation>Avanzado</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121" />
+        <location filename="../screens/SettingsScreen.qml" line="121"/>
         <source>Debug logging</source>
         <translation>Registro de depuración</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126" />
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Upload log file</source>
         <translation>Subir archivo de registro</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131" />
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
         <source>About / License</source>
         <translation>Acerca de / Licencia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147" />
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
         <source>Optimizing</source>
         <translation>Optimizando</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149" />
-        <location filename="../screens/SettingsScreen.qml" line="158" />
+        <location filename="../screens/SettingsScreen.qml" line="149"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
         <source>Paused</source>
         <translation>Pausado</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149" />
-        <location filename="../screens/SettingsScreen.qml" line="158" />
+        <location filename="../screens/SettingsScreen.qml" line="149"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
         <source>In progress</source>
         <translation>En progreso</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152" />
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>%1 indexed</source>
         <translation>%1 indexados</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="161" />
+        <location filename="../screens/SettingsScreen.qml" line="161"/>
         <source>%1 scraped</source>
         <translation>%1 extraídos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270" />
+        <location filename="../screens/SettingsScreen.qml" line="266"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270" />
+        <location filename="../screens/SettingsScreen.qml" line="266"/>
         <source>Start</source>
         <translation>Iniciar</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="272" />
+        <location filename="../screens/SettingsScreen.qml" line="268"/>
         <source>Upload</source>
         <translation>Subir</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="274" />
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="346" />
+        <location filename="../screens/SettingsScreen.qml" line="342"/>
         <source>English</source>
         <translation>Inglés</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="348" />
+        <location filename="../screens/SettingsScreen.qml" line="344"/>
         <source>Italian</source>
         <translation>Italiano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="350" />
+        <location filename="../screens/SettingsScreen.qml" line="346"/>
         <source>German</source>
         <translation>Alemán</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="352" />
+        <location filename="../screens/SettingsScreen.qml" line="348"/>
         <source>Greek</source>
         <translation>Griego</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="354" />
+        <location filename="../screens/SettingsScreen.qml" line="350"/>
         <source>Japanese</source>
         <translation>Japonés</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="356" />
+        <location filename="../screens/SettingsScreen.qml" line="352"/>
         <source>Korean</source>
         <translation>Coreano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="358" />
+        <location filename="../screens/SettingsScreen.qml" line="354"/>
         <source>Dutch</source>
         <translation>Neerlandés</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="360" />
+        <location filename="../screens/SettingsScreen.qml" line="356"/>
         <source>Romanian</source>
         <translation>Rumano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="362" />
+        <location filename="../screens/SettingsScreen.qml" line="358"/>
         <source>Slovak</source>
         <translation>Eslovaco</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="364" />
+        <location filename="../screens/SettingsScreen.qml" line="360"/>
         <source>Ukrainian</source>
         <translation>Ucraniano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="366" />
+        <location filename="../screens/SettingsScreen.qml" line="362"/>
         <source>Chinese (Simplified)</source>
         <translation>Chino (simplificado)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="368" />
+        <location filename="../screens/SettingsScreen.qml" line="364"/>
         <source>Hebrew</source>
         <translation>Hebreo</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="370" />
+        <location filename="../screens/SettingsScreen.qml" line="366"/>
         <source>Arabic</source>
-        <translation type="unfinished" />
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="372" />
+        <location filename="../screens/SettingsScreen.qml" line="368"/>
         <source>Hindi</source>
-        <translation type="unfinished" />
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="373" />
+        <location filename="../screens/SettingsScreen.qml" line="369"/>
         <source>Auto</source>
         <translation>Automático</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="378" />
+        <location filename="../screens/SettingsScreen.qml" line="374"/>
         <source>Detailed list view</source>
         <translation>Vista de lista detallada</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="379" />
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Grid view</source>
         <translation>Vista de cuadrícula</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="384" />
+        <location filename="../screens/SettingsScreen.qml" line="380"/>
         <source>Style B</source>
         <translation>Estilo B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="386" />
+        <location filename="../screens/SettingsScreen.qml" line="382"/>
         <source>Style C</source>
         <translation>Estilo C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="388" />
+        <location filename="../screens/SettingsScreen.qml" line="384"/>
         <source>Style D</source>
         <translation>Estilo D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="389" />
+        <location filename="../screens/SettingsScreen.qml" line="385"/>
         <source>Style A</source>
         <translation>Estilo A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="326" />
+        <location filename="../screens/SettingsScreen.qml" line="322"/>
         <source>Default</source>
         <translation>Por defecto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399" />
+        <location filename="../screens/SettingsScreen.qml" line="395"/>
         <source>Off</source>
         <translation>Desactivado</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="401" />
+        <location filename="../screens/SettingsScreen.qml" line="397"/>
         <source>1 second (testing)</source>
         <translation>1 segundo (prueba)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="403" />
+        <location filename="../screens/SettingsScreen.qml" line="399"/>
         <source>1 minute</source>
         <translation>1 minuto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405" />
+        <location filename="../screens/SettingsScreen.qml" line="401"/>
         <source>2 minutes</source>
         <translation>2 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="407" />
+        <location filename="../screens/SettingsScreen.qml" line="403"/>
         <source>5 minutes</source>
         <translation>5 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="409" />
+        <location filename="../screens/SettingsScreen.qml" line="405"/>
         <source>10 minutes</source>
         <translation>10 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="411" />
+        <location filename="../screens/SettingsScreen.qml" line="407"/>
         <source>15 minutes</source>
         <translation>15 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="413" />
+        <location filename="../screens/SettingsScreen.qml" line="409"/>
         <source>30 minutes</source>
         <translation>30 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="414" />
+        <location filename="../screens/SettingsScreen.qml" line="410"/>
         <source>%1 seconds</source>
         <translation>%1 segundos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="427" />
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="423"/>
         <source>Resolution</source>
         <translation>Resolución</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="555" />
+        <location filename="../screens/SettingsScreen.qml" line="563"/>
         <source>Settings</source>
         <translation>Ajustes</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="745" />
+        <location filename="../screens/SettingsScreen.qml" line="755"/>
         <source>No settings available on this platform</source>
         <translation>No hay ajustes en esta plataforma</translation>
     </message>
@@ -927,17 +1014,23 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="182" />
+        <location filename="../screens/SystemsScreen.qml" line="185"/>
+        <location filename="../screens/SystemsScreen.qml" line="313"/>
         <source>%1 systems</source>
         <translation>%1 sistemas</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="279" />
+        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SystemsScreen.qml" line="345"/>
         <source>No systems in this category</source>
         <translation>No hay sistemas en esta categoría</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="280" />
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>
@@ -945,7 +1038,7 @@
 <context>
     <name>TopStatusStrip</name>
     <message>
-        <location filename="../components/TopStatusStrip.qml" line="88" />
+        <location filename="../components/TopStatusStrip.qml" line="90"/>
         <source>Page %1 / %2</source>
         <translation>Página %1 / %2</translation>
     </message>

--- a/src/ui/translations/launcher_es.ts
+++ b/src/ui/translations/launcher_es.ts
@@ -90,38 +90,48 @@
         <translation type="unfinished">Cargando…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="43"/>
+        <location filename="../components/BrowseDetailPane.qml" line="44"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="45"/>
+        <location filename="../components/BrowseDetailPane.qml" line="46"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <location filename="../components/BrowseDetailPane.qml" line="48"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <location filename="../components/BrowseDetailPane.qml" line="50"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <location filename="../components/BrowseDetailPane.qml" line="52"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <location filename="../components/BrowseDetailPane.qml" line="54"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="55"/>
-        <source>Filename</source>
+        <location filename="../components/BrowseDetailPane.qml" line="56"/>
+        <source>Category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="58"/>
+        <source>Release date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="60"/>
+        <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -253,12 +263,17 @@
         <translation>%1 entradas</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="309"/>
+        <location filename="../screens/FavoritesScreen.qml" line="190"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/FavoritesScreen.qml" line="280"/>
         <source>No favorites yet</source>
         <translation>Aún no hay favoritos</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="310"/>
+        <location filename="../screens/FavoritesScreen.qml" line="281"/>
         <source>Loading favorites…</source>
         <translation>Cargando favoritos…</translation>
     </message>
@@ -340,33 +355,35 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="367"/>
-        <location filename="../screens/GamesScreen.qml" line="537"/>
+        <location filename="../screens/GamesScreen.qml" line="373"/>
+        <location filename="../screens/GamesScreen.qml" line="520"/>
         <source>%1 files</source>
         <translation>%1 archivos</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="437"/>
+        <location filename="../screens/GamesScreen.qml" line="409"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="554"/>
+        <location filename="../screens/GamesScreen.qml" line="382"/>
+        <location filename="../screens/GamesScreen.qml" line="537"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="570"/>
+        <location filename="../screens/GamesScreen.qml" line="553"/>
         <source>Loading games…</source>
         <translation>Cargando juegos…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="592"/>
+        <location filename="../screens/GamesScreen.qml" line="378"/>
+        <location filename="../screens/GamesScreen.qml" line="575"/>
         <source>Loading more…</source>
         <translation>Cargando más…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="569"/>
+        <location filename="../screens/GamesScreen.qml" line="552"/>
         <source>No games in this system</source>
         <translation>No hay juegos en este sistema</translation>
     </message>
@@ -688,12 +705,17 @@
         <translation>%1 entradas</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="312"/>
+        <location filename="../screens/RecentsScreen.qml" line="191"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/RecentsScreen.qml" line="283"/>
         <source>Loading recently played…</source>
         <translation>Cargando jugados recientemente…</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="311"/>
+        <location filename="../screens/RecentsScreen.qml" line="282"/>
         <source>Nothing played yet</source>
         <translation>No se ha jugado a nada todavía</translation>
     </message>
@@ -1015,22 +1037,23 @@
     <name>SystemsScreen</name>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="185"/>
-        <location filename="../screens/SystemsScreen.qml" line="313"/>
+        <location filename="../screens/SystemsScreen.qml" line="285"/>
         <source>%1 systems</source>
         <translation>%1 sistemas</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <location filename="../screens/SystemsScreen.qml" line="189"/>
+        <location filename="../screens/SystemsScreen.qml" line="302"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="345"/>
+        <location filename="../screens/SystemsScreen.qml" line="317"/>
         <source>No systems in this category</source>
         <translation>No hay sistemas en esta categoría</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="318"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>
@@ -1038,7 +1061,7 @@
 <context>
     <name>TopStatusStrip</name>
     <message>
-        <location filename="../components/TopStatusStrip.qml" line="90"/>
+        <location filename="../components/TopStatusStrip.qml" line="91"/>
         <source>Page %1 / %2</source>
         <translation>Página %1 / %2</translation>
     </message>

--- a/src/ui/translations/launcher_es.ts
+++ b/src/ui/translations/launcher_es.ts
@@ -253,27 +253,27 @@
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="183"/>
+        <location filename="../screens/FavoritesScreen.qml" line="225"/>
         <source>Favorites</source>
         <translation>Favoritos</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="186"/>
+        <location filename="../screens/FavoritesScreen.qml" line="228"/>
         <source>%1 entries</source>
         <translation>%1 entradas</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="190"/>
+        <location filename="../screens/FavoritesScreen.qml" line="232"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="280"/>
+        <location filename="../screens/FavoritesScreen.qml" line="334"/>
         <source>No favorites yet</source>
         <translation>Aún no hay favoritos</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="281"/>
+        <location filename="../screens/FavoritesScreen.qml" line="335"/>
         <source>Loading favorites…</source>
         <translation>Cargando favoritos…</translation>
     </message>
@@ -342,13 +342,13 @@
 <context>
     <name>GameInfoModal</name>
     <message>
-        <location filename="../components/GameInfoModal.qml" line="86"/>
-        <source>Back to close</source>
+        <location filename="../components/GameInfoModal.qml" line="104"/>
+        <source>Loading details…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/GameInfoModal.qml" line="114"/>
-        <source>Loading details…</source>
+        <location filename="../components/GameInfoModal.qml" line="174"/>
+        <source>Loading image…</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -460,12 +460,6 @@
         <translation>Lanzar core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="781"/>
-        <source>More info</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../app/Main.qml" line="785"/>
         <source>Remove from favorites</source>
         <translation>Eliminar de favoritos</translation>
@@ -490,6 +484,12 @@
         <location filename="../app/Main.qml" line="804"/>
         <source>Launch game</source>
         <translation>Iniciar juego</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="761"/>
+        <location filename="../app/Main.qml" line="781"/>
+        <source>View details</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1652"/>
@@ -695,27 +695,27 @@
 <context>
     <name>RecentsScreen</name>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="184"/>
+        <location filename="../screens/RecentsScreen.qml" line="226"/>
         <source>Recently Played</source>
         <translation>Jugados Recientemente</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="187"/>
+        <location filename="../screens/RecentsScreen.qml" line="229"/>
         <source>%1 entries</source>
         <translation>%1 entradas</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="191"/>
+        <location filename="../screens/RecentsScreen.qml" line="233"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="283"/>
+        <location filename="../screens/RecentsScreen.qml" line="337"/>
         <source>Loading recently played…</source>
         <translation>Cargando jugados recientemente…</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="282"/>
+        <location filename="../screens/RecentsScreen.qml" line="336"/>
         <source>Nothing played yet</source>
         <translation>No se ha jugado a nada todavía</translation>
     </message>

--- a/src/ui/translations/launcher_he.ts
+++ b/src/ui/translations/launcher_he.ts
@@ -1,59 +1,60 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
 <TS version="2.1" language="he" sourcelanguage="en">
 <context>
     <name>AboutScreen</name>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="72" />
+        <location filename="../screens/AboutScreen.qml" line="71"/>
         <source>About / License</source>
         <translation>אודות / רישיון</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="154" />
+        <location filename="../screens/AboutScreen.qml" line="153"/>
         <source>Zaparoo Launcher</source>
         <translation>מפעיל Zaparoo</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="165" />
+        <location filename="../screens/AboutScreen.qml" line="164"/>
         <source>Version %1 · %2 · %3</source>
         <translation>גרסה %1 · %2 · %3</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="178" />
+        <location filename="../screens/AboutScreen.qml" line="174"/>
         <source>Built %1</source>
         <translation>נבנה %1</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="189" />
+        <location filename="../screens/AboutScreen.qml" line="185"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>כל הזכויות שמורות 2026 ל-Wizzo Pty Ltd ולתורמי פרויקט Zaparoo.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="200" />
+        <location filename="../screens/AboutScreen.qml" line="196"/>
         <source>Source available under the PolyForm Noncommercial License 1.0.0. Free for personal, non-commercial use. Commercial use or redistribution requires a separate license.</source>
         <translation>קוד המקור זמין תחת רישיון PolyForm Noncommercial 1.0.0. חינם לשימוש אישי ולא מסחרי. שימוש מסחרי או הפצה מחדש דורשים רישיון נפרד.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="211" />
+        <location filename="../screens/AboutScreen.qml" line="207"/>
         <source>Commercial licensing: legal@zaparoo.org</source>
         <translation>רישוי מסחרי: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="222" />
+        <location filename="../screens/AboutScreen.qml" line="218"/>
         <source>Project: https://zaparoo.org</source>
         <translation>פרויקט: https://zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="232" />
+        <location filename="../screens/AboutScreen.qml" line="228"/>
         <source>Created by</source>
         <translation>נוצר על ידי</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="256" />
+        <location filename="../screens/AboutScreen.qml" line="252"/>
         <source>Translations</source>
         <translation>תרגומים</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="280" />
+        <location filename="../screens/AboutScreen.qml" line="276"/>
         <source>Full license text in COPYING.</source>
         <translation>נוסח הרישיון המלא נמצא ב-COPYING.</translation>
     </message>
@@ -61,60 +62,103 @@
 <context>
     <name>BootOverlay</name>
     <message>
-        <location filename="../components/BootOverlay.qml" line="76" />
-        <source>Can't reach Zaparoo Core. Check your connection.</source>
+        <location filename="../components/BootOverlay.qml" line="76"/>
+        <source>Can&apos;t reach Zaparoo Core. Check your connection.</source>
         <translation>לא ניתן להגיע אל Zaparoo Core. בדקו את החיבור.</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="78" />
+        <location filename="../components/BootOverlay.qml" line="78"/>
         <source>Reconnecting…</source>
         <translation>מתחבר מחדש…</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="80" />
+        <location filename="../components/BootOverlay.qml" line="80"/>
         <source>Loading library…</source>
         <translation>טוען ספרייה…</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="85" />
+        <location filename="../components/BootOverlay.qml" line="85"/>
         <source>Connecting to Zaparoo Core…</source>
         <translation>מתחבר אל Zaparoo Core…</translation>
     </message>
 </context>
 <context>
+    <name>BrowseDetailPane</name>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="22"/>
+        <source>Loading…</source>
+        <translation type="unfinished">טוען…</translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="43"/>
+        <source>Year</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="45"/>
+        <source>Genre</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <source>Players</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <source>Developer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <source>Publisher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <source>Rating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="55"/>
+        <source>Filename</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommercialNoticeModal</name>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="59" />
+        <location filename="../components/CommercialNoticeModal.qml" line="59"/>
         <source>Welcome to Zaparoo Launcher</source>
         <translation>ברוכים הבאים ל-Zaparoo Launcher</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="68" />
+        <location filename="../components/CommercialNoticeModal.qml" line="68"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>כל הזכויות שמורות 2026 ל-Wizzo Pty Ltd ולתורמי פרויקט Zaparoo.</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="79" />
+        <location filename="../components/CommercialNoticeModal.qml" line="79"/>
         <source>This free source-available build is for personal and non-commercial use only. Commercial use or redistribution requires a license.</source>
         <translation>בנייה חינמית זו עם קוד מקור זמין מיועדת לשימוש אישי ולא מסחרי בלבד. שימוש מסחרי או הפצה מחדש דורשים רישיון.</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="90" />
+        <location filename="../components/CommercialNoticeModal.qml" line="90"/>
         <source>Contact: legal@zaparoo.org</source>
         <translation>יצירת קשר: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="101" />
+        <location filename="../components/CommercialNoticeModal.qml" line="101"/>
         <source>Full details available any time under Settings &gt; About / License.</source>
         <translation>פרטים מלאים זמינים בכל עת תחת הגדרות &gt; אודות / רישיון.</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="119" />
+        <location filename="../components/CommercialNoticeModal.qml" line="119"/>
         <source>Created by</source>
         <translation>נוצר על ידי</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="162" />
+        <location filename="../components/CommercialNoticeModal.qml" line="162"/>
         <source>I understand</source>
         <translation>הבנתי</translation>
     </message>
@@ -122,68 +166,68 @@
 <context>
     <name>CoreStatusPill</name>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="44" />
-        <location filename="../components/CoreStatusPill.qml" line="50" />
+        <location filename="../components/CoreStatusPill.qml" line="44"/>
+        <location filename="../components/CoreStatusPill.qml" line="50"/>
         <source>Disconnected</source>
         <translation>מנותק</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="47" />
+        <location filename="../components/CoreStatusPill.qml" line="47"/>
         <source>Reconnecting…</source>
         <translation>מתחבר מחדש…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="53" />
+        <location filename="../components/CoreStatusPill.qml" line="53"/>
         <source>Connecting…</source>
         <translation>מתחבר…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="56" />
+        <location filename="../components/CoreStatusPill.qml" line="56"/>
         <source>Core error</source>
         <translation>שגיאת Core</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="60" />
+        <location filename="../components/CoreStatusPill.qml" line="60"/>
         <source>Optimizing database</source>
         <translation>מבצע אופטימיזציה למסד הנתונים</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="67" />
+        <location filename="../components/CoreStatusPill.qml" line="67"/>
         <source>Indexing paused</source>
         <translation>יצירת האינדקס הושהתה</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="70" />
+        <location filename="../components/CoreStatusPill.qml" line="70"/>
         <source>Indexing %1/%2 - %3</source>
         <translation>מאנדקס %1/%2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="73" />
+        <location filename="../components/CoreStatusPill.qml" line="73"/>
         <source>Indexing %1/%2</source>
         <translation>מאנדקס %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="75" />
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
         <source>Indexing…</source>
         <translation>מאנדקס…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="83" />
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Scrape paused</source>
         <translation>איסוף הנתונים הושהה</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="86" />
+        <location filename="../components/CoreStatusPill.qml" line="86"/>
         <source>Scraping %1/%2 - %3</source>
         <translation>אוסף נתונים %1/%2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="89" />
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
         <source>Scraping %1/%2</source>
         <translation>אוסף נתונים %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="91" />
+        <location filename="../components/CoreStatusPill.qml" line="91"/>
         <source>Scraping…</source>
         <translation>אוסף נתונים…</translation>
     </message>
@@ -191,22 +235,22 @@
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="182" />
+        <location filename="../screens/FavoritesScreen.qml" line="183"/>
         <source>Favorites</source>
         <translation>מועדפים</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="185" />
+        <location filename="../screens/FavoritesScreen.qml" line="186"/>
         <source>%1 entries</source>
         <translation>%1 פריטים</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="283" />
+        <location filename="../screens/FavoritesScreen.qml" line="309"/>
         <source>No favorites yet</source>
         <translation>עדיין אין מועדפים</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="284" />
+        <location filename="../screens/FavoritesScreen.qml" line="310"/>
         <source>Loading favorites…</source>
         <translation>טוען מועדפים…</translation>
     </message>
@@ -214,75 +258,99 @@
 <context>
     <name>FirstRunIndexModal</name>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="127" />
+        <location filename="../components/FirstRunIndexModal.qml" line="127"/>
         <source>First-time setup</source>
         <translation>הגדרה ראשונית</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="136" />
+        <location filename="../components/FirstRunIndexModal.qml" line="136"/>
         <source>Zaparoo needs to scan your games before you can use the launcher. This usually takes a few minutes.</source>
         <translation>לפני שאפשר להשתמש במפעיל, Zaparoo צריך לסרוק את המשחקים שלך. זה בדרך כלל לוקח כמה דקות.</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="158" />
+        <location filename="../components/FirstRunIndexModal.qml" line="158"/>
         <source>Optimizing database - almost done</source>
         <translation>מבצע אופטימיזציה למסד הנתונים - כמעט סיים</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="211" />
+        <location filename="../components/FirstRunIndexModal.qml" line="211"/>
         <source>Indexing paused</source>
         <translation>יצירת האינדקס הושהתה</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="213" />
+        <location filename="../components/FirstRunIndexModal.qml" line="213"/>
         <source>Step %1 of %2 - %3</source>
         <translation>שלב %1 מתוך %2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="215" />
+        <location filename="../components/FirstRunIndexModal.qml" line="215"/>
         <source>Step %1 of %2</source>
         <translation>שלב %1 מתוך %2</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="216" />
+        <location filename="../components/FirstRunIndexModal.qml" line="216"/>
         <source>Preparing…</source>
         <translation>מכין…</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="233" />
+        <location filename="../components/FirstRunIndexModal.qml" line="233"/>
         <source>Done. %1 files indexed.</source>
         <translation>הושלם. %1 קבצים אונדקסו.</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="263" />
+        <location filename="../components/FirstRunIndexModal.qml" line="263"/>
         <source>Cancel</source>
         <translation>ביטול</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="263" />
+        <location filename="../components/FirstRunIndexModal.qml" line="263"/>
         <source>Start scan</source>
         <translation>התחל סריקה</translation>
     </message>
 </context>
 <context>
+    <name>GameInfoModal</name>
+    <message>
+        <location filename="../components/GameInfoModal.qml" line="86"/>
+        <source>Back to close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/GameInfoModal.qml" line="114"/>
+        <source>Loading details…</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="363" />
+        <location filename="../screens/GamesScreen.qml" line="367"/>
+        <location filename="../screens/GamesScreen.qml" line="537"/>
         <source>%1 files</source>
         <translation>%1 קבצים</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="533" />
+        <location filename="../screens/GamesScreen.qml" line="437"/>
+        <source>Loading game…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/GamesScreen.qml" line="554"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/GamesScreen.qml" line="569"/>
         <source>No games in this system</source>
         <translation>אין משחקים במערכת זו</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="534" />
+        <location filename="../screens/GamesScreen.qml" line="570"/>
         <source>Loading games…</source>
         <translation>טוען משחקים…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="556" />
+        <location filename="../screens/GamesScreen.qml" line="592"/>
         <source>Loading more…</source>
         <translation>טוען עוד…</translation>
     </message>
@@ -290,30 +358,30 @@
 <context>
     <name>HubScreen</name>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91" />
+        <location filename="../screens/HubScreen.qml" line="91"/>
         <source>Favorites</source>
         <translation>מועדפים</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="96" />
+        <location filename="../screens/HubScreen.qml" line="96"/>
         <source>Recently Played</source>
         <translation>שוחקו לאחרונה</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="101" />
+        <location filename="../screens/HubScreen.qml" line="101"/>
         <source>Settings</source>
         <translation>הגדרות</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="537" />
+        <location filename="../screens/HubScreen.qml" line="537"/>
         <source>No systems available. Run Update media database from Settings.</source>
-        <translation>אין מערכות זמינות. הפעילו "עדכון מסד נתוני מדיה" מההגדרות.</translation>
+        <translation>אין מערכות זמינות. הפעילו &quot;עדכון מסד נתוני מדיה&quot; מההגדרות.</translation>
     </message>
 </context>
 <context>
     <name>LoadingIndicator</name>
     <message>
-        <location filename="../components/LoadingIndicator.qml" line="26" />
+        <location filename="../components/LoadingIndicator.qml" line="26"/>
         <source>Loading…</source>
         <translation>טוען…</translation>
     </message>
@@ -321,32 +389,32 @@
 <context>
     <name>LogUploadModal</name>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="87" />
+        <location filename="../components/LogUploadModal.qml" line="87"/>
         <source>Upload log file</source>
         <translation>העלאת קובץ יומן</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="97" />
+        <location filename="../components/LogUploadModal.qml" line="97"/>
         <source>Uploading log file - this may take a moment.</source>
         <translation>מעלה קובץ יומן - זה עשוי לקחת רגע.</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197" />
+        <location filename="../components/LogUploadModal.qml" line="197"/>
         <source>Upload failed: %1</source>
         <translation>ההעלאה נכשלה: %1</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197" />
+        <location filename="../components/LogUploadModal.qml" line="197"/>
         <source>Upload failed.</source>
         <translation>ההעלאה נכשלה.</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="227" />
+        <location filename="../components/LogUploadModal.qml" line="227"/>
         <source>Retry</source>
         <translation>נסה שוב</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="227" />
+        <location filename="../components/LogUploadModal.qml" line="227"/>
         <source>Done</source>
         <translation>הושלם</translation>
     </message>
@@ -354,58 +422,64 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="723" />
+        <location filename="../app/Main.qml" line="753"/>
         <source>Launch core</source>
         <translation>הפעל את הליבה</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="731" />
-        <location filename="../app/Main.qml" line="755" />
+        <location filename="../app/Main.qml" line="761"/>
+        <location filename="../app/Main.qml" line="781"/>
+        <source>More info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="765"/>
+        <location filename="../app/Main.qml" line="804"/>
         <source>Launch game</source>
         <translation>הפעל משחק</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="741" />
+        <location filename="../app/Main.qml" line="785"/>
         <source>Remove from favorites</source>
         <translation>הסר מהמועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="741" />
+        <location filename="../app/Main.qml" line="785"/>
         <source>Add to favorites</source>
         <translation>הוסף למועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="747" />
+        <location filename="../app/Main.qml" line="790"/>
         <source>Write to NFC token</source>
         <translation>כתוב לטוקן NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="751" />
+        <location filename="../app/Main.qml" line="794"/>
         <source>QR code</source>
         <translation>קוד QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1437" />
+        <location filename="../app/Main.qml" line="1652"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1439" />
+        <location filename="../app/Main.qml" line="1654"/>
         <source>Loading games…</source>
         <translation>טוען משחקים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1441" />
+        <location filename="../app/Main.qml" line="1656"/>
         <source>Loading favorites…</source>
         <translation>טוען מועדפים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1443" />
+        <location filename="../app/Main.qml" line="1658"/>
         <source>Loading recently played…</source>
         <translation>טוען את הפריטים ששוחקו לאחרונה…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1445" />
+        <location filename="../app/Main.qml" line="1660"/>
         <source>Loading…</source>
         <translation>טוען…</translation>
     </message>
@@ -413,144 +487,151 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="127" />
+        <location filename="../app/MainLayout.qml" line="141"/>
         <source>Zaparoo Launcher</source>
         <translation>מפעיל Zaparoo</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="475" />
+        <location filename="../app/MainLayout.qml" line="545"/>
         <source>Writing failed</source>
         <translation>הכתיבה נכשלה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="475" />
+        <location filename="../app/MainLayout.qml" line="545"/>
         <source>Put a writable card near the reader</source>
         <translation>הניחו כרטיס הניתן לכתיבה ליד הקורא</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="540" />
+        <location filename="../app/MainLayout.qml" line="556"/>
+        <source>Quit and restart Zaparoo Launcher?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="557"/>
+        <source>In order to apply this setting we need to restart the launcher.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="632"/>
         <source>Quit Zaparoo Launcher?</source>
         <translation>לצאת מ-Zaparoo Launcher?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="541" />
+        <location filename="../app/MainLayout.qml" line="633"/>
         <source>Are you sure you want to exit?</source>
         <translation>האם אתה בטוח שברצונך לצאת?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="613" />
-        <location filename="../app/MainLayout.qml" line="685" />
-        <location filename="../app/MainLayout.qml" line="700" />
-        <location filename="../app/MainLayout.qml" line="743" />
-        <location filename="../app/MainLayout.qml" line="772" />
-        <location filename="../app/MainLayout.qml" line="819" />
-        <location filename="../app/MainLayout.qml" line="860" />
-        <location filename="../app/MainLayout.qml" line="924" />
+        <location filename="../app/MainLayout.qml" line="705"/>
+        <location filename="../app/MainLayout.qml" line="777"/>
+        <location filename="../app/MainLayout.qml" line="820"/>
+        <location filename="../app/MainLayout.qml" line="849"/>
+        <location filename="../app/MainLayout.qml" line="896"/>
+        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="1001"/>
         <source>Move</source>
         <translation>הזזה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="617" />
-        <location filename="../app/MainLayout.qml" line="689" />
-        <location filename="../app/MainLayout.qml" line="704" />
+        <location filename="../app/MainLayout.qml" line="709"/>
+        <location filename="../app/MainLayout.qml" line="781"/>
         <source>Select</source>
         <translation>בחירה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="621" />
-        <location filename="../app/MainLayout.qml" line="625" />
-        <location filename="../app/MainLayout.qml" line="639" />
-        <location filename="../app/MainLayout.qml" line="652" />
-        <location filename="../app/MainLayout.qml" line="663" />
+        <location filename="../app/MainLayout.qml" line="713"/>
+        <location filename="../app/MainLayout.qml" line="717"/>
+        <location filename="../app/MainLayout.qml" line="731"/>
+        <location filename="../app/MainLayout.qml" line="744"/>
+        <location filename="../app/MainLayout.qml" line="755"/>
         <source>Close</source>
         <translation>סגור</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="632" />
-        <location filename="../app/MainLayout.qml" line="670" />
-        <location filename="../app/MainLayout.qml" line="693" />
-        <location filename="../app/MainLayout.qml" line="708" />
-        <location filename="../app/MainLayout.qml" line="719" />
+        <location filename="../app/MainLayout.qml" line="724"/>
+        <location filename="../app/MainLayout.qml" line="762"/>
+        <location filename="../app/MainLayout.qml" line="785"/>
+        <location filename="../app/MainLayout.qml" line="796"/>
         <source>Cancel</source>
         <translation>ביטול</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="648" />
+        <location filename="../app/MainLayout.qml" line="740"/>
         <source>Done</source>
         <translation>הושלם</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="659" />
-        <location filename="../app/MainLayout.qml" line="795" />
-        <location filename="../app/MainLayout.qml" line="845" />
-        <location filename="../app/MainLayout.qml" line="950" />
+        <location filename="../app/MainLayout.qml" line="751"/>
+        <location filename="../app/MainLayout.qml" line="872"/>
+        <location filename="../app/MainLayout.qml" line="922"/>
+        <location filename="../app/MainLayout.qml" line="1027"/>
         <source>Retry</source>
         <translation>נסה שוב</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="678" />
+        <location filename="../app/MainLayout.qml" line="770"/>
         <source>I understand</source>
         <translation>הבנתי</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="727" />
+        <location filename="../app/MainLayout.qml" line="804"/>
         <source>Start</source>
         <translation>התחל</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="747" />
-        <location filename="../app/MainLayout.qml" line="782" />
-        <location filename="../app/MainLayout.qml" line="829" />
-        <location filename="../app/MainLayout.qml" line="934" />
+        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="859"/>
+        <location filename="../app/MainLayout.qml" line="906"/>
+        <location filename="../app/MainLayout.qml" line="1011"/>
         <source>Open</source>
         <translation>פתח</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="751" />
+        <location filename="../app/MainLayout.qml" line="828"/>
         <source>Quit</source>
         <translation>יציאה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="760" />
-        <location filename="../app/MainLayout.qml" line="788" />
-        <location filename="../app/MainLayout.qml" line="799" />
-        <location filename="../app/MainLayout.qml" line="811" />
-        <location filename="../app/MainLayout.qml" line="838" />
-        <location filename="../app/MainLayout.qml" line="849" />
-        <location filename="../app/MainLayout.qml" line="884" />
-        <location filename="../app/MainLayout.qml" line="900" />
-        <location filename="../app/MainLayout.qml" line="909" />
-        <location filename="../app/MainLayout.qml" line="943" />
-        <location filename="../app/MainLayout.qml" line="954" />
+        <location filename="../app/MainLayout.qml" line="837"/>
+        <location filename="../app/MainLayout.qml" line="865"/>
+        <location filename="../app/MainLayout.qml" line="876"/>
+        <location filename="../app/MainLayout.qml" line="888"/>
+        <location filename="../app/MainLayout.qml" line="915"/>
+        <location filename="../app/MainLayout.qml" line="926"/>
+        <location filename="../app/MainLayout.qml" line="961"/>
+        <location filename="../app/MainLayout.qml" line="977"/>
+        <location filename="../app/MainLayout.qml" line="986"/>
+        <location filename="../app/MainLayout.qml" line="1020"/>
+        <location filename="../app/MainLayout.qml" line="1031"/>
         <source>Back</source>
         <translation>חזרה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="778" />
-        <location filename="../app/MainLayout.qml" line="825" />
-        <location filename="../app/MainLayout.qml" line="930" />
+        <location filename="../app/MainLayout.qml" line="855"/>
+        <location filename="../app/MainLayout.qml" line="902"/>
+        <location filename="../app/MainLayout.qml" line="1007"/>
         <source>Page</source>
         <translation>עמוד</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="785" />
-        <location filename="../app/MainLayout.qml" line="834" />
-        <location filename="../app/MainLayout.qml" line="939" />
+        <location filename="../app/MainLayout.qml" line="862"/>
+        <location filename="../app/MainLayout.qml" line="911"/>
+        <location filename="../app/MainLayout.qml" line="1016"/>
         <source>Options</source>
         <translation>אפשרויות</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="869" />
+        <location filename="../app/MainLayout.qml" line="946"/>
         <source>Change</source>
         <translation>שינוי</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="875" />
+        <location filename="../app/MainLayout.qml" line="952"/>
         <source>Toggle</source>
         <translation>החלף</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="896" />
+        <location filename="../app/MainLayout.qml" line="973"/>
         <source>Scroll</source>
         <translation>גלילה</translation>
     </message>
@@ -558,22 +639,22 @@
 <context>
     <name>Modal</name>
     <message>
-        <location filename="../components/Modal.qml" line="49" />
+        <location filename="../components/Modal.qml" line="49"/>
         <source>OK</source>
         <translation>אישור</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="50" />
+        <location filename="../components/Modal.qml" line="50"/>
         <source>Yes</source>
         <translation>כן</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="51" />
+        <location filename="../components/Modal.qml" line="51"/>
         <source>No</source>
         <translation>לא</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="198" />
+        <location filename="../components/Modal.qml" line="198"/>
         <source>Cancel</source>
         <translation>ביטול</translation>
     </message>
@@ -581,22 +662,22 @@
 <context>
     <name>RecentsScreen</name>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="183" />
+        <location filename="../screens/RecentsScreen.qml" line="184"/>
         <source>Recently Played</source>
         <translation>שוחקו לאחרונה</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="186" />
+        <location filename="../screens/RecentsScreen.qml" line="187"/>
         <source>%1 entries</source>
         <translation>%1 פריטים</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="281" />
+        <location filename="../screens/RecentsScreen.qml" line="311"/>
         <source>Nothing played yet</source>
         <translation>עדיין לא שוחק דבר</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="282" />
+        <location filename="../screens/RecentsScreen.qml" line="312"/>
         <source>Loading recently played…</source>
         <translation>טוען את הפריטים ששוחקו לאחרונה…</translation>
     </message>
@@ -604,17 +685,17 @@
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="26" />
+        <location filename="../components/ScreenStateOverlay.qml" line="26"/>
         <source>Nothing here</source>
         <translation>אין כאן כלום</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27" />
+        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
         <source>Loading…</source>
         <translation>טוען…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="57" />
+        <location filename="../components/ScreenStateOverlay.qml" line="57"/>
         <source>Failed to load</source>
         <translation>הטעינה נכשלה</translation>
     </message>
@@ -622,288 +703,294 @@
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="61" />
+        <location filename="../screens/SettingsScreen.qml" line="61"/>
         <source>General</source>
         <translation>כללי</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78" />
-        <location filename="../screens/SettingsScreen.qml" line="436" />
+        <location filename="../screens/SettingsScreen.qml" line="73"/>
+        <location filename="../screens/SettingsScreen.qml" line="432"/>
         <source>Language</source>
         <translation>שפה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83" />
-        <location filename="../screens/SettingsScreen.qml" line="445" />
+        <location filename="../screens/SettingsScreen.qml" line="78"/>
+        <location filename="../screens/SettingsScreen.qml" line="441"/>
         <source>Browsing layout</source>
         <translation>פריסת עיון</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88" />
-        <location filename="../screens/SettingsScreen.qml" line="454" />
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="450"/>
         <source>Button style</source>
         <translation>סגנון כפתורים</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="93" />
-        <location filename="../screens/SettingsScreen.qml" line="463" />
+        <location filename="../screens/SettingsScreen.qml" line="88"/>
+        <location filename="../screens/SettingsScreen.qml" line="459"/>
         <source>Screensaver</source>
         <translation>שומר מסך</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97" />
+        <location filename="../screens/SettingsScreen.qml" line="92"/>
         <source>Library</source>
         <translation>ספרייה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102" />
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <source>Discover arcade alternate versions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
         <source>Update media database</source>
         <translation>עדכון מסד נתוני המדיה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="107" />
+        <location filename="../screens/SettingsScreen.qml" line="107"/>
         <source>Scrape metadata</source>
         <translation>איסוף מטא-נתונים</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111" />
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
         <source>Advanced</source>
         <translation>מתקדם</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116" />
+        <location filename="../screens/SettingsScreen.qml" line="116"/>
         <source>Mouse support</source>
         <translation>תמיכת עכבר</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121" />
+        <location filename="../screens/SettingsScreen.qml" line="121"/>
         <source>Debug logging</source>
         <translation>רישום ניפוי שגיאות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126" />
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Upload log file</source>
         <translation>העלאת קובץ יומן</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131" />
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
         <source>About / License</source>
         <translation>אודות / רישיון</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147" />
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
         <source>Optimizing</source>
         <translation>מבצע אופטימיזציה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149" />
-        <location filename="../screens/SettingsScreen.qml" line="158" />
+        <location filename="../screens/SettingsScreen.qml" line="149"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
         <source>Paused</source>
         <translation>מושהה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149" />
-        <location filename="../screens/SettingsScreen.qml" line="158" />
+        <location filename="../screens/SettingsScreen.qml" line="149"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
         <source>In progress</source>
         <translation>בתהליך</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152" />
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>%1 indexed</source>
         <translation>%1 אונדקסו</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="161" />
+        <location filename="../screens/SettingsScreen.qml" line="161"/>
         <source>%1 scraped</source>
         <translation>%1 נאספו</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270" />
+        <location filename="../screens/SettingsScreen.qml" line="266"/>
         <source>Cancel</source>
         <translation>ביטול</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270" />
+        <location filename="../screens/SettingsScreen.qml" line="266"/>
         <source>Start</source>
         <translation>התחל</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="272" />
+        <location filename="../screens/SettingsScreen.qml" line="268"/>
         <source>Upload</source>
         <translation>העלאה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="274" />
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
         <source>Open</source>
         <translation>פתח</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="326" />
+        <location filename="../screens/SettingsScreen.qml" line="322"/>
         <source>Default</source>
         <translation>ברירת מחדל</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="346" />
+        <location filename="../screens/SettingsScreen.qml" line="342"/>
         <source>English</source>
         <translation>אנגלית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="348" />
+        <location filename="../screens/SettingsScreen.qml" line="344"/>
         <source>Italian</source>
         <translation>איטלקית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="350" />
+        <location filename="../screens/SettingsScreen.qml" line="346"/>
         <source>German</source>
         <translation>גרמנית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="352" />
+        <location filename="../screens/SettingsScreen.qml" line="348"/>
         <source>Greek</source>
         <translation>יוונית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="354" />
+        <location filename="../screens/SettingsScreen.qml" line="350"/>
         <source>Japanese</source>
         <translation>יפנית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="356" />
+        <location filename="../screens/SettingsScreen.qml" line="352"/>
         <source>Korean</source>
         <translation>קוריאנית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="358" />
+        <location filename="../screens/SettingsScreen.qml" line="354"/>
         <source>Dutch</source>
         <translation>הולנדית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="360" />
+        <location filename="../screens/SettingsScreen.qml" line="356"/>
         <source>Romanian</source>
         <translation>רומנית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="362" />
+        <location filename="../screens/SettingsScreen.qml" line="358"/>
         <source>Slovak</source>
         <translation>סלובקית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="364" />
+        <location filename="../screens/SettingsScreen.qml" line="360"/>
         <source>Ukrainian</source>
         <translation>אוקראינית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="366" />
+        <location filename="../screens/SettingsScreen.qml" line="362"/>
         <source>Chinese (Simplified)</source>
         <translation>סינית (מפושטת)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="368" />
+        <location filename="../screens/SettingsScreen.qml" line="364"/>
         <source>Hebrew</source>
         <translation>עברית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="370" />
+        <location filename="../screens/SettingsScreen.qml" line="366"/>
         <source>Arabic</source>
-        <translation type="unfinished" />
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="372" />
+        <location filename="../screens/SettingsScreen.qml" line="368"/>
         <source>Hindi</source>
-        <translation type="unfinished" />
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="373" />
+        <location filename="../screens/SettingsScreen.qml" line="369"/>
         <source>Auto</source>
         <translation>אוטומטי</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="378" />
+        <location filename="../screens/SettingsScreen.qml" line="374"/>
         <source>Detailed list view</source>
         <translation>תצוגת רשימה מפורטת</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="379" />
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Grid view</source>
         <translation>תצוגת רשת</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="384" />
+        <location filename="../screens/SettingsScreen.qml" line="380"/>
         <source>Style B</source>
         <translation>סגנון B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="386" />
+        <location filename="../screens/SettingsScreen.qml" line="382"/>
         <source>Style C</source>
         <translation>סגנון C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="388" />
+        <location filename="../screens/SettingsScreen.qml" line="384"/>
         <source>Style D</source>
         <translation>סגנון D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="389" />
+        <location filename="../screens/SettingsScreen.qml" line="385"/>
         <source>Style A</source>
         <translation>סגנון A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399" />
+        <location filename="../screens/SettingsScreen.qml" line="395"/>
         <source>Off</source>
         <translation>כבוי</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="401" />
+        <location filename="../screens/SettingsScreen.qml" line="397"/>
         <source>1 second (testing)</source>
         <translation>שנייה אחת (לבדיקה)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="403" />
+        <location filename="../screens/SettingsScreen.qml" line="399"/>
         <source>1 minute</source>
         <translation>דקה אחת</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405" />
+        <location filename="../screens/SettingsScreen.qml" line="401"/>
         <source>2 minutes</source>
         <translation>2 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="407" />
+        <location filename="../screens/SettingsScreen.qml" line="403"/>
         <source>5 minutes</source>
         <translation>5 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="409" />
+        <location filename="../screens/SettingsScreen.qml" line="405"/>
         <source>10 minutes</source>
         <translation>10 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="411" />
+        <location filename="../screens/SettingsScreen.qml" line="407"/>
         <source>15 minutes</source>
         <translation>15 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="413" />
+        <location filename="../screens/SettingsScreen.qml" line="409"/>
         <source>30 minutes</source>
         <translation>30 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="414" />
+        <location filename="../screens/SettingsScreen.qml" line="410"/>
         <source>%1 seconds</source>
         <translation>%1 שניות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="427" />
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="423"/>
         <source>Resolution</source>
         <translation>רזולוציה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="555" />
+        <location filename="../screens/SettingsScreen.qml" line="563"/>
         <source>Settings</source>
         <translation>הגדרות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="745" />
+        <location filename="../screens/SettingsScreen.qml" line="755"/>
         <source>No settings available on this platform</source>
         <translation>אין הגדרות זמינות בפלטפורמה זו</translation>
     </message>
@@ -911,17 +998,23 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="182" />
+        <location filename="../screens/SystemsScreen.qml" line="185"/>
+        <location filename="../screens/SystemsScreen.qml" line="313"/>
         <source>%1 systems</source>
         <translation>%1 מערכות</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="279" />
+        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SystemsScreen.qml" line="345"/>
         <source>No systems in this category</source>
         <translation>אין מערכות בקטגוריה זו</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="280" />
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>
@@ -929,7 +1022,7 @@
 <context>
     <name>TopStatusStrip</name>
     <message>
-        <location filename="../components/TopStatusStrip.qml" line="88" />
+        <location filename="../components/TopStatusStrip.qml" line="90"/>
         <source>Page %1 / %2</source>
         <translation>עמוד %1 / %2</translation>
     </message>

--- a/src/ui/translations/launcher_he.ts
+++ b/src/ui/translations/launcher_he.ts
@@ -245,27 +245,27 @@
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="183"/>
+        <location filename="../screens/FavoritesScreen.qml" line="225"/>
         <source>Favorites</source>
         <translation>מועדפים</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="186"/>
+        <location filename="../screens/FavoritesScreen.qml" line="228"/>
         <source>%1 entries</source>
         <translation>%1 פריטים</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="190"/>
+        <location filename="../screens/FavoritesScreen.qml" line="232"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="280"/>
+        <location filename="../screens/FavoritesScreen.qml" line="334"/>
         <source>No favorites yet</source>
         <translation>עדיין אין מועדפים</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="281"/>
+        <location filename="../screens/FavoritesScreen.qml" line="335"/>
         <source>Loading favorites…</source>
         <translation>טוען מועדפים…</translation>
     </message>
@@ -326,13 +326,13 @@
 <context>
     <name>GameInfoModal</name>
     <message>
-        <location filename="../components/GameInfoModal.qml" line="86"/>
-        <source>Back to close</source>
+        <location filename="../components/GameInfoModal.qml" line="104"/>
+        <source>Loading details…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/GameInfoModal.qml" line="114"/>
-        <source>Loading details…</source>
+        <location filename="../components/GameInfoModal.qml" line="174"/>
+        <source>Loading image…</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -446,7 +446,7 @@
     <message>
         <location filename="../app/Main.qml" line="761"/>
         <location filename="../app/Main.qml" line="781"/>
-        <source>More info</source>
+        <source>View details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -679,27 +679,27 @@
 <context>
     <name>RecentsScreen</name>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="184"/>
+        <location filename="../screens/RecentsScreen.qml" line="226"/>
         <source>Recently Played</source>
         <translation>שוחקו לאחרונה</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="187"/>
+        <location filename="../screens/RecentsScreen.qml" line="229"/>
         <source>%1 entries</source>
         <translation>%1 פריטים</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="191"/>
+        <location filename="../screens/RecentsScreen.qml" line="233"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="282"/>
+        <location filename="../screens/RecentsScreen.qml" line="336"/>
         <source>Nothing played yet</source>
         <translation>עדיין לא שוחק דבר</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="283"/>
+        <location filename="../screens/RecentsScreen.qml" line="337"/>
         <source>Loading recently played…</source>
         <translation>טוען את הפריטים ששוחקו לאחרונה…</translation>
     </message>

--- a/src/ui/translations/launcher_he.ts
+++ b/src/ui/translations/launcher_he.ts
@@ -90,38 +90,48 @@
         <translation type="unfinished">טוען…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="43"/>
+        <location filename="../components/BrowseDetailPane.qml" line="44"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="45"/>
+        <location filename="../components/BrowseDetailPane.qml" line="46"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <location filename="../components/BrowseDetailPane.qml" line="48"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <location filename="../components/BrowseDetailPane.qml" line="50"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <location filename="../components/BrowseDetailPane.qml" line="52"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <location filename="../components/BrowseDetailPane.qml" line="54"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="55"/>
-        <source>Filename</source>
+        <location filename="../components/BrowseDetailPane.qml" line="56"/>
+        <source>Category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="58"/>
+        <source>Release date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="60"/>
+        <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -245,12 +255,17 @@
         <translation>%1 פריטים</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="309"/>
+        <location filename="../screens/FavoritesScreen.qml" line="190"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/FavoritesScreen.qml" line="280"/>
         <source>No favorites yet</source>
         <translation>עדיין אין מועדפים</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="310"/>
+        <location filename="../screens/FavoritesScreen.qml" line="281"/>
         <source>Loading favorites…</source>
         <translation>טוען מועדפים…</translation>
     </message>
@@ -324,33 +339,35 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="367"/>
-        <location filename="../screens/GamesScreen.qml" line="537"/>
+        <location filename="../screens/GamesScreen.qml" line="373"/>
+        <location filename="../screens/GamesScreen.qml" line="520"/>
         <source>%1 files</source>
         <translation>%1 קבצים</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="437"/>
+        <location filename="../screens/GamesScreen.qml" line="409"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="554"/>
+        <location filename="../screens/GamesScreen.qml" line="382"/>
+        <location filename="../screens/GamesScreen.qml" line="537"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="569"/>
+        <location filename="../screens/GamesScreen.qml" line="552"/>
         <source>No games in this system</source>
         <translation>אין משחקים במערכת זו</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="570"/>
+        <location filename="../screens/GamesScreen.qml" line="553"/>
         <source>Loading games…</source>
         <translation>טוען משחקים…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="592"/>
+        <location filename="../screens/GamesScreen.qml" line="378"/>
+        <location filename="../screens/GamesScreen.qml" line="575"/>
         <source>Loading more…</source>
         <translation>טוען עוד…</translation>
     </message>
@@ -672,12 +689,17 @@
         <translation>%1 פריטים</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="311"/>
+        <location filename="../screens/RecentsScreen.qml" line="191"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/RecentsScreen.qml" line="282"/>
         <source>Nothing played yet</source>
         <translation>עדיין לא שוחק דבר</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="312"/>
+        <location filename="../screens/RecentsScreen.qml" line="283"/>
         <source>Loading recently played…</source>
         <translation>טוען את הפריטים ששוחקו לאחרונה…</translation>
     </message>
@@ -999,22 +1021,23 @@
     <name>SystemsScreen</name>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="185"/>
-        <location filename="../screens/SystemsScreen.qml" line="313"/>
+        <location filename="../screens/SystemsScreen.qml" line="285"/>
         <source>%1 systems</source>
         <translation>%1 מערכות</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <location filename="../screens/SystemsScreen.qml" line="189"/>
+        <location filename="../screens/SystemsScreen.qml" line="302"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="345"/>
+        <location filename="../screens/SystemsScreen.qml" line="317"/>
         <source>No systems in this category</source>
         <translation>אין מערכות בקטגוריה זו</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="318"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>
@@ -1022,7 +1045,7 @@
 <context>
     <name>TopStatusStrip</name>
     <message>
-        <location filename="../components/TopStatusStrip.qml" line="90"/>
+        <location filename="../components/TopStatusStrip.qml" line="91"/>
         <source>Page %1 / %2</source>
         <translation>עמוד %1 / %2</translation>
     </message>

--- a/src/ui/translations/launcher_hi.ts
+++ b/src/ui/translations/launcher_hi.ts
@@ -1,59 +1,60 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
 <TS version="2.1" language="hi" sourcelanguage="en">
 <context>
     <name>AboutScreen</name>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="72" />
+        <location filename="../screens/AboutScreen.qml" line="71"/>
         <source>About / License</source>
         <translation>परिचय / लाइसेंस</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="154" />
+        <location filename="../screens/AboutScreen.qml" line="153"/>
         <source>Zaparoo Launcher</source>
         <translation>Zaparoo लॉन्चर</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="165" />
+        <location filename="../screens/AboutScreen.qml" line="164"/>
         <source>Version %1 · %2 · %3</source>
         <translation>संस्करण %1 · %2 · %3</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="178" />
+        <location filename="../screens/AboutScreen.qml" line="174"/>
         <source>Built %1</source>
         <translation>%1 को निर्मित</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="189" />
+        <location filename="../screens/AboutScreen.qml" line="185"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>कॉपीराइट 2026 Wizzo Pty Ltd और Zaparoo परियोजना के योगदानकर्ता।</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="200" />
+        <location filename="../screens/AboutScreen.qml" line="196"/>
         <source>Source available under the PolyForm Noncommercial License 1.0.0. Free for personal, non-commercial use. Commercial use or redistribution requires a separate license.</source>
         <translation>स्रोत PolyForm Noncommercial License 1.0.0 के अंतर्गत उपलब्ध है। व्यक्तिगत, गैर-व्यावसायिक उपयोग के लिए निःशुल्क। व्यावसायिक उपयोग या पुनर्वितरण के लिए अलग लाइसेंस आवश्यक है।</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="211" />
+        <location filename="../screens/AboutScreen.qml" line="207"/>
         <source>Commercial licensing: legal@zaparoo.org</source>
         <translation>व्यावसायिक लाइसेंसिंग: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="222" />
+        <location filename="../screens/AboutScreen.qml" line="218"/>
         <source>Project: https://zaparoo.org</source>
         <translation>परियोजना: https://zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="232" />
+        <location filename="../screens/AboutScreen.qml" line="228"/>
         <source>Created by</source>
         <translation>निर्माता</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="256" />
+        <location filename="../screens/AboutScreen.qml" line="252"/>
         <source>Translations</source>
         <translation>अनुवाद</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="280" />
+        <location filename="../screens/AboutScreen.qml" line="276"/>
         <source>Full license text in COPYING.</source>
         <translation>पूरा लाइसेंस पाठ COPYING में है।</translation>
     </message>
@@ -61,60 +62,103 @@
 <context>
     <name>BootOverlay</name>
     <message>
-        <location filename="../components/BootOverlay.qml" line="76" />
-        <source>Can't reach Zaparoo Core. Check your connection.</source>
+        <location filename="../components/BootOverlay.qml" line="76"/>
+        <source>Can&apos;t reach Zaparoo Core. Check your connection.</source>
         <translation>Zaparoo Core तक पहुंच नहीं हो रही। कनेक्शन जांचें।</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="78" />
+        <location filename="../components/BootOverlay.qml" line="78"/>
         <source>Reconnecting…</source>
         <translation>फिर से कनेक्ट किया जा रहा है…</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="80" />
+        <location filename="../components/BootOverlay.qml" line="80"/>
         <source>Loading library…</source>
         <translation>लाइब्रेरी लोड हो रही है…</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="85" />
+        <location filename="../components/BootOverlay.qml" line="85"/>
         <source>Connecting to Zaparoo Core…</source>
         <translation>Zaparoo Core से कनेक्ट किया जा रहा है…</translation>
     </message>
 </context>
 <context>
+    <name>BrowseDetailPane</name>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="22"/>
+        <source>Loading…</source>
+        <translation type="unfinished">लोड हो रहा है…</translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="43"/>
+        <source>Year</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="45"/>
+        <source>Genre</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <source>Players</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <source>Developer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <source>Publisher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <source>Rating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="55"/>
+        <source>Filename</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommercialNoticeModal</name>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="59" />
+        <location filename="../components/CommercialNoticeModal.qml" line="59"/>
         <source>Welcome to Zaparoo Launcher</source>
         <translation>Zaparoo लॉन्चर में आपका स्वागत है</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="68" />
+        <location filename="../components/CommercialNoticeModal.qml" line="68"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>कॉपीराइट 2026 Wizzo Pty Ltd और Zaparoo परियोजना के योगदानकर्ता।</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="79" />
+        <location filename="../components/CommercialNoticeModal.qml" line="79"/>
         <source>This free source-available build is for personal and non-commercial use only. Commercial use or redistribution requires a license.</source>
         <translation>यह निःशुल्क स्रोत-उपलब्ध बिल्ड केवल व्यक्तिगत और गैर-व्यावसायिक उपयोग के लिए है। व्यावसायिक उपयोग या पुनर्वितरण के लिए लाइसेंस आवश्यक है।</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="90" />
+        <location filename="../components/CommercialNoticeModal.qml" line="90"/>
         <source>Contact: legal@zaparoo.org</source>
         <translation>संपर्क: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="101" />
+        <location filename="../components/CommercialNoticeModal.qml" line="101"/>
         <source>Full details available any time under Settings &gt; About / License.</source>
         <translation>पूरी जानकारी कभी भी सेटिंग्स &gt; परिचय / लाइसेंस में उपलब्ध है।</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="119" />
+        <location filename="../components/CommercialNoticeModal.qml" line="119"/>
         <source>Created by</source>
         <translation>निर्माता</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="162" />
+        <location filename="../components/CommercialNoticeModal.qml" line="162"/>
         <source>I understand</source>
         <translation>मैं समझ गया</translation>
     </message>
@@ -122,68 +166,68 @@
 <context>
     <name>CoreStatusPill</name>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="44" />
-        <location filename="../components/CoreStatusPill.qml" line="50" />
+        <location filename="../components/CoreStatusPill.qml" line="44"/>
+        <location filename="../components/CoreStatusPill.qml" line="50"/>
         <source>Disconnected</source>
         <translation>डिस्कनेक्टेड</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="47" />
+        <location filename="../components/CoreStatusPill.qml" line="47"/>
         <source>Reconnecting…</source>
         <translation>फिर से कनेक्ट किया जा रहा है…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="53" />
+        <location filename="../components/CoreStatusPill.qml" line="53"/>
         <source>Connecting…</source>
         <translation>कनेक्ट किया जा रहा है…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="56" />
+        <location filename="../components/CoreStatusPill.qml" line="56"/>
         <source>Core error</source>
         <translation>कोर त्रुटि</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="60" />
+        <location filename="../components/CoreStatusPill.qml" line="60"/>
         <source>Optimizing database</source>
         <translation>डेटाबेस अनुकूलित किया जा रहा है</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="67" />
+        <location filename="../components/CoreStatusPill.qml" line="67"/>
         <source>Indexing paused</source>
         <translation>इंडेक्सिंग रोकी गई</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="70" />
+        <location filename="../components/CoreStatusPill.qml" line="70"/>
         <source>Indexing %1/%2 - %3</source>
         <translation>इंडेक्सिंग %1/%2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="73" />
+        <location filename="../components/CoreStatusPill.qml" line="73"/>
         <source>Indexing %1/%2</source>
         <translation>इंडेक्सिंग %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="75" />
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
         <source>Indexing…</source>
         <translation>इंडेक्सिंग…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="83" />
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Scrape paused</source>
         <translation>स्क्रैप रोका गया</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="86" />
+        <location filename="../components/CoreStatusPill.qml" line="86"/>
         <source>Scraping %1/%2 - %3</source>
         <translation>स्क्रैपिंग %1/%2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="89" />
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
         <source>Scraping %1/%2</source>
         <translation>स्क्रैपिंग %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="91" />
+        <location filename="../components/CoreStatusPill.qml" line="91"/>
         <source>Scraping…</source>
         <translation>स्क्रैपिंग…</translation>
     </message>
@@ -191,22 +235,22 @@
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="182" />
+        <location filename="../screens/FavoritesScreen.qml" line="183"/>
         <source>Favorites</source>
         <translation>पसंदीदा</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="185" />
+        <location filename="../screens/FavoritesScreen.qml" line="186"/>
         <source>%1 entries</source>
         <translation>%1 प्रविष्टियाँ</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="283" />
+        <location filename="../screens/FavoritesScreen.qml" line="309"/>
         <source>No favorites yet</source>
         <translation>अभी तक कोई पसंदीदा नहीं</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="284" />
+        <location filename="../screens/FavoritesScreen.qml" line="310"/>
         <source>Loading favorites…</source>
         <translation>पसंदीदा लोड हो रहे हैं…</translation>
     </message>
@@ -214,75 +258,99 @@
 <context>
     <name>FirstRunIndexModal</name>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="127" />
+        <location filename="../components/FirstRunIndexModal.qml" line="127"/>
         <source>First-time setup</source>
         <translation>पहली बार सेटअप</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="136" />
+        <location filename="../components/FirstRunIndexModal.qml" line="136"/>
         <source>Zaparoo needs to scan your games before you can use the launcher. This usually takes a few minutes.</source>
         <translation>लॉन्चर का उपयोग करने से पहले Zaparoo को आपके गेम स्कैन करने होंगे। इसमें आमतौर पर कुछ मिनट लगते हैं।</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="158" />
+        <location filename="../components/FirstRunIndexModal.qml" line="158"/>
         <source>Optimizing database - almost done</source>
         <translation>डेटाबेस अनुकूलित किया जा रहा है - लगभग पूरा</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="211" />
+        <location filename="../components/FirstRunIndexModal.qml" line="211"/>
         <source>Indexing paused</source>
         <translation>इंडेक्सिंग रोकी गई</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="213" />
+        <location filename="../components/FirstRunIndexModal.qml" line="213"/>
         <source>Step %1 of %2 - %3</source>
         <translation>%2 में से चरण %1 - %3</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="215" />
+        <location filename="../components/FirstRunIndexModal.qml" line="215"/>
         <source>Step %1 of %2</source>
         <translation>%2 में से चरण %1</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="216" />
+        <location filename="../components/FirstRunIndexModal.qml" line="216"/>
         <source>Preparing…</source>
         <translation>तैयार किया जा रहा है…</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="233" />
+        <location filename="../components/FirstRunIndexModal.qml" line="233"/>
         <source>Done. %1 files indexed.</source>
         <translation>पूरा हुआ। %1 फ़ाइलें इंडेक्स की गईं।</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="263" />
+        <location filename="../components/FirstRunIndexModal.qml" line="263"/>
         <source>Cancel</source>
         <translation>रद्द करें</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="263" />
+        <location filename="../components/FirstRunIndexModal.qml" line="263"/>
         <source>Start scan</source>
         <translation>स्कैन शुरू करें</translation>
     </message>
 </context>
 <context>
+    <name>GameInfoModal</name>
+    <message>
+        <location filename="../components/GameInfoModal.qml" line="86"/>
+        <source>Back to close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/GameInfoModal.qml" line="114"/>
+        <source>Loading details…</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="363" />
+        <location filename="../screens/GamesScreen.qml" line="367"/>
+        <location filename="../screens/GamesScreen.qml" line="537"/>
         <source>%1 files</source>
         <translation>%1 फ़ाइलें</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="533" />
+        <location filename="../screens/GamesScreen.qml" line="437"/>
+        <source>Loading game…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/GamesScreen.qml" line="554"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/GamesScreen.qml" line="569"/>
         <source>No games in this system</source>
         <translation>इस सिस्टम में कोई गेम नहीं है</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="534" />
+        <location filename="../screens/GamesScreen.qml" line="570"/>
         <source>Loading games…</source>
         <translation>गेम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="556" />
+        <location filename="../screens/GamesScreen.qml" line="592"/>
         <source>Loading more…</source>
         <translation>और लोड हो रहा है…</translation>
     </message>
@@ -290,22 +358,22 @@
 <context>
     <name>HubScreen</name>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91" />
+        <location filename="../screens/HubScreen.qml" line="91"/>
         <source>Favorites</source>
         <translation>पसंदीदा</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="96" />
+        <location filename="../screens/HubScreen.qml" line="96"/>
         <source>Recently Played</source>
         <translation>हाल ही में खेले गए</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="101" />
+        <location filename="../screens/HubScreen.qml" line="101"/>
         <source>Settings</source>
         <translation>सेटिंग्स</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="537" />
+        <location filename="../screens/HubScreen.qml" line="537"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>कोई सिस्टम उपलब्ध नहीं है। सेटिंग्स से मीडिया डेटाबेस अपडेट चलाएँ।</translation>
     </message>
@@ -313,7 +381,7 @@
 <context>
     <name>LoadingIndicator</name>
     <message>
-        <location filename="../components/LoadingIndicator.qml" line="26" />
+        <location filename="../components/LoadingIndicator.qml" line="26"/>
         <source>Loading…</source>
         <translation>लोड हो रहा है…</translation>
     </message>
@@ -321,32 +389,32 @@
 <context>
     <name>LogUploadModal</name>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="87" />
+        <location filename="../components/LogUploadModal.qml" line="87"/>
         <source>Upload log file</source>
         <translation>लॉग फ़ाइल अपलोड करें</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="97" />
+        <location filename="../components/LogUploadModal.qml" line="97"/>
         <source>Uploading log file - this may take a moment.</source>
         <translation>लॉग फ़ाइल अपलोड की जा रही है - इसमें थोड़ा समय लग सकता है।</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197" />
+        <location filename="../components/LogUploadModal.qml" line="197"/>
         <source>Upload failed: %1</source>
         <translation>अपलोड विफल हुआ: %1</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197" />
+        <location filename="../components/LogUploadModal.qml" line="197"/>
         <source>Upload failed.</source>
         <translation>अपलोड विफल हुआ।</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="227" />
+        <location filename="../components/LogUploadModal.qml" line="227"/>
         <source>Retry</source>
         <translation>फिर से प्रयास करें</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="227" />
+        <location filename="../components/LogUploadModal.qml" line="227"/>
         <source>Done</source>
         <translation>पूरा</translation>
     </message>
@@ -354,58 +422,64 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="723" />
+        <location filename="../app/Main.qml" line="753"/>
         <source>Launch core</source>
         <translation>कोर चलाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="731" />
-        <location filename="../app/Main.qml" line="755" />
+        <location filename="../app/Main.qml" line="761"/>
+        <location filename="../app/Main.qml" line="781"/>
+        <source>More info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="765"/>
+        <location filename="../app/Main.qml" line="804"/>
         <source>Launch game</source>
         <translation>गेम चलाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="741" />
+        <location filename="../app/Main.qml" line="785"/>
         <source>Remove from favorites</source>
         <translation>पसंदीदा से हटाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="741" />
+        <location filename="../app/Main.qml" line="785"/>
         <source>Add to favorites</source>
         <translation>पसंदीदा में जोड़ें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="747" />
+        <location filename="../app/Main.qml" line="790"/>
         <source>Write to NFC token</source>
         <translation>NFC टोकन पर लिखें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="751" />
+        <location filename="../app/Main.qml" line="794"/>
         <source>QR code</source>
         <translation>QR कोड</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1437" />
+        <location filename="../app/Main.qml" line="1652"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1439" />
+        <location filename="../app/Main.qml" line="1654"/>
         <source>Loading games…</source>
         <translation>गेम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1441" />
+        <location filename="../app/Main.qml" line="1656"/>
         <source>Loading favorites…</source>
         <translation>पसंदीदा लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1443" />
+        <location filename="../app/Main.qml" line="1658"/>
         <source>Loading recently played…</source>
         <translation>हाल ही में खेले गए लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1445" />
+        <location filename="../app/Main.qml" line="1660"/>
         <source>Loading…</source>
         <translation>लोड हो रहा है…</translation>
     </message>
@@ -413,144 +487,151 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="127" />
+        <location filename="../app/MainLayout.qml" line="141"/>
         <source>Zaparoo Launcher</source>
         <translation>Zaparoo लॉन्चर</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="475" />
+        <location filename="../app/MainLayout.qml" line="545"/>
         <source>Writing failed</source>
         <translation>लिखना विफल हुआ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="475" />
+        <location filename="../app/MainLayout.qml" line="545"/>
         <source>Put a writable card near the reader</source>
         <translation>रीडर के पास लिखने योग्य कार्ड रखें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="540" />
+        <location filename="../app/MainLayout.qml" line="556"/>
+        <source>Quit and restart Zaparoo Launcher?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="557"/>
+        <source>In order to apply this setting we need to restart the launcher.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="632"/>
         <source>Quit Zaparoo Launcher?</source>
         <translation>क्या Zaparoo लॉन्चर बंद करें?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="541" />
+        <location filename="../app/MainLayout.qml" line="633"/>
         <source>Are you sure you want to exit?</source>
         <translation>क्या आप वाकई बाहर निकलना चाहते हैं?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="613" />
-        <location filename="../app/MainLayout.qml" line="685" />
-        <location filename="../app/MainLayout.qml" line="700" />
-        <location filename="../app/MainLayout.qml" line="743" />
-        <location filename="../app/MainLayout.qml" line="772" />
-        <location filename="../app/MainLayout.qml" line="819" />
-        <location filename="../app/MainLayout.qml" line="860" />
-        <location filename="../app/MainLayout.qml" line="924" />
+        <location filename="../app/MainLayout.qml" line="705"/>
+        <location filename="../app/MainLayout.qml" line="777"/>
+        <location filename="../app/MainLayout.qml" line="820"/>
+        <location filename="../app/MainLayout.qml" line="849"/>
+        <location filename="../app/MainLayout.qml" line="896"/>
+        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="1001"/>
         <source>Move</source>
         <translation>स्थानांतरित करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="617" />
-        <location filename="../app/MainLayout.qml" line="689" />
-        <location filename="../app/MainLayout.qml" line="704" />
+        <location filename="../app/MainLayout.qml" line="709"/>
+        <location filename="../app/MainLayout.qml" line="781"/>
         <source>Select</source>
         <translation>चुनें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="621" />
-        <location filename="../app/MainLayout.qml" line="625" />
-        <location filename="../app/MainLayout.qml" line="639" />
-        <location filename="../app/MainLayout.qml" line="652" />
-        <location filename="../app/MainLayout.qml" line="663" />
+        <location filename="../app/MainLayout.qml" line="713"/>
+        <location filename="../app/MainLayout.qml" line="717"/>
+        <location filename="../app/MainLayout.qml" line="731"/>
+        <location filename="../app/MainLayout.qml" line="744"/>
+        <location filename="../app/MainLayout.qml" line="755"/>
         <source>Close</source>
         <translation>बंद करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="632" />
-        <location filename="../app/MainLayout.qml" line="670" />
-        <location filename="../app/MainLayout.qml" line="693" />
-        <location filename="../app/MainLayout.qml" line="708" />
-        <location filename="../app/MainLayout.qml" line="719" />
+        <location filename="../app/MainLayout.qml" line="724"/>
+        <location filename="../app/MainLayout.qml" line="762"/>
+        <location filename="../app/MainLayout.qml" line="785"/>
+        <location filename="../app/MainLayout.qml" line="796"/>
         <source>Cancel</source>
         <translation>रद्द करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="648" />
+        <location filename="../app/MainLayout.qml" line="740"/>
         <source>Done</source>
         <translation>पूरा</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="659" />
-        <location filename="../app/MainLayout.qml" line="795" />
-        <location filename="../app/MainLayout.qml" line="845" />
-        <location filename="../app/MainLayout.qml" line="950" />
+        <location filename="../app/MainLayout.qml" line="751"/>
+        <location filename="../app/MainLayout.qml" line="872"/>
+        <location filename="../app/MainLayout.qml" line="922"/>
+        <location filename="../app/MainLayout.qml" line="1027"/>
         <source>Retry</source>
         <translation>फिर से प्रयास करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="678" />
+        <location filename="../app/MainLayout.qml" line="770"/>
         <source>I understand</source>
         <translation>मैं समझ गया</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="727" />
+        <location filename="../app/MainLayout.qml" line="804"/>
         <source>Start</source>
         <translation>शुरू करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="747" />
-        <location filename="../app/MainLayout.qml" line="782" />
-        <location filename="../app/MainLayout.qml" line="829" />
-        <location filename="../app/MainLayout.qml" line="934" />
+        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="859"/>
+        <location filename="../app/MainLayout.qml" line="906"/>
+        <location filename="../app/MainLayout.qml" line="1011"/>
         <source>Open</source>
         <translation>खोलें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="751" />
+        <location filename="../app/MainLayout.qml" line="828"/>
         <source>Quit</source>
         <translation>बंद करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="760" />
-        <location filename="../app/MainLayout.qml" line="788" />
-        <location filename="../app/MainLayout.qml" line="799" />
-        <location filename="../app/MainLayout.qml" line="811" />
-        <location filename="../app/MainLayout.qml" line="838" />
-        <location filename="../app/MainLayout.qml" line="849" />
-        <location filename="../app/MainLayout.qml" line="884" />
-        <location filename="../app/MainLayout.qml" line="900" />
-        <location filename="../app/MainLayout.qml" line="909" />
-        <location filename="../app/MainLayout.qml" line="943" />
-        <location filename="../app/MainLayout.qml" line="954" />
+        <location filename="../app/MainLayout.qml" line="837"/>
+        <location filename="../app/MainLayout.qml" line="865"/>
+        <location filename="../app/MainLayout.qml" line="876"/>
+        <location filename="../app/MainLayout.qml" line="888"/>
+        <location filename="../app/MainLayout.qml" line="915"/>
+        <location filename="../app/MainLayout.qml" line="926"/>
+        <location filename="../app/MainLayout.qml" line="961"/>
+        <location filename="../app/MainLayout.qml" line="977"/>
+        <location filename="../app/MainLayout.qml" line="986"/>
+        <location filename="../app/MainLayout.qml" line="1020"/>
+        <location filename="../app/MainLayout.qml" line="1031"/>
         <source>Back</source>
         <translation>वापस</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="778" />
-        <location filename="../app/MainLayout.qml" line="825" />
-        <location filename="../app/MainLayout.qml" line="930" />
+        <location filename="../app/MainLayout.qml" line="855"/>
+        <location filename="../app/MainLayout.qml" line="902"/>
+        <location filename="../app/MainLayout.qml" line="1007"/>
         <source>Page</source>
         <translation>पृष्ठ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="785" />
-        <location filename="../app/MainLayout.qml" line="834" />
-        <location filename="../app/MainLayout.qml" line="939" />
+        <location filename="../app/MainLayout.qml" line="862"/>
+        <location filename="../app/MainLayout.qml" line="911"/>
+        <location filename="../app/MainLayout.qml" line="1016"/>
         <source>Options</source>
         <translation>विकल्प</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="869" />
+        <location filename="../app/MainLayout.qml" line="946"/>
         <source>Change</source>
         <translation>बदलें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="875" />
+        <location filename="../app/MainLayout.qml" line="952"/>
         <source>Toggle</source>
         <translation>टॉगल</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="896" />
+        <location filename="../app/MainLayout.qml" line="973"/>
         <source>Scroll</source>
         <translation>स्क्रॉल</translation>
     </message>
@@ -558,22 +639,22 @@
 <context>
     <name>Modal</name>
     <message>
-        <location filename="../components/Modal.qml" line="49" />
+        <location filename="../components/Modal.qml" line="49"/>
         <source>OK</source>
         <translation>ठीक है</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="50" />
+        <location filename="../components/Modal.qml" line="50"/>
         <source>Yes</source>
         <translation>हाँ</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="51" />
+        <location filename="../components/Modal.qml" line="51"/>
         <source>No</source>
         <translation>नहीं</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="198" />
+        <location filename="../components/Modal.qml" line="198"/>
         <source>Cancel</source>
         <translation>रद्द करें</translation>
     </message>
@@ -581,22 +662,22 @@
 <context>
     <name>RecentsScreen</name>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="183" />
+        <location filename="../screens/RecentsScreen.qml" line="184"/>
         <source>Recently Played</source>
         <translation>हाल ही में खेले गए</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="186" />
+        <location filename="../screens/RecentsScreen.qml" line="187"/>
         <source>%1 entries</source>
         <translation>%1 प्रविष्टियाँ</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="281" />
+        <location filename="../screens/RecentsScreen.qml" line="311"/>
         <source>Nothing played yet</source>
         <translation>अभी तक कुछ नहीं खेला गया</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="282" />
+        <location filename="../screens/RecentsScreen.qml" line="312"/>
         <source>Loading recently played…</source>
         <translation>हाल ही में खेले गए लोड हो रहे हैं…</translation>
     </message>
@@ -604,17 +685,17 @@
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="26" />
+        <location filename="../components/ScreenStateOverlay.qml" line="26"/>
         <source>Nothing here</source>
         <translation>यहाँ कुछ नहीं है</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27" />
+        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
         <source>Loading…</source>
         <translation>लोड हो रहा है…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="57" />
+        <location filename="../components/ScreenStateOverlay.qml" line="57"/>
         <source>Failed to load</source>
         <translation>लोड करने में विफल</translation>
     </message>
@@ -622,288 +703,294 @@
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="61" />
+        <location filename="../screens/SettingsScreen.qml" line="61"/>
         <source>General</source>
         <translation>सामान्य</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78" />
-        <location filename="../screens/SettingsScreen.qml" line="436" />
+        <location filename="../screens/SettingsScreen.qml" line="73"/>
+        <location filename="../screens/SettingsScreen.qml" line="432"/>
         <source>Language</source>
         <translation>भाषा</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83" />
-        <location filename="../screens/SettingsScreen.qml" line="445" />
+        <location filename="../screens/SettingsScreen.qml" line="78"/>
+        <location filename="../screens/SettingsScreen.qml" line="441"/>
         <source>Browsing layout</source>
         <translation>ब्राउज़िंग लेआउट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88" />
-        <location filename="../screens/SettingsScreen.qml" line="454" />
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="450"/>
         <source>Button style</source>
         <translation>बटन शैली</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="93" />
-        <location filename="../screens/SettingsScreen.qml" line="463" />
+        <location filename="../screens/SettingsScreen.qml" line="88"/>
+        <location filename="../screens/SettingsScreen.qml" line="459"/>
         <source>Screensaver</source>
         <translation>स्क्रीनसेवर</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97" />
+        <location filename="../screens/SettingsScreen.qml" line="92"/>
         <source>Library</source>
         <translation>लाइब्रेरी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102" />
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <source>Discover arcade alternate versions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
         <source>Update media database</source>
         <translation>मीडिया डेटाबेस अपडेट करें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="107" />
+        <location filename="../screens/SettingsScreen.qml" line="107"/>
         <source>Scrape metadata</source>
         <translation>मेटाडेटा स्क्रैप करें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111" />
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
         <source>Advanced</source>
         <translation>उन्नत</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116" />
+        <location filename="../screens/SettingsScreen.qml" line="116"/>
         <source>Mouse support</source>
         <translation>माउस समर्थन</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121" />
+        <location filename="../screens/SettingsScreen.qml" line="121"/>
         <source>Debug logging</source>
         <translation>डीबग लॉगिंग</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126" />
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Upload log file</source>
         <translation>लॉग फ़ाइल अपलोड करें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131" />
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
         <source>About / License</source>
         <translation>परिचय / लाइसेंस</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147" />
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
         <source>Optimizing</source>
         <translation>अनुकूलित किया जा रहा है</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149" />
-        <location filename="../screens/SettingsScreen.qml" line="158" />
+        <location filename="../screens/SettingsScreen.qml" line="149"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
         <source>Paused</source>
         <translation>रोक दिया गया</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149" />
-        <location filename="../screens/SettingsScreen.qml" line="158" />
+        <location filename="../screens/SettingsScreen.qml" line="149"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
         <source>In progress</source>
         <translation>प्रगति पर</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152" />
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>%1 indexed</source>
         <translation>%1 इंडेक्स किए गए</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="161" />
+        <location filename="../screens/SettingsScreen.qml" line="161"/>
         <source>%1 scraped</source>
         <translation>%1 स्क्रैप किए गए</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270" />
+        <location filename="../screens/SettingsScreen.qml" line="266"/>
         <source>Cancel</source>
         <translation>रद्द करें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270" />
+        <location filename="../screens/SettingsScreen.qml" line="266"/>
         <source>Start</source>
         <translation>शुरू करें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="272" />
+        <location filename="../screens/SettingsScreen.qml" line="268"/>
         <source>Upload</source>
         <translation>अपलोड</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="274" />
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
         <source>Open</source>
         <translation>खोलें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="326" />
+        <location filename="../screens/SettingsScreen.qml" line="322"/>
         <source>Default</source>
         <translation>डिफ़ॉल्ट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="346" />
+        <location filename="../screens/SettingsScreen.qml" line="342"/>
         <source>English</source>
         <translation>अंग्रेज़ी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="348" />
+        <location filename="../screens/SettingsScreen.qml" line="344"/>
         <source>Italian</source>
         <translation>इतालवी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="350" />
+        <location filename="../screens/SettingsScreen.qml" line="346"/>
         <source>German</source>
         <translation>जर्मन</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="352" />
+        <location filename="../screens/SettingsScreen.qml" line="348"/>
         <source>Greek</source>
         <translation>ग्रीक</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="354" />
+        <location filename="../screens/SettingsScreen.qml" line="350"/>
         <source>Japanese</source>
         <translation>जापानी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="356" />
+        <location filename="../screens/SettingsScreen.qml" line="352"/>
         <source>Korean</source>
         <translation>कोरियाई</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="358" />
+        <location filename="../screens/SettingsScreen.qml" line="354"/>
         <source>Dutch</source>
         <translation>डच</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="360" />
+        <location filename="../screens/SettingsScreen.qml" line="356"/>
         <source>Romanian</source>
         <translation>रोमानियाई</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="362" />
+        <location filename="../screens/SettingsScreen.qml" line="358"/>
         <source>Slovak</source>
         <translation>स्लोवाक</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="364" />
+        <location filename="../screens/SettingsScreen.qml" line="360"/>
         <source>Ukrainian</source>
         <translation>यूक्रेनी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="366" />
+        <location filename="../screens/SettingsScreen.qml" line="362"/>
         <source>Chinese (Simplified)</source>
         <translation>चीनी (सरलीकृत)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="368" />
+        <location filename="../screens/SettingsScreen.qml" line="364"/>
         <source>Hebrew</source>
         <translation>हिब्रू</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="370" />
+        <location filename="../screens/SettingsScreen.qml" line="366"/>
         <source>Arabic</source>
         <translation>अरबी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="372" />
+        <location filename="../screens/SettingsScreen.qml" line="368"/>
         <source>Hindi</source>
         <translation>हिंदी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="373" />
+        <location filename="../screens/SettingsScreen.qml" line="369"/>
         <source>Auto</source>
         <translation>स्वचालित</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="378" />
+        <location filename="../screens/SettingsScreen.qml" line="374"/>
         <source>Detailed list view</source>
         <translation>विस्तृत सूची दृश्य</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="379" />
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Grid view</source>
         <translation>ग्रिड दृश्य</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="384" />
+        <location filename="../screens/SettingsScreen.qml" line="380"/>
         <source>Style B</source>
         <translation>शैली B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="386" />
+        <location filename="../screens/SettingsScreen.qml" line="382"/>
         <source>Style C</source>
         <translation>शैली C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="388" />
+        <location filename="../screens/SettingsScreen.qml" line="384"/>
         <source>Style D</source>
         <translation>शैली D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="389" />
+        <location filename="../screens/SettingsScreen.qml" line="385"/>
         <source>Style A</source>
         <translation>शैली A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399" />
+        <location filename="../screens/SettingsScreen.qml" line="395"/>
         <source>Off</source>
         <translation>बंद</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="401" />
+        <location filename="../screens/SettingsScreen.qml" line="397"/>
         <source>1 second (testing)</source>
         <translation>1 सेकंड (परीक्षण)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="403" />
+        <location filename="../screens/SettingsScreen.qml" line="399"/>
         <source>1 minute</source>
         <translation>1 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405" />
+        <location filename="../screens/SettingsScreen.qml" line="401"/>
         <source>2 minutes</source>
         <translation>2 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="407" />
+        <location filename="../screens/SettingsScreen.qml" line="403"/>
         <source>5 minutes</source>
         <translation>5 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="409" />
+        <location filename="../screens/SettingsScreen.qml" line="405"/>
         <source>10 minutes</source>
         <translation>10 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="411" />
+        <location filename="../screens/SettingsScreen.qml" line="407"/>
         <source>15 minutes</source>
         <translation>15 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="413" />
+        <location filename="../screens/SettingsScreen.qml" line="409"/>
         <source>30 minutes</source>
         <translation>30 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="414" />
+        <location filename="../screens/SettingsScreen.qml" line="410"/>
         <source>%1 seconds</source>
         <translation>%1 सेकंड</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="427" />
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="423"/>
         <source>Resolution</source>
         <translation>रिज़ॉल्यूशन</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="555" />
+        <location filename="../screens/SettingsScreen.qml" line="563"/>
         <source>Settings</source>
         <translation>सेटिंग्स</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="745" />
+        <location filename="../screens/SettingsScreen.qml" line="755"/>
         <source>No settings available on this platform</source>
         <translation>इस प्लेटफ़ॉर्म पर कोई सेटिंग उपलब्ध नहीं है</translation>
     </message>
@@ -911,17 +998,23 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="182" />
+        <location filename="../screens/SystemsScreen.qml" line="185"/>
+        <location filename="../screens/SystemsScreen.qml" line="313"/>
         <source>%1 systems</source>
         <translation>%1 सिस्टम</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="279" />
+        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SystemsScreen.qml" line="345"/>
         <source>No systems in this category</source>
         <translation>इस श्रेणी में कोई सिस्टम नहीं है</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="280" />
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>
@@ -929,7 +1022,7 @@
 <context>
     <name>TopStatusStrip</name>
     <message>
-        <location filename="../components/TopStatusStrip.qml" line="88" />
+        <location filename="../components/TopStatusStrip.qml" line="90"/>
         <source>Page %1 / %2</source>
         <translation>पृष्ठ %1 / %2</translation>
     </message>

--- a/src/ui/translations/launcher_hi.ts
+++ b/src/ui/translations/launcher_hi.ts
@@ -245,27 +245,27 @@
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="183"/>
+        <location filename="../screens/FavoritesScreen.qml" line="225"/>
         <source>Favorites</source>
         <translation>पसंदीदा</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="186"/>
+        <location filename="../screens/FavoritesScreen.qml" line="228"/>
         <source>%1 entries</source>
         <translation>%1 प्रविष्टियाँ</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="190"/>
+        <location filename="../screens/FavoritesScreen.qml" line="232"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="280"/>
+        <location filename="../screens/FavoritesScreen.qml" line="334"/>
         <source>No favorites yet</source>
         <translation>अभी तक कोई पसंदीदा नहीं</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="281"/>
+        <location filename="../screens/FavoritesScreen.qml" line="335"/>
         <source>Loading favorites…</source>
         <translation>पसंदीदा लोड हो रहे हैं…</translation>
     </message>
@@ -326,13 +326,13 @@
 <context>
     <name>GameInfoModal</name>
     <message>
-        <location filename="../components/GameInfoModal.qml" line="86"/>
-        <source>Back to close</source>
+        <location filename="../components/GameInfoModal.qml" line="104"/>
+        <source>Loading details…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/GameInfoModal.qml" line="114"/>
-        <source>Loading details…</source>
+        <location filename="../components/GameInfoModal.qml" line="174"/>
+        <source>Loading image…</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -446,7 +446,7 @@
     <message>
         <location filename="../app/Main.qml" line="761"/>
         <location filename="../app/Main.qml" line="781"/>
-        <source>More info</source>
+        <source>View details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -679,27 +679,27 @@
 <context>
     <name>RecentsScreen</name>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="184"/>
+        <location filename="../screens/RecentsScreen.qml" line="226"/>
         <source>Recently Played</source>
         <translation>हाल ही में खेले गए</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="187"/>
+        <location filename="../screens/RecentsScreen.qml" line="229"/>
         <source>%1 entries</source>
         <translation>%1 प्रविष्टियाँ</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="191"/>
+        <location filename="../screens/RecentsScreen.qml" line="233"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="282"/>
+        <location filename="../screens/RecentsScreen.qml" line="336"/>
         <source>Nothing played yet</source>
         <translation>अभी तक कुछ नहीं खेला गया</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="283"/>
+        <location filename="../screens/RecentsScreen.qml" line="337"/>
         <source>Loading recently played…</source>
         <translation>हाल ही में खेले गए लोड हो रहे हैं…</translation>
     </message>

--- a/src/ui/translations/launcher_hi.ts
+++ b/src/ui/translations/launcher_hi.ts
@@ -90,38 +90,48 @@
         <translation type="unfinished">लोड हो रहा है…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="43"/>
+        <location filename="../components/BrowseDetailPane.qml" line="44"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="45"/>
+        <location filename="../components/BrowseDetailPane.qml" line="46"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <location filename="../components/BrowseDetailPane.qml" line="48"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <location filename="../components/BrowseDetailPane.qml" line="50"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <location filename="../components/BrowseDetailPane.qml" line="52"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <location filename="../components/BrowseDetailPane.qml" line="54"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="55"/>
-        <source>Filename</source>
+        <location filename="../components/BrowseDetailPane.qml" line="56"/>
+        <source>Category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="58"/>
+        <source>Release date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="60"/>
+        <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -245,12 +255,17 @@
         <translation>%1 प्रविष्टियाँ</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="309"/>
+        <location filename="../screens/FavoritesScreen.qml" line="190"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/FavoritesScreen.qml" line="280"/>
         <source>No favorites yet</source>
         <translation>अभी तक कोई पसंदीदा नहीं</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="310"/>
+        <location filename="../screens/FavoritesScreen.qml" line="281"/>
         <source>Loading favorites…</source>
         <translation>पसंदीदा लोड हो रहे हैं…</translation>
     </message>
@@ -324,33 +339,35 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="367"/>
-        <location filename="../screens/GamesScreen.qml" line="537"/>
+        <location filename="../screens/GamesScreen.qml" line="373"/>
+        <location filename="../screens/GamesScreen.qml" line="520"/>
         <source>%1 files</source>
         <translation>%1 फ़ाइलें</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="437"/>
+        <location filename="../screens/GamesScreen.qml" line="409"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="554"/>
+        <location filename="../screens/GamesScreen.qml" line="382"/>
+        <location filename="../screens/GamesScreen.qml" line="537"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="569"/>
+        <location filename="../screens/GamesScreen.qml" line="552"/>
         <source>No games in this system</source>
         <translation>इस सिस्टम में कोई गेम नहीं है</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="570"/>
+        <location filename="../screens/GamesScreen.qml" line="553"/>
         <source>Loading games…</source>
         <translation>गेम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="592"/>
+        <location filename="../screens/GamesScreen.qml" line="378"/>
+        <location filename="../screens/GamesScreen.qml" line="575"/>
         <source>Loading more…</source>
         <translation>और लोड हो रहा है…</translation>
     </message>
@@ -672,12 +689,17 @@
         <translation>%1 प्रविष्टियाँ</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="311"/>
+        <location filename="../screens/RecentsScreen.qml" line="191"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/RecentsScreen.qml" line="282"/>
         <source>Nothing played yet</source>
         <translation>अभी तक कुछ नहीं खेला गया</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="312"/>
+        <location filename="../screens/RecentsScreen.qml" line="283"/>
         <source>Loading recently played…</source>
         <translation>हाल ही में खेले गए लोड हो रहे हैं…</translation>
     </message>
@@ -999,22 +1021,23 @@
     <name>SystemsScreen</name>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="185"/>
-        <location filename="../screens/SystemsScreen.qml" line="313"/>
+        <location filename="../screens/SystemsScreen.qml" line="285"/>
         <source>%1 systems</source>
         <translation>%1 सिस्टम</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <location filename="../screens/SystemsScreen.qml" line="189"/>
+        <location filename="../screens/SystemsScreen.qml" line="302"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="345"/>
+        <location filename="../screens/SystemsScreen.qml" line="317"/>
         <source>No systems in this category</source>
         <translation>इस श्रेणी में कोई सिस्टम नहीं है</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="318"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>
@@ -1022,7 +1045,7 @@
 <context>
     <name>TopStatusStrip</name>
     <message>
-        <location filename="../components/TopStatusStrip.qml" line="90"/>
+        <location filename="../components/TopStatusStrip.qml" line="91"/>
         <source>Page %1 / %2</source>
         <translation>पृष्ठ %1 / %2</translation>
     </message>

--- a/src/ui/translations/launcher_it.ts
+++ b/src/ui/translations/launcher_it.ts
@@ -1,59 +1,60 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
 <TS version="2.1" language="it_IT">
 <context>
     <name>AboutScreen</name>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="72" />
+        <location filename="../screens/AboutScreen.qml" line="71"/>
         <source>About / License</source>
         <translation>Informazioni / Licenza</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="154" />
+        <location filename="../screens/AboutScreen.qml" line="153"/>
         <source>Zaparoo Launcher</source>
         <translation>Launcher Zaparoo</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="165" />
+        <location filename="../screens/AboutScreen.qml" line="164"/>
         <source>Version %1 · %2 · %3</source>
         <translation>Versione %1 · %2 · %3</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="178" />
+        <location filename="../screens/AboutScreen.qml" line="174"/>
         <source>Built %1</source>
         <translation>Compilato %1</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="189" />
+        <location filename="../screens/AboutScreen.qml" line="185"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>Copyright 2026 Wizzo Pty Ltd e i collaboratori del progetto Zaparoo.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="200" />
+        <location filename="../screens/AboutScreen.qml" line="196"/>
         <source>Source available under the PolyForm Noncommercial License 1.0.0. Free for personal, non-commercial use. Commercial use or redistribution requires a separate license.</source>
-        <translation>Codice sorgente disponibile sotto la licenza PolyForm Noncommercial 1.0.0. Gratuito per uso personale e non commerciale. L'uso commerciale o la ridistribuzione richiedono una licenza separata.</translation>
+        <translation>Codice sorgente disponibile sotto la licenza PolyForm Noncommercial 1.0.0. Gratuito per uso personale e non commerciale. L&apos;uso commerciale o la ridistribuzione richiedono una licenza separata.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="211" />
+        <location filename="../screens/AboutScreen.qml" line="207"/>
         <source>Commercial licensing: legal@zaparoo.org</source>
         <translation>Licenze commerciali: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="222" />
+        <location filename="../screens/AboutScreen.qml" line="218"/>
         <source>Project: https://zaparoo.org</source>
         <translation>Progetto: https://zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="232" />
+        <location filename="../screens/AboutScreen.qml" line="228"/>
         <source>Created by</source>
         <translation>Creato da</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="256" />
+        <location filename="../screens/AboutScreen.qml" line="252"/>
         <source>Translations</source>
         <translation>Traduzioni</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="280" />
+        <location filename="../screens/AboutScreen.qml" line="276"/>
         <source>Full license text in COPYING.</source>
         <translation>Testo completo della licenza in COPYING.</translation>
     </message>
@@ -61,60 +62,103 @@
 <context>
     <name>BootOverlay</name>
     <message>
-        <location filename="../components/BootOverlay.qml" line="76" />
-        <source>Can't reach Zaparoo Core. Check your connection.</source>
+        <location filename="../components/BootOverlay.qml" line="76"/>
+        <source>Can&apos;t reach Zaparoo Core. Check your connection.</source>
         <translation>Impossibile raggiungere Zaparoo Core. Controlla la connessione.</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="78" />
+        <location filename="../components/BootOverlay.qml" line="78"/>
         <source>Reconnecting…</source>
         <translation>Riconnessione…</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="80" />
+        <location filename="../components/BootOverlay.qml" line="80"/>
         <source>Loading library…</source>
         <translation>Caricamento libreria…</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="85" />
+        <location filename="../components/BootOverlay.qml" line="85"/>
         <source>Connecting to Zaparoo Core…</source>
         <translation>Connessione a Zaparoo Core…</translation>
     </message>
 </context>
 <context>
+    <name>BrowseDetailPane</name>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="22"/>
+        <source>Loading…</source>
+        <translation type="unfinished">Caricamento…</translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="43"/>
+        <source>Year</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="45"/>
+        <source>Genre</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <source>Players</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <source>Developer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <source>Publisher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <source>Rating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="55"/>
+        <source>Filename</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommercialNoticeModal</name>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="59" />
+        <location filename="../components/CommercialNoticeModal.qml" line="59"/>
         <source>Welcome to Zaparoo Launcher</source>
         <translation>Benvenuto in Zaparoo Launcher</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="68" />
+        <location filename="../components/CommercialNoticeModal.qml" line="68"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>Copyright 2026 Wizzo Pty Ltd e i collaboratori del progetto Zaparoo.</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="79" />
+        <location filename="../components/CommercialNoticeModal.qml" line="79"/>
         <source>This free source-available build is for personal and non-commercial use only. Commercial use or redistribution requires a license.</source>
-        <translation>Questa build gratuita con codice sorgente disponibile è solo per uso personale e non commerciale. L'uso commerciale o la ridistribuzione richiedono una licenza.</translation>
+        <translation>Questa build gratuita con codice sorgente disponibile è solo per uso personale e non commerciale. L&apos;uso commerciale o la ridistribuzione richiedono una licenza.</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="90" />
+        <location filename="../components/CommercialNoticeModal.qml" line="90"/>
         <source>Contact: legal@zaparoo.org</source>
         <translation>Contatto: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="101" />
+        <location filename="../components/CommercialNoticeModal.qml" line="101"/>
         <source>Full details available any time under Settings &gt; About / License.</source>
         <translation>Tutti i dettagli sono disponibili in qualsiasi momento in Impostazioni &gt; Informazioni / Licenza.</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="119" />
+        <location filename="../components/CommercialNoticeModal.qml" line="119"/>
         <source>Created by</source>
         <translation>Creato da</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="162" />
+        <location filename="../components/CommercialNoticeModal.qml" line="162"/>
         <source>I understand</source>
         <translation>Ho capito</translation>
     </message>
@@ -122,68 +166,68 @@
 <context>
     <name>CoreStatusPill</name>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="44" />
-        <location filename="../components/CoreStatusPill.qml" line="50" />
+        <location filename="../components/CoreStatusPill.qml" line="44"/>
+        <location filename="../components/CoreStatusPill.qml" line="50"/>
         <source>Disconnected</source>
         <translation>Disconnesso</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="47" />
+        <location filename="../components/CoreStatusPill.qml" line="47"/>
         <source>Reconnecting…</source>
         <translation>Riconnessione…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="53" />
+        <location filename="../components/CoreStatusPill.qml" line="53"/>
         <source>Connecting…</source>
         <translation>Connessione…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="56" />
+        <location filename="../components/CoreStatusPill.qml" line="56"/>
         <source>Core error</source>
         <translation>Errore del Core</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="60" />
+        <location filename="../components/CoreStatusPill.qml" line="60"/>
         <source>Optimizing database</source>
         <translation>Ottimizzazione database</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="67" />
+        <location filename="../components/CoreStatusPill.qml" line="67"/>
         <source>Indexing paused</source>
         <translation>Indicizzazione in pausa</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="70" />
+        <location filename="../components/CoreStatusPill.qml" line="70"/>
         <source>Indexing %1/%2 - %3</source>
         <translation>Indicizzazione %1/%2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="86" />
+        <location filename="../components/CoreStatusPill.qml" line="86"/>
         <source>Scraping %1/%2 - %3</source>
         <translation>Recupero %1/%2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="73" />
+        <location filename="../components/CoreStatusPill.qml" line="73"/>
         <source>Indexing %1/%2</source>
         <translation>Indicizzazione %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="75" />
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
         <source>Indexing…</source>
         <translation>Indicizzazione…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="83" />
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Scrape paused</source>
         <translation>Recupero in pausa</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="89" />
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
         <source>Scraping %1/%2</source>
         <translation>Recupero %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="91" />
+        <location filename="../components/CoreStatusPill.qml" line="91"/>
         <source>Scraping…</source>
         <translation>Recupero metadati…</translation>
     </message>
@@ -191,22 +235,22 @@
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="182" />
+        <location filename="../screens/FavoritesScreen.qml" line="183"/>
         <source>Favorites</source>
         <translation>Preferiti</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="185" />
+        <location filename="../screens/FavoritesScreen.qml" line="186"/>
         <source>%1 entries</source>
         <translation>%1 elementi</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="283" />
+        <location filename="../screens/FavoritesScreen.qml" line="309"/>
         <source>No favorites yet</source>
         <translation>Nessun preferito ancora</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="284" />
+        <location filename="../screens/FavoritesScreen.qml" line="310"/>
         <source>Loading favorites…</source>
         <translation>Caricamento preferiti…</translation>
     </message>
@@ -214,75 +258,99 @@
 <context>
     <name>FirstRunIndexModal</name>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="127" />
+        <location filename="../components/FirstRunIndexModal.qml" line="127"/>
         <source>First-time setup</source>
         <translation>Configurazione iniziale</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="136" />
+        <location filename="../components/FirstRunIndexModal.qml" line="136"/>
         <source>Zaparoo needs to scan your games before you can use the launcher. This usually takes a few minutes.</source>
         <translation>Zaparoo deve scansionare i tuoi giochi prima che tu possa usare il launcher. Di solito richiede alcuni minuti.</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="211" />
+        <location filename="../components/FirstRunIndexModal.qml" line="211"/>
         <source>Indexing paused</source>
         <translation>Indicizzazione in pausa</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="158" />
+        <location filename="../components/FirstRunIndexModal.qml" line="158"/>
         <source>Optimizing database - almost done</source>
         <translation>Ottimizzazione database - quasi finito</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="213" />
+        <location filename="../components/FirstRunIndexModal.qml" line="213"/>
         <source>Step %1 of %2 - %3</source>
         <translation>Passo %1 di %2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="215" />
+        <location filename="../components/FirstRunIndexModal.qml" line="215"/>
         <source>Step %1 of %2</source>
         <translation>Passo %1 di %2</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="216" />
+        <location filename="../components/FirstRunIndexModal.qml" line="216"/>
         <source>Preparing…</source>
         <translation>Preparazione…</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="233" />
+        <location filename="../components/FirstRunIndexModal.qml" line="233"/>
         <source>Done. %1 files indexed.</source>
         <translation>Fatto. %1 file indicizzati.</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="263" />
+        <location filename="../components/FirstRunIndexModal.qml" line="263"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="263" />
+        <location filename="../components/FirstRunIndexModal.qml" line="263"/>
         <source>Start scan</source>
         <translation>Avvia scansione</translation>
     </message>
 </context>
 <context>
+    <name>GameInfoModal</name>
+    <message>
+        <location filename="../components/GameInfoModal.qml" line="86"/>
+        <source>Back to close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/GameInfoModal.qml" line="114"/>
+        <source>Loading details…</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="363" />
+        <location filename="../screens/GamesScreen.qml" line="367"/>
+        <location filename="../screens/GamesScreen.qml" line="537"/>
         <source>%1 files</source>
         <translation>%1 file</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="534" />
+        <location filename="../screens/GamesScreen.qml" line="437"/>
+        <source>Loading game…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/GamesScreen.qml" line="554"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/GamesScreen.qml" line="570"/>
         <source>Loading games…</source>
         <translation>Caricamento giochi…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="556" />
+        <location filename="../screens/GamesScreen.qml" line="592"/>
         <source>Loading more…</source>
         <translation>Caricamento altro…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="533" />
+        <location filename="../screens/GamesScreen.qml" line="569"/>
         <source>No games in this system</source>
         <translation>Nessun gioco in questo sistema</translation>
     </message>
@@ -290,22 +358,22 @@
 <context>
     <name>HubScreen</name>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91" />
+        <location filename="../screens/HubScreen.qml" line="91"/>
         <source>Favorites</source>
         <translation>Preferiti</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="96" />
+        <location filename="../screens/HubScreen.qml" line="96"/>
         <source>Recently Played</source>
         <translation>Giocati di recente</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="101" />
+        <location filename="../screens/HubScreen.qml" line="101"/>
         <source>Settings</source>
         <translation>Impostazioni</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="537" />
+        <location filename="../screens/HubScreen.qml" line="537"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Nessun sistema disponibile. Esegui Aggiorna database multimediale dalle Impostazioni.</translation>
     </message>
@@ -313,7 +381,7 @@
 <context>
     <name>LoadingIndicator</name>
     <message>
-        <location filename="../components/LoadingIndicator.qml" line="26" />
+        <location filename="../components/LoadingIndicator.qml" line="26"/>
         <source>Loading…</source>
         <translation>Caricamento…</translation>
     </message>
@@ -321,32 +389,32 @@
 <context>
     <name>LogUploadModal</name>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="87" />
+        <location filename="../components/LogUploadModal.qml" line="87"/>
         <source>Upload log file</source>
         <translation>Carica file di log</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="97" />
+        <location filename="../components/LogUploadModal.qml" line="97"/>
         <source>Uploading log file - this may take a moment.</source>
         <translation>Caricamento del file di log - potrebbe richiedere un momento.</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197" />
+        <location filename="../components/LogUploadModal.qml" line="197"/>
         <source>Upload failed: %1</source>
         <translation>Caricamento fallito: %1</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197" />
+        <location filename="../components/LogUploadModal.qml" line="197"/>
         <source>Upload failed.</source>
         <translation>Caricamento fallito.</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="227" />
+        <location filename="../components/LogUploadModal.qml" line="227"/>
         <source>Retry</source>
         <translation>Riprova</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="227" />
+        <location filename="../components/LogUploadModal.qml" line="227"/>
         <source>Done</source>
         <translation>Fatto</translation>
     </message>
@@ -354,58 +422,64 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="723" />
+        <location filename="../app/Main.qml" line="753"/>
         <source>Launch core</source>
         <translation>Avvia core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="741" />
+        <location filename="../app/Main.qml" line="761"/>
+        <location filename="../app/Main.qml" line="781"/>
+        <source>More info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="785"/>
         <source>Remove from favorites</source>
         <translation>Rimuovi dai preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="741" />
+        <location filename="../app/Main.qml" line="785"/>
         <source>Add to favorites</source>
         <translation>Aggiungi ai preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="747" />
+        <location filename="../app/Main.qml" line="790"/>
         <source>Write to NFC token</source>
         <translation>Scrivi sul token NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="751" />
+        <location filename="../app/Main.qml" line="794"/>
         <source>QR code</source>
         <translation>Codice QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="731" />
-        <location filename="../app/Main.qml" line="755" />
+        <location filename="../app/Main.qml" line="765"/>
+        <location filename="../app/Main.qml" line="804"/>
         <source>Launch game</source>
         <translation>Avvia gioco</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1437" />
+        <location filename="../app/Main.qml" line="1652"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1441" />
+        <location filename="../app/Main.qml" line="1656"/>
         <source>Loading favorites…</source>
         <translation>Caricamento preferiti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1439" />
+        <location filename="../app/Main.qml" line="1654"/>
         <source>Loading games…</source>
         <translation>Caricamento giochi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1443" />
+        <location filename="../app/Main.qml" line="1658"/>
         <source>Loading recently played…</source>
         <translation>Caricamento recenti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1445" />
+        <location filename="../app/Main.qml" line="1660"/>
         <source>Loading…</source>
         <translation>Caricamento…</translation>
     </message>
@@ -413,144 +487,151 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="127" />
+        <location filename="../app/MainLayout.qml" line="141"/>
         <source>Zaparoo Launcher</source>
         <translation>Launcher Zaparoo</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="475" />
+        <location filename="../app/MainLayout.qml" line="545"/>
         <source>Writing failed</source>
         <translation>Scrittura non riuscita</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="475" />
+        <location filename="../app/MainLayout.qml" line="545"/>
         <source>Put a writable card near the reader</source>
         <translation>Avvicina una scheda scrivibile al lettore</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="540" />
+        <location filename="../app/MainLayout.qml" line="556"/>
+        <source>Quit and restart Zaparoo Launcher?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="557"/>
+        <source>In order to apply this setting we need to restart the launcher.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="632"/>
         <source>Quit Zaparoo Launcher?</source>
         <translation>Uscire da Zaparoo Launcher?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="541" />
+        <location filename="../app/MainLayout.qml" line="633"/>
         <source>Are you sure you want to exit?</source>
         <translation>Sei sicuro di voler uscire?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="617" />
-        <location filename="../app/MainLayout.qml" line="689" />
-        <location filename="../app/MainLayout.qml" line="704" />
+        <location filename="../app/MainLayout.qml" line="709"/>
+        <location filename="../app/MainLayout.qml" line="781"/>
         <source>Select</source>
         <translation>Seleziona</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="621" />
-        <location filename="../app/MainLayout.qml" line="625" />
-        <location filename="../app/MainLayout.qml" line="639" />
-        <location filename="../app/MainLayout.qml" line="652" />
-        <location filename="../app/MainLayout.qml" line="663" />
+        <location filename="../app/MainLayout.qml" line="713"/>
+        <location filename="../app/MainLayout.qml" line="717"/>
+        <location filename="../app/MainLayout.qml" line="731"/>
+        <location filename="../app/MainLayout.qml" line="744"/>
+        <location filename="../app/MainLayout.qml" line="755"/>
         <source>Close</source>
         <translation>Chiudi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="632" />
-        <location filename="../app/MainLayout.qml" line="670" />
-        <location filename="../app/MainLayout.qml" line="693" />
-        <location filename="../app/MainLayout.qml" line="708" />
-        <location filename="../app/MainLayout.qml" line="719" />
+        <location filename="../app/MainLayout.qml" line="724"/>
+        <location filename="../app/MainLayout.qml" line="762"/>
+        <location filename="../app/MainLayout.qml" line="785"/>
+        <location filename="../app/MainLayout.qml" line="796"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="648" />
+        <location filename="../app/MainLayout.qml" line="740"/>
         <source>Done</source>
         <translation>Fatto</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="678" />
+        <location filename="../app/MainLayout.qml" line="770"/>
         <source>I understand</source>
         <translation>Ho capito</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="727" />
+        <location filename="../app/MainLayout.qml" line="804"/>
         <source>Start</source>
         <translation>Avvia</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="896" />
+        <location filename="../app/MainLayout.qml" line="973"/>
         <source>Scroll</source>
         <translation>Scorri</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="613" />
-        <location filename="../app/MainLayout.qml" line="685" />
-        <location filename="../app/MainLayout.qml" line="700" />
-        <location filename="../app/MainLayout.qml" line="743" />
-        <location filename="../app/MainLayout.qml" line="772" />
-        <location filename="../app/MainLayout.qml" line="819" />
-        <location filename="../app/MainLayout.qml" line="860" />
-        <location filename="../app/MainLayout.qml" line="924" />
+        <location filename="../app/MainLayout.qml" line="705"/>
+        <location filename="../app/MainLayout.qml" line="777"/>
+        <location filename="../app/MainLayout.qml" line="820"/>
+        <location filename="../app/MainLayout.qml" line="849"/>
+        <location filename="../app/MainLayout.qml" line="896"/>
+        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="1001"/>
         <source>Move</source>
         <translation>Muovi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="747" />
-        <location filename="../app/MainLayout.qml" line="782" />
-        <location filename="../app/MainLayout.qml" line="829" />
-        <location filename="../app/MainLayout.qml" line="934" />
+        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="859"/>
+        <location filename="../app/MainLayout.qml" line="906"/>
+        <location filename="../app/MainLayout.qml" line="1011"/>
         <source>Open</source>
         <translation>Apri</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="751" />
+        <location filename="../app/MainLayout.qml" line="828"/>
         <source>Quit</source>
         <translation>Esci</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="760" />
-        <location filename="../app/MainLayout.qml" line="788" />
-        <location filename="../app/MainLayout.qml" line="799" />
-        <location filename="../app/MainLayout.qml" line="811" />
-        <location filename="../app/MainLayout.qml" line="838" />
-        <location filename="../app/MainLayout.qml" line="849" />
-        <location filename="../app/MainLayout.qml" line="884" />
-        <location filename="../app/MainLayout.qml" line="900" />
-        <location filename="../app/MainLayout.qml" line="909" />
-        <location filename="../app/MainLayout.qml" line="943" />
-        <location filename="../app/MainLayout.qml" line="954" />
+        <location filename="../app/MainLayout.qml" line="837"/>
+        <location filename="../app/MainLayout.qml" line="865"/>
+        <location filename="../app/MainLayout.qml" line="876"/>
+        <location filename="../app/MainLayout.qml" line="888"/>
+        <location filename="../app/MainLayout.qml" line="915"/>
+        <location filename="../app/MainLayout.qml" line="926"/>
+        <location filename="../app/MainLayout.qml" line="961"/>
+        <location filename="../app/MainLayout.qml" line="977"/>
+        <location filename="../app/MainLayout.qml" line="986"/>
+        <location filename="../app/MainLayout.qml" line="1020"/>
+        <location filename="../app/MainLayout.qml" line="1031"/>
         <source>Back</source>
         <translation>Indietro</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="778" />
-        <location filename="../app/MainLayout.qml" line="825" />
-        <location filename="../app/MainLayout.qml" line="930" />
+        <location filename="../app/MainLayout.qml" line="855"/>
+        <location filename="../app/MainLayout.qml" line="902"/>
+        <location filename="../app/MainLayout.qml" line="1007"/>
         <source>Page</source>
         <translation>Pagina</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="785" />
-        <location filename="../app/MainLayout.qml" line="834" />
-        <location filename="../app/MainLayout.qml" line="939" />
+        <location filename="../app/MainLayout.qml" line="862"/>
+        <location filename="../app/MainLayout.qml" line="911"/>
+        <location filename="../app/MainLayout.qml" line="1016"/>
         <source>Options</source>
         <translation>Opzioni</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="659" />
-        <location filename="../app/MainLayout.qml" line="795" />
-        <location filename="../app/MainLayout.qml" line="845" />
-        <location filename="../app/MainLayout.qml" line="950" />
+        <location filename="../app/MainLayout.qml" line="751"/>
+        <location filename="../app/MainLayout.qml" line="872"/>
+        <location filename="../app/MainLayout.qml" line="922"/>
+        <location filename="../app/MainLayout.qml" line="1027"/>
         <source>Retry</source>
         <translation>Riprova</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="869" />
+        <location filename="../app/MainLayout.qml" line="946"/>
         <source>Change</source>
         <translation>Cambia</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="875" />
+        <location filename="../app/MainLayout.qml" line="952"/>
         <source>Toggle</source>
         <translation>Alterna</translation>
     </message>
@@ -558,22 +639,22 @@
 <context>
     <name>Modal</name>
     <message>
-        <location filename="../components/Modal.qml" line="49" />
+        <location filename="../components/Modal.qml" line="49"/>
         <source>OK</source>
         <translation>Va bene</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="50" />
+        <location filename="../components/Modal.qml" line="50"/>
         <source>Yes</source>
         <translation>Sì</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="51" />
+        <location filename="../components/Modal.qml" line="51"/>
         <source>No</source>
         <translation>No</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="198" />
+        <location filename="../components/Modal.qml" line="198"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
@@ -581,22 +662,22 @@
 <context>
     <name>RecentsScreen</name>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="183" />
+        <location filename="../screens/RecentsScreen.qml" line="184"/>
         <source>Recently Played</source>
         <translation>Giocati di recente</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="186" />
+        <location filename="../screens/RecentsScreen.qml" line="187"/>
         <source>%1 entries</source>
         <translation>%1 elementi</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="282" />
+        <location filename="../screens/RecentsScreen.qml" line="312"/>
         <source>Loading recently played…</source>
         <translation>Caricamento recenti…</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="281" />
+        <location filename="../screens/RecentsScreen.qml" line="311"/>
         <source>Nothing played yet</source>
         <translation>Nessun elemento avviato</translation>
     </message>
@@ -604,17 +685,17 @@
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="26" />
+        <location filename="../components/ScreenStateOverlay.qml" line="26"/>
         <source>Nothing here</source>
         <translation>Niente qui</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27" />
+        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
         <source>Loading…</source>
         <translation>Caricamento…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="57" />
+        <location filename="../components/ScreenStateOverlay.qml" line="57"/>
         <source>Failed to load</source>
         <translation>Caricamento non riuscito</translation>
     </message>
@@ -622,288 +703,294 @@
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78" />
-        <location filename="../screens/SettingsScreen.qml" line="436" />
+        <location filename="../screens/SettingsScreen.qml" line="73"/>
+        <location filename="../screens/SettingsScreen.qml" line="432"/>
         <source>Language</source>
         <translation>Lingua</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83" />
-        <location filename="../screens/SettingsScreen.qml" line="445" />
+        <location filename="../screens/SettingsScreen.qml" line="78"/>
+        <location filename="../screens/SettingsScreen.qml" line="441"/>
         <source>Browsing layout</source>
         <translation>Layout navigazione</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116" />
+        <location filename="../screens/SettingsScreen.qml" line="116"/>
         <source>Mouse support</source>
         <translation>Supporto mouse</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102" />
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
         <source>Update media database</source>
         <translation>Aggiorna database multimediale</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="61" />
+        <location filename="../screens/SettingsScreen.qml" line="61"/>
         <source>General</source>
         <translation>Generale</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88" />
-        <location filename="../screens/SettingsScreen.qml" line="454" />
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="450"/>
         <source>Button style</source>
         <translation>Stile pulsanti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="93" />
-        <location filename="../screens/SettingsScreen.qml" line="463" />
+        <location filename="../screens/SettingsScreen.qml" line="88"/>
+        <location filename="../screens/SettingsScreen.qml" line="459"/>
         <source>Screensaver</source>
         <translation>Salvaschermo</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97" />
+        <location filename="../screens/SettingsScreen.qml" line="92"/>
         <source>Library</source>
         <translation>Libreria</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="107" />
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <source>Discover arcade alternate versions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="107"/>
         <source>Scrape metadata</source>
         <translation>Recupera metadati</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111" />
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
         <source>Advanced</source>
         <translation>Avanzate</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121" />
+        <location filename="../screens/SettingsScreen.qml" line="121"/>
         <source>Debug logging</source>
         <translation>Log di debug</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126" />
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Upload log file</source>
         <translation>Carica file di log</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131" />
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
         <source>About / License</source>
         <translation>Informazioni / Licenza</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147" />
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
         <source>Optimizing</source>
         <translation>Ottimizzazione</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149" />
-        <location filename="../screens/SettingsScreen.qml" line="158" />
+        <location filename="../screens/SettingsScreen.qml" line="149"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
         <source>Paused</source>
         <translation>In pausa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149" />
-        <location filename="../screens/SettingsScreen.qml" line="158" />
+        <location filename="../screens/SettingsScreen.qml" line="149"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
         <source>In progress</source>
         <translation>In corso</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152" />
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>%1 indexed</source>
         <translation>%1 indicizzati</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="161" />
+        <location filename="../screens/SettingsScreen.qml" line="161"/>
         <source>%1 scraped</source>
         <translation>%1 recuperati</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270" />
+        <location filename="../screens/SettingsScreen.qml" line="266"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270" />
+        <location filename="../screens/SettingsScreen.qml" line="266"/>
         <source>Start</source>
         <translation>Avvia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="272" />
+        <location filename="../screens/SettingsScreen.qml" line="268"/>
         <source>Upload</source>
         <translation>Carica</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="274" />
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
         <source>Open</source>
         <translation>Apri</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="346" />
+        <location filename="../screens/SettingsScreen.qml" line="342"/>
         <source>English</source>
         <translation>Inglese</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="348" />
+        <location filename="../screens/SettingsScreen.qml" line="344"/>
         <source>Italian</source>
         <translation>Italiano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="350" />
+        <location filename="../screens/SettingsScreen.qml" line="346"/>
         <source>German</source>
         <translation>Tedesco</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="352" />
+        <location filename="../screens/SettingsScreen.qml" line="348"/>
         <source>Greek</source>
         <translation>Greco</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="354" />
+        <location filename="../screens/SettingsScreen.qml" line="350"/>
         <source>Japanese</source>
         <translation>Giapponese</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="356" />
+        <location filename="../screens/SettingsScreen.qml" line="352"/>
         <source>Korean</source>
         <translation>Coreano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="358" />
+        <location filename="../screens/SettingsScreen.qml" line="354"/>
         <source>Dutch</source>
         <translation>Olandese</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="360" />
+        <location filename="../screens/SettingsScreen.qml" line="356"/>
         <source>Romanian</source>
         <translation>Rumeno</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="362" />
+        <location filename="../screens/SettingsScreen.qml" line="358"/>
         <source>Slovak</source>
         <translation>Slovacco</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="364" />
+        <location filename="../screens/SettingsScreen.qml" line="360"/>
         <source>Ukrainian</source>
         <translation>Ucraino</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="366" />
+        <location filename="../screens/SettingsScreen.qml" line="362"/>
         <source>Chinese (Simplified)</source>
         <translation>Cinese (semplificato)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="368" />
+        <location filename="../screens/SettingsScreen.qml" line="364"/>
         <source>Hebrew</source>
         <translation>Ebraico</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="370" />
+        <location filename="../screens/SettingsScreen.qml" line="366"/>
         <source>Arabic</source>
-        <translation type="unfinished" />
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="372" />
+        <location filename="../screens/SettingsScreen.qml" line="368"/>
         <source>Hindi</source>
-        <translation type="unfinished" />
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="373" />
+        <location filename="../screens/SettingsScreen.qml" line="369"/>
         <source>Auto</source>
         <translation>Automatico</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="378" />
+        <location filename="../screens/SettingsScreen.qml" line="374"/>
         <source>Detailed list view</source>
         <translation>Vista elenco dettagliata</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="379" />
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Grid view</source>
         <translation>Vista griglia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="384" />
+        <location filename="../screens/SettingsScreen.qml" line="380"/>
         <source>Style B</source>
         <translation>Stile B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="386" />
+        <location filename="../screens/SettingsScreen.qml" line="382"/>
         <source>Style C</source>
         <translation>Stile C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="388" />
+        <location filename="../screens/SettingsScreen.qml" line="384"/>
         <source>Style D</source>
         <translation>Stile D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="389" />
+        <location filename="../screens/SettingsScreen.qml" line="385"/>
         <source>Style A</source>
         <translation>Stile A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="326" />
+        <location filename="../screens/SettingsScreen.qml" line="322"/>
         <source>Default</source>
         <translation>Predefinito</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399" />
+        <location filename="../screens/SettingsScreen.qml" line="395"/>
         <source>Off</source>
         <translation>Disattivato</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="401" />
+        <location filename="../screens/SettingsScreen.qml" line="397"/>
         <source>1 second (testing)</source>
         <translation>1 secondo (test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="403" />
+        <location filename="../screens/SettingsScreen.qml" line="399"/>
         <source>1 minute</source>
         <translation>1 minuto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405" />
+        <location filename="../screens/SettingsScreen.qml" line="401"/>
         <source>2 minutes</source>
         <translation>2 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="407" />
+        <location filename="../screens/SettingsScreen.qml" line="403"/>
         <source>5 minutes</source>
         <translation>5 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="409" />
+        <location filename="../screens/SettingsScreen.qml" line="405"/>
         <source>10 minutes</source>
         <translation>10 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="411" />
+        <location filename="../screens/SettingsScreen.qml" line="407"/>
         <source>15 minutes</source>
         <translation>15 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="413" />
+        <location filename="../screens/SettingsScreen.qml" line="409"/>
         <source>30 minutes</source>
         <translation>30 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="414" />
+        <location filename="../screens/SettingsScreen.qml" line="410"/>
         <source>%1 seconds</source>
         <translation>%1 secondi</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="427" />
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="423"/>
         <source>Resolution</source>
         <translation>Risoluzione</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="555" />
+        <location filename="../screens/SettingsScreen.qml" line="563"/>
         <source>Settings</source>
         <translation>Impostazioni</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="745" />
+        <location filename="../screens/SettingsScreen.qml" line="755"/>
         <source>No settings available on this platform</source>
         <translation>Nessuna impostazione disponibile su questa piattaforma</translation>
     </message>
@@ -911,17 +998,23 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="182" />
+        <location filename="../screens/SystemsScreen.qml" line="185"/>
+        <location filename="../screens/SystemsScreen.qml" line="313"/>
         <source>%1 systems</source>
         <translation>%1 sistemi</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="279" />
+        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SystemsScreen.qml" line="345"/>
         <source>No systems in this category</source>
         <translation>Nessun sistema in questa categoria</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="280" />
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>
@@ -929,7 +1022,7 @@
 <context>
     <name>TopStatusStrip</name>
     <message>
-        <location filename="../components/TopStatusStrip.qml" line="88" />
+        <location filename="../components/TopStatusStrip.qml" line="90"/>
         <source>Page %1 / %2</source>
         <translation>Pagina %1 / %2</translation>
     </message>

--- a/src/ui/translations/launcher_it.ts
+++ b/src/ui/translations/launcher_it.ts
@@ -245,27 +245,27 @@
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="183"/>
+        <location filename="../screens/FavoritesScreen.qml" line="225"/>
         <source>Favorites</source>
         <translation>Preferiti</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="186"/>
+        <location filename="../screens/FavoritesScreen.qml" line="228"/>
         <source>%1 entries</source>
         <translation>%1 elementi</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="190"/>
+        <location filename="../screens/FavoritesScreen.qml" line="232"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="280"/>
+        <location filename="../screens/FavoritesScreen.qml" line="334"/>
         <source>No favorites yet</source>
         <translation>Nessun preferito ancora</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="281"/>
+        <location filename="../screens/FavoritesScreen.qml" line="335"/>
         <source>Loading favorites…</source>
         <translation>Caricamento preferiti…</translation>
     </message>
@@ -326,13 +326,13 @@
 <context>
     <name>GameInfoModal</name>
     <message>
-        <location filename="../components/GameInfoModal.qml" line="86"/>
-        <source>Back to close</source>
+        <location filename="../components/GameInfoModal.qml" line="104"/>
+        <source>Loading details…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/GameInfoModal.qml" line="114"/>
-        <source>Loading details…</source>
+        <location filename="../components/GameInfoModal.qml" line="174"/>
+        <source>Loading image…</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -444,12 +444,6 @@
         <translation>Avvia core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="781"/>
-        <source>More info</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../app/Main.qml" line="785"/>
         <source>Remove from favorites</source>
         <translation>Rimuovi dai preferiti</translation>
@@ -474,6 +468,12 @@
         <location filename="../app/Main.qml" line="804"/>
         <source>Launch game</source>
         <translation>Avvia gioco</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="761"/>
+        <location filename="../app/Main.qml" line="781"/>
+        <source>View details</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1652"/>
@@ -679,27 +679,27 @@
 <context>
     <name>RecentsScreen</name>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="184"/>
+        <location filename="../screens/RecentsScreen.qml" line="226"/>
         <source>Recently Played</source>
         <translation>Giocati di recente</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="187"/>
+        <location filename="../screens/RecentsScreen.qml" line="229"/>
         <source>%1 entries</source>
         <translation>%1 elementi</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="191"/>
+        <location filename="../screens/RecentsScreen.qml" line="233"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="283"/>
+        <location filename="../screens/RecentsScreen.qml" line="337"/>
         <source>Loading recently played…</source>
         <translation>Caricamento recenti…</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="282"/>
+        <location filename="../screens/RecentsScreen.qml" line="336"/>
         <source>Nothing played yet</source>
         <translation>Nessun elemento avviato</translation>
     </message>

--- a/src/ui/translations/launcher_it.ts
+++ b/src/ui/translations/launcher_it.ts
@@ -90,38 +90,48 @@
         <translation type="unfinished">Caricamento…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="43"/>
+        <location filename="../components/BrowseDetailPane.qml" line="44"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="45"/>
+        <location filename="../components/BrowseDetailPane.qml" line="46"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <location filename="../components/BrowseDetailPane.qml" line="48"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <location filename="../components/BrowseDetailPane.qml" line="50"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <location filename="../components/BrowseDetailPane.qml" line="52"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <location filename="../components/BrowseDetailPane.qml" line="54"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="55"/>
-        <source>Filename</source>
+        <location filename="../components/BrowseDetailPane.qml" line="56"/>
+        <source>Category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="58"/>
+        <source>Release date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="60"/>
+        <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -245,12 +255,17 @@
         <translation>%1 elementi</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="309"/>
+        <location filename="../screens/FavoritesScreen.qml" line="190"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/FavoritesScreen.qml" line="280"/>
         <source>No favorites yet</source>
         <translation>Nessun preferito ancora</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="310"/>
+        <location filename="../screens/FavoritesScreen.qml" line="281"/>
         <source>Loading favorites…</source>
         <translation>Caricamento preferiti…</translation>
     </message>
@@ -324,33 +339,35 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="367"/>
-        <location filename="../screens/GamesScreen.qml" line="537"/>
+        <location filename="../screens/GamesScreen.qml" line="373"/>
+        <location filename="../screens/GamesScreen.qml" line="520"/>
         <source>%1 files</source>
         <translation>%1 file</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="437"/>
+        <location filename="../screens/GamesScreen.qml" line="409"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="554"/>
+        <location filename="../screens/GamesScreen.qml" line="382"/>
+        <location filename="../screens/GamesScreen.qml" line="537"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="570"/>
+        <location filename="../screens/GamesScreen.qml" line="553"/>
         <source>Loading games…</source>
         <translation>Caricamento giochi…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="592"/>
+        <location filename="../screens/GamesScreen.qml" line="378"/>
+        <location filename="../screens/GamesScreen.qml" line="575"/>
         <source>Loading more…</source>
         <translation>Caricamento altro…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="569"/>
+        <location filename="../screens/GamesScreen.qml" line="552"/>
         <source>No games in this system</source>
         <translation>Nessun gioco in questo sistema</translation>
     </message>
@@ -672,12 +689,17 @@
         <translation>%1 elementi</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="312"/>
+        <location filename="../screens/RecentsScreen.qml" line="191"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/RecentsScreen.qml" line="283"/>
         <source>Loading recently played…</source>
         <translation>Caricamento recenti…</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="311"/>
+        <location filename="../screens/RecentsScreen.qml" line="282"/>
         <source>Nothing played yet</source>
         <translation>Nessun elemento avviato</translation>
     </message>
@@ -999,22 +1021,23 @@
     <name>SystemsScreen</name>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="185"/>
-        <location filename="../screens/SystemsScreen.qml" line="313"/>
+        <location filename="../screens/SystemsScreen.qml" line="285"/>
         <source>%1 systems</source>
         <translation>%1 sistemi</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <location filename="../screens/SystemsScreen.qml" line="189"/>
+        <location filename="../screens/SystemsScreen.qml" line="302"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="345"/>
+        <location filename="../screens/SystemsScreen.qml" line="317"/>
         <source>No systems in this category</source>
         <translation>Nessun sistema in questa categoria</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="318"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>
@@ -1022,7 +1045,7 @@
 <context>
     <name>TopStatusStrip</name>
     <message>
-        <location filename="../components/TopStatusStrip.qml" line="90"/>
+        <location filename="../components/TopStatusStrip.qml" line="91"/>
         <source>Page %1 / %2</source>
         <translation>Pagina %1 / %2</translation>
     </message>

--- a/src/ui/translations/launcher_ja.ts
+++ b/src/ui/translations/launcher_ja.ts
@@ -90,38 +90,48 @@
         <translation type="unfinished">読み込み中…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="43"/>
+        <location filename="../components/BrowseDetailPane.qml" line="44"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="45"/>
+        <location filename="../components/BrowseDetailPane.qml" line="46"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <location filename="../components/BrowseDetailPane.qml" line="48"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <location filename="../components/BrowseDetailPane.qml" line="50"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <location filename="../components/BrowseDetailPane.qml" line="52"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <location filename="../components/BrowseDetailPane.qml" line="54"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="55"/>
-        <source>Filename</source>
+        <location filename="../components/BrowseDetailPane.qml" line="56"/>
+        <source>Category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="58"/>
+        <source>Release date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="60"/>
+        <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -245,12 +255,17 @@
         <translation>%1 件</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="309"/>
+        <location filename="../screens/FavoritesScreen.qml" line="190"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/FavoritesScreen.qml" line="280"/>
         <source>No favorites yet</source>
         <translation>お気に入りはまだありません</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="310"/>
+        <location filename="../screens/FavoritesScreen.qml" line="281"/>
         <source>Loading favorites…</source>
         <translation>お気に入りを読み込み中…</translation>
     </message>
@@ -324,33 +339,35 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="367"/>
-        <location filename="../screens/GamesScreen.qml" line="537"/>
+        <location filename="../screens/GamesScreen.qml" line="373"/>
+        <location filename="../screens/GamesScreen.qml" line="520"/>
         <source>%1 files</source>
         <translation>%1 ファイル</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="437"/>
+        <location filename="../screens/GamesScreen.qml" line="409"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="554"/>
+        <location filename="../screens/GamesScreen.qml" line="382"/>
+        <location filename="../screens/GamesScreen.qml" line="537"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="570"/>
+        <location filename="../screens/GamesScreen.qml" line="553"/>
         <source>Loading games…</source>
         <translation>ゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="592"/>
+        <location filename="../screens/GamesScreen.qml" line="378"/>
+        <location filename="../screens/GamesScreen.qml" line="575"/>
         <source>Loading more…</source>
         <translation>さらに読み込み中…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="569"/>
+        <location filename="../screens/GamesScreen.qml" line="552"/>
         <source>No games in this system</source>
         <translation>このシステムにゲームはありません</translation>
     </message>
@@ -672,12 +689,17 @@
         <translation>%1 件</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="312"/>
+        <location filename="../screens/RecentsScreen.qml" line="191"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/RecentsScreen.qml" line="283"/>
         <source>Loading recently played…</source>
         <translation>最近プレイしたゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="311"/>
+        <location filename="../screens/RecentsScreen.qml" line="282"/>
         <source>Nothing played yet</source>
         <translation>まだプレイ履歴がありません</translation>
     </message>
@@ -999,22 +1021,23 @@
     <name>SystemsScreen</name>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="185"/>
-        <location filename="../screens/SystemsScreen.qml" line="313"/>
+        <location filename="../screens/SystemsScreen.qml" line="285"/>
         <source>%1 systems</source>
         <translation>%1 システム</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <location filename="../screens/SystemsScreen.qml" line="189"/>
+        <location filename="../screens/SystemsScreen.qml" line="302"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="345"/>
+        <location filename="../screens/SystemsScreen.qml" line="317"/>
         <source>No systems in this category</source>
         <translation>このカテゴリにシステムはありません</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="318"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>
@@ -1022,7 +1045,7 @@
 <context>
     <name>TopStatusStrip</name>
     <message>
-        <location filename="../components/TopStatusStrip.qml" line="90"/>
+        <location filename="../components/TopStatusStrip.qml" line="91"/>
         <source>Page %1 / %2</source>
         <translation>ページ %1 / %2</translation>
     </message>

--- a/src/ui/translations/launcher_ja.ts
+++ b/src/ui/translations/launcher_ja.ts
@@ -245,27 +245,27 @@
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="183"/>
+        <location filename="../screens/FavoritesScreen.qml" line="225"/>
         <source>Favorites</source>
         <translation>お気に入り</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="186"/>
+        <location filename="../screens/FavoritesScreen.qml" line="228"/>
         <source>%1 entries</source>
         <translation>%1 件</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="190"/>
+        <location filename="../screens/FavoritesScreen.qml" line="232"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="280"/>
+        <location filename="../screens/FavoritesScreen.qml" line="334"/>
         <source>No favorites yet</source>
         <translation>お気に入りはまだありません</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="281"/>
+        <location filename="../screens/FavoritesScreen.qml" line="335"/>
         <source>Loading favorites…</source>
         <translation>お気に入りを読み込み中…</translation>
     </message>
@@ -326,13 +326,13 @@
 <context>
     <name>GameInfoModal</name>
     <message>
-        <location filename="../components/GameInfoModal.qml" line="86"/>
-        <source>Back to close</source>
+        <location filename="../components/GameInfoModal.qml" line="104"/>
+        <source>Loading details…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/GameInfoModal.qml" line="114"/>
-        <source>Loading details…</source>
+        <location filename="../components/GameInfoModal.qml" line="174"/>
+        <source>Loading image…</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -444,12 +444,6 @@
         <translation>コアを起動</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="781"/>
-        <source>More info</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../app/Main.qml" line="785"/>
         <source>Remove from favorites</source>
         <translation>お気に入りから削除</translation>
@@ -474,6 +468,12 @@
         <location filename="../app/Main.qml" line="804"/>
         <source>Launch game</source>
         <translation>ゲームを起動</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="761"/>
+        <location filename="../app/Main.qml" line="781"/>
+        <source>View details</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1652"/>
@@ -679,27 +679,27 @@
 <context>
     <name>RecentsScreen</name>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="184"/>
+        <location filename="../screens/RecentsScreen.qml" line="226"/>
         <source>Recently Played</source>
         <translation>最近プレイしたゲーム</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="187"/>
+        <location filename="../screens/RecentsScreen.qml" line="229"/>
         <source>%1 entries</source>
         <translation>%1 件</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="191"/>
+        <location filename="../screens/RecentsScreen.qml" line="233"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="283"/>
+        <location filename="../screens/RecentsScreen.qml" line="337"/>
         <source>Loading recently played…</source>
         <translation>最近プレイしたゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="282"/>
+        <location filename="../screens/RecentsScreen.qml" line="336"/>
         <source>Nothing played yet</source>
         <translation>まだプレイ履歴がありません</translation>
     </message>

--- a/src/ui/translations/launcher_ja.ts
+++ b/src/ui/translations/launcher_ja.ts
@@ -1,59 +1,60 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
 <TS version="2.1" language="ja" sourcelanguage="en">
 <context>
     <name>AboutScreen</name>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="72" />
+        <location filename="../screens/AboutScreen.qml" line="71"/>
         <source>About / License</source>
         <translation>情報 / ライセンス</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="154" />
+        <location filename="../screens/AboutScreen.qml" line="153"/>
         <source>Zaparoo Launcher</source>
         <translation>Zaparooランチャー</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="165" />
+        <location filename="../screens/AboutScreen.qml" line="164"/>
         <source>Version %1 · %2 · %3</source>
         <translation>バージョン %1 · %2 · %3</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="178" />
+        <location filename="../screens/AboutScreen.qml" line="174"/>
         <source>Built %1</source>
         <translation>ビルド日 %1</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="189" />
+        <location filename="../screens/AboutScreen.qml" line="185"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>Copyright 2026 Wizzo Pty Ltd および Zaparoo Project contributors.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="200" />
+        <location filename="../screens/AboutScreen.qml" line="196"/>
         <source>Source available under the PolyForm Noncommercial License 1.0.0. Free for personal, non-commercial use. Commercial use or redistribution requires a separate license.</source>
         <translation>PolyForm Noncommercial License 1.0.0 のもとでソースを公開しています。個人・非商用利用は無料です。商用利用または再配布には別途ライセンスが必要です。</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="211" />
+        <location filename="../screens/AboutScreen.qml" line="207"/>
         <source>Commercial licensing: legal@zaparoo.org</source>
         <translation>商用ライセンス: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="222" />
+        <location filename="../screens/AboutScreen.qml" line="218"/>
         <source>Project: https://zaparoo.org</source>
         <translation>プロジェクト: https://zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="232" />
+        <location filename="../screens/AboutScreen.qml" line="228"/>
         <source>Created by</source>
         <translation>制作</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="256" />
+        <location filename="../screens/AboutScreen.qml" line="252"/>
         <source>Translations</source>
         <translation>翻訳</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="280" />
+        <location filename="../screens/AboutScreen.qml" line="276"/>
         <source>Full license text in COPYING.</source>
         <translation>ライセンス全文は COPYING をご覧ください。</translation>
     </message>
@@ -61,60 +62,103 @@
 <context>
     <name>BootOverlay</name>
     <message>
-        <location filename="../components/BootOverlay.qml" line="76" />
-        <source>Can't reach Zaparoo Core. Check your connection.</source>
+        <location filename="../components/BootOverlay.qml" line="76"/>
+        <source>Can&apos;t reach Zaparoo Core. Check your connection.</source>
         <translation>Zaparoo Core に接続できません。接続を確認してください。</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="78" />
+        <location filename="../components/BootOverlay.qml" line="78"/>
         <source>Reconnecting…</source>
         <translation>再接続中…</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="80" />
+        <location filename="../components/BootOverlay.qml" line="80"/>
         <source>Loading library…</source>
         <translation>ライブラリを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="85" />
+        <location filename="../components/BootOverlay.qml" line="85"/>
         <source>Connecting to Zaparoo Core…</source>
         <translation>Zaparoo Core に接続中…</translation>
     </message>
 </context>
 <context>
+    <name>BrowseDetailPane</name>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="22"/>
+        <source>Loading…</source>
+        <translation type="unfinished">読み込み中…</translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="43"/>
+        <source>Year</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="45"/>
+        <source>Genre</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <source>Players</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <source>Developer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <source>Publisher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <source>Rating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="55"/>
+        <source>Filename</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommercialNoticeModal</name>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="59" />
+        <location filename="../components/CommercialNoticeModal.qml" line="59"/>
         <source>Welcome to Zaparoo Launcher</source>
         <translation>Zaparoo Launcher へようこそ</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="68" />
+        <location filename="../components/CommercialNoticeModal.qml" line="68"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>Copyright 2026 Wizzo Pty Ltd および Zaparoo Project contributors.</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="79" />
+        <location filename="../components/CommercialNoticeModal.qml" line="79"/>
         <source>This free source-available build is for personal and non-commercial use only. Commercial use or redistribution requires a license.</source>
         <translation>この無料のソース公開ビルドは個人・非商用利用専用です。商用利用または再配布にはライセンスが必要です。</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="90" />
+        <location filename="../components/CommercialNoticeModal.qml" line="90"/>
         <source>Contact: legal@zaparoo.org</source>
         <translation>連絡先: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="101" />
+        <location filename="../components/CommercialNoticeModal.qml" line="101"/>
         <source>Full details available any time under Settings &gt; About / License.</source>
         <translation>詳細はいつでも 設定 &gt; 情報 / ライセンス でご確認いただけます。</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="119" />
+        <location filename="../components/CommercialNoticeModal.qml" line="119"/>
         <source>Created by</source>
         <translation>制作</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="162" />
+        <location filename="../components/CommercialNoticeModal.qml" line="162"/>
         <source>I understand</source>
         <translation>了解しました</translation>
     </message>
@@ -122,68 +166,68 @@
 <context>
     <name>CoreStatusPill</name>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="44" />
-        <location filename="../components/CoreStatusPill.qml" line="50" />
+        <location filename="../components/CoreStatusPill.qml" line="44"/>
+        <location filename="../components/CoreStatusPill.qml" line="50"/>
         <source>Disconnected</source>
         <translation>切断済み</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="47" />
+        <location filename="../components/CoreStatusPill.qml" line="47"/>
         <source>Reconnecting…</source>
         <translation>再接続中…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="53" />
+        <location filename="../components/CoreStatusPill.qml" line="53"/>
         <source>Connecting…</source>
         <translation>接続中…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="56" />
+        <location filename="../components/CoreStatusPill.qml" line="56"/>
         <source>Core error</source>
         <translation>Core エラー</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="60" />
+        <location filename="../components/CoreStatusPill.qml" line="60"/>
         <source>Optimizing database</source>
         <translation>データベースを最適化中</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="67" />
+        <location filename="../components/CoreStatusPill.qml" line="67"/>
         <source>Indexing paused</source>
         <translation>インデックス作成を一時停止</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="70" />
+        <location filename="../components/CoreStatusPill.qml" line="70"/>
         <source>Indexing %1/%2 - %3</source>
         <translation>インデックス作成中 %1/%2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="86" />
+        <location filename="../components/CoreStatusPill.qml" line="86"/>
         <source>Scraping %1/%2 - %3</source>
         <translation>スクレイピング中 %1/%2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="73" />
+        <location filename="../components/CoreStatusPill.qml" line="73"/>
         <source>Indexing %1/%2</source>
         <translation>インデックス作成中 %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="75" />
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
         <source>Indexing…</source>
         <translation>インデックス作成中…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="83" />
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Scrape paused</source>
         <translation>スクレイピングを一時停止</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="89" />
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
         <source>Scraping %1/%2</source>
         <translation>スクレイピング中 %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="91" />
+        <location filename="../components/CoreStatusPill.qml" line="91"/>
         <source>Scraping…</source>
         <translation>スクレイピング中…</translation>
     </message>
@@ -191,22 +235,22 @@
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="182" />
+        <location filename="../screens/FavoritesScreen.qml" line="183"/>
         <source>Favorites</source>
         <translation>お気に入り</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="185" />
+        <location filename="../screens/FavoritesScreen.qml" line="186"/>
         <source>%1 entries</source>
         <translation>%1 件</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="283" />
+        <location filename="../screens/FavoritesScreen.qml" line="309"/>
         <source>No favorites yet</source>
         <translation>お気に入りはまだありません</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="284" />
+        <location filename="../screens/FavoritesScreen.qml" line="310"/>
         <source>Loading favorites…</source>
         <translation>お気に入りを読み込み中…</translation>
     </message>
@@ -214,75 +258,99 @@
 <context>
     <name>FirstRunIndexModal</name>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="127" />
+        <location filename="../components/FirstRunIndexModal.qml" line="127"/>
         <source>First-time setup</source>
         <translation>初回セットアップ</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="136" />
+        <location filename="../components/FirstRunIndexModal.qml" line="136"/>
         <source>Zaparoo needs to scan your games before you can use the launcher. This usually takes a few minutes.</source>
         <translation>Zaparoo はランチャーを使用する前にゲームをスキャンする必要があります。通常数分かかります。</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="211" />
+        <location filename="../components/FirstRunIndexModal.qml" line="211"/>
         <source>Indexing paused</source>
         <translation>インデックス作成を一時停止</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="158" />
+        <location filename="../components/FirstRunIndexModal.qml" line="158"/>
         <source>Optimizing database - almost done</source>
         <translation>データベースを最適化中 - もうすぐ完了</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="213" />
+        <location filename="../components/FirstRunIndexModal.qml" line="213"/>
         <source>Step %1 of %2 - %3</source>
         <translation>ステップ %1 / %2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="215" />
+        <location filename="../components/FirstRunIndexModal.qml" line="215"/>
         <source>Step %1 of %2</source>
         <translation>ステップ %1 / %2</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="216" />
+        <location filename="../components/FirstRunIndexModal.qml" line="216"/>
         <source>Preparing…</source>
         <translation>準備中…</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="233" />
+        <location filename="../components/FirstRunIndexModal.qml" line="233"/>
         <source>Done. %1 files indexed.</source>
         <translation>完了。%1 ファイルをインデックスしました。</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="263" />
+        <location filename="../components/FirstRunIndexModal.qml" line="263"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="263" />
+        <location filename="../components/FirstRunIndexModal.qml" line="263"/>
         <source>Start scan</source>
         <translation>スキャン開始</translation>
     </message>
 </context>
 <context>
+    <name>GameInfoModal</name>
+    <message>
+        <location filename="../components/GameInfoModal.qml" line="86"/>
+        <source>Back to close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/GameInfoModal.qml" line="114"/>
+        <source>Loading details…</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="363" />
+        <location filename="../screens/GamesScreen.qml" line="367"/>
+        <location filename="../screens/GamesScreen.qml" line="537"/>
         <source>%1 files</source>
         <translation>%1 ファイル</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="534" />
+        <location filename="../screens/GamesScreen.qml" line="437"/>
+        <source>Loading game…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/GamesScreen.qml" line="554"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/GamesScreen.qml" line="570"/>
         <source>Loading games…</source>
         <translation>ゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="556" />
+        <location filename="../screens/GamesScreen.qml" line="592"/>
         <source>Loading more…</source>
         <translation>さらに読み込み中…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="533" />
+        <location filename="../screens/GamesScreen.qml" line="569"/>
         <source>No games in this system</source>
         <translation>このシステムにゲームはありません</translation>
     </message>
@@ -290,22 +358,22 @@
 <context>
     <name>HubScreen</name>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91" />
+        <location filename="../screens/HubScreen.qml" line="91"/>
         <source>Favorites</source>
         <translation>お気に入り</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="96" />
+        <location filename="../screens/HubScreen.qml" line="96"/>
         <source>Recently Played</source>
         <translation>最近プレイしたゲーム</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="101" />
+        <location filename="../screens/HubScreen.qml" line="101"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="537" />
+        <location filename="../screens/HubScreen.qml" line="537"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>利用可能なシステムがありません。設定からメディアデータベースの更新を実行してください。</translation>
     </message>
@@ -313,7 +381,7 @@
 <context>
     <name>LoadingIndicator</name>
     <message>
-        <location filename="../components/LoadingIndicator.qml" line="26" />
+        <location filename="../components/LoadingIndicator.qml" line="26"/>
         <source>Loading…</source>
         <translation>読み込み中…</translation>
     </message>
@@ -321,32 +389,32 @@
 <context>
     <name>LogUploadModal</name>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="87" />
+        <location filename="../components/LogUploadModal.qml" line="87"/>
         <source>Upload log file</source>
         <translation>ログファイルをアップロード</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="97" />
+        <location filename="../components/LogUploadModal.qml" line="97"/>
         <source>Uploading log file - this may take a moment.</source>
         <translation>ログファイルをアップロード中 - しばらくお待ちください。</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197" />
+        <location filename="../components/LogUploadModal.qml" line="197"/>
         <source>Upload failed: %1</source>
         <translation>アップロード失敗: %1</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197" />
+        <location filename="../components/LogUploadModal.qml" line="197"/>
         <source>Upload failed.</source>
         <translation>アップロードに失敗しました。</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="227" />
+        <location filename="../components/LogUploadModal.qml" line="227"/>
         <source>Retry</source>
         <translation>再試行</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="227" />
+        <location filename="../components/LogUploadModal.qml" line="227"/>
         <source>Done</source>
         <translation>完了</translation>
     </message>
@@ -354,58 +422,64 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="723" />
+        <location filename="../app/Main.qml" line="753"/>
         <source>Launch core</source>
         <translation>コアを起動</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="741" />
+        <location filename="../app/Main.qml" line="761"/>
+        <location filename="../app/Main.qml" line="781"/>
+        <source>More info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="785"/>
         <source>Remove from favorites</source>
         <translation>お気に入りから削除</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="741" />
+        <location filename="../app/Main.qml" line="785"/>
         <source>Add to favorites</source>
         <translation>お気に入りに追加</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="747" />
+        <location filename="../app/Main.qml" line="790"/>
         <source>Write to NFC token</source>
         <translation>NFC トークンに書き込む</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="751" />
+        <location filename="../app/Main.qml" line="794"/>
         <source>QR code</source>
         <translation>QR コード</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="731" />
-        <location filename="../app/Main.qml" line="755" />
+        <location filename="../app/Main.qml" line="765"/>
+        <location filename="../app/Main.qml" line="804"/>
         <source>Launch game</source>
         <translation>ゲームを起動</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1437" />
+        <location filename="../app/Main.qml" line="1652"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1441" />
+        <location filename="../app/Main.qml" line="1656"/>
         <source>Loading favorites…</source>
         <translation>お気に入りを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1439" />
+        <location filename="../app/Main.qml" line="1654"/>
         <source>Loading games…</source>
         <translation>ゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1443" />
+        <location filename="../app/Main.qml" line="1658"/>
         <source>Loading recently played…</source>
         <translation>最近プレイしたゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1445" />
+        <location filename="../app/Main.qml" line="1660"/>
         <source>Loading…</source>
         <translation>読み込み中…</translation>
     </message>
@@ -413,144 +487,151 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="127" />
+        <location filename="../app/MainLayout.qml" line="141"/>
         <source>Zaparoo Launcher</source>
         <translation>Zaparooランチャー</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="475" />
+        <location filename="../app/MainLayout.qml" line="545"/>
         <source>Writing failed</source>
         <translation>書き込み失敗</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="475" />
+        <location filename="../app/MainLayout.qml" line="545"/>
         <source>Put a writable card near the reader</source>
         <translation>書き込み可能なカードをリーダーに近づけてください</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="540" />
+        <location filename="../app/MainLayout.qml" line="556"/>
+        <source>Quit and restart Zaparoo Launcher?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="557"/>
+        <source>In order to apply this setting we need to restart the launcher.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="632"/>
         <source>Quit Zaparoo Launcher?</source>
         <translation>Zaparoo Launcher を終了しますか？</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="541" />
+        <location filename="../app/MainLayout.qml" line="633"/>
         <source>Are you sure you want to exit?</source>
         <translation>本当に終了しますか？</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="617" />
-        <location filename="../app/MainLayout.qml" line="689" />
-        <location filename="../app/MainLayout.qml" line="704" />
+        <location filename="../app/MainLayout.qml" line="709"/>
+        <location filename="../app/MainLayout.qml" line="781"/>
         <source>Select</source>
         <translation>選択</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="621" />
-        <location filename="../app/MainLayout.qml" line="625" />
-        <location filename="../app/MainLayout.qml" line="639" />
-        <location filename="../app/MainLayout.qml" line="652" />
-        <location filename="../app/MainLayout.qml" line="663" />
+        <location filename="../app/MainLayout.qml" line="713"/>
+        <location filename="../app/MainLayout.qml" line="717"/>
+        <location filename="../app/MainLayout.qml" line="731"/>
+        <location filename="../app/MainLayout.qml" line="744"/>
+        <location filename="../app/MainLayout.qml" line="755"/>
         <source>Close</source>
         <translation>閉じる</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="632" />
-        <location filename="../app/MainLayout.qml" line="670" />
-        <location filename="../app/MainLayout.qml" line="693" />
-        <location filename="../app/MainLayout.qml" line="708" />
-        <location filename="../app/MainLayout.qml" line="719" />
+        <location filename="../app/MainLayout.qml" line="724"/>
+        <location filename="../app/MainLayout.qml" line="762"/>
+        <location filename="../app/MainLayout.qml" line="785"/>
+        <location filename="../app/MainLayout.qml" line="796"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="648" />
+        <location filename="../app/MainLayout.qml" line="740"/>
         <source>Done</source>
         <translation>完了</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="678" />
+        <location filename="../app/MainLayout.qml" line="770"/>
         <source>I understand</source>
         <translation>了解しました</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="727" />
+        <location filename="../app/MainLayout.qml" line="804"/>
         <source>Start</source>
         <translation>開始</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="896" />
+        <location filename="../app/MainLayout.qml" line="973"/>
         <source>Scroll</source>
         <translation>スクロール</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="613" />
-        <location filename="../app/MainLayout.qml" line="685" />
-        <location filename="../app/MainLayout.qml" line="700" />
-        <location filename="../app/MainLayout.qml" line="743" />
-        <location filename="../app/MainLayout.qml" line="772" />
-        <location filename="../app/MainLayout.qml" line="819" />
-        <location filename="../app/MainLayout.qml" line="860" />
-        <location filename="../app/MainLayout.qml" line="924" />
+        <location filename="../app/MainLayout.qml" line="705"/>
+        <location filename="../app/MainLayout.qml" line="777"/>
+        <location filename="../app/MainLayout.qml" line="820"/>
+        <location filename="../app/MainLayout.qml" line="849"/>
+        <location filename="../app/MainLayout.qml" line="896"/>
+        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="1001"/>
         <source>Move</source>
         <translation>移動</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="747" />
-        <location filename="../app/MainLayout.qml" line="782" />
-        <location filename="../app/MainLayout.qml" line="829" />
-        <location filename="../app/MainLayout.qml" line="934" />
+        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="859"/>
+        <location filename="../app/MainLayout.qml" line="906"/>
+        <location filename="../app/MainLayout.qml" line="1011"/>
         <source>Open</source>
         <translation>開く</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="751" />
+        <location filename="../app/MainLayout.qml" line="828"/>
         <source>Quit</source>
         <translation>終了</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="760" />
-        <location filename="../app/MainLayout.qml" line="788" />
-        <location filename="../app/MainLayout.qml" line="799" />
-        <location filename="../app/MainLayout.qml" line="811" />
-        <location filename="../app/MainLayout.qml" line="838" />
-        <location filename="../app/MainLayout.qml" line="849" />
-        <location filename="../app/MainLayout.qml" line="884" />
-        <location filename="../app/MainLayout.qml" line="900" />
-        <location filename="../app/MainLayout.qml" line="909" />
-        <location filename="../app/MainLayout.qml" line="943" />
-        <location filename="../app/MainLayout.qml" line="954" />
+        <location filename="../app/MainLayout.qml" line="837"/>
+        <location filename="../app/MainLayout.qml" line="865"/>
+        <location filename="../app/MainLayout.qml" line="876"/>
+        <location filename="../app/MainLayout.qml" line="888"/>
+        <location filename="../app/MainLayout.qml" line="915"/>
+        <location filename="../app/MainLayout.qml" line="926"/>
+        <location filename="../app/MainLayout.qml" line="961"/>
+        <location filename="../app/MainLayout.qml" line="977"/>
+        <location filename="../app/MainLayout.qml" line="986"/>
+        <location filename="../app/MainLayout.qml" line="1020"/>
+        <location filename="../app/MainLayout.qml" line="1031"/>
         <source>Back</source>
         <translation>戻る</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="778" />
-        <location filename="../app/MainLayout.qml" line="825" />
-        <location filename="../app/MainLayout.qml" line="930" />
+        <location filename="../app/MainLayout.qml" line="855"/>
+        <location filename="../app/MainLayout.qml" line="902"/>
+        <location filename="../app/MainLayout.qml" line="1007"/>
         <source>Page</source>
         <translation>ページ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="785" />
-        <location filename="../app/MainLayout.qml" line="834" />
-        <location filename="../app/MainLayout.qml" line="939" />
+        <location filename="../app/MainLayout.qml" line="862"/>
+        <location filename="../app/MainLayout.qml" line="911"/>
+        <location filename="../app/MainLayout.qml" line="1016"/>
         <source>Options</source>
         <translation>オプション</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="659" />
-        <location filename="../app/MainLayout.qml" line="795" />
-        <location filename="../app/MainLayout.qml" line="845" />
-        <location filename="../app/MainLayout.qml" line="950" />
+        <location filename="../app/MainLayout.qml" line="751"/>
+        <location filename="../app/MainLayout.qml" line="872"/>
+        <location filename="../app/MainLayout.qml" line="922"/>
+        <location filename="../app/MainLayout.qml" line="1027"/>
         <source>Retry</source>
         <translation>再試行</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="869" />
+        <location filename="../app/MainLayout.qml" line="946"/>
         <source>Change</source>
         <translation>変更</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="875" />
+        <location filename="../app/MainLayout.qml" line="952"/>
         <source>Toggle</source>
         <translation>切り替え</translation>
     </message>
@@ -558,22 +639,22 @@
 <context>
     <name>Modal</name>
     <message>
-        <location filename="../components/Modal.qml" line="49" />
+        <location filename="../components/Modal.qml" line="49"/>
         <source>OK</source>
         <translation>決定</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="50" />
+        <location filename="../components/Modal.qml" line="50"/>
         <source>Yes</source>
         <translation>はい</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="51" />
+        <location filename="../components/Modal.qml" line="51"/>
         <source>No</source>
         <translation>いいえ</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="198" />
+        <location filename="../components/Modal.qml" line="198"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
@@ -581,22 +662,22 @@
 <context>
     <name>RecentsScreen</name>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="183" />
+        <location filename="../screens/RecentsScreen.qml" line="184"/>
         <source>Recently Played</source>
         <translation>最近プレイしたゲーム</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="186" />
+        <location filename="../screens/RecentsScreen.qml" line="187"/>
         <source>%1 entries</source>
         <translation>%1 件</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="282" />
+        <location filename="../screens/RecentsScreen.qml" line="312"/>
         <source>Loading recently played…</source>
         <translation>最近プレイしたゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="281" />
+        <location filename="../screens/RecentsScreen.qml" line="311"/>
         <source>Nothing played yet</source>
         <translation>まだプレイ履歴がありません</translation>
     </message>
@@ -604,17 +685,17 @@
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="26" />
+        <location filename="../components/ScreenStateOverlay.qml" line="26"/>
         <source>Nothing here</source>
         <translation>ここには何もありません</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27" />
+        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
         <source>Loading…</source>
         <translation>読み込み中…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="57" />
+        <location filename="../components/ScreenStateOverlay.qml" line="57"/>
         <source>Failed to load</source>
         <translation>読み込みに失敗しました</translation>
     </message>
@@ -622,288 +703,294 @@
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78" />
-        <location filename="../screens/SettingsScreen.qml" line="436" />
+        <location filename="../screens/SettingsScreen.qml" line="73"/>
+        <location filename="../screens/SettingsScreen.qml" line="432"/>
         <source>Language</source>
         <translation>言語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83" />
-        <location filename="../screens/SettingsScreen.qml" line="445" />
+        <location filename="../screens/SettingsScreen.qml" line="78"/>
+        <location filename="../screens/SettingsScreen.qml" line="441"/>
         <source>Browsing layout</source>
         <translation>ブラウジングレイアウト</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116" />
+        <location filename="../screens/SettingsScreen.qml" line="116"/>
         <source>Mouse support</source>
         <translation>マウスサポート</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102" />
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
         <source>Update media database</source>
         <translation>メディアデータベースを更新</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="61" />
+        <location filename="../screens/SettingsScreen.qml" line="61"/>
         <source>General</source>
         <translation>一般</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88" />
-        <location filename="../screens/SettingsScreen.qml" line="454" />
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="450"/>
         <source>Button style</source>
         <translation>ボタンスタイル</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="93" />
-        <location filename="../screens/SettingsScreen.qml" line="463" />
+        <location filename="../screens/SettingsScreen.qml" line="88"/>
+        <location filename="../screens/SettingsScreen.qml" line="459"/>
         <source>Screensaver</source>
         <translation>スクリーンセーバー</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97" />
+        <location filename="../screens/SettingsScreen.qml" line="92"/>
         <source>Library</source>
         <translation>ライブラリ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="107" />
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <source>Discover arcade alternate versions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="107"/>
         <source>Scrape metadata</source>
         <translation>メタデータをスクレイピング</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111" />
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
         <source>Advanced</source>
         <translation>詳細設定</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121" />
+        <location filename="../screens/SettingsScreen.qml" line="121"/>
         <source>Debug logging</source>
         <translation>デバッグログ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126" />
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Upload log file</source>
         <translation>ログファイルをアップロード</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131" />
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
         <source>About / License</source>
         <translation>情報 / ライセンス</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147" />
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
         <source>Optimizing</source>
         <translation>最適化中</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149" />
-        <location filename="../screens/SettingsScreen.qml" line="158" />
+        <location filename="../screens/SettingsScreen.qml" line="149"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
         <source>Paused</source>
         <translation>一時停止中</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149" />
-        <location filename="../screens/SettingsScreen.qml" line="158" />
+        <location filename="../screens/SettingsScreen.qml" line="149"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
         <source>In progress</source>
         <translation>実行中</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152" />
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>%1 indexed</source>
         <translation>%1 件を索引化</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="161" />
+        <location filename="../screens/SettingsScreen.qml" line="161"/>
         <source>%1 scraped</source>
         <translation>%1 件取得済み</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270" />
+        <location filename="../screens/SettingsScreen.qml" line="266"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270" />
+        <location filename="../screens/SettingsScreen.qml" line="266"/>
         <source>Start</source>
         <translation>開始</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="272" />
+        <location filename="../screens/SettingsScreen.qml" line="268"/>
         <source>Upload</source>
         <translation>アップロード</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="274" />
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
         <source>Open</source>
         <translation>開く</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="346" />
+        <location filename="../screens/SettingsScreen.qml" line="342"/>
         <source>English</source>
         <translation>英語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="348" />
+        <location filename="../screens/SettingsScreen.qml" line="344"/>
         <source>Italian</source>
         <translation>イタリア語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="350" />
+        <location filename="../screens/SettingsScreen.qml" line="346"/>
         <source>German</source>
         <translation>ドイツ語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="352" />
+        <location filename="../screens/SettingsScreen.qml" line="348"/>
         <source>Greek</source>
         <translation>ギリシャ語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="354" />
+        <location filename="../screens/SettingsScreen.qml" line="350"/>
         <source>Japanese</source>
         <translation>日本語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="356" />
+        <location filename="../screens/SettingsScreen.qml" line="352"/>
         <source>Korean</source>
         <translation>韓国語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="358" />
+        <location filename="../screens/SettingsScreen.qml" line="354"/>
         <source>Dutch</source>
         <translation>オランダ語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="360" />
+        <location filename="../screens/SettingsScreen.qml" line="356"/>
         <source>Romanian</source>
         <translation>ルーマニア語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="362" />
+        <location filename="../screens/SettingsScreen.qml" line="358"/>
         <source>Slovak</source>
         <translation>スロバキア語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="364" />
+        <location filename="../screens/SettingsScreen.qml" line="360"/>
         <source>Ukrainian</source>
         <translation>ウクライナ語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="366" />
+        <location filename="../screens/SettingsScreen.qml" line="362"/>
         <source>Chinese (Simplified)</source>
         <translation>中国語（簡体字）</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="368" />
+        <location filename="../screens/SettingsScreen.qml" line="364"/>
         <source>Hebrew</source>
         <translation>ヘブライ語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="370" />
+        <location filename="../screens/SettingsScreen.qml" line="366"/>
         <source>Arabic</source>
-        <translation type="unfinished" />
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="372" />
+        <location filename="../screens/SettingsScreen.qml" line="368"/>
         <source>Hindi</source>
-        <translation type="unfinished" />
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="373" />
+        <location filename="../screens/SettingsScreen.qml" line="369"/>
         <source>Auto</source>
         <translation>自動</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="378" />
+        <location filename="../screens/SettingsScreen.qml" line="374"/>
         <source>Detailed list view</source>
         <translation>詳細リスト表示</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="379" />
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Grid view</source>
         <translation>グリッド表示</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="384" />
+        <location filename="../screens/SettingsScreen.qml" line="380"/>
         <source>Style B</source>
         <translation>スタイル B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="386" />
+        <location filename="../screens/SettingsScreen.qml" line="382"/>
         <source>Style C</source>
         <translation>スタイル C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="388" />
+        <location filename="../screens/SettingsScreen.qml" line="384"/>
         <source>Style D</source>
         <translation>スタイル D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="389" />
+        <location filename="../screens/SettingsScreen.qml" line="385"/>
         <source>Style A</source>
         <translation>スタイル A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="326" />
+        <location filename="../screens/SettingsScreen.qml" line="322"/>
         <source>Default</source>
         <translation>デフォルト</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399" />
+        <location filename="../screens/SettingsScreen.qml" line="395"/>
         <source>Off</source>
         <translation>オフ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="401" />
+        <location filename="../screens/SettingsScreen.qml" line="397"/>
         <source>1 second (testing)</source>
         <translation>1秒（テスト）</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="403" />
+        <location filename="../screens/SettingsScreen.qml" line="399"/>
         <source>1 minute</source>
         <translation>1分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405" />
+        <location filename="../screens/SettingsScreen.qml" line="401"/>
         <source>2 minutes</source>
         <translation>2分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="407" />
+        <location filename="../screens/SettingsScreen.qml" line="403"/>
         <source>5 minutes</source>
         <translation>5分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="409" />
+        <location filename="../screens/SettingsScreen.qml" line="405"/>
         <source>10 minutes</source>
         <translation>10分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="411" />
+        <location filename="../screens/SettingsScreen.qml" line="407"/>
         <source>15 minutes</source>
         <translation>15分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="413" />
+        <location filename="../screens/SettingsScreen.qml" line="409"/>
         <source>30 minutes</source>
         <translation>30分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="414" />
+        <location filename="../screens/SettingsScreen.qml" line="410"/>
         <source>%1 seconds</source>
         <translation>%1秒</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="427" />
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="423"/>
         <source>Resolution</source>
         <translation>解像度</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="555" />
+        <location filename="../screens/SettingsScreen.qml" line="563"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="745" />
+        <location filename="../screens/SettingsScreen.qml" line="755"/>
         <source>No settings available on this platform</source>
         <translation>このプラットフォームでは設定項目がありません</translation>
     </message>
@@ -911,17 +998,23 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="182" />
+        <location filename="../screens/SystemsScreen.qml" line="185"/>
+        <location filename="../screens/SystemsScreen.qml" line="313"/>
         <source>%1 systems</source>
         <translation>%1 システム</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="279" />
+        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SystemsScreen.qml" line="345"/>
         <source>No systems in this category</source>
         <translation>このカテゴリにシステムはありません</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="280" />
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>
@@ -929,7 +1022,7 @@
 <context>
     <name>TopStatusStrip</name>
     <message>
-        <location filename="../components/TopStatusStrip.qml" line="88" />
+        <location filename="../components/TopStatusStrip.qml" line="90"/>
         <source>Page %1 / %2</source>
         <translation>ページ %1 / %2</translation>
     </message>

--- a/src/ui/translations/launcher_ko.ts
+++ b/src/ui/translations/launcher_ko.ts
@@ -245,27 +245,27 @@
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="183"/>
+        <location filename="../screens/FavoritesScreen.qml" line="225"/>
         <source>Favorites</source>
         <translation>즐겨찾기</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="186"/>
+        <location filename="../screens/FavoritesScreen.qml" line="228"/>
         <source>%1 entries</source>
         <translation>항목 %1개</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="190"/>
+        <location filename="../screens/FavoritesScreen.qml" line="232"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="280"/>
+        <location filename="../screens/FavoritesScreen.qml" line="334"/>
         <source>No favorites yet</source>
         <translation>아직 즐겨찾기가 없습니다</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="281"/>
+        <location filename="../screens/FavoritesScreen.qml" line="335"/>
         <source>Loading favorites…</source>
         <translation>즐겨찾기 불러오는 중…</translation>
     </message>
@@ -326,13 +326,13 @@
 <context>
     <name>GameInfoModal</name>
     <message>
-        <location filename="../components/GameInfoModal.qml" line="86"/>
-        <source>Back to close</source>
+        <location filename="../components/GameInfoModal.qml" line="104"/>
+        <source>Loading details…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/GameInfoModal.qml" line="114"/>
-        <source>Loading details…</source>
+        <location filename="../components/GameInfoModal.qml" line="174"/>
+        <source>Loading image…</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -446,7 +446,7 @@
     <message>
         <location filename="../app/Main.qml" line="761"/>
         <location filename="../app/Main.qml" line="781"/>
-        <source>More info</source>
+        <source>View details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -679,27 +679,27 @@
 <context>
     <name>RecentsScreen</name>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="184"/>
+        <location filename="../screens/RecentsScreen.qml" line="226"/>
         <source>Recently Played</source>
         <translation>최근 플레이</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="187"/>
+        <location filename="../screens/RecentsScreen.qml" line="229"/>
         <source>%1 entries</source>
         <translation>항목 %1개</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="191"/>
+        <location filename="../screens/RecentsScreen.qml" line="233"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="282"/>
+        <location filename="../screens/RecentsScreen.qml" line="336"/>
         <source>Nothing played yet</source>
         <translation>아직 플레이한 항목이 없습니다</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="283"/>
+        <location filename="../screens/RecentsScreen.qml" line="337"/>
         <source>Loading recently played…</source>
         <translation>최근 플레이 불러오는 중…</translation>
     </message>

--- a/src/ui/translations/launcher_ko.ts
+++ b/src/ui/translations/launcher_ko.ts
@@ -1,59 +1,60 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
 <TS version="2.1" language="ko" sourcelanguage="en">
 <context>
     <name>AboutScreen</name>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="72" />
+        <location filename="../screens/AboutScreen.qml" line="71"/>
         <source>About / License</source>
         <translation>정보 / 라이선스</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="154" />
+        <location filename="../screens/AboutScreen.qml" line="153"/>
         <source>Zaparoo Launcher</source>
         <translation>자파루 런처</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="165" />
+        <location filename="../screens/AboutScreen.qml" line="164"/>
         <source>Version %1 · %2 · %3</source>
         <translation>버전 %1 · %2 · %3</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="178" />
+        <location filename="../screens/AboutScreen.qml" line="174"/>
         <source>Built %1</source>
         <translation>빌드 %1</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="189" />
+        <location filename="../screens/AboutScreen.qml" line="185"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>Copyright 2026 Wizzo Pty Ltd 및 Zaparoo Project 기여자.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="200" />
+        <location filename="../screens/AboutScreen.qml" line="196"/>
         <source>Source available under the PolyForm Noncommercial License 1.0.0. Free for personal, non-commercial use. Commercial use or redistribution requires a separate license.</source>
         <translation>소스는 PolyForm Noncommercial License 1.0.0에 따라 제공됩니다. 개인적이고 비상업적인 용도로 무료로 사용할 수 있습니다. 상업적 사용 또는 재배포에는 별도 라이선스가 필요합니다.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="211" />
+        <location filename="../screens/AboutScreen.qml" line="207"/>
         <source>Commercial licensing: legal@zaparoo.org</source>
         <translation>상업용 라이선스: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="222" />
+        <location filename="../screens/AboutScreen.qml" line="218"/>
         <source>Project: https://zaparoo.org</source>
         <translation>프로젝트: https://zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="232" />
+        <location filename="../screens/AboutScreen.qml" line="228"/>
         <source>Created by</source>
         <translation>만든 사람</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="256" />
+        <location filename="../screens/AboutScreen.qml" line="252"/>
         <source>Translations</source>
         <translation>번역</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="280" />
+        <location filename="../screens/AboutScreen.qml" line="276"/>
         <source>Full license text in COPYING.</source>
         <translation>전체 라이선스 텍스트는 COPYING에 있습니다.</translation>
     </message>
@@ -61,60 +62,103 @@
 <context>
     <name>BootOverlay</name>
     <message>
-        <location filename="../components/BootOverlay.qml" line="76" />
-        <source>Can't reach Zaparoo Core. Check your connection.</source>
+        <location filename="../components/BootOverlay.qml" line="76"/>
+        <source>Can&apos;t reach Zaparoo Core. Check your connection.</source>
         <translation>Zaparoo Core에 연결할 수 없습니다. 연결을 확인하세요.</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="78" />
+        <location filename="../components/BootOverlay.qml" line="78"/>
         <source>Reconnecting…</source>
         <translation>재연결 중…</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="80" />
+        <location filename="../components/BootOverlay.qml" line="80"/>
         <source>Loading library…</source>
         <translation>라이브러리 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="85" />
+        <location filename="../components/BootOverlay.qml" line="85"/>
         <source>Connecting to Zaparoo Core…</source>
         <translation>Zaparoo Core에 연결하는 중…</translation>
     </message>
 </context>
 <context>
+    <name>BrowseDetailPane</name>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="22"/>
+        <source>Loading…</source>
+        <translation type="unfinished">불러오는 중…</translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="43"/>
+        <source>Year</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="45"/>
+        <source>Genre</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <source>Players</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <source>Developer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <source>Publisher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <source>Rating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="55"/>
+        <source>Filename</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommercialNoticeModal</name>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="59" />
+        <location filename="../components/CommercialNoticeModal.qml" line="59"/>
         <source>Welcome to Zaparoo Launcher</source>
         <translation>Zaparoo Launcher에 오신 것을 환영합니다</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="68" />
+        <location filename="../components/CommercialNoticeModal.qml" line="68"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>Copyright 2026 Wizzo Pty Ltd 및 Zaparoo Project 기여자.</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="79" />
+        <location filename="../components/CommercialNoticeModal.qml" line="79"/>
         <source>This free source-available build is for personal and non-commercial use only. Commercial use or redistribution requires a license.</source>
         <translation>이 무료 소스 제공 빌드는 개인적이고 비상업적인 용도로만 사용할 수 있습니다. 상업적 사용 또는 재배포에는 라이선스가 필요합니다.</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="90" />
+        <location filename="../components/CommercialNoticeModal.qml" line="90"/>
         <source>Contact: legal@zaparoo.org</source>
         <translation>문의: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="101" />
+        <location filename="../components/CommercialNoticeModal.qml" line="101"/>
         <source>Full details available any time under Settings &gt; About / License.</source>
         <translation>전체 내용은 언제든 설정 &gt; 정보 / 라이선스에서 확인할 수 있습니다.</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="119" />
+        <location filename="../components/CommercialNoticeModal.qml" line="119"/>
         <source>Created by</source>
         <translation>만든 사람</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="162" />
+        <location filename="../components/CommercialNoticeModal.qml" line="162"/>
         <source>I understand</source>
         <translation>이해했습니다</translation>
     </message>
@@ -122,68 +166,68 @@
 <context>
     <name>CoreStatusPill</name>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="44" />
-        <location filename="../components/CoreStatusPill.qml" line="50" />
+        <location filename="../components/CoreStatusPill.qml" line="44"/>
+        <location filename="../components/CoreStatusPill.qml" line="50"/>
         <source>Disconnected</source>
         <translation>연결 끊김</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="47" />
+        <location filename="../components/CoreStatusPill.qml" line="47"/>
         <source>Reconnecting…</source>
         <translation>재연결 중…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="53" />
+        <location filename="../components/CoreStatusPill.qml" line="53"/>
         <source>Connecting…</source>
         <translation>연결 중…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="56" />
+        <location filename="../components/CoreStatusPill.qml" line="56"/>
         <source>Core error</source>
         <translation>코어 오류</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="60" />
+        <location filename="../components/CoreStatusPill.qml" line="60"/>
         <source>Optimizing database</source>
         <translation>데이터베이스 최적화 중</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="67" />
+        <location filename="../components/CoreStatusPill.qml" line="67"/>
         <source>Indexing paused</source>
         <translation>인덱싱 일시중지됨</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="70" />
+        <location filename="../components/CoreStatusPill.qml" line="70"/>
         <source>Indexing %1/%2 - %3</source>
         <translation>인덱싱 %1/%2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="73" />
+        <location filename="../components/CoreStatusPill.qml" line="73"/>
         <source>Indexing %1/%2</source>
         <translation>인덱싱 %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="75" />
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
         <source>Indexing…</source>
         <translation>인덱싱 중…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="83" />
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Scrape paused</source>
         <translation>수집 일시중지됨</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="86" />
+        <location filename="../components/CoreStatusPill.qml" line="86"/>
         <source>Scraping %1/%2 - %3</source>
         <translation>메타데이터 수집 %1/%2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="89" />
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
         <source>Scraping %1/%2</source>
         <translation>메타데이터 수집 %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="91" />
+        <location filename="../components/CoreStatusPill.qml" line="91"/>
         <source>Scraping…</source>
         <translation>메타데이터 수집 중…</translation>
     </message>
@@ -191,22 +235,22 @@
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="182" />
+        <location filename="../screens/FavoritesScreen.qml" line="183"/>
         <source>Favorites</source>
         <translation>즐겨찾기</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="185" />
+        <location filename="../screens/FavoritesScreen.qml" line="186"/>
         <source>%1 entries</source>
         <translation>항목 %1개</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="283" />
+        <location filename="../screens/FavoritesScreen.qml" line="309"/>
         <source>No favorites yet</source>
         <translation>아직 즐겨찾기가 없습니다</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="284" />
+        <location filename="../screens/FavoritesScreen.qml" line="310"/>
         <source>Loading favorites…</source>
         <translation>즐겨찾기 불러오는 중…</translation>
     </message>
@@ -214,75 +258,99 @@
 <context>
     <name>FirstRunIndexModal</name>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="127" />
+        <location filename="../components/FirstRunIndexModal.qml" line="127"/>
         <source>First-time setup</source>
         <translation>최초 설정</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="136" />
+        <location filename="../components/FirstRunIndexModal.qml" line="136"/>
         <source>Zaparoo needs to scan your games before you can use the launcher. This usually takes a few minutes.</source>
         <translation>Zaparoo를 사용하기 전에 게임을 스캔해야 합니다. 보통 몇 분 정도 걸립니다.</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="158" />
+        <location filename="../components/FirstRunIndexModal.qml" line="158"/>
         <source>Optimizing database - almost done</source>
         <translation>데이터베이스 최적화 중 - 거의 완료됨</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="211" />
+        <location filename="../components/FirstRunIndexModal.qml" line="211"/>
         <source>Indexing paused</source>
         <translation>인덱싱 일시중지됨</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="213" />
+        <location filename="../components/FirstRunIndexModal.qml" line="213"/>
         <source>Step %1 of %2 - %3</source>
         <translation>%2 중 %1단계 - %3</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="215" />
+        <location filename="../components/FirstRunIndexModal.qml" line="215"/>
         <source>Step %1 of %2</source>
         <translation>%2 중 %1단계</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="216" />
+        <location filename="../components/FirstRunIndexModal.qml" line="216"/>
         <source>Preparing…</source>
         <translation>준비 중…</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="233" />
+        <location filename="../components/FirstRunIndexModal.qml" line="233"/>
         <source>Done. %1 files indexed.</source>
         <translation>완료. 파일 %1개를 인덱싱했습니다.</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="263" />
+        <location filename="../components/FirstRunIndexModal.qml" line="263"/>
         <source>Cancel</source>
         <translation>취소</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="263" />
+        <location filename="../components/FirstRunIndexModal.qml" line="263"/>
         <source>Start scan</source>
         <translation>스캔 시작</translation>
     </message>
 </context>
 <context>
+    <name>GameInfoModal</name>
+    <message>
+        <location filename="../components/GameInfoModal.qml" line="86"/>
+        <source>Back to close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/GameInfoModal.qml" line="114"/>
+        <source>Loading details…</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="363" />
+        <location filename="../screens/GamesScreen.qml" line="367"/>
+        <location filename="../screens/GamesScreen.qml" line="537"/>
         <source>%1 files</source>
         <translation>파일 %1개</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="533" />
+        <location filename="../screens/GamesScreen.qml" line="437"/>
+        <source>Loading game…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/GamesScreen.qml" line="554"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/GamesScreen.qml" line="569"/>
         <source>No games in this system</source>
         <translation>이 시스템에는 게임이 없습니다</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="534" />
+        <location filename="../screens/GamesScreen.qml" line="570"/>
         <source>Loading games…</source>
         <translation>게임 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="556" />
+        <location filename="../screens/GamesScreen.qml" line="592"/>
         <source>Loading more…</source>
         <translation>더 불러오는 중…</translation>
     </message>
@@ -290,22 +358,22 @@
 <context>
     <name>HubScreen</name>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91" />
+        <location filename="../screens/HubScreen.qml" line="91"/>
         <source>Favorites</source>
         <translation>즐겨찾기</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="96" />
+        <location filename="../screens/HubScreen.qml" line="96"/>
         <source>Recently Played</source>
         <translation>최근 플레이</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="101" />
+        <location filename="../screens/HubScreen.qml" line="101"/>
         <source>Settings</source>
         <translation>설정</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="537" />
+        <location filename="../screens/HubScreen.qml" line="537"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>사용 가능한 시스템이 없습니다. 설정에서 미디어 데이터베이스 업데이트를 실행하세요.</translation>
     </message>
@@ -313,7 +381,7 @@
 <context>
     <name>LoadingIndicator</name>
     <message>
-        <location filename="../components/LoadingIndicator.qml" line="26" />
+        <location filename="../components/LoadingIndicator.qml" line="26"/>
         <source>Loading…</source>
         <translation>불러오는 중…</translation>
     </message>
@@ -321,32 +389,32 @@
 <context>
     <name>LogUploadModal</name>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="87" />
+        <location filename="../components/LogUploadModal.qml" line="87"/>
         <source>Upload log file</source>
         <translation>로그 파일 업로드</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="97" />
+        <location filename="../components/LogUploadModal.qml" line="97"/>
         <source>Uploading log file - this may take a moment.</source>
         <translation>로그 파일을 업로드하는 중입니다. 잠시 걸릴 수 있습니다.</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197" />
+        <location filename="../components/LogUploadModal.qml" line="197"/>
         <source>Upload failed: %1</source>
         <translation>업로드 실패: %1</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197" />
+        <location filename="../components/LogUploadModal.qml" line="197"/>
         <source>Upload failed.</source>
         <translation>업로드 실패.</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="227" />
+        <location filename="../components/LogUploadModal.qml" line="227"/>
         <source>Retry</source>
         <translation>다시 시도</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="227" />
+        <location filename="../components/LogUploadModal.qml" line="227"/>
         <source>Done</source>
         <translation>완료</translation>
     </message>
@@ -354,58 +422,64 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="723" />
+        <location filename="../app/Main.qml" line="753"/>
         <source>Launch core</source>
         <translation>코어 실행</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="731" />
-        <location filename="../app/Main.qml" line="755" />
+        <location filename="../app/Main.qml" line="761"/>
+        <location filename="../app/Main.qml" line="781"/>
+        <source>More info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="765"/>
+        <location filename="../app/Main.qml" line="804"/>
         <source>Launch game</source>
         <translation>게임 실행</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="741" />
+        <location filename="../app/Main.qml" line="785"/>
         <source>Remove from favorites</source>
         <translation>즐겨찾기에서 제거</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="741" />
+        <location filename="../app/Main.qml" line="785"/>
         <source>Add to favorites</source>
         <translation>즐겨찾기에 추가</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="747" />
+        <location filename="../app/Main.qml" line="790"/>
         <source>Write to NFC token</source>
         <translation>NFC 토큰에 쓰기</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="751" />
+        <location filename="../app/Main.qml" line="794"/>
         <source>QR code</source>
         <translation>QR 코드</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1437" />
+        <location filename="../app/Main.qml" line="1652"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1439" />
+        <location filename="../app/Main.qml" line="1654"/>
         <source>Loading games…</source>
         <translation>게임 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1441" />
+        <location filename="../app/Main.qml" line="1656"/>
         <source>Loading favorites…</source>
         <translation>즐겨찾기 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1443" />
+        <location filename="../app/Main.qml" line="1658"/>
         <source>Loading recently played…</source>
         <translation>최근 플레이 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1445" />
+        <location filename="../app/Main.qml" line="1660"/>
         <source>Loading…</source>
         <translation>불러오는 중…</translation>
     </message>
@@ -413,144 +487,151 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="127" />
+        <location filename="../app/MainLayout.qml" line="141"/>
         <source>Zaparoo Launcher</source>
         <translation>자파루 런처</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="475" />
+        <location filename="../app/MainLayout.qml" line="545"/>
         <source>Writing failed</source>
         <translation>쓰기 실패</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="475" />
+        <location filename="../app/MainLayout.qml" line="545"/>
         <source>Put a writable card near the reader</source>
         <translation>기록 가능한 카드를 리더 근처에 놓으세요</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="540" />
+        <location filename="../app/MainLayout.qml" line="556"/>
+        <source>Quit and restart Zaparoo Launcher?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="557"/>
+        <source>In order to apply this setting we need to restart the launcher.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="632"/>
         <source>Quit Zaparoo Launcher?</source>
         <translation>Zaparoo Launcher를 종료할까요?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="541" />
+        <location filename="../app/MainLayout.qml" line="633"/>
         <source>Are you sure you want to exit?</source>
         <translation>정말 종료하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="613" />
-        <location filename="../app/MainLayout.qml" line="685" />
-        <location filename="../app/MainLayout.qml" line="700" />
-        <location filename="../app/MainLayout.qml" line="743" />
-        <location filename="../app/MainLayout.qml" line="772" />
-        <location filename="../app/MainLayout.qml" line="819" />
-        <location filename="../app/MainLayout.qml" line="860" />
-        <location filename="../app/MainLayout.qml" line="924" />
+        <location filename="../app/MainLayout.qml" line="705"/>
+        <location filename="../app/MainLayout.qml" line="777"/>
+        <location filename="../app/MainLayout.qml" line="820"/>
+        <location filename="../app/MainLayout.qml" line="849"/>
+        <location filename="../app/MainLayout.qml" line="896"/>
+        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="1001"/>
         <source>Move</source>
         <translation>이동</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="617" />
-        <location filename="../app/MainLayout.qml" line="689" />
-        <location filename="../app/MainLayout.qml" line="704" />
+        <location filename="../app/MainLayout.qml" line="709"/>
+        <location filename="../app/MainLayout.qml" line="781"/>
         <source>Select</source>
         <translation>선택</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="621" />
-        <location filename="../app/MainLayout.qml" line="625" />
-        <location filename="../app/MainLayout.qml" line="639" />
-        <location filename="../app/MainLayout.qml" line="652" />
-        <location filename="../app/MainLayout.qml" line="663" />
+        <location filename="../app/MainLayout.qml" line="713"/>
+        <location filename="../app/MainLayout.qml" line="717"/>
+        <location filename="../app/MainLayout.qml" line="731"/>
+        <location filename="../app/MainLayout.qml" line="744"/>
+        <location filename="../app/MainLayout.qml" line="755"/>
         <source>Close</source>
         <translation>닫기</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="632" />
-        <location filename="../app/MainLayout.qml" line="670" />
-        <location filename="../app/MainLayout.qml" line="693" />
-        <location filename="../app/MainLayout.qml" line="708" />
-        <location filename="../app/MainLayout.qml" line="719" />
+        <location filename="../app/MainLayout.qml" line="724"/>
+        <location filename="../app/MainLayout.qml" line="762"/>
+        <location filename="../app/MainLayout.qml" line="785"/>
+        <location filename="../app/MainLayout.qml" line="796"/>
         <source>Cancel</source>
         <translation>취소</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="648" />
+        <location filename="../app/MainLayout.qml" line="740"/>
         <source>Done</source>
         <translation>완료</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="659" />
-        <location filename="../app/MainLayout.qml" line="795" />
-        <location filename="../app/MainLayout.qml" line="845" />
-        <location filename="../app/MainLayout.qml" line="950" />
+        <location filename="../app/MainLayout.qml" line="751"/>
+        <location filename="../app/MainLayout.qml" line="872"/>
+        <location filename="../app/MainLayout.qml" line="922"/>
+        <location filename="../app/MainLayout.qml" line="1027"/>
         <source>Retry</source>
         <translation>다시 시도</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="678" />
+        <location filename="../app/MainLayout.qml" line="770"/>
         <source>I understand</source>
         <translation>이해했습니다</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="727" />
+        <location filename="../app/MainLayout.qml" line="804"/>
         <source>Start</source>
         <translation>시작</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="747" />
-        <location filename="../app/MainLayout.qml" line="782" />
-        <location filename="../app/MainLayout.qml" line="829" />
-        <location filename="../app/MainLayout.qml" line="934" />
+        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="859"/>
+        <location filename="../app/MainLayout.qml" line="906"/>
+        <location filename="../app/MainLayout.qml" line="1011"/>
         <source>Open</source>
         <translation>열기</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="751" />
+        <location filename="../app/MainLayout.qml" line="828"/>
         <source>Quit</source>
         <translation>종료</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="760" />
-        <location filename="../app/MainLayout.qml" line="788" />
-        <location filename="../app/MainLayout.qml" line="799" />
-        <location filename="../app/MainLayout.qml" line="811" />
-        <location filename="../app/MainLayout.qml" line="838" />
-        <location filename="../app/MainLayout.qml" line="849" />
-        <location filename="../app/MainLayout.qml" line="884" />
-        <location filename="../app/MainLayout.qml" line="900" />
-        <location filename="../app/MainLayout.qml" line="909" />
-        <location filename="../app/MainLayout.qml" line="943" />
-        <location filename="../app/MainLayout.qml" line="954" />
+        <location filename="../app/MainLayout.qml" line="837"/>
+        <location filename="../app/MainLayout.qml" line="865"/>
+        <location filename="../app/MainLayout.qml" line="876"/>
+        <location filename="../app/MainLayout.qml" line="888"/>
+        <location filename="../app/MainLayout.qml" line="915"/>
+        <location filename="../app/MainLayout.qml" line="926"/>
+        <location filename="../app/MainLayout.qml" line="961"/>
+        <location filename="../app/MainLayout.qml" line="977"/>
+        <location filename="../app/MainLayout.qml" line="986"/>
+        <location filename="../app/MainLayout.qml" line="1020"/>
+        <location filename="../app/MainLayout.qml" line="1031"/>
         <source>Back</source>
         <translation>뒤로</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="778" />
-        <location filename="../app/MainLayout.qml" line="825" />
-        <location filename="../app/MainLayout.qml" line="930" />
+        <location filename="../app/MainLayout.qml" line="855"/>
+        <location filename="../app/MainLayout.qml" line="902"/>
+        <location filename="../app/MainLayout.qml" line="1007"/>
         <source>Page</source>
         <translation>페이지</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="785" />
-        <location filename="../app/MainLayout.qml" line="834" />
-        <location filename="../app/MainLayout.qml" line="939" />
+        <location filename="../app/MainLayout.qml" line="862"/>
+        <location filename="../app/MainLayout.qml" line="911"/>
+        <location filename="../app/MainLayout.qml" line="1016"/>
         <source>Options</source>
         <translation>옵션</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="869" />
+        <location filename="../app/MainLayout.qml" line="946"/>
         <source>Change</source>
         <translation>변경</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="875" />
+        <location filename="../app/MainLayout.qml" line="952"/>
         <source>Toggle</source>
         <translation>전환</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="896" />
+        <location filename="../app/MainLayout.qml" line="973"/>
         <source>Scroll</source>
         <translation>스크롤</translation>
     </message>
@@ -558,22 +639,22 @@
 <context>
     <name>Modal</name>
     <message>
-        <location filename="../components/Modal.qml" line="49" />
+        <location filename="../components/Modal.qml" line="49"/>
         <source>OK</source>
         <translation>확인</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="50" />
+        <location filename="../components/Modal.qml" line="50"/>
         <source>Yes</source>
         <translation>예</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="51" />
+        <location filename="../components/Modal.qml" line="51"/>
         <source>No</source>
         <translation>아니요</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="198" />
+        <location filename="../components/Modal.qml" line="198"/>
         <source>Cancel</source>
         <translation>취소</translation>
     </message>
@@ -581,22 +662,22 @@
 <context>
     <name>RecentsScreen</name>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="183" />
+        <location filename="../screens/RecentsScreen.qml" line="184"/>
         <source>Recently Played</source>
         <translation>최근 플레이</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="186" />
+        <location filename="../screens/RecentsScreen.qml" line="187"/>
         <source>%1 entries</source>
         <translation>항목 %1개</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="281" />
+        <location filename="../screens/RecentsScreen.qml" line="311"/>
         <source>Nothing played yet</source>
         <translation>아직 플레이한 항목이 없습니다</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="282" />
+        <location filename="../screens/RecentsScreen.qml" line="312"/>
         <source>Loading recently played…</source>
         <translation>최근 플레이 불러오는 중…</translation>
     </message>
@@ -604,17 +685,17 @@
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="26" />
+        <location filename="../components/ScreenStateOverlay.qml" line="26"/>
         <source>Nothing here</source>
         <translation>여기에 아무것도 없습니다</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27" />
+        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
         <source>Loading…</source>
         <translation>불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="57" />
+        <location filename="../components/ScreenStateOverlay.qml" line="57"/>
         <source>Failed to load</source>
         <translation>불러오지 못했습니다</translation>
     </message>
@@ -622,288 +703,294 @@
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="61" />
+        <location filename="../screens/SettingsScreen.qml" line="61"/>
         <source>General</source>
         <translation>일반</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78" />
-        <location filename="../screens/SettingsScreen.qml" line="436" />
+        <location filename="../screens/SettingsScreen.qml" line="73"/>
+        <location filename="../screens/SettingsScreen.qml" line="432"/>
         <source>Language</source>
         <translation>언어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83" />
-        <location filename="../screens/SettingsScreen.qml" line="445" />
+        <location filename="../screens/SettingsScreen.qml" line="78"/>
+        <location filename="../screens/SettingsScreen.qml" line="441"/>
         <source>Browsing layout</source>
         <translation>탐색 레이아웃</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88" />
-        <location filename="../screens/SettingsScreen.qml" line="454" />
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="450"/>
         <source>Button style</source>
         <translation>버튼 스타일</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="93" />
-        <location filename="../screens/SettingsScreen.qml" line="463" />
+        <location filename="../screens/SettingsScreen.qml" line="88"/>
+        <location filename="../screens/SettingsScreen.qml" line="459"/>
         <source>Screensaver</source>
         <translation>화면 보호기</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97" />
+        <location filename="../screens/SettingsScreen.qml" line="92"/>
         <source>Library</source>
         <translation>라이브러리</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102" />
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <source>Discover arcade alternate versions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
         <source>Update media database</source>
         <translation>미디어 데이터베이스 업데이트</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="107" />
+        <location filename="../screens/SettingsScreen.qml" line="107"/>
         <source>Scrape metadata</source>
         <translation>메타데이터 수집</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111" />
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
         <source>Advanced</source>
         <translation>고급</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116" />
+        <location filename="../screens/SettingsScreen.qml" line="116"/>
         <source>Mouse support</source>
         <translation>마우스 지원</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121" />
+        <location filename="../screens/SettingsScreen.qml" line="121"/>
         <source>Debug logging</source>
         <translation>디버그 로깅</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126" />
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Upload log file</source>
         <translation>로그 파일 업로드</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131" />
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
         <source>About / License</source>
         <translation>정보 / 라이선스</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147" />
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
         <source>Optimizing</source>
         <translation>최적화 중</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149" />
-        <location filename="../screens/SettingsScreen.qml" line="158" />
+        <location filename="../screens/SettingsScreen.qml" line="149"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
         <source>Paused</source>
         <translation>일시중지됨</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149" />
-        <location filename="../screens/SettingsScreen.qml" line="158" />
+        <location filename="../screens/SettingsScreen.qml" line="149"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
         <source>In progress</source>
         <translation>진행 중</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152" />
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>%1 indexed</source>
         <translation>%1개 인덱싱됨</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="161" />
+        <location filename="../screens/SettingsScreen.qml" line="161"/>
         <source>%1 scraped</source>
         <translation>%1개 수집됨</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270" />
+        <location filename="../screens/SettingsScreen.qml" line="266"/>
         <source>Cancel</source>
         <translation>취소</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270" />
+        <location filename="../screens/SettingsScreen.qml" line="266"/>
         <source>Start</source>
         <translation>시작</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="272" />
+        <location filename="../screens/SettingsScreen.qml" line="268"/>
         <source>Upload</source>
         <translation>업로드</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="274" />
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
         <source>Open</source>
         <translation>열기</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="326" />
+        <location filename="../screens/SettingsScreen.qml" line="322"/>
         <source>Default</source>
         <translation>기본값</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="346" />
+        <location filename="../screens/SettingsScreen.qml" line="342"/>
         <source>English</source>
         <translation>영어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="348" />
+        <location filename="../screens/SettingsScreen.qml" line="344"/>
         <source>Italian</source>
         <translation>이탈리아어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="350" />
+        <location filename="../screens/SettingsScreen.qml" line="346"/>
         <source>German</source>
         <translation>독일어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="352" />
+        <location filename="../screens/SettingsScreen.qml" line="348"/>
         <source>Greek</source>
         <translation>그리스어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="354" />
+        <location filename="../screens/SettingsScreen.qml" line="350"/>
         <source>Japanese</source>
         <translation>일본어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="356" />
+        <location filename="../screens/SettingsScreen.qml" line="352"/>
         <source>Korean</source>
         <translation>한국어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="358" />
+        <location filename="../screens/SettingsScreen.qml" line="354"/>
         <source>Dutch</source>
         <translation>네덜란드어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="360" />
+        <location filename="../screens/SettingsScreen.qml" line="356"/>
         <source>Romanian</source>
         <translation>루마니아어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="362" />
+        <location filename="../screens/SettingsScreen.qml" line="358"/>
         <source>Slovak</source>
         <translation>슬로바키아어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="364" />
+        <location filename="../screens/SettingsScreen.qml" line="360"/>
         <source>Ukrainian</source>
         <translation>우크라이나어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="366" />
+        <location filename="../screens/SettingsScreen.qml" line="362"/>
         <source>Chinese (Simplified)</source>
         <translation>중국어(간체)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="368" />
+        <location filename="../screens/SettingsScreen.qml" line="364"/>
         <source>Hebrew</source>
         <translation>히브리어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="370" />
+        <location filename="../screens/SettingsScreen.qml" line="366"/>
         <source>Arabic</source>
-        <translation type="unfinished" />
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="372" />
+        <location filename="../screens/SettingsScreen.qml" line="368"/>
         <source>Hindi</source>
-        <translation type="unfinished" />
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="373" />
+        <location filename="../screens/SettingsScreen.qml" line="369"/>
         <source>Auto</source>
         <translation>자동</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="378" />
+        <location filename="../screens/SettingsScreen.qml" line="374"/>
         <source>Detailed list view</source>
         <translation>자세한 목록 보기</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="379" />
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Grid view</source>
         <translation>그리드 보기</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="384" />
+        <location filename="../screens/SettingsScreen.qml" line="380"/>
         <source>Style B</source>
         <translation>스타일 B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="386" />
+        <location filename="../screens/SettingsScreen.qml" line="382"/>
         <source>Style C</source>
         <translation>스타일 C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="388" />
+        <location filename="../screens/SettingsScreen.qml" line="384"/>
         <source>Style D</source>
         <translation>스타일 D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="389" />
+        <location filename="../screens/SettingsScreen.qml" line="385"/>
         <source>Style A</source>
         <translation>스타일 A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399" />
+        <location filename="../screens/SettingsScreen.qml" line="395"/>
         <source>Off</source>
         <translation>끔</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="401" />
+        <location filename="../screens/SettingsScreen.qml" line="397"/>
         <source>1 second (testing)</source>
         <translation>1초 (테스트용)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="403" />
+        <location filename="../screens/SettingsScreen.qml" line="399"/>
         <source>1 minute</source>
         <translation>1분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405" />
+        <location filename="../screens/SettingsScreen.qml" line="401"/>
         <source>2 minutes</source>
         <translation>2분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="407" />
+        <location filename="../screens/SettingsScreen.qml" line="403"/>
         <source>5 minutes</source>
         <translation>5분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="409" />
+        <location filename="../screens/SettingsScreen.qml" line="405"/>
         <source>10 minutes</source>
         <translation>10분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="411" />
+        <location filename="../screens/SettingsScreen.qml" line="407"/>
         <source>15 minutes</source>
         <translation>15분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="413" />
+        <location filename="../screens/SettingsScreen.qml" line="409"/>
         <source>30 minutes</source>
         <translation>30분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="414" />
+        <location filename="../screens/SettingsScreen.qml" line="410"/>
         <source>%1 seconds</source>
         <translation>%1초</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="427" />
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="423"/>
         <source>Resolution</source>
         <translation>해상도</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="555" />
+        <location filename="../screens/SettingsScreen.qml" line="563"/>
         <source>Settings</source>
         <translation>설정</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="745" />
+        <location filename="../screens/SettingsScreen.qml" line="755"/>
         <source>No settings available on this platform</source>
         <translation>이 플랫폼에서는 설정을 사용할 수 없습니다</translation>
     </message>
@@ -911,17 +998,23 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="182" />
+        <location filename="../screens/SystemsScreen.qml" line="185"/>
+        <location filename="../screens/SystemsScreen.qml" line="313"/>
         <source>%1 systems</source>
         <translation>시스템 %1개</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="279" />
+        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SystemsScreen.qml" line="345"/>
         <source>No systems in this category</source>
         <translation>이 카테고리에는 시스템이 없습니다</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="280" />
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>
@@ -929,7 +1022,7 @@
 <context>
     <name>TopStatusStrip</name>
     <message>
-        <location filename="../components/TopStatusStrip.qml" line="88" />
+        <location filename="../components/TopStatusStrip.qml" line="90"/>
         <source>Page %1 / %2</source>
         <translation>페이지 %1 / %2</translation>
     </message>

--- a/src/ui/translations/launcher_ko.ts
+++ b/src/ui/translations/launcher_ko.ts
@@ -90,38 +90,48 @@
         <translation type="unfinished">불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="43"/>
+        <location filename="../components/BrowseDetailPane.qml" line="44"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="45"/>
+        <location filename="../components/BrowseDetailPane.qml" line="46"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <location filename="../components/BrowseDetailPane.qml" line="48"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <location filename="../components/BrowseDetailPane.qml" line="50"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <location filename="../components/BrowseDetailPane.qml" line="52"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <location filename="../components/BrowseDetailPane.qml" line="54"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="55"/>
-        <source>Filename</source>
+        <location filename="../components/BrowseDetailPane.qml" line="56"/>
+        <source>Category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="58"/>
+        <source>Release date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="60"/>
+        <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -245,12 +255,17 @@
         <translation>항목 %1개</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="309"/>
+        <location filename="../screens/FavoritesScreen.qml" line="190"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/FavoritesScreen.qml" line="280"/>
         <source>No favorites yet</source>
         <translation>아직 즐겨찾기가 없습니다</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="310"/>
+        <location filename="../screens/FavoritesScreen.qml" line="281"/>
         <source>Loading favorites…</source>
         <translation>즐겨찾기 불러오는 중…</translation>
     </message>
@@ -324,33 +339,35 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="367"/>
-        <location filename="../screens/GamesScreen.qml" line="537"/>
+        <location filename="../screens/GamesScreen.qml" line="373"/>
+        <location filename="../screens/GamesScreen.qml" line="520"/>
         <source>%1 files</source>
         <translation>파일 %1개</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="437"/>
+        <location filename="../screens/GamesScreen.qml" line="409"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="554"/>
+        <location filename="../screens/GamesScreen.qml" line="382"/>
+        <location filename="../screens/GamesScreen.qml" line="537"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="569"/>
+        <location filename="../screens/GamesScreen.qml" line="552"/>
         <source>No games in this system</source>
         <translation>이 시스템에는 게임이 없습니다</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="570"/>
+        <location filename="../screens/GamesScreen.qml" line="553"/>
         <source>Loading games…</source>
         <translation>게임 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="592"/>
+        <location filename="../screens/GamesScreen.qml" line="378"/>
+        <location filename="../screens/GamesScreen.qml" line="575"/>
         <source>Loading more…</source>
         <translation>더 불러오는 중…</translation>
     </message>
@@ -672,12 +689,17 @@
         <translation>항목 %1개</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="311"/>
+        <location filename="../screens/RecentsScreen.qml" line="191"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/RecentsScreen.qml" line="282"/>
         <source>Nothing played yet</source>
         <translation>아직 플레이한 항목이 없습니다</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="312"/>
+        <location filename="../screens/RecentsScreen.qml" line="283"/>
         <source>Loading recently played…</source>
         <translation>최근 플레이 불러오는 중…</translation>
     </message>
@@ -999,22 +1021,23 @@
     <name>SystemsScreen</name>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="185"/>
-        <location filename="../screens/SystemsScreen.qml" line="313"/>
+        <location filename="../screens/SystemsScreen.qml" line="285"/>
         <source>%1 systems</source>
         <translation>시스템 %1개</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <location filename="../screens/SystemsScreen.qml" line="189"/>
+        <location filename="../screens/SystemsScreen.qml" line="302"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="345"/>
+        <location filename="../screens/SystemsScreen.qml" line="317"/>
         <source>No systems in this category</source>
         <translation>이 카테고리에는 시스템이 없습니다</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="318"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>
@@ -1022,7 +1045,7 @@
 <context>
     <name>TopStatusStrip</name>
     <message>
-        <location filename="../components/TopStatusStrip.qml" line="90"/>
+        <location filename="../components/TopStatusStrip.qml" line="91"/>
         <source>Page %1 / %2</source>
         <translation>페이지 %1 / %2</translation>
     </message>

--- a/src/ui/translations/launcher_nl.ts
+++ b/src/ui/translations/launcher_nl.ts
@@ -1,59 +1,60 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
 <TS version="2.1" language="nl" sourcelanguage="en">
 <context>
     <name>AboutScreen</name>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="72" />
+        <location filename="../screens/AboutScreen.qml" line="71"/>
         <source>About / License</source>
         <translation>Over / Licentie</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="154" />
+        <location filename="../screens/AboutScreen.qml" line="153"/>
         <source>Zaparoo Launcher</source>
         <translation>Zaparoo-launcher</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="165" />
+        <location filename="../screens/AboutScreen.qml" line="164"/>
         <source>Version %1 · %2 · %3</source>
         <translation>Versie %1 · %2 · %3</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="178" />
+        <location filename="../screens/AboutScreen.qml" line="174"/>
         <source>Built %1</source>
         <translation>Gebouwd op %1</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="189" />
+        <location filename="../screens/AboutScreen.qml" line="185"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>Copyright 2026 Wizzo Pty Ltd en de bijdragers aan het Zaparoo-project.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="200" />
+        <location filename="../screens/AboutScreen.qml" line="196"/>
         <source>Source available under the PolyForm Noncommercial License 1.0.0. Free for personal, non-commercial use. Commercial use or redistribution requires a separate license.</source>
         <translation>Broncode beschikbaar onder de PolyForm Noncommercial License 1.0.0. Gratis voor persoonlijk, niet-commercieel gebruik. Commercieel gebruik of herdistributie vereist een aparte licentie.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="211" />
+        <location filename="../screens/AboutScreen.qml" line="207"/>
         <source>Commercial licensing: legal@zaparoo.org</source>
         <translation>Commerciële licenties: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="222" />
+        <location filename="../screens/AboutScreen.qml" line="218"/>
         <source>Project: https://zaparoo.org</source>
         <translation>Projectwebsite: https://zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="232" />
+        <location filename="../screens/AboutScreen.qml" line="228"/>
         <source>Created by</source>
         <translation>Gemaakt door</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="256" />
+        <location filename="../screens/AboutScreen.qml" line="252"/>
         <source>Translations</source>
         <translation>Vertalingen</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="280" />
+        <location filename="../screens/AboutScreen.qml" line="276"/>
         <source>Full license text in COPYING.</source>
         <translation>Volledige licentietekst in COPYING.</translation>
     </message>
@@ -61,60 +62,103 @@
 <context>
     <name>BootOverlay</name>
     <message>
-        <location filename="../components/BootOverlay.qml" line="76" />
-        <source>Can't reach Zaparoo Core. Check your connection.</source>
+        <location filename="../components/BootOverlay.qml" line="76"/>
+        <source>Can&apos;t reach Zaparoo Core. Check your connection.</source>
         <translation>Kan Zaparoo Core niet bereiken. Controleer uw verbinding.</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="78" />
+        <location filename="../components/BootOverlay.qml" line="78"/>
         <source>Reconnecting…</source>
         <translation>Opnieuw verbinden…</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="80" />
+        <location filename="../components/BootOverlay.qml" line="80"/>
         <source>Loading library…</source>
         <translation>Bibliotheek laden…</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="85" />
+        <location filename="../components/BootOverlay.qml" line="85"/>
         <source>Connecting to Zaparoo Core…</source>
         <translation>Verbinden met Zaparoo Core…</translation>
     </message>
 </context>
 <context>
+    <name>BrowseDetailPane</name>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="22"/>
+        <source>Loading…</source>
+        <translation type="unfinished">Laden…</translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="43"/>
+        <source>Year</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="45"/>
+        <source>Genre</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <source>Players</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <source>Developer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <source>Publisher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <source>Rating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="55"/>
+        <source>Filename</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommercialNoticeModal</name>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="59" />
+        <location filename="../components/CommercialNoticeModal.qml" line="59"/>
         <source>Welcome to Zaparoo Launcher</source>
         <translation>Welkom bij Zaparoo Launcher</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="68" />
+        <location filename="../components/CommercialNoticeModal.qml" line="68"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>Copyright 2026 Wizzo Pty Ltd en de bijdragers aan het Zaparoo-project.</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="79" />
+        <location filename="../components/CommercialNoticeModal.qml" line="79"/>
         <source>This free source-available build is for personal and non-commercial use only. Commercial use or redistribution requires a license.</source>
         <translation>Deze gratis build is alleen voor persoonlijk en niet-commercieel gebruik. Commercieel gebruik of verspreiding vereist een licentie.</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="90" />
+        <location filename="../components/CommercialNoticeModal.qml" line="90"/>
         <source>Contact: legal@zaparoo.org</source>
         <translation>Neem contact op: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="101" />
+        <location filename="../components/CommercialNoticeModal.qml" line="101"/>
         <source>Full details available any time under Settings &gt; About / License.</source>
         <translation>Volledige details altijd beschikbaar onder Instellingen &gt; Over / Licentie.</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="119" />
+        <location filename="../components/CommercialNoticeModal.qml" line="119"/>
         <source>Created by</source>
         <translation>Gemaakt door</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="162" />
+        <location filename="../components/CommercialNoticeModal.qml" line="162"/>
         <source>I understand</source>
         <translation>Ik begrijp het</translation>
     </message>
@@ -122,68 +166,68 @@
 <context>
     <name>CoreStatusPill</name>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="44" />
-        <location filename="../components/CoreStatusPill.qml" line="50" />
+        <location filename="../components/CoreStatusPill.qml" line="44"/>
+        <location filename="../components/CoreStatusPill.qml" line="50"/>
         <source>Disconnected</source>
         <translation>Verbroken</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="47" />
+        <location filename="../components/CoreStatusPill.qml" line="47"/>
         <source>Reconnecting…</source>
         <translation>Opnieuw verbinden…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="53" />
+        <location filename="../components/CoreStatusPill.qml" line="53"/>
         <source>Connecting…</source>
         <translation>Verbinden…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="56" />
+        <location filename="../components/CoreStatusPill.qml" line="56"/>
         <source>Core error</source>
         <translation>Core-fout</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="60" />
+        <location filename="../components/CoreStatusPill.qml" line="60"/>
         <source>Optimizing database</source>
         <translation>Database optimaliseren</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="67" />
+        <location filename="../components/CoreStatusPill.qml" line="67"/>
         <source>Indexing paused</source>
         <translation>Indexering gepauzeerd</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="70" />
+        <location filename="../components/CoreStatusPill.qml" line="70"/>
         <source>Indexing %1/%2 - %3</source>
         <translation>Indexering %1/%2 – %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="86" />
+        <location filename="../components/CoreStatusPill.qml" line="86"/>
         <source>Scraping %1/%2 - %3</source>
         <translation>Scraping %1/%2 – %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="73" />
+        <location filename="../components/CoreStatusPill.qml" line="73"/>
         <source>Indexing %1/%2</source>
         <translation>Indexering %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="75" />
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
         <source>Indexing…</source>
         <translation>Indexering…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="83" />
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Scrape paused</source>
         <translation>Scraping gepauzeerd</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="89" />
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
         <source>Scraping %1/%2</source>
         <translation>Scrapen %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="91" />
+        <location filename="../components/CoreStatusPill.qml" line="91"/>
         <source>Scraping…</source>
         <translation>Bezig met scrapen…</translation>
     </message>
@@ -191,22 +235,22 @@
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="182" />
+        <location filename="../screens/FavoritesScreen.qml" line="183"/>
         <source>Favorites</source>
         <translation>Favorieten</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="185" />
+        <location filename="../screens/FavoritesScreen.qml" line="186"/>
         <source>%1 entries</source>
         <translation>%1 items</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="283" />
+        <location filename="../screens/FavoritesScreen.qml" line="309"/>
         <source>No favorites yet</source>
         <translation>Nog geen favorieten</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="284" />
+        <location filename="../screens/FavoritesScreen.qml" line="310"/>
         <source>Loading favorites…</source>
         <translation>Favorieten laden…</translation>
     </message>
@@ -214,75 +258,99 @@
 <context>
     <name>FirstRunIndexModal</name>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="127" />
+        <location filename="../components/FirstRunIndexModal.qml" line="127"/>
         <source>First-time setup</source>
         <translation>Eerste installatie</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="136" />
+        <location filename="../components/FirstRunIndexModal.qml" line="136"/>
         <source>Zaparoo needs to scan your games before you can use the launcher. This usually takes a few minutes.</source>
         <translation>Zaparoo moet uw games scannen voordat u de launcher kunt gebruiken. Dit duurt gewoonlijk een paar minuten.</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="211" />
+        <location filename="../components/FirstRunIndexModal.qml" line="211"/>
         <source>Indexing paused</source>
         <translation>Indexering gepauzeerd</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="158" />
+        <location filename="../components/FirstRunIndexModal.qml" line="158"/>
         <source>Optimizing database - almost done</source>
         <translation>Database optimaliseren – bijna klaar</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="213" />
+        <location filename="../components/FirstRunIndexModal.qml" line="213"/>
         <source>Step %1 of %2 - %3</source>
         <translation>Stap %1 van %2 – %3</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="215" />
+        <location filename="../components/FirstRunIndexModal.qml" line="215"/>
         <source>Step %1 of %2</source>
         <translation>Stap %1 van %2</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="216" />
+        <location filename="../components/FirstRunIndexModal.qml" line="216"/>
         <source>Preparing…</source>
         <translation>Voorbereiden…</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="233" />
+        <location filename="../components/FirstRunIndexModal.qml" line="233"/>
         <source>Done. %1 files indexed.</source>
         <translation>Klaar. %1 bestanden geïndexeerd.</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="263" />
+        <location filename="../components/FirstRunIndexModal.qml" line="263"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="263" />
+        <location filename="../components/FirstRunIndexModal.qml" line="263"/>
         <source>Start scan</source>
         <translation>Scan starten</translation>
     </message>
 </context>
 <context>
+    <name>GameInfoModal</name>
+    <message>
+        <location filename="../components/GameInfoModal.qml" line="86"/>
+        <source>Back to close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/GameInfoModal.qml" line="114"/>
+        <source>Loading details…</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="363" />
+        <location filename="../screens/GamesScreen.qml" line="367"/>
+        <location filename="../screens/GamesScreen.qml" line="537"/>
         <source>%1 files</source>
         <translation>%1 bestanden</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="534" />
+        <location filename="../screens/GamesScreen.qml" line="437"/>
+        <source>Loading game…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/GamesScreen.qml" line="554"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/GamesScreen.qml" line="570"/>
         <source>Loading games…</source>
         <translation>Games laden…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="556" />
+        <location filename="../screens/GamesScreen.qml" line="592"/>
         <source>Loading more…</source>
         <translation>Meer laden…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="533" />
+        <location filename="../screens/GamesScreen.qml" line="569"/>
         <source>No games in this system</source>
         <translation>Geen games in dit systeem</translation>
     </message>
@@ -290,22 +358,22 @@
 <context>
     <name>HubScreen</name>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91" />
+        <location filename="../screens/HubScreen.qml" line="91"/>
         <source>Favorites</source>
         <translation>Favorieten</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="96" />
+        <location filename="../screens/HubScreen.qml" line="96"/>
         <source>Recently Played</source>
         <translation>Recent gespeeld</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="101" />
+        <location filename="../screens/HubScreen.qml" line="101"/>
         <source>Settings</source>
         <translation>Instellingen</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="537" />
+        <location filename="../screens/HubScreen.qml" line="537"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Geen systemen beschikbaar. Voer Database bijwerken uit via Instellingen.</translation>
     </message>
@@ -313,7 +381,7 @@
 <context>
     <name>LoadingIndicator</name>
     <message>
-        <location filename="../components/LoadingIndicator.qml" line="26" />
+        <location filename="../components/LoadingIndicator.qml" line="26"/>
         <source>Loading…</source>
         <translation>Laden…</translation>
     </message>
@@ -321,32 +389,32 @@
 <context>
     <name>LogUploadModal</name>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="87" />
+        <location filename="../components/LogUploadModal.qml" line="87"/>
         <source>Upload log file</source>
         <translation>Logbestand uploaden</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="97" />
+        <location filename="../components/LogUploadModal.qml" line="97"/>
         <source>Uploading log file - this may take a moment.</source>
         <translation>Logbestand uploaden – dit kan even duren.</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197" />
+        <location filename="../components/LogUploadModal.qml" line="197"/>
         <source>Upload failed: %1</source>
         <translation>Upload mislukt: %1</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197" />
+        <location filename="../components/LogUploadModal.qml" line="197"/>
         <source>Upload failed.</source>
         <translation>Upload mislukt.</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="227" />
+        <location filename="../components/LogUploadModal.qml" line="227"/>
         <source>Retry</source>
         <translation>Opnieuw proberen</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="227" />
+        <location filename="../components/LogUploadModal.qml" line="227"/>
         <source>Done</source>
         <translation>Klaar</translation>
     </message>
@@ -354,58 +422,64 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="723" />
+        <location filename="../app/Main.qml" line="753"/>
         <source>Launch core</source>
         <translation>Core starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="741" />
+        <location filename="../app/Main.qml" line="761"/>
+        <location filename="../app/Main.qml" line="781"/>
+        <source>More info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="785"/>
         <source>Remove from favorites</source>
         <translation>Uit favorieten verwijderen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="741" />
+        <location filename="../app/Main.qml" line="785"/>
         <source>Add to favorites</source>
         <translation>Aan favorieten toevoegen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="747" />
+        <location filename="../app/Main.qml" line="790"/>
         <source>Write to NFC token</source>
         <translation>Naar NFC-token schrijven</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="751" />
+        <location filename="../app/Main.qml" line="794"/>
         <source>QR code</source>
         <translation>QR-code</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="731" />
-        <location filename="../app/Main.qml" line="755" />
+        <location filename="../app/Main.qml" line="765"/>
+        <location filename="../app/Main.qml" line="804"/>
         <source>Launch game</source>
         <translation>Game starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1437" />
+        <location filename="../app/Main.qml" line="1652"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1441" />
+        <location filename="../app/Main.qml" line="1656"/>
         <source>Loading favorites…</source>
         <translation>Favorieten laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1439" />
+        <location filename="../app/Main.qml" line="1654"/>
         <source>Loading games…</source>
         <translation>Games laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1443" />
+        <location filename="../app/Main.qml" line="1658"/>
         <source>Loading recently played…</source>
         <translation>Recent gespeeld laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1445" />
+        <location filename="../app/Main.qml" line="1660"/>
         <source>Loading…</source>
         <translation>Laden…</translation>
     </message>
@@ -413,144 +487,151 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="127" />
+        <location filename="../app/MainLayout.qml" line="141"/>
         <source>Zaparoo Launcher</source>
         <translation>Zaparoo-launcher</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="475" />
+        <location filename="../app/MainLayout.qml" line="545"/>
         <source>Writing failed</source>
         <translation>Schrijven mislukt</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="475" />
+        <location filename="../app/MainLayout.qml" line="545"/>
         <source>Put a writable card near the reader</source>
         <translation>Houd een beschrijfbare kaart bij de lezer</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="540" />
+        <location filename="../app/MainLayout.qml" line="556"/>
+        <source>Quit and restart Zaparoo Launcher?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="557"/>
+        <source>In order to apply this setting we need to restart the launcher.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="632"/>
         <source>Quit Zaparoo Launcher?</source>
         <translation>Zaparoo Launcher afsluiten?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="541" />
+        <location filename="../app/MainLayout.qml" line="633"/>
         <source>Are you sure you want to exit?</source>
         <translation>Weet u zeker dat u wilt afsluiten?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="617" />
-        <location filename="../app/MainLayout.qml" line="689" />
-        <location filename="../app/MainLayout.qml" line="704" />
+        <location filename="../app/MainLayout.qml" line="709"/>
+        <location filename="../app/MainLayout.qml" line="781"/>
         <source>Select</source>
         <translation>Selecteren</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="621" />
-        <location filename="../app/MainLayout.qml" line="625" />
-        <location filename="../app/MainLayout.qml" line="639" />
-        <location filename="../app/MainLayout.qml" line="652" />
-        <location filename="../app/MainLayout.qml" line="663" />
+        <location filename="../app/MainLayout.qml" line="713"/>
+        <location filename="../app/MainLayout.qml" line="717"/>
+        <location filename="../app/MainLayout.qml" line="731"/>
+        <location filename="../app/MainLayout.qml" line="744"/>
+        <location filename="../app/MainLayout.qml" line="755"/>
         <source>Close</source>
         <translation>Sluiten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="632" />
-        <location filename="../app/MainLayout.qml" line="670" />
-        <location filename="../app/MainLayout.qml" line="693" />
-        <location filename="../app/MainLayout.qml" line="708" />
-        <location filename="../app/MainLayout.qml" line="719" />
+        <location filename="../app/MainLayout.qml" line="724"/>
+        <location filename="../app/MainLayout.qml" line="762"/>
+        <location filename="../app/MainLayout.qml" line="785"/>
+        <location filename="../app/MainLayout.qml" line="796"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="648" />
+        <location filename="../app/MainLayout.qml" line="740"/>
         <source>Done</source>
         <translation>Klaar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="678" />
+        <location filename="../app/MainLayout.qml" line="770"/>
         <source>I understand</source>
         <translation>Ik begrijp het</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="727" />
+        <location filename="../app/MainLayout.qml" line="804"/>
         <source>Start</source>
         <translation>Starten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="896" />
+        <location filename="../app/MainLayout.qml" line="973"/>
         <source>Scroll</source>
         <translation>Scrollen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="613" />
-        <location filename="../app/MainLayout.qml" line="685" />
-        <location filename="../app/MainLayout.qml" line="700" />
-        <location filename="../app/MainLayout.qml" line="743" />
-        <location filename="../app/MainLayout.qml" line="772" />
-        <location filename="../app/MainLayout.qml" line="819" />
-        <location filename="../app/MainLayout.qml" line="860" />
-        <location filename="../app/MainLayout.qml" line="924" />
+        <location filename="../app/MainLayout.qml" line="705"/>
+        <location filename="../app/MainLayout.qml" line="777"/>
+        <location filename="../app/MainLayout.qml" line="820"/>
+        <location filename="../app/MainLayout.qml" line="849"/>
+        <location filename="../app/MainLayout.qml" line="896"/>
+        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="1001"/>
         <source>Move</source>
         <translation>Bewegen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="747" />
-        <location filename="../app/MainLayout.qml" line="782" />
-        <location filename="../app/MainLayout.qml" line="829" />
-        <location filename="../app/MainLayout.qml" line="934" />
+        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="859"/>
+        <location filename="../app/MainLayout.qml" line="906"/>
+        <location filename="../app/MainLayout.qml" line="1011"/>
         <source>Open</source>
         <translation>Openen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="751" />
+        <location filename="../app/MainLayout.qml" line="828"/>
         <source>Quit</source>
         <translation>Afsluiten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="760" />
-        <location filename="../app/MainLayout.qml" line="788" />
-        <location filename="../app/MainLayout.qml" line="799" />
-        <location filename="../app/MainLayout.qml" line="811" />
-        <location filename="../app/MainLayout.qml" line="838" />
-        <location filename="../app/MainLayout.qml" line="849" />
-        <location filename="../app/MainLayout.qml" line="884" />
-        <location filename="../app/MainLayout.qml" line="900" />
-        <location filename="../app/MainLayout.qml" line="909" />
-        <location filename="../app/MainLayout.qml" line="943" />
-        <location filename="../app/MainLayout.qml" line="954" />
+        <location filename="../app/MainLayout.qml" line="837"/>
+        <location filename="../app/MainLayout.qml" line="865"/>
+        <location filename="../app/MainLayout.qml" line="876"/>
+        <location filename="../app/MainLayout.qml" line="888"/>
+        <location filename="../app/MainLayout.qml" line="915"/>
+        <location filename="../app/MainLayout.qml" line="926"/>
+        <location filename="../app/MainLayout.qml" line="961"/>
+        <location filename="../app/MainLayout.qml" line="977"/>
+        <location filename="../app/MainLayout.qml" line="986"/>
+        <location filename="../app/MainLayout.qml" line="1020"/>
+        <location filename="../app/MainLayout.qml" line="1031"/>
         <source>Back</source>
         <translation>Terug</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="778" />
-        <location filename="../app/MainLayout.qml" line="825" />
-        <location filename="../app/MainLayout.qml" line="930" />
+        <location filename="../app/MainLayout.qml" line="855"/>
+        <location filename="../app/MainLayout.qml" line="902"/>
+        <location filename="../app/MainLayout.qml" line="1007"/>
         <source>Page</source>
         <translation>Pagina</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="785" />
-        <location filename="../app/MainLayout.qml" line="834" />
-        <location filename="../app/MainLayout.qml" line="939" />
+        <location filename="../app/MainLayout.qml" line="862"/>
+        <location filename="../app/MainLayout.qml" line="911"/>
+        <location filename="../app/MainLayout.qml" line="1016"/>
         <source>Options</source>
         <translation>Opties</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="659" />
-        <location filename="../app/MainLayout.qml" line="795" />
-        <location filename="../app/MainLayout.qml" line="845" />
-        <location filename="../app/MainLayout.qml" line="950" />
+        <location filename="../app/MainLayout.qml" line="751"/>
+        <location filename="../app/MainLayout.qml" line="872"/>
+        <location filename="../app/MainLayout.qml" line="922"/>
+        <location filename="../app/MainLayout.qml" line="1027"/>
         <source>Retry</source>
         <translation>Opnieuw proberen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="869" />
+        <location filename="../app/MainLayout.qml" line="946"/>
         <source>Change</source>
         <translation>Wijzigen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="875" />
+        <location filename="../app/MainLayout.qml" line="952"/>
         <source>Toggle</source>
         <translation>Schakelen</translation>
     </message>
@@ -558,22 +639,22 @@
 <context>
     <name>Modal</name>
     <message>
-        <location filename="../components/Modal.qml" line="49" />
+        <location filename="../components/Modal.qml" line="49"/>
         <source>OK</source>
         <translation>Akkoord</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="50" />
+        <location filename="../components/Modal.qml" line="50"/>
         <source>Yes</source>
         <translation>Ja</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="51" />
+        <location filename="../components/Modal.qml" line="51"/>
         <source>No</source>
         <translation>Nee</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="198" />
+        <location filename="../components/Modal.qml" line="198"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
@@ -581,22 +662,22 @@
 <context>
     <name>RecentsScreen</name>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="183" />
+        <location filename="../screens/RecentsScreen.qml" line="184"/>
         <source>Recently Played</source>
         <translation>Recent gespeeld</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="186" />
+        <location filename="../screens/RecentsScreen.qml" line="187"/>
         <source>%1 entries</source>
         <translation>%1 items</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="282" />
+        <location filename="../screens/RecentsScreen.qml" line="312"/>
         <source>Loading recently played…</source>
         <translation>Recent gespeeld laden…</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="281" />
+        <location filename="../screens/RecentsScreen.qml" line="311"/>
         <source>Nothing played yet</source>
         <translation>Nog niets gespeeld</translation>
     </message>
@@ -604,17 +685,17 @@
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="26" />
+        <location filename="../components/ScreenStateOverlay.qml" line="26"/>
         <source>Nothing here</source>
         <translation>Niets hier</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27" />
+        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
         <source>Loading…</source>
         <translation>Laden…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="57" />
+        <location filename="../components/ScreenStateOverlay.qml" line="57"/>
         <source>Failed to load</source>
         <translation>Laden mislukt</translation>
     </message>
@@ -622,288 +703,294 @@
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78" />
-        <location filename="../screens/SettingsScreen.qml" line="436" />
+        <location filename="../screens/SettingsScreen.qml" line="73"/>
+        <location filename="../screens/SettingsScreen.qml" line="432"/>
         <source>Language</source>
         <translation>Taal</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83" />
-        <location filename="../screens/SettingsScreen.qml" line="445" />
+        <location filename="../screens/SettingsScreen.qml" line="78"/>
+        <location filename="../screens/SettingsScreen.qml" line="441"/>
         <source>Browsing layout</source>
         <translation>Bladerlayout</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116" />
+        <location filename="../screens/SettingsScreen.qml" line="116"/>
         <source>Mouse support</source>
         <translation>Muisondersteuning</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102" />
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
         <source>Update media database</source>
         <translation>Mediadatabase bijwerken</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="61" />
+        <location filename="../screens/SettingsScreen.qml" line="61"/>
         <source>General</source>
         <translation>Algemeen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88" />
-        <location filename="../screens/SettingsScreen.qml" line="454" />
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="450"/>
         <source>Button style</source>
         <translation>Knopstijl</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="93" />
-        <location filename="../screens/SettingsScreen.qml" line="463" />
+        <location filename="../screens/SettingsScreen.qml" line="88"/>
+        <location filename="../screens/SettingsScreen.qml" line="459"/>
         <source>Screensaver</source>
         <translation>Schermbeveiliging</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97" />
+        <location filename="../screens/SettingsScreen.qml" line="92"/>
         <source>Library</source>
         <translation>Bibliotheek</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="107" />
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <source>Discover arcade alternate versions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="107"/>
         <source>Scrape metadata</source>
         <translation>Metadata ophalen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111" />
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
         <source>Advanced</source>
         <translation>Geavanceerd</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121" />
+        <location filename="../screens/SettingsScreen.qml" line="121"/>
         <source>Debug logging</source>
         <translation>Debug-logging</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126" />
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Upload log file</source>
         <translation>Logbestand uploaden</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131" />
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
         <source>About / License</source>
         <translation>Over / Licentie</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147" />
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
         <source>Optimizing</source>
         <translation>Optimaliseren</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149" />
-        <location filename="../screens/SettingsScreen.qml" line="158" />
+        <location filename="../screens/SettingsScreen.qml" line="149"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
         <source>Paused</source>
         <translation>Gepauzeerd</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149" />
-        <location filename="../screens/SettingsScreen.qml" line="158" />
+        <location filename="../screens/SettingsScreen.qml" line="149"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
         <source>In progress</source>
         <translation>Bezig</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152" />
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>%1 indexed</source>
         <translation>%1 geïndexeerd</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="161" />
+        <location filename="../screens/SettingsScreen.qml" line="161"/>
         <source>%1 scraped</source>
         <translation>%1 opgehaald</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270" />
+        <location filename="../screens/SettingsScreen.qml" line="266"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270" />
+        <location filename="../screens/SettingsScreen.qml" line="266"/>
         <source>Start</source>
         <translation>Starten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="272" />
+        <location filename="../screens/SettingsScreen.qml" line="268"/>
         <source>Upload</source>
         <translation>Uploaden</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="274" />
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
         <source>Open</source>
         <translation>Openen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="346" />
+        <location filename="../screens/SettingsScreen.qml" line="342"/>
         <source>English</source>
         <translation>Engels</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="348" />
+        <location filename="../screens/SettingsScreen.qml" line="344"/>
         <source>Italian</source>
         <translation>Italiaans</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="350" />
+        <location filename="../screens/SettingsScreen.qml" line="346"/>
         <source>German</source>
         <translation>Duits</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="352" />
+        <location filename="../screens/SettingsScreen.qml" line="348"/>
         <source>Greek</source>
         <translation>Grieks</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="354" />
+        <location filename="../screens/SettingsScreen.qml" line="350"/>
         <source>Japanese</source>
         <translation>Japans</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="356" />
+        <location filename="../screens/SettingsScreen.qml" line="352"/>
         <source>Korean</source>
         <translation>Koreaans</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="358" />
+        <location filename="../screens/SettingsScreen.qml" line="354"/>
         <source>Dutch</source>
         <translation>Nederlands</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="360" />
+        <location filename="../screens/SettingsScreen.qml" line="356"/>
         <source>Romanian</source>
         <translation>Roemeens</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="362" />
+        <location filename="../screens/SettingsScreen.qml" line="358"/>
         <source>Slovak</source>
         <translation>Slowaaks</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="364" />
+        <location filename="../screens/SettingsScreen.qml" line="360"/>
         <source>Ukrainian</source>
         <translation>Oekraïens</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="366" />
+        <location filename="../screens/SettingsScreen.qml" line="362"/>
         <source>Chinese (Simplified)</source>
         <translation>Chinees (vereenvoudigd)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="368" />
+        <location filename="../screens/SettingsScreen.qml" line="364"/>
         <source>Hebrew</source>
         <translation>Hebreeuws</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="370" />
+        <location filename="../screens/SettingsScreen.qml" line="366"/>
         <source>Arabic</source>
-        <translation type="unfinished" />
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="372" />
+        <location filename="../screens/SettingsScreen.qml" line="368"/>
         <source>Hindi</source>
-        <translation type="unfinished" />
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="373" />
+        <location filename="../screens/SettingsScreen.qml" line="369"/>
         <source>Auto</source>
         <translation>Automatisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="378" />
+        <location filename="../screens/SettingsScreen.qml" line="374"/>
         <source>Detailed list view</source>
         <translation>Gedetailleerde lijstweergave</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="379" />
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Grid view</source>
         <translation>Rasterweergave</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="384" />
+        <location filename="../screens/SettingsScreen.qml" line="380"/>
         <source>Style B</source>
         <translation>Stijl B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="386" />
+        <location filename="../screens/SettingsScreen.qml" line="382"/>
         <source>Style C</source>
         <translation>Stijl C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="388" />
+        <location filename="../screens/SettingsScreen.qml" line="384"/>
         <source>Style D</source>
         <translation>Stijl D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="389" />
+        <location filename="../screens/SettingsScreen.qml" line="385"/>
         <source>Style A</source>
         <translation>Stijl A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="326" />
+        <location filename="../screens/SettingsScreen.qml" line="322"/>
         <source>Default</source>
         <translation>Standaard</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399" />
+        <location filename="../screens/SettingsScreen.qml" line="395"/>
         <source>Off</source>
         <translation>Uit</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="401" />
+        <location filename="../screens/SettingsScreen.qml" line="397"/>
         <source>1 second (testing)</source>
         <translation>1 seconde (test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="403" />
+        <location filename="../screens/SettingsScreen.qml" line="399"/>
         <source>1 minute</source>
         <translation>1 minuut</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405" />
+        <location filename="../screens/SettingsScreen.qml" line="401"/>
         <source>2 minutes</source>
         <translation>2 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="407" />
+        <location filename="../screens/SettingsScreen.qml" line="403"/>
         <source>5 minutes</source>
         <translation>5 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="409" />
+        <location filename="../screens/SettingsScreen.qml" line="405"/>
         <source>10 minutes</source>
         <translation>10 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="411" />
+        <location filename="../screens/SettingsScreen.qml" line="407"/>
         <source>15 minutes</source>
         <translation>15 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="413" />
+        <location filename="../screens/SettingsScreen.qml" line="409"/>
         <source>30 minutes</source>
         <translation>30 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="414" />
+        <location filename="../screens/SettingsScreen.qml" line="410"/>
         <source>%1 seconds</source>
         <translation>%1 seconden</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="427" />
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="423"/>
         <source>Resolution</source>
         <translation>Resolutie</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="555" />
+        <location filename="../screens/SettingsScreen.qml" line="563"/>
         <source>Settings</source>
         <translation>Instellingen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="745" />
+        <location filename="../screens/SettingsScreen.qml" line="755"/>
         <source>No settings available on this platform</source>
         <translation>Geen instellingen beschikbaar op dit platform</translation>
     </message>
@@ -911,17 +998,23 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="182" />
+        <location filename="../screens/SystemsScreen.qml" line="185"/>
+        <location filename="../screens/SystemsScreen.qml" line="313"/>
         <source>%1 systems</source>
         <translation>%1 systemen</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="279" />
+        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SystemsScreen.qml" line="345"/>
         <source>No systems in this category</source>
         <translation>Geen systemen in deze categorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="280" />
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>
@@ -929,7 +1022,7 @@
 <context>
     <name>TopStatusStrip</name>
     <message>
-        <location filename="../components/TopStatusStrip.qml" line="88" />
+        <location filename="../components/TopStatusStrip.qml" line="90"/>
         <source>Page %1 / %2</source>
         <translation>Pagina %1 / %2</translation>
     </message>

--- a/src/ui/translations/launcher_nl.ts
+++ b/src/ui/translations/launcher_nl.ts
@@ -90,38 +90,48 @@
         <translation type="unfinished">Laden…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="43"/>
+        <location filename="../components/BrowseDetailPane.qml" line="44"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="45"/>
+        <location filename="../components/BrowseDetailPane.qml" line="46"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <location filename="../components/BrowseDetailPane.qml" line="48"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <location filename="../components/BrowseDetailPane.qml" line="50"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <location filename="../components/BrowseDetailPane.qml" line="52"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <location filename="../components/BrowseDetailPane.qml" line="54"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="55"/>
-        <source>Filename</source>
+        <location filename="../components/BrowseDetailPane.qml" line="56"/>
+        <source>Category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="58"/>
+        <source>Release date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="60"/>
+        <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -245,12 +255,17 @@
         <translation>%1 items</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="309"/>
+        <location filename="../screens/FavoritesScreen.qml" line="190"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/FavoritesScreen.qml" line="280"/>
         <source>No favorites yet</source>
         <translation>Nog geen favorieten</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="310"/>
+        <location filename="../screens/FavoritesScreen.qml" line="281"/>
         <source>Loading favorites…</source>
         <translation>Favorieten laden…</translation>
     </message>
@@ -324,33 +339,35 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="367"/>
-        <location filename="../screens/GamesScreen.qml" line="537"/>
+        <location filename="../screens/GamesScreen.qml" line="373"/>
+        <location filename="../screens/GamesScreen.qml" line="520"/>
         <source>%1 files</source>
         <translation>%1 bestanden</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="437"/>
+        <location filename="../screens/GamesScreen.qml" line="409"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="554"/>
+        <location filename="../screens/GamesScreen.qml" line="382"/>
+        <location filename="../screens/GamesScreen.qml" line="537"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="570"/>
+        <location filename="../screens/GamesScreen.qml" line="553"/>
         <source>Loading games…</source>
         <translation>Games laden…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="592"/>
+        <location filename="../screens/GamesScreen.qml" line="378"/>
+        <location filename="../screens/GamesScreen.qml" line="575"/>
         <source>Loading more…</source>
         <translation>Meer laden…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="569"/>
+        <location filename="../screens/GamesScreen.qml" line="552"/>
         <source>No games in this system</source>
         <translation>Geen games in dit systeem</translation>
     </message>
@@ -672,12 +689,17 @@
         <translation>%1 items</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="312"/>
+        <location filename="../screens/RecentsScreen.qml" line="191"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/RecentsScreen.qml" line="283"/>
         <source>Loading recently played…</source>
         <translation>Recent gespeeld laden…</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="311"/>
+        <location filename="../screens/RecentsScreen.qml" line="282"/>
         <source>Nothing played yet</source>
         <translation>Nog niets gespeeld</translation>
     </message>
@@ -999,22 +1021,23 @@
     <name>SystemsScreen</name>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="185"/>
-        <location filename="../screens/SystemsScreen.qml" line="313"/>
+        <location filename="../screens/SystemsScreen.qml" line="285"/>
         <source>%1 systems</source>
         <translation>%1 systemen</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <location filename="../screens/SystemsScreen.qml" line="189"/>
+        <location filename="../screens/SystemsScreen.qml" line="302"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="345"/>
+        <location filename="../screens/SystemsScreen.qml" line="317"/>
         <source>No systems in this category</source>
         <translation>Geen systemen in deze categorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="318"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>
@@ -1022,7 +1045,7 @@
 <context>
     <name>TopStatusStrip</name>
     <message>
-        <location filename="../components/TopStatusStrip.qml" line="90"/>
+        <location filename="../components/TopStatusStrip.qml" line="91"/>
         <source>Page %1 / %2</source>
         <translation>Pagina %1 / %2</translation>
     </message>

--- a/src/ui/translations/launcher_nl.ts
+++ b/src/ui/translations/launcher_nl.ts
@@ -245,27 +245,27 @@
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="183"/>
+        <location filename="../screens/FavoritesScreen.qml" line="225"/>
         <source>Favorites</source>
         <translation>Favorieten</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="186"/>
+        <location filename="../screens/FavoritesScreen.qml" line="228"/>
         <source>%1 entries</source>
         <translation>%1 items</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="190"/>
+        <location filename="../screens/FavoritesScreen.qml" line="232"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="280"/>
+        <location filename="../screens/FavoritesScreen.qml" line="334"/>
         <source>No favorites yet</source>
         <translation>Nog geen favorieten</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="281"/>
+        <location filename="../screens/FavoritesScreen.qml" line="335"/>
         <source>Loading favorites…</source>
         <translation>Favorieten laden…</translation>
     </message>
@@ -326,13 +326,13 @@
 <context>
     <name>GameInfoModal</name>
     <message>
-        <location filename="../components/GameInfoModal.qml" line="86"/>
-        <source>Back to close</source>
+        <location filename="../components/GameInfoModal.qml" line="104"/>
+        <source>Loading details…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/GameInfoModal.qml" line="114"/>
-        <source>Loading details…</source>
+        <location filename="../components/GameInfoModal.qml" line="174"/>
+        <source>Loading image…</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -444,12 +444,6 @@
         <translation>Core starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="781"/>
-        <source>More info</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../app/Main.qml" line="785"/>
         <source>Remove from favorites</source>
         <translation>Uit favorieten verwijderen</translation>
@@ -474,6 +468,12 @@
         <location filename="../app/Main.qml" line="804"/>
         <source>Launch game</source>
         <translation>Game starten</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="761"/>
+        <location filename="../app/Main.qml" line="781"/>
+        <source>View details</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1652"/>
@@ -679,27 +679,27 @@
 <context>
     <name>RecentsScreen</name>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="184"/>
+        <location filename="../screens/RecentsScreen.qml" line="226"/>
         <source>Recently Played</source>
         <translation>Recent gespeeld</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="187"/>
+        <location filename="../screens/RecentsScreen.qml" line="229"/>
         <source>%1 entries</source>
         <translation>%1 items</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="191"/>
+        <location filename="../screens/RecentsScreen.qml" line="233"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="283"/>
+        <location filename="../screens/RecentsScreen.qml" line="337"/>
         <source>Loading recently played…</source>
         <translation>Recent gespeeld laden…</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="282"/>
+        <location filename="../screens/RecentsScreen.qml" line="336"/>
         <source>Nothing played yet</source>
         <translation>Nog niets gespeeld</translation>
     </message>

--- a/src/ui/translations/launcher_ro.ts
+++ b/src/ui/translations/launcher_ro.ts
@@ -1,59 +1,60 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
 <TS version="2.1" language="ro" sourcelanguage="en">
 <context>
     <name>AboutScreen</name>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="72" />
+        <location filename="../screens/AboutScreen.qml" line="71"/>
         <source>About / License</source>
         <translation>Despre / Licență</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="154" />
+        <location filename="../screens/AboutScreen.qml" line="153"/>
         <source>Zaparoo Launcher</source>
         <translation>Lansator Zaparoo</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="165" />
+        <location filename="../screens/AboutScreen.qml" line="164"/>
         <source>Version %1 · %2 · %3</source>
         <translation>Versiune %1 · %2 · %3</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="178" />
+        <location filename="../screens/AboutScreen.qml" line="174"/>
         <source>Built %1</source>
         <translation>Compilat %1</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="189" />
+        <location filename="../screens/AboutScreen.qml" line="185"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>Copyright 2026 Wizzo Pty Ltd și colaboratorii proiectului Zaparoo.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="200" />
+        <location filename="../screens/AboutScreen.qml" line="196"/>
         <source>Source available under the PolyForm Noncommercial License 1.0.0. Free for personal, non-commercial use. Commercial use or redistribution requires a separate license.</source>
         <translation>Sursa este disponibilă sub licența PolyForm Noncommercial License 1.0.0. Gratuit pentru uz personal, necomercial. Utilizarea comercială sau redistribuirea necesită o licență separată.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="211" />
+        <location filename="../screens/AboutScreen.qml" line="207"/>
         <source>Commercial licensing: legal@zaparoo.org</source>
         <translation>Licențiere comercială: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="222" />
+        <location filename="../screens/AboutScreen.qml" line="218"/>
         <source>Project: https://zaparoo.org</source>
         <translation>Proiect: https://zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="232" />
+        <location filename="../screens/AboutScreen.qml" line="228"/>
         <source>Created by</source>
         <translation>Creat de</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="256" />
+        <location filename="../screens/AboutScreen.qml" line="252"/>
         <source>Translations</source>
         <translation>Traduceri</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="280" />
+        <location filename="../screens/AboutScreen.qml" line="276"/>
         <source>Full license text in COPYING.</source>
         <translation>Textul complet al licenței se găsește în COPYING.</translation>
     </message>
@@ -61,60 +62,103 @@
 <context>
     <name>BootOverlay</name>
     <message>
-        <location filename="../components/BootOverlay.qml" line="76" />
-        <source>Can't reach Zaparoo Core. Check your connection.</source>
+        <location filename="../components/BootOverlay.qml" line="76"/>
+        <source>Can&apos;t reach Zaparoo Core. Check your connection.</source>
         <translation>Nu se poate accesa Zaparoo Core. Verificați conexiunea.</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="78" />
+        <location filename="../components/BootOverlay.qml" line="78"/>
         <source>Reconnecting…</source>
         <translation>Reconectare…</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="80" />
+        <location filename="../components/BootOverlay.qml" line="80"/>
         <source>Loading library…</source>
         <translation>Se încarcă biblioteca…</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="85" />
+        <location filename="../components/BootOverlay.qml" line="85"/>
         <source>Connecting to Zaparoo Core…</source>
         <translation>Conectare la Zaparoo Core…</translation>
     </message>
 </context>
 <context>
+    <name>BrowseDetailPane</name>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="22"/>
+        <source>Loading…</source>
+        <translation type="unfinished">Se încarcă…</translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="43"/>
+        <source>Year</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="45"/>
+        <source>Genre</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <source>Players</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <source>Developer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <source>Publisher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <source>Rating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="55"/>
+        <source>Filename</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommercialNoticeModal</name>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="59" />
+        <location filename="../components/CommercialNoticeModal.qml" line="59"/>
         <source>Welcome to Zaparoo Launcher</source>
         <translation>Bun venit în Zaparoo Launcher</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="68" />
+        <location filename="../components/CommercialNoticeModal.qml" line="68"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>Copyright 2026 Wizzo Pty Ltd și colaboratorii proiectului Zaparoo.</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="79" />
+        <location filename="../components/CommercialNoticeModal.qml" line="79"/>
         <source>This free source-available build is for personal and non-commercial use only. Commercial use or redistribution requires a license.</source>
         <translation>Această versiune gratuită cu sursă disponibilă este destinată exclusiv utilizării personale și necomerciale. Utilizarea comercială sau redistribuirea necesită o licență.</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="90" />
+        <location filename="../components/CommercialNoticeModal.qml" line="90"/>
         <source>Contact: legal@zaparoo.org</source>
         <translation>Contactați: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="101" />
+        <location filename="../components/CommercialNoticeModal.qml" line="101"/>
         <source>Full details available any time under Settings &gt; About / License.</source>
         <translation>Detalii complete disponibile oricând la Setări &gt; Despre / Licență.</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="119" />
+        <location filename="../components/CommercialNoticeModal.qml" line="119"/>
         <source>Created by</source>
         <translation>Creat de</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="162" />
+        <location filename="../components/CommercialNoticeModal.qml" line="162"/>
         <source>I understand</source>
         <translation>Am înțeles</translation>
     </message>
@@ -122,68 +166,68 @@
 <context>
     <name>CoreStatusPill</name>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="44" />
-        <location filename="../components/CoreStatusPill.qml" line="50" />
+        <location filename="../components/CoreStatusPill.qml" line="44"/>
+        <location filename="../components/CoreStatusPill.qml" line="50"/>
         <source>Disconnected</source>
         <translation>Deconectat</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="47" />
+        <location filename="../components/CoreStatusPill.qml" line="47"/>
         <source>Reconnecting…</source>
         <translation>Reconectare…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="53" />
+        <location filename="../components/CoreStatusPill.qml" line="53"/>
         <source>Connecting…</source>
         <translation>Conectare…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="56" />
+        <location filename="../components/CoreStatusPill.qml" line="56"/>
         <source>Core error</source>
         <translation>Eroare Core</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="60" />
+        <location filename="../components/CoreStatusPill.qml" line="60"/>
         <source>Optimizing database</source>
         <translation>Optimizare bază de date</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="67" />
+        <location filename="../components/CoreStatusPill.qml" line="67"/>
         <source>Indexing paused</source>
         <translation>Indexare în pauză</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="70" />
+        <location filename="../components/CoreStatusPill.qml" line="70"/>
         <source>Indexing %1/%2 - %3</source>
         <translation>Indexare %1/%2 – %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="86" />
+        <location filename="../components/CoreStatusPill.qml" line="86"/>
         <source>Scraping %1/%2 - %3</source>
         <translation>Scraping %1/%2 – %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="73" />
+        <location filename="../components/CoreStatusPill.qml" line="73"/>
         <source>Indexing %1/%2</source>
         <translation>Indexare %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="75" />
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
         <source>Indexing…</source>
         <translation>Indexare…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="83" />
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Scrape paused</source>
         <translation>Scraping în pauză</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="89" />
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
         <source>Scraping %1/%2</source>
         <translation>Preluare %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="91" />
+        <location filename="../components/CoreStatusPill.qml" line="91"/>
         <source>Scraping…</source>
         <translation>Se preiau datele…</translation>
     </message>
@@ -191,22 +235,22 @@
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="182" />
+        <location filename="../screens/FavoritesScreen.qml" line="183"/>
         <source>Favorites</source>
         <translation>Favorite</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="185" />
+        <location filename="../screens/FavoritesScreen.qml" line="186"/>
         <source>%1 entries</source>
         <translation>%1 intrări</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="283" />
+        <location filename="../screens/FavoritesScreen.qml" line="309"/>
         <source>No favorites yet</source>
         <translation>Nicio intrare la favorite</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="284" />
+        <location filename="../screens/FavoritesScreen.qml" line="310"/>
         <source>Loading favorites…</source>
         <translation>Se încarcă favoritele…</translation>
     </message>
@@ -214,75 +258,99 @@
 <context>
     <name>FirstRunIndexModal</name>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="127" />
+        <location filename="../components/FirstRunIndexModal.qml" line="127"/>
         <source>First-time setup</source>
         <translation>Configurare inițială</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="136" />
+        <location filename="../components/FirstRunIndexModal.qml" line="136"/>
         <source>Zaparoo needs to scan your games before you can use the launcher. This usually takes a few minutes.</source>
         <translation>Zaparoo trebuie să scaneze jocurile înainte de a putea folosi launcher-ul. Aceasta durează de obicei câteva minute.</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="211" />
+        <location filename="../components/FirstRunIndexModal.qml" line="211"/>
         <source>Indexing paused</source>
         <translation>Indexare în pauză</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="158" />
+        <location filename="../components/FirstRunIndexModal.qml" line="158"/>
         <source>Optimizing database - almost done</source>
         <translation>Optimizare bază de date – aproape gata</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="213" />
+        <location filename="../components/FirstRunIndexModal.qml" line="213"/>
         <source>Step %1 of %2 - %3</source>
         <translation>Pasul %1 din %2 – %3</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="215" />
+        <location filename="../components/FirstRunIndexModal.qml" line="215"/>
         <source>Step %1 of %2</source>
         <translation>Pasul %1 din %2</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="216" />
+        <location filename="../components/FirstRunIndexModal.qml" line="216"/>
         <source>Preparing…</source>
         <translation>Pregătire…</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="233" />
+        <location filename="../components/FirstRunIndexModal.qml" line="233"/>
         <source>Done. %1 files indexed.</source>
         <translation>Gata. %1 fișiere indexate.</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="263" />
+        <location filename="../components/FirstRunIndexModal.qml" line="263"/>
         <source>Cancel</source>
         <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="263" />
+        <location filename="../components/FirstRunIndexModal.qml" line="263"/>
         <source>Start scan</source>
         <translation>Pornire scanare</translation>
     </message>
 </context>
 <context>
+    <name>GameInfoModal</name>
+    <message>
+        <location filename="../components/GameInfoModal.qml" line="86"/>
+        <source>Back to close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/GameInfoModal.qml" line="114"/>
+        <source>Loading details…</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="363" />
+        <location filename="../screens/GamesScreen.qml" line="367"/>
+        <location filename="../screens/GamesScreen.qml" line="537"/>
         <source>%1 files</source>
         <translation>%1 fișiere</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="534" />
+        <location filename="../screens/GamesScreen.qml" line="437"/>
+        <source>Loading game…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/GamesScreen.qml" line="554"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/GamesScreen.qml" line="570"/>
         <source>Loading games…</source>
         <translation>Se încarcă jocurile…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="556" />
+        <location filename="../screens/GamesScreen.qml" line="592"/>
         <source>Loading more…</source>
         <translation>Se încarcă mai multe…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="533" />
+        <location filename="../screens/GamesScreen.qml" line="569"/>
         <source>No games in this system</source>
         <translation>Niciun joc în acest sistem</translation>
     </message>
@@ -290,22 +358,22 @@
 <context>
     <name>HubScreen</name>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91" />
+        <location filename="../screens/HubScreen.qml" line="91"/>
         <source>Favorites</source>
         <translation>Favorite</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="96" />
+        <location filename="../screens/HubScreen.qml" line="96"/>
         <source>Recently Played</source>
         <translation>Recent Jucate</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="101" />
+        <location filename="../screens/HubScreen.qml" line="101"/>
         <source>Settings</source>
         <translation>Setări</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="537" />
+        <location filename="../screens/HubScreen.qml" line="537"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Niciun sistem disponibil. Rulați Actualizare bază de date din Setări.</translation>
     </message>
@@ -313,7 +381,7 @@
 <context>
     <name>LoadingIndicator</name>
     <message>
-        <location filename="../components/LoadingIndicator.qml" line="26" />
+        <location filename="../components/LoadingIndicator.qml" line="26"/>
         <source>Loading…</source>
         <translation>Se încarcă…</translation>
     </message>
@@ -321,32 +389,32 @@
 <context>
     <name>LogUploadModal</name>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="87" />
+        <location filename="../components/LogUploadModal.qml" line="87"/>
         <source>Upload log file</source>
         <translation>Încărcare fișier jurnal</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="97" />
+        <location filename="../components/LogUploadModal.qml" line="97"/>
         <source>Uploading log file - this may take a moment.</source>
         <translation>Se încarcă fișierul jurnal – poate dura puțin.</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197" />
+        <location filename="../components/LogUploadModal.qml" line="197"/>
         <source>Upload failed: %1</source>
         <translation>Încărcare eșuată: %1</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197" />
+        <location filename="../components/LogUploadModal.qml" line="197"/>
         <source>Upload failed.</source>
         <translation>Încărcare eșuată.</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="227" />
+        <location filename="../components/LogUploadModal.qml" line="227"/>
         <source>Retry</source>
         <translation>Reîncercare</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="227" />
+        <location filename="../components/LogUploadModal.qml" line="227"/>
         <source>Done</source>
         <translation>Gata</translation>
     </message>
@@ -354,58 +422,64 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="723" />
+        <location filename="../app/Main.qml" line="753"/>
         <source>Launch core</source>
         <translation>Lansare core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="741" />
+        <location filename="../app/Main.qml" line="761"/>
+        <location filename="../app/Main.qml" line="781"/>
+        <source>More info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="785"/>
         <source>Remove from favorites</source>
         <translation>Elimină din favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="741" />
+        <location filename="../app/Main.qml" line="785"/>
         <source>Add to favorites</source>
         <translation>Adaugă la favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="747" />
+        <location filename="../app/Main.qml" line="790"/>
         <source>Write to NFC token</source>
         <translation>Scriere pe token NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="751" />
+        <location filename="../app/Main.qml" line="794"/>
         <source>QR code</source>
         <translation>Cod QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="731" />
-        <location filename="../app/Main.qml" line="755" />
+        <location filename="../app/Main.qml" line="765"/>
+        <location filename="../app/Main.qml" line="804"/>
         <source>Launch game</source>
         <translation>Lansare joc</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1437" />
+        <location filename="../app/Main.qml" line="1652"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1441" />
+        <location filename="../app/Main.qml" line="1656"/>
         <source>Loading favorites…</source>
         <translation>Se încarcă favoritele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1439" />
+        <location filename="../app/Main.qml" line="1654"/>
         <source>Loading games…</source>
         <translation>Se încarcă jocurile…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1443" />
+        <location filename="../app/Main.qml" line="1658"/>
         <source>Loading recently played…</source>
         <translation>Se încarcă recent jucatele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1445" />
+        <location filename="../app/Main.qml" line="1660"/>
         <source>Loading…</source>
         <translation>Se încarcă…</translation>
     </message>
@@ -413,144 +487,151 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="127" />
+        <location filename="../app/MainLayout.qml" line="141"/>
         <source>Zaparoo Launcher</source>
         <translation>Lansator Zaparoo</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="475" />
+        <location filename="../app/MainLayout.qml" line="545"/>
         <source>Writing failed</source>
         <translation>Scriere eșuată</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="475" />
+        <location filename="../app/MainLayout.qml" line="545"/>
         <source>Put a writable card near the reader</source>
         <translation>Apropiați un card inscriptibil de cititor</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="540" />
+        <location filename="../app/MainLayout.qml" line="556"/>
+        <source>Quit and restart Zaparoo Launcher?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="557"/>
+        <source>In order to apply this setting we need to restart the launcher.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="632"/>
         <source>Quit Zaparoo Launcher?</source>
         <translation>Ieșire din Zaparoo Launcher?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="541" />
+        <location filename="../app/MainLayout.qml" line="633"/>
         <source>Are you sure you want to exit?</source>
         <translation>Sigur doriți să ieșiți?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="617" />
-        <location filename="../app/MainLayout.qml" line="689" />
-        <location filename="../app/MainLayout.qml" line="704" />
+        <location filename="../app/MainLayout.qml" line="709"/>
+        <location filename="../app/MainLayout.qml" line="781"/>
         <source>Select</source>
         <translation>Selectare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="621" />
-        <location filename="../app/MainLayout.qml" line="625" />
-        <location filename="../app/MainLayout.qml" line="639" />
-        <location filename="../app/MainLayout.qml" line="652" />
-        <location filename="../app/MainLayout.qml" line="663" />
+        <location filename="../app/MainLayout.qml" line="713"/>
+        <location filename="../app/MainLayout.qml" line="717"/>
+        <location filename="../app/MainLayout.qml" line="731"/>
+        <location filename="../app/MainLayout.qml" line="744"/>
+        <location filename="../app/MainLayout.qml" line="755"/>
         <source>Close</source>
         <translation>Închidere</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="632" />
-        <location filename="../app/MainLayout.qml" line="670" />
-        <location filename="../app/MainLayout.qml" line="693" />
-        <location filename="../app/MainLayout.qml" line="708" />
-        <location filename="../app/MainLayout.qml" line="719" />
+        <location filename="../app/MainLayout.qml" line="724"/>
+        <location filename="../app/MainLayout.qml" line="762"/>
+        <location filename="../app/MainLayout.qml" line="785"/>
+        <location filename="../app/MainLayout.qml" line="796"/>
         <source>Cancel</source>
         <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="648" />
+        <location filename="../app/MainLayout.qml" line="740"/>
         <source>Done</source>
         <translation>Gata</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="678" />
+        <location filename="../app/MainLayout.qml" line="770"/>
         <source>I understand</source>
         <translation>Am înțeles</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="727" />
+        <location filename="../app/MainLayout.qml" line="804"/>
         <source>Start</source>
         <translation>Pornire</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="896" />
+        <location filename="../app/MainLayout.qml" line="973"/>
         <source>Scroll</source>
         <translation>Derulare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="613" />
-        <location filename="../app/MainLayout.qml" line="685" />
-        <location filename="../app/MainLayout.qml" line="700" />
-        <location filename="../app/MainLayout.qml" line="743" />
-        <location filename="../app/MainLayout.qml" line="772" />
-        <location filename="../app/MainLayout.qml" line="819" />
-        <location filename="../app/MainLayout.qml" line="860" />
-        <location filename="../app/MainLayout.qml" line="924" />
+        <location filename="../app/MainLayout.qml" line="705"/>
+        <location filename="../app/MainLayout.qml" line="777"/>
+        <location filename="../app/MainLayout.qml" line="820"/>
+        <location filename="../app/MainLayout.qml" line="849"/>
+        <location filename="../app/MainLayout.qml" line="896"/>
+        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="1001"/>
         <source>Move</source>
         <translation>Mutare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="747" />
-        <location filename="../app/MainLayout.qml" line="782" />
-        <location filename="../app/MainLayout.qml" line="829" />
-        <location filename="../app/MainLayout.qml" line="934" />
+        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="859"/>
+        <location filename="../app/MainLayout.qml" line="906"/>
+        <location filename="../app/MainLayout.qml" line="1011"/>
         <source>Open</source>
         <translation>Deschidere</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="751" />
+        <location filename="../app/MainLayout.qml" line="828"/>
         <source>Quit</source>
         <translation>Ieșire</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="760" />
-        <location filename="../app/MainLayout.qml" line="788" />
-        <location filename="../app/MainLayout.qml" line="799" />
-        <location filename="../app/MainLayout.qml" line="811" />
-        <location filename="../app/MainLayout.qml" line="838" />
-        <location filename="../app/MainLayout.qml" line="849" />
-        <location filename="../app/MainLayout.qml" line="884" />
-        <location filename="../app/MainLayout.qml" line="900" />
-        <location filename="../app/MainLayout.qml" line="909" />
-        <location filename="../app/MainLayout.qml" line="943" />
-        <location filename="../app/MainLayout.qml" line="954" />
+        <location filename="../app/MainLayout.qml" line="837"/>
+        <location filename="../app/MainLayout.qml" line="865"/>
+        <location filename="../app/MainLayout.qml" line="876"/>
+        <location filename="../app/MainLayout.qml" line="888"/>
+        <location filename="../app/MainLayout.qml" line="915"/>
+        <location filename="../app/MainLayout.qml" line="926"/>
+        <location filename="../app/MainLayout.qml" line="961"/>
+        <location filename="../app/MainLayout.qml" line="977"/>
+        <location filename="../app/MainLayout.qml" line="986"/>
+        <location filename="../app/MainLayout.qml" line="1020"/>
+        <location filename="../app/MainLayout.qml" line="1031"/>
         <source>Back</source>
         <translation>Înapoi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="778" />
-        <location filename="../app/MainLayout.qml" line="825" />
-        <location filename="../app/MainLayout.qml" line="930" />
+        <location filename="../app/MainLayout.qml" line="855"/>
+        <location filename="../app/MainLayout.qml" line="902"/>
+        <location filename="../app/MainLayout.qml" line="1007"/>
         <source>Page</source>
         <translation>Pagină</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="785" />
-        <location filename="../app/MainLayout.qml" line="834" />
-        <location filename="../app/MainLayout.qml" line="939" />
+        <location filename="../app/MainLayout.qml" line="862"/>
+        <location filename="../app/MainLayout.qml" line="911"/>
+        <location filename="../app/MainLayout.qml" line="1016"/>
         <source>Options</source>
         <translation>Opțiuni</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="659" />
-        <location filename="../app/MainLayout.qml" line="795" />
-        <location filename="../app/MainLayout.qml" line="845" />
-        <location filename="../app/MainLayout.qml" line="950" />
+        <location filename="../app/MainLayout.qml" line="751"/>
+        <location filename="../app/MainLayout.qml" line="872"/>
+        <location filename="../app/MainLayout.qml" line="922"/>
+        <location filename="../app/MainLayout.qml" line="1027"/>
         <source>Retry</source>
         <translation>Reîncercare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="869" />
+        <location filename="../app/MainLayout.qml" line="946"/>
         <source>Change</source>
         <translation>Schimbare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="875" />
+        <location filename="../app/MainLayout.qml" line="952"/>
         <source>Toggle</source>
         <translation>Comutare</translation>
     </message>
@@ -558,22 +639,22 @@
 <context>
     <name>Modal</name>
     <message>
-        <location filename="../components/Modal.qml" line="49" />
+        <location filename="../components/Modal.qml" line="49"/>
         <source>OK</source>
         <translation>În regulă</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="50" />
+        <location filename="../components/Modal.qml" line="50"/>
         <source>Yes</source>
         <translation>Da</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="51" />
+        <location filename="../components/Modal.qml" line="51"/>
         <source>No</source>
         <translation>Nu</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="198" />
+        <location filename="../components/Modal.qml" line="198"/>
         <source>Cancel</source>
         <translation>Anulare</translation>
     </message>
@@ -581,22 +662,22 @@
 <context>
     <name>RecentsScreen</name>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="183" />
+        <location filename="../screens/RecentsScreen.qml" line="184"/>
         <source>Recently Played</source>
         <translation>Recent Jucate</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="186" />
+        <location filename="../screens/RecentsScreen.qml" line="187"/>
         <source>%1 entries</source>
         <translation>%1 intrări</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="282" />
+        <location filename="../screens/RecentsScreen.qml" line="312"/>
         <source>Loading recently played…</source>
         <translation>Se încarcă recent jucatele…</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="281" />
+        <location filename="../screens/RecentsScreen.qml" line="311"/>
         <source>Nothing played yet</source>
         <translation>Nimic jucat încă</translation>
     </message>
@@ -604,17 +685,17 @@
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="26" />
+        <location filename="../components/ScreenStateOverlay.qml" line="26"/>
         <source>Nothing here</source>
         <translation>Nimic aici</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27" />
+        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
         <source>Loading…</source>
         <translation>Se încarcă…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="57" />
+        <location filename="../components/ScreenStateOverlay.qml" line="57"/>
         <source>Failed to load</source>
         <translation>Încărcare eșuată</translation>
     </message>
@@ -622,288 +703,294 @@
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78" />
-        <location filename="../screens/SettingsScreen.qml" line="436" />
+        <location filename="../screens/SettingsScreen.qml" line="73"/>
+        <location filename="../screens/SettingsScreen.qml" line="432"/>
         <source>Language</source>
         <translation>Limbă</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83" />
-        <location filename="../screens/SettingsScreen.qml" line="445" />
+        <location filename="../screens/SettingsScreen.qml" line="78"/>
+        <location filename="../screens/SettingsScreen.qml" line="441"/>
         <source>Browsing layout</source>
         <translation>Aspect navigare</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116" />
+        <location filename="../screens/SettingsScreen.qml" line="116"/>
         <source>Mouse support</source>
         <translation>Suport mouse</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102" />
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
         <source>Update media database</source>
         <translation>Actualizare bază de date media</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="61" />
+        <location filename="../screens/SettingsScreen.qml" line="61"/>
         <source>General</source>
         <translation>Generale</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88" />
-        <location filename="../screens/SettingsScreen.qml" line="454" />
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="450"/>
         <source>Button style</source>
         <translation>Stil butoane</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="93" />
-        <location filename="../screens/SettingsScreen.qml" line="463" />
+        <location filename="../screens/SettingsScreen.qml" line="88"/>
+        <location filename="../screens/SettingsScreen.qml" line="459"/>
         <source>Screensaver</source>
         <translation>Economizor de ecran</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97" />
+        <location filename="../screens/SettingsScreen.qml" line="92"/>
         <source>Library</source>
         <translation>Bibliotecă</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="107" />
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <source>Discover arcade alternate versions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="107"/>
         <source>Scrape metadata</source>
         <translation>Extragere metadate</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111" />
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
         <source>Advanced</source>
         <translation>Avansat</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121" />
+        <location filename="../screens/SettingsScreen.qml" line="121"/>
         <source>Debug logging</source>
         <translation>Jurnal depanare</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126" />
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Upload log file</source>
         <translation>Încărcare fișier jurnal</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131" />
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
         <source>About / License</source>
         <translation>Despre / Licență</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147" />
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
         <source>Optimizing</source>
         <translation>Optimizare</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149" />
-        <location filename="../screens/SettingsScreen.qml" line="158" />
+        <location filename="../screens/SettingsScreen.qml" line="149"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
         <source>Paused</source>
         <translation>În pauză</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149" />
-        <location filename="../screens/SettingsScreen.qml" line="158" />
+        <location filename="../screens/SettingsScreen.qml" line="149"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
         <source>In progress</source>
         <translation>În curs</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152" />
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>%1 indexed</source>
         <translation>%1 indexate</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="161" />
+        <location filename="../screens/SettingsScreen.qml" line="161"/>
         <source>%1 scraped</source>
         <translation>%1 extrase</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270" />
+        <location filename="../screens/SettingsScreen.qml" line="266"/>
         <source>Cancel</source>
         <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270" />
+        <location filename="../screens/SettingsScreen.qml" line="266"/>
         <source>Start</source>
         <translation>Pornire</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="272" />
+        <location filename="../screens/SettingsScreen.qml" line="268"/>
         <source>Upload</source>
         <translation>Încărcare</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="274" />
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
         <source>Open</source>
         <translation>Deschidere</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="346" />
+        <location filename="../screens/SettingsScreen.qml" line="342"/>
         <source>English</source>
         <translation>Engleză</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="348" />
+        <location filename="../screens/SettingsScreen.qml" line="344"/>
         <source>Italian</source>
         <translation>Italiană</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="350" />
+        <location filename="../screens/SettingsScreen.qml" line="346"/>
         <source>German</source>
         <translation>Germană</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="352" />
+        <location filename="../screens/SettingsScreen.qml" line="348"/>
         <source>Greek</source>
         <translation>Greacă</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="354" />
+        <location filename="../screens/SettingsScreen.qml" line="350"/>
         <source>Japanese</source>
         <translation>Japoneză</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="356" />
+        <location filename="../screens/SettingsScreen.qml" line="352"/>
         <source>Korean</source>
         <translation>Coreeană</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="358" />
+        <location filename="../screens/SettingsScreen.qml" line="354"/>
         <source>Dutch</source>
         <translation>Olandeză</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="360" />
+        <location filename="../screens/SettingsScreen.qml" line="356"/>
         <source>Romanian</source>
         <translation>Română</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="362" />
+        <location filename="../screens/SettingsScreen.qml" line="358"/>
         <source>Slovak</source>
         <translation>Slovacă</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="364" />
+        <location filename="../screens/SettingsScreen.qml" line="360"/>
         <source>Ukrainian</source>
         <translation>Ucraineană</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="366" />
+        <location filename="../screens/SettingsScreen.qml" line="362"/>
         <source>Chinese (Simplified)</source>
         <translation>Chineză (simplificată)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="368" />
+        <location filename="../screens/SettingsScreen.qml" line="364"/>
         <source>Hebrew</source>
         <translation>Ebraică</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="370" />
+        <location filename="../screens/SettingsScreen.qml" line="366"/>
         <source>Arabic</source>
-        <translation type="unfinished" />
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="372" />
+        <location filename="../screens/SettingsScreen.qml" line="368"/>
         <source>Hindi</source>
-        <translation type="unfinished" />
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="373" />
+        <location filename="../screens/SettingsScreen.qml" line="369"/>
         <source>Auto</source>
         <translation>Automat</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="378" />
+        <location filename="../screens/SettingsScreen.qml" line="374"/>
         <source>Detailed list view</source>
         <translation>Vizualizare listă detaliată</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="379" />
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Grid view</source>
         <translation>Vizualizare grilă</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="384" />
+        <location filename="../screens/SettingsScreen.qml" line="380"/>
         <source>Style B</source>
         <translation>Stil B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="386" />
+        <location filename="../screens/SettingsScreen.qml" line="382"/>
         <source>Style C</source>
         <translation>Stil C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="388" />
+        <location filename="../screens/SettingsScreen.qml" line="384"/>
         <source>Style D</source>
         <translation>Stil D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="389" />
+        <location filename="../screens/SettingsScreen.qml" line="385"/>
         <source>Style A</source>
         <translation>Stil A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="326" />
+        <location filename="../screens/SettingsScreen.qml" line="322"/>
         <source>Default</source>
         <translation>Implicit</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399" />
+        <location filename="../screens/SettingsScreen.qml" line="395"/>
         <source>Off</source>
         <translation>Dezactivat</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="401" />
+        <location filename="../screens/SettingsScreen.qml" line="397"/>
         <source>1 second (testing)</source>
         <translation>1 secundă (test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="403" />
+        <location filename="../screens/SettingsScreen.qml" line="399"/>
         <source>1 minute</source>
         <translation>1 minut</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405" />
+        <location filename="../screens/SettingsScreen.qml" line="401"/>
         <source>2 minutes</source>
         <translation>2 minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="407" />
+        <location filename="../screens/SettingsScreen.qml" line="403"/>
         <source>5 minutes</source>
         <translation>5 minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="409" />
+        <location filename="../screens/SettingsScreen.qml" line="405"/>
         <source>10 minutes</source>
         <translation>10 minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="411" />
+        <location filename="../screens/SettingsScreen.qml" line="407"/>
         <source>15 minutes</source>
         <translation>15 minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="413" />
+        <location filename="../screens/SettingsScreen.qml" line="409"/>
         <source>30 minutes</source>
         <translation>30 de minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="414" />
+        <location filename="../screens/SettingsScreen.qml" line="410"/>
         <source>%1 seconds</source>
         <translation>%1 secunde</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="427" />
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="423"/>
         <source>Resolution</source>
         <translation>Rezoluție</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="555" />
+        <location filename="../screens/SettingsScreen.qml" line="563"/>
         <source>Settings</source>
         <translation>Setări</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="745" />
+        <location filename="../screens/SettingsScreen.qml" line="755"/>
         <source>No settings available on this platform</source>
         <translation>Nicio setare disponibilă pe această platformă</translation>
     </message>
@@ -911,17 +998,23 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="182" />
+        <location filename="../screens/SystemsScreen.qml" line="185"/>
+        <location filename="../screens/SystemsScreen.qml" line="313"/>
         <source>%1 systems</source>
         <translation>%1 sisteme</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="279" />
+        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SystemsScreen.qml" line="345"/>
         <source>No systems in this category</source>
         <translation>Niciun sistem în această categorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="280" />
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>
@@ -929,7 +1022,7 @@
 <context>
     <name>TopStatusStrip</name>
     <message>
-        <location filename="../components/TopStatusStrip.qml" line="88" />
+        <location filename="../components/TopStatusStrip.qml" line="90"/>
         <source>Page %1 / %2</source>
         <translation>Pagina %1 / %2</translation>
     </message>

--- a/src/ui/translations/launcher_ro.ts
+++ b/src/ui/translations/launcher_ro.ts
@@ -245,27 +245,27 @@
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="183"/>
+        <location filename="../screens/FavoritesScreen.qml" line="225"/>
         <source>Favorites</source>
         <translation>Favorite</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="186"/>
+        <location filename="../screens/FavoritesScreen.qml" line="228"/>
         <source>%1 entries</source>
         <translation>%1 intrări</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="190"/>
+        <location filename="../screens/FavoritesScreen.qml" line="232"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="280"/>
+        <location filename="../screens/FavoritesScreen.qml" line="334"/>
         <source>No favorites yet</source>
         <translation>Nicio intrare la favorite</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="281"/>
+        <location filename="../screens/FavoritesScreen.qml" line="335"/>
         <source>Loading favorites…</source>
         <translation>Se încarcă favoritele…</translation>
     </message>
@@ -326,13 +326,13 @@
 <context>
     <name>GameInfoModal</name>
     <message>
-        <location filename="../components/GameInfoModal.qml" line="86"/>
-        <source>Back to close</source>
+        <location filename="../components/GameInfoModal.qml" line="104"/>
+        <source>Loading details…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/GameInfoModal.qml" line="114"/>
-        <source>Loading details…</source>
+        <location filename="../components/GameInfoModal.qml" line="174"/>
+        <source>Loading image…</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -444,12 +444,6 @@
         <translation>Lansare core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="781"/>
-        <source>More info</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../app/Main.qml" line="785"/>
         <source>Remove from favorites</source>
         <translation>Elimină din favorite</translation>
@@ -474,6 +468,12 @@
         <location filename="../app/Main.qml" line="804"/>
         <source>Launch game</source>
         <translation>Lansare joc</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="761"/>
+        <location filename="../app/Main.qml" line="781"/>
+        <source>View details</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1652"/>
@@ -679,27 +679,27 @@
 <context>
     <name>RecentsScreen</name>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="184"/>
+        <location filename="../screens/RecentsScreen.qml" line="226"/>
         <source>Recently Played</source>
         <translation>Recent Jucate</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="187"/>
+        <location filename="../screens/RecentsScreen.qml" line="229"/>
         <source>%1 entries</source>
         <translation>%1 intrări</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="191"/>
+        <location filename="../screens/RecentsScreen.qml" line="233"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="283"/>
+        <location filename="../screens/RecentsScreen.qml" line="337"/>
         <source>Loading recently played…</source>
         <translation>Se încarcă recent jucatele…</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="282"/>
+        <location filename="../screens/RecentsScreen.qml" line="336"/>
         <source>Nothing played yet</source>
         <translation>Nimic jucat încă</translation>
     </message>

--- a/src/ui/translations/launcher_ro.ts
+++ b/src/ui/translations/launcher_ro.ts
@@ -90,38 +90,48 @@
         <translation type="unfinished">Se încarcă…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="43"/>
+        <location filename="../components/BrowseDetailPane.qml" line="44"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="45"/>
+        <location filename="../components/BrowseDetailPane.qml" line="46"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <location filename="../components/BrowseDetailPane.qml" line="48"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <location filename="../components/BrowseDetailPane.qml" line="50"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <location filename="../components/BrowseDetailPane.qml" line="52"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <location filename="../components/BrowseDetailPane.qml" line="54"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="55"/>
-        <source>Filename</source>
+        <location filename="../components/BrowseDetailPane.qml" line="56"/>
+        <source>Category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="58"/>
+        <source>Release date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="60"/>
+        <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -245,12 +255,17 @@
         <translation>%1 intrări</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="309"/>
+        <location filename="../screens/FavoritesScreen.qml" line="190"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/FavoritesScreen.qml" line="280"/>
         <source>No favorites yet</source>
         <translation>Nicio intrare la favorite</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="310"/>
+        <location filename="../screens/FavoritesScreen.qml" line="281"/>
         <source>Loading favorites…</source>
         <translation>Se încarcă favoritele…</translation>
     </message>
@@ -324,33 +339,35 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="367"/>
-        <location filename="../screens/GamesScreen.qml" line="537"/>
+        <location filename="../screens/GamesScreen.qml" line="373"/>
+        <location filename="../screens/GamesScreen.qml" line="520"/>
         <source>%1 files</source>
         <translation>%1 fișiere</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="437"/>
+        <location filename="../screens/GamesScreen.qml" line="409"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="554"/>
+        <location filename="../screens/GamesScreen.qml" line="382"/>
+        <location filename="../screens/GamesScreen.qml" line="537"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="570"/>
+        <location filename="../screens/GamesScreen.qml" line="553"/>
         <source>Loading games…</source>
         <translation>Se încarcă jocurile…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="592"/>
+        <location filename="../screens/GamesScreen.qml" line="378"/>
+        <location filename="../screens/GamesScreen.qml" line="575"/>
         <source>Loading more…</source>
         <translation>Se încarcă mai multe…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="569"/>
+        <location filename="../screens/GamesScreen.qml" line="552"/>
         <source>No games in this system</source>
         <translation>Niciun joc în acest sistem</translation>
     </message>
@@ -672,12 +689,17 @@
         <translation>%1 intrări</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="312"/>
+        <location filename="../screens/RecentsScreen.qml" line="191"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/RecentsScreen.qml" line="283"/>
         <source>Loading recently played…</source>
         <translation>Se încarcă recent jucatele…</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="311"/>
+        <location filename="../screens/RecentsScreen.qml" line="282"/>
         <source>Nothing played yet</source>
         <translation>Nimic jucat încă</translation>
     </message>
@@ -999,22 +1021,23 @@
     <name>SystemsScreen</name>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="185"/>
-        <location filename="../screens/SystemsScreen.qml" line="313"/>
+        <location filename="../screens/SystemsScreen.qml" line="285"/>
         <source>%1 systems</source>
         <translation>%1 sisteme</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <location filename="../screens/SystemsScreen.qml" line="189"/>
+        <location filename="../screens/SystemsScreen.qml" line="302"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="345"/>
+        <location filename="../screens/SystemsScreen.qml" line="317"/>
         <source>No systems in this category</source>
         <translation>Niciun sistem în această categorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="318"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>
@@ -1022,7 +1045,7 @@
 <context>
     <name>TopStatusStrip</name>
     <message>
-        <location filename="../components/TopStatusStrip.qml" line="90"/>
+        <location filename="../components/TopStatusStrip.qml" line="91"/>
         <source>Page %1 / %2</source>
         <translation>Pagina %1 / %2</translation>
     </message>

--- a/src/ui/translations/launcher_sk.ts
+++ b/src/ui/translations/launcher_sk.ts
@@ -90,38 +90,48 @@
         <translation type="unfinished">Načítanie…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="43"/>
+        <location filename="../components/BrowseDetailPane.qml" line="44"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="45"/>
+        <location filename="../components/BrowseDetailPane.qml" line="46"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <location filename="../components/BrowseDetailPane.qml" line="48"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <location filename="../components/BrowseDetailPane.qml" line="50"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <location filename="../components/BrowseDetailPane.qml" line="52"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <location filename="../components/BrowseDetailPane.qml" line="54"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="55"/>
-        <source>Filename</source>
+        <location filename="../components/BrowseDetailPane.qml" line="56"/>
+        <source>Category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="58"/>
+        <source>Release date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="60"/>
+        <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -245,12 +255,17 @@
         <translation>%1 položiek</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="309"/>
+        <location filename="../screens/FavoritesScreen.qml" line="190"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/FavoritesScreen.qml" line="280"/>
         <source>No favorites yet</source>
         <translation>Zatiaľ žiadne obľúbené</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="310"/>
+        <location filename="../screens/FavoritesScreen.qml" line="281"/>
         <source>Loading favorites…</source>
         <translation>Načítanie obľúbených…</translation>
     </message>
@@ -324,33 +339,35 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="367"/>
-        <location filename="../screens/GamesScreen.qml" line="537"/>
+        <location filename="../screens/GamesScreen.qml" line="373"/>
+        <location filename="../screens/GamesScreen.qml" line="520"/>
         <source>%1 files</source>
         <translation>%1 súborov</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="437"/>
+        <location filename="../screens/GamesScreen.qml" line="409"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="554"/>
+        <location filename="../screens/GamesScreen.qml" line="382"/>
+        <location filename="../screens/GamesScreen.qml" line="537"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="570"/>
+        <location filename="../screens/GamesScreen.qml" line="553"/>
         <source>Loading games…</source>
         <translation>Načítanie hier…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="592"/>
+        <location filename="../screens/GamesScreen.qml" line="378"/>
+        <location filename="../screens/GamesScreen.qml" line="575"/>
         <source>Loading more…</source>
         <translation>Načítava sa viac…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="569"/>
+        <location filename="../screens/GamesScreen.qml" line="552"/>
         <source>No games in this system</source>
         <translation>V tomto systéme nie sú žiadne hry</translation>
     </message>
@@ -672,12 +689,17 @@
         <translation>%1 položiek</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="312"/>
+        <location filename="../screens/RecentsScreen.qml" line="191"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/RecentsScreen.qml" line="283"/>
         <source>Loading recently played…</source>
         <translation>Načítanie nedávno hraných…</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="311"/>
+        <location filename="../screens/RecentsScreen.qml" line="282"/>
         <source>Nothing played yet</source>
         <translation>Zatiaľ nič hrané</translation>
     </message>
@@ -999,22 +1021,23 @@
     <name>SystemsScreen</name>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="185"/>
-        <location filename="../screens/SystemsScreen.qml" line="313"/>
+        <location filename="../screens/SystemsScreen.qml" line="285"/>
         <source>%1 systems</source>
         <translation>%1 systémov</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <location filename="../screens/SystemsScreen.qml" line="189"/>
+        <location filename="../screens/SystemsScreen.qml" line="302"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="345"/>
+        <location filename="../screens/SystemsScreen.qml" line="317"/>
         <source>No systems in this category</source>
         <translation>V tejto kategórii nie sú žiadne systémy</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="318"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>
@@ -1022,7 +1045,7 @@
 <context>
     <name>TopStatusStrip</name>
     <message>
-        <location filename="../components/TopStatusStrip.qml" line="90"/>
+        <location filename="../components/TopStatusStrip.qml" line="91"/>
         <source>Page %1 / %2</source>
         <translation>Stránka %1 / %2</translation>
     </message>

--- a/src/ui/translations/launcher_sk.ts
+++ b/src/ui/translations/launcher_sk.ts
@@ -245,27 +245,27 @@
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="183"/>
+        <location filename="../screens/FavoritesScreen.qml" line="225"/>
         <source>Favorites</source>
         <translation>Obľúbené</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="186"/>
+        <location filename="../screens/FavoritesScreen.qml" line="228"/>
         <source>%1 entries</source>
         <translation>%1 položiek</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="190"/>
+        <location filename="../screens/FavoritesScreen.qml" line="232"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="280"/>
+        <location filename="../screens/FavoritesScreen.qml" line="334"/>
         <source>No favorites yet</source>
         <translation>Zatiaľ žiadne obľúbené</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="281"/>
+        <location filename="../screens/FavoritesScreen.qml" line="335"/>
         <source>Loading favorites…</source>
         <translation>Načítanie obľúbených…</translation>
     </message>
@@ -326,13 +326,13 @@
 <context>
     <name>GameInfoModal</name>
     <message>
-        <location filename="../components/GameInfoModal.qml" line="86"/>
-        <source>Back to close</source>
+        <location filename="../components/GameInfoModal.qml" line="104"/>
+        <source>Loading details…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/GameInfoModal.qml" line="114"/>
-        <source>Loading details…</source>
+        <location filename="../components/GameInfoModal.qml" line="174"/>
+        <source>Loading image…</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -444,12 +444,6 @@
         <translation>Spustiť core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="781"/>
-        <source>More info</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../app/Main.qml" line="785"/>
         <source>Remove from favorites</source>
         <translation>Odstrániť z obľúbených</translation>
@@ -474,6 +468,12 @@
         <location filename="../app/Main.qml" line="804"/>
         <source>Launch game</source>
         <translation>Spustiť hru</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="761"/>
+        <location filename="../app/Main.qml" line="781"/>
+        <source>View details</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1652"/>
@@ -679,27 +679,27 @@
 <context>
     <name>RecentsScreen</name>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="184"/>
+        <location filename="../screens/RecentsScreen.qml" line="226"/>
         <source>Recently Played</source>
         <translation>Nedávno hrané</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="187"/>
+        <location filename="../screens/RecentsScreen.qml" line="229"/>
         <source>%1 entries</source>
         <translation>%1 položiek</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="191"/>
+        <location filename="../screens/RecentsScreen.qml" line="233"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="283"/>
+        <location filename="../screens/RecentsScreen.qml" line="337"/>
         <source>Loading recently played…</source>
         <translation>Načítanie nedávno hraných…</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="282"/>
+        <location filename="../screens/RecentsScreen.qml" line="336"/>
         <source>Nothing played yet</source>
         <translation>Zatiaľ nič hrané</translation>
     </message>

--- a/src/ui/translations/launcher_sk.ts
+++ b/src/ui/translations/launcher_sk.ts
@@ -1,59 +1,60 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
 <TS version="2.1" language="sk" sourcelanguage="en">
 <context>
     <name>AboutScreen</name>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="72" />
+        <location filename="../screens/AboutScreen.qml" line="71"/>
         <source>About / License</source>
         <translation>O aplikácii / Licencia</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="154" />
+        <location filename="../screens/AboutScreen.qml" line="153"/>
         <source>Zaparoo Launcher</source>
         <translation>Spúšťač Zaparoo</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="165" />
+        <location filename="../screens/AboutScreen.qml" line="164"/>
         <source>Version %1 · %2 · %3</source>
         <translation>Verzia %1 · %2 · %3</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="178" />
+        <location filename="../screens/AboutScreen.qml" line="174"/>
         <source>Built %1</source>
         <translation>Zostavené %1</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="189" />
+        <location filename="../screens/AboutScreen.qml" line="185"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>Autorské práva 2026 Wizzo Pty Ltd a prispievatelia projektu Zaparoo.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="200" />
+        <location filename="../screens/AboutScreen.qml" line="196"/>
         <source>Source available under the PolyForm Noncommercial License 1.0.0. Free for personal, non-commercial use. Commercial use or redistribution requires a separate license.</source>
         <translation>Zdrojový kód je dostupný pod licenciou PolyForm Noncommercial License 1.0.0. Bezplatne na osobné, nekomerčné použitie. Komerčné použitie alebo redistribúcia vyžaduje samostatnú licenciu.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="211" />
+        <location filename="../screens/AboutScreen.qml" line="207"/>
         <source>Commercial licensing: legal@zaparoo.org</source>
         <translation>Komerčné licencovanie: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="222" />
+        <location filename="../screens/AboutScreen.qml" line="218"/>
         <source>Project: https://zaparoo.org</source>
         <translation>Projekt: https://zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="232" />
+        <location filename="../screens/AboutScreen.qml" line="228"/>
         <source>Created by</source>
         <translation>Vytvorili</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="256" />
+        <location filename="../screens/AboutScreen.qml" line="252"/>
         <source>Translations</source>
         <translation>Preklady</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="280" />
+        <location filename="../screens/AboutScreen.qml" line="276"/>
         <source>Full license text in COPYING.</source>
         <translation>Úplný text licencie v súbore COPYING.</translation>
     </message>
@@ -61,60 +62,103 @@
 <context>
     <name>BootOverlay</name>
     <message>
-        <location filename="../components/BootOverlay.qml" line="76" />
-        <source>Can't reach Zaparoo Core. Check your connection.</source>
+        <location filename="../components/BootOverlay.qml" line="76"/>
+        <source>Can&apos;t reach Zaparoo Core. Check your connection.</source>
         <translation>Zaparoo Core nie je dostupný. Skontrolujte pripojenie.</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="78" />
+        <location filename="../components/BootOverlay.qml" line="78"/>
         <source>Reconnecting…</source>
         <translation>Opätovné pripojenie…</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="80" />
+        <location filename="../components/BootOverlay.qml" line="80"/>
         <source>Loading library…</source>
         <translation>Načítanie knižnice…</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="85" />
+        <location filename="../components/BootOverlay.qml" line="85"/>
         <source>Connecting to Zaparoo Core…</source>
         <translation>Pripájanie k Zaparoo Core…</translation>
     </message>
 </context>
 <context>
+    <name>BrowseDetailPane</name>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="22"/>
+        <source>Loading…</source>
+        <translation type="unfinished">Načítanie…</translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="43"/>
+        <source>Year</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="45"/>
+        <source>Genre</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <source>Players</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <source>Developer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <source>Publisher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <source>Rating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="55"/>
+        <source>Filename</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommercialNoticeModal</name>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="59" />
+        <location filename="../components/CommercialNoticeModal.qml" line="59"/>
         <source>Welcome to Zaparoo Launcher</source>
         <translation>Vitajte v Zaparoo Launcher</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="68" />
+        <location filename="../components/CommercialNoticeModal.qml" line="68"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>Autorské práva 2026 Wizzo Pty Ltd a prispievatelia projektu Zaparoo.</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="79" />
+        <location filename="../components/CommercialNoticeModal.qml" line="79"/>
         <source>This free source-available build is for personal and non-commercial use only. Commercial use or redistribution requires a license.</source>
         <translation>Táto bezplatná verzia je určená iba na osobné a nekomerčné použitie. Komerčné využitie alebo ďalšie šírenie vyžaduje licenciu.</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="90" />
+        <location filename="../components/CommercialNoticeModal.qml" line="90"/>
         <source>Contact: legal@zaparoo.org</source>
         <translation>Kontakt: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="101" />
+        <location filename="../components/CommercialNoticeModal.qml" line="101"/>
         <source>Full details available any time under Settings &gt; About / License.</source>
         <translation>Úplné podrobnosti sú kedykoľvek dostupné v Nastaveniach &gt; O aplikácii / Licencia.</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="119" />
+        <location filename="../components/CommercialNoticeModal.qml" line="119"/>
         <source>Created by</source>
         <translation>Vytvorili</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="162" />
+        <location filename="../components/CommercialNoticeModal.qml" line="162"/>
         <source>I understand</source>
         <translation>Rozumiem</translation>
     </message>
@@ -122,68 +166,68 @@
 <context>
     <name>CoreStatusPill</name>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="44" />
-        <location filename="../components/CoreStatusPill.qml" line="50" />
+        <location filename="../components/CoreStatusPill.qml" line="44"/>
+        <location filename="../components/CoreStatusPill.qml" line="50"/>
         <source>Disconnected</source>
         <translation>Odpojené</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="47" />
+        <location filename="../components/CoreStatusPill.qml" line="47"/>
         <source>Reconnecting…</source>
         <translation>Opätovné pripojenie…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="53" />
+        <location filename="../components/CoreStatusPill.qml" line="53"/>
         <source>Connecting…</source>
         <translation>Pripájanie…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="56" />
+        <location filename="../components/CoreStatusPill.qml" line="56"/>
         <source>Core error</source>
         <translation>Chyba Core</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="60" />
+        <location filename="../components/CoreStatusPill.qml" line="60"/>
         <source>Optimizing database</source>
         <translation>Optimalizácia databázy</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="67" />
+        <location filename="../components/CoreStatusPill.qml" line="67"/>
         <source>Indexing paused</source>
         <translation>Indexovanie pozastavené</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="70" />
+        <location filename="../components/CoreStatusPill.qml" line="70"/>
         <source>Indexing %1/%2 - %3</source>
         <translation>Indexovanie %1/%2 – %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="86" />
+        <location filename="../components/CoreStatusPill.qml" line="86"/>
         <source>Scraping %1/%2 - %3</source>
         <translation>Scraping %1/%2 – %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="73" />
+        <location filename="../components/CoreStatusPill.qml" line="73"/>
         <source>Indexing %1/%2</source>
         <translation>Indexovanie %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="75" />
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
         <source>Indexing…</source>
         <translation>Indexovanie…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="83" />
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Scrape paused</source>
         <translation>Scraping pozastavený</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="89" />
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
         <source>Scraping %1/%2</source>
         <translation>Sťahovanie %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="91" />
+        <location filename="../components/CoreStatusPill.qml" line="91"/>
         <source>Scraping…</source>
         <translation>Prebieha sťahovanie…</translation>
     </message>
@@ -191,22 +235,22 @@
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="182" />
+        <location filename="../screens/FavoritesScreen.qml" line="183"/>
         <source>Favorites</source>
         <translation>Obľúbené</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="185" />
+        <location filename="../screens/FavoritesScreen.qml" line="186"/>
         <source>%1 entries</source>
         <translation>%1 položiek</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="283" />
+        <location filename="../screens/FavoritesScreen.qml" line="309"/>
         <source>No favorites yet</source>
         <translation>Zatiaľ žiadne obľúbené</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="284" />
+        <location filename="../screens/FavoritesScreen.qml" line="310"/>
         <source>Loading favorites…</source>
         <translation>Načítanie obľúbených…</translation>
     </message>
@@ -214,75 +258,99 @@
 <context>
     <name>FirstRunIndexModal</name>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="127" />
+        <location filename="../components/FirstRunIndexModal.qml" line="127"/>
         <source>First-time setup</source>
         <translation>Prvé nastavenie</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="136" />
+        <location filename="../components/FirstRunIndexModal.qml" line="136"/>
         <source>Zaparoo needs to scan your games before you can use the launcher. This usually takes a few minutes.</source>
         <translation>Zaparoo musí pred použitím launchera skenovať vaše hry. Zvyčajne to trvá niekoľko minút.</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="211" />
+        <location filename="../components/FirstRunIndexModal.qml" line="211"/>
         <source>Indexing paused</source>
         <translation>Indexovanie pozastavené</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="158" />
+        <location filename="../components/FirstRunIndexModal.qml" line="158"/>
         <source>Optimizing database - almost done</source>
         <translation>Optimalizácia databázy – takmer hotovo</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="213" />
+        <location filename="../components/FirstRunIndexModal.qml" line="213"/>
         <source>Step %1 of %2 - %3</source>
         <translation>Krok %1 z %2 – %3</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="215" />
+        <location filename="../components/FirstRunIndexModal.qml" line="215"/>
         <source>Step %1 of %2</source>
         <translation>Krok %1 z %2</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="216" />
+        <location filename="../components/FirstRunIndexModal.qml" line="216"/>
         <source>Preparing…</source>
         <translation>Príprava…</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="233" />
+        <location filename="../components/FirstRunIndexModal.qml" line="233"/>
         <source>Done. %1 files indexed.</source>
         <translation>Hotovo. Indexovaných %1 súborov.</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="263" />
+        <location filename="../components/FirstRunIndexModal.qml" line="263"/>
         <source>Cancel</source>
         <translation>Zrušiť</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="263" />
+        <location filename="../components/FirstRunIndexModal.qml" line="263"/>
         <source>Start scan</source>
         <translation>Spustiť skenovanie</translation>
     </message>
 </context>
 <context>
+    <name>GameInfoModal</name>
+    <message>
+        <location filename="../components/GameInfoModal.qml" line="86"/>
+        <source>Back to close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/GameInfoModal.qml" line="114"/>
+        <source>Loading details…</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="363" />
+        <location filename="../screens/GamesScreen.qml" line="367"/>
+        <location filename="../screens/GamesScreen.qml" line="537"/>
         <source>%1 files</source>
         <translation>%1 súborov</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="534" />
+        <location filename="../screens/GamesScreen.qml" line="437"/>
+        <source>Loading game…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/GamesScreen.qml" line="554"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/GamesScreen.qml" line="570"/>
         <source>Loading games…</source>
         <translation>Načítanie hier…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="556" />
+        <location filename="../screens/GamesScreen.qml" line="592"/>
         <source>Loading more…</source>
         <translation>Načítava sa viac…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="533" />
+        <location filename="../screens/GamesScreen.qml" line="569"/>
         <source>No games in this system</source>
         <translation>V tomto systéme nie sú žiadne hry</translation>
     </message>
@@ -290,22 +358,22 @@
 <context>
     <name>HubScreen</name>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91" />
+        <location filename="../screens/HubScreen.qml" line="91"/>
         <source>Favorites</source>
         <translation>Obľúbené</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="96" />
+        <location filename="../screens/HubScreen.qml" line="96"/>
         <source>Recently Played</source>
         <translation>Nedávno hrané</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="101" />
+        <location filename="../screens/HubScreen.qml" line="101"/>
         <source>Settings</source>
         <translation>Nastavenia</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="537" />
+        <location filename="../screens/HubScreen.qml" line="537"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Žiadne systémy nie sú dostupné. Spustite Aktualizovať databázu médií v Nastaveniach.</translation>
     </message>
@@ -313,7 +381,7 @@
 <context>
     <name>LoadingIndicator</name>
     <message>
-        <location filename="../components/LoadingIndicator.qml" line="26" />
+        <location filename="../components/LoadingIndicator.qml" line="26"/>
         <source>Loading…</source>
         <translation>Načítanie…</translation>
     </message>
@@ -321,32 +389,32 @@
 <context>
     <name>LogUploadModal</name>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="87" />
+        <location filename="../components/LogUploadModal.qml" line="87"/>
         <source>Upload log file</source>
         <translation>Nahrať súbor protokolu</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="97" />
+        <location filename="../components/LogUploadModal.qml" line="97"/>
         <source>Uploading log file - this may take a moment.</source>
         <translation>Nahrávanie súboru protokolu – môže to chvíľu trvať.</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197" />
+        <location filename="../components/LogUploadModal.qml" line="197"/>
         <source>Upload failed: %1</source>
         <translation>Nahrávanie zlyhalo: %1</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197" />
+        <location filename="../components/LogUploadModal.qml" line="197"/>
         <source>Upload failed.</source>
         <translation>Nahrávanie zlyhalo.</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="227" />
+        <location filename="../components/LogUploadModal.qml" line="227"/>
         <source>Retry</source>
         <translation>Skúsiť znova</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="227" />
+        <location filename="../components/LogUploadModal.qml" line="227"/>
         <source>Done</source>
         <translation>Hotovo</translation>
     </message>
@@ -354,58 +422,64 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="723" />
+        <location filename="../app/Main.qml" line="753"/>
         <source>Launch core</source>
         <translation>Spustiť core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="741" />
+        <location filename="../app/Main.qml" line="761"/>
+        <location filename="../app/Main.qml" line="781"/>
+        <source>More info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="785"/>
         <source>Remove from favorites</source>
         <translation>Odstrániť z obľúbených</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="741" />
+        <location filename="../app/Main.qml" line="785"/>
         <source>Add to favorites</source>
         <translation>Pridať do obľúbených</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="747" />
+        <location filename="../app/Main.qml" line="790"/>
         <source>Write to NFC token</source>
         <translation>Zapísať na NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="751" />
+        <location filename="../app/Main.qml" line="794"/>
         <source>QR code</source>
         <translation>QR kód</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="731" />
-        <location filename="../app/Main.qml" line="755" />
+        <location filename="../app/Main.qml" line="765"/>
+        <location filename="../app/Main.qml" line="804"/>
         <source>Launch game</source>
         <translation>Spustiť hru</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1437" />
+        <location filename="../app/Main.qml" line="1652"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1441" />
+        <location filename="../app/Main.qml" line="1656"/>
         <source>Loading favorites…</source>
         <translation>Načítanie obľúbených…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1439" />
+        <location filename="../app/Main.qml" line="1654"/>
         <source>Loading games…</source>
         <translation>Načítanie hier…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1443" />
+        <location filename="../app/Main.qml" line="1658"/>
         <source>Loading recently played…</source>
         <translation>Načítanie nedávno hraných…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1445" />
+        <location filename="../app/Main.qml" line="1660"/>
         <source>Loading…</source>
         <translation>Načítanie…</translation>
     </message>
@@ -413,144 +487,151 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="127" />
+        <location filename="../app/MainLayout.qml" line="141"/>
         <source>Zaparoo Launcher</source>
         <translation>Spúšťač Zaparoo</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="475" />
+        <location filename="../app/MainLayout.qml" line="545"/>
         <source>Writing failed</source>
         <translation>Zápis zlyhal</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="475" />
+        <location filename="../app/MainLayout.qml" line="545"/>
         <source>Put a writable card near the reader</source>
         <translation>Priložte zapisovateľnú kartu k čítačke</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="540" />
+        <location filename="../app/MainLayout.qml" line="556"/>
+        <source>Quit and restart Zaparoo Launcher?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="557"/>
+        <source>In order to apply this setting we need to restart the launcher.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="632"/>
         <source>Quit Zaparoo Launcher?</source>
         <translation>Ukončiť Zaparoo Launcher?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="541" />
+        <location filename="../app/MainLayout.qml" line="633"/>
         <source>Are you sure you want to exit?</source>
         <translation>Naozaj chcete ukončiť?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="617" />
-        <location filename="../app/MainLayout.qml" line="689" />
-        <location filename="../app/MainLayout.qml" line="704" />
+        <location filename="../app/MainLayout.qml" line="709"/>
+        <location filename="../app/MainLayout.qml" line="781"/>
         <source>Select</source>
         <translation>Vybrať</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="621" />
-        <location filename="../app/MainLayout.qml" line="625" />
-        <location filename="../app/MainLayout.qml" line="639" />
-        <location filename="../app/MainLayout.qml" line="652" />
-        <location filename="../app/MainLayout.qml" line="663" />
+        <location filename="../app/MainLayout.qml" line="713"/>
+        <location filename="../app/MainLayout.qml" line="717"/>
+        <location filename="../app/MainLayout.qml" line="731"/>
+        <location filename="../app/MainLayout.qml" line="744"/>
+        <location filename="../app/MainLayout.qml" line="755"/>
         <source>Close</source>
         <translation>Zavrieť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="632" />
-        <location filename="../app/MainLayout.qml" line="670" />
-        <location filename="../app/MainLayout.qml" line="693" />
-        <location filename="../app/MainLayout.qml" line="708" />
-        <location filename="../app/MainLayout.qml" line="719" />
+        <location filename="../app/MainLayout.qml" line="724"/>
+        <location filename="../app/MainLayout.qml" line="762"/>
+        <location filename="../app/MainLayout.qml" line="785"/>
+        <location filename="../app/MainLayout.qml" line="796"/>
         <source>Cancel</source>
         <translation>Zrušiť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="648" />
+        <location filename="../app/MainLayout.qml" line="740"/>
         <source>Done</source>
         <translation>Hotovo</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="678" />
+        <location filename="../app/MainLayout.qml" line="770"/>
         <source>I understand</source>
         <translation>Rozumiem</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="727" />
+        <location filename="../app/MainLayout.qml" line="804"/>
         <source>Start</source>
         <translation>Spustiť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="896" />
+        <location filename="../app/MainLayout.qml" line="973"/>
         <source>Scroll</source>
         <translation>Posúvať</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="613" />
-        <location filename="../app/MainLayout.qml" line="685" />
-        <location filename="../app/MainLayout.qml" line="700" />
-        <location filename="../app/MainLayout.qml" line="743" />
-        <location filename="../app/MainLayout.qml" line="772" />
-        <location filename="../app/MainLayout.qml" line="819" />
-        <location filename="../app/MainLayout.qml" line="860" />
-        <location filename="../app/MainLayout.qml" line="924" />
+        <location filename="../app/MainLayout.qml" line="705"/>
+        <location filename="../app/MainLayout.qml" line="777"/>
+        <location filename="../app/MainLayout.qml" line="820"/>
+        <location filename="../app/MainLayout.qml" line="849"/>
+        <location filename="../app/MainLayout.qml" line="896"/>
+        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="1001"/>
         <source>Move</source>
         <translation>Presunúť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="747" />
-        <location filename="../app/MainLayout.qml" line="782" />
-        <location filename="../app/MainLayout.qml" line="829" />
-        <location filename="../app/MainLayout.qml" line="934" />
+        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="859"/>
+        <location filename="../app/MainLayout.qml" line="906"/>
+        <location filename="../app/MainLayout.qml" line="1011"/>
         <source>Open</source>
         <translation>Otvoriť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="751" />
+        <location filename="../app/MainLayout.qml" line="828"/>
         <source>Quit</source>
         <translation>Ukončiť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="760" />
-        <location filename="../app/MainLayout.qml" line="788" />
-        <location filename="../app/MainLayout.qml" line="799" />
-        <location filename="../app/MainLayout.qml" line="811" />
-        <location filename="../app/MainLayout.qml" line="838" />
-        <location filename="../app/MainLayout.qml" line="849" />
-        <location filename="../app/MainLayout.qml" line="884" />
-        <location filename="../app/MainLayout.qml" line="900" />
-        <location filename="../app/MainLayout.qml" line="909" />
-        <location filename="../app/MainLayout.qml" line="943" />
-        <location filename="../app/MainLayout.qml" line="954" />
+        <location filename="../app/MainLayout.qml" line="837"/>
+        <location filename="../app/MainLayout.qml" line="865"/>
+        <location filename="../app/MainLayout.qml" line="876"/>
+        <location filename="../app/MainLayout.qml" line="888"/>
+        <location filename="../app/MainLayout.qml" line="915"/>
+        <location filename="../app/MainLayout.qml" line="926"/>
+        <location filename="../app/MainLayout.qml" line="961"/>
+        <location filename="../app/MainLayout.qml" line="977"/>
+        <location filename="../app/MainLayout.qml" line="986"/>
+        <location filename="../app/MainLayout.qml" line="1020"/>
+        <location filename="../app/MainLayout.qml" line="1031"/>
         <source>Back</source>
         <translation>Späť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="778" />
-        <location filename="../app/MainLayout.qml" line="825" />
-        <location filename="../app/MainLayout.qml" line="930" />
+        <location filename="../app/MainLayout.qml" line="855"/>
+        <location filename="../app/MainLayout.qml" line="902"/>
+        <location filename="../app/MainLayout.qml" line="1007"/>
         <source>Page</source>
         <translation>Stránka</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="785" />
-        <location filename="../app/MainLayout.qml" line="834" />
-        <location filename="../app/MainLayout.qml" line="939" />
+        <location filename="../app/MainLayout.qml" line="862"/>
+        <location filename="../app/MainLayout.qml" line="911"/>
+        <location filename="../app/MainLayout.qml" line="1016"/>
         <source>Options</source>
         <translation>Možnosti</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="659" />
-        <location filename="../app/MainLayout.qml" line="795" />
-        <location filename="../app/MainLayout.qml" line="845" />
-        <location filename="../app/MainLayout.qml" line="950" />
+        <location filename="../app/MainLayout.qml" line="751"/>
+        <location filename="../app/MainLayout.qml" line="872"/>
+        <location filename="../app/MainLayout.qml" line="922"/>
+        <location filename="../app/MainLayout.qml" line="1027"/>
         <source>Retry</source>
         <translation>Skúsiť znova</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="869" />
+        <location filename="../app/MainLayout.qml" line="946"/>
         <source>Change</source>
         <translation>Zmeniť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="875" />
+        <location filename="../app/MainLayout.qml" line="952"/>
         <source>Toggle</source>
         <translation>Prepínať</translation>
     </message>
@@ -558,22 +639,22 @@
 <context>
     <name>Modal</name>
     <message>
-        <location filename="../components/Modal.qml" line="49" />
+        <location filename="../components/Modal.qml" line="49"/>
         <source>OK</source>
         <translation>V poriadku</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="50" />
+        <location filename="../components/Modal.qml" line="50"/>
         <source>Yes</source>
         <translation>Áno</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="51" />
+        <location filename="../components/Modal.qml" line="51"/>
         <source>No</source>
         <translation>Nie</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="198" />
+        <location filename="../components/Modal.qml" line="198"/>
         <source>Cancel</source>
         <translation>Zrušiť</translation>
     </message>
@@ -581,22 +662,22 @@
 <context>
     <name>RecentsScreen</name>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="183" />
+        <location filename="../screens/RecentsScreen.qml" line="184"/>
         <source>Recently Played</source>
         <translation>Nedávno hrané</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="186" />
+        <location filename="../screens/RecentsScreen.qml" line="187"/>
         <source>%1 entries</source>
         <translation>%1 položiek</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="282" />
+        <location filename="../screens/RecentsScreen.qml" line="312"/>
         <source>Loading recently played…</source>
         <translation>Načítanie nedávno hraných…</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="281" />
+        <location filename="../screens/RecentsScreen.qml" line="311"/>
         <source>Nothing played yet</source>
         <translation>Zatiaľ nič hrané</translation>
     </message>
@@ -604,17 +685,17 @@
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="26" />
+        <location filename="../components/ScreenStateOverlay.qml" line="26"/>
         <source>Nothing here</source>
         <translation>Nič tu nie je</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27" />
+        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
         <source>Loading…</source>
         <translation>Načítanie…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="57" />
+        <location filename="../components/ScreenStateOverlay.qml" line="57"/>
         <source>Failed to load</source>
         <translation>Načítanie zlyhalo</translation>
     </message>
@@ -622,288 +703,294 @@
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78" />
-        <location filename="../screens/SettingsScreen.qml" line="436" />
+        <location filename="../screens/SettingsScreen.qml" line="73"/>
+        <location filename="../screens/SettingsScreen.qml" line="432"/>
         <source>Language</source>
         <translation>Jazyk</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83" />
-        <location filename="../screens/SettingsScreen.qml" line="445" />
+        <location filename="../screens/SettingsScreen.qml" line="78"/>
+        <location filename="../screens/SettingsScreen.qml" line="441"/>
         <source>Browsing layout</source>
         <translation>Rozloženie prehliadania</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116" />
+        <location filename="../screens/SettingsScreen.qml" line="116"/>
         <source>Mouse support</source>
         <translation>Podpora myši</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102" />
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
         <source>Update media database</source>
         <translation>Aktualizovať databázu médií</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="61" />
+        <location filename="../screens/SettingsScreen.qml" line="61"/>
         <source>General</source>
         <translation>Všeobecné</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88" />
-        <location filename="../screens/SettingsScreen.qml" line="454" />
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="450"/>
         <source>Button style</source>
         <translation>Štýl tlačidiel</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="93" />
-        <location filename="../screens/SettingsScreen.qml" line="463" />
+        <location filename="../screens/SettingsScreen.qml" line="88"/>
+        <location filename="../screens/SettingsScreen.qml" line="459"/>
         <source>Screensaver</source>
         <translation>Šetrič obrazovky</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97" />
+        <location filename="../screens/SettingsScreen.qml" line="92"/>
         <source>Library</source>
         <translation>Knižnica</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="107" />
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <source>Discover arcade alternate versions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="107"/>
         <source>Scrape metadata</source>
         <translation>Získať metadáta</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111" />
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
         <source>Advanced</source>
         <translation>Rozšírené</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121" />
+        <location filename="../screens/SettingsScreen.qml" line="121"/>
         <source>Debug logging</source>
         <translation>Ladiace záznamy</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126" />
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Upload log file</source>
         <translation>Nahrať súbor protokolu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131" />
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
         <source>About / License</source>
         <translation>O aplikácii / Licencia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147" />
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
         <source>Optimizing</source>
         <translation>Optimalizácia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149" />
-        <location filename="../screens/SettingsScreen.qml" line="158" />
+        <location filename="../screens/SettingsScreen.qml" line="149"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
         <source>Paused</source>
         <translation>Pozastavené</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149" />
-        <location filename="../screens/SettingsScreen.qml" line="158" />
+        <location filename="../screens/SettingsScreen.qml" line="149"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
         <source>In progress</source>
         <translation>Prebieha</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152" />
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>%1 indexed</source>
         <translation>%1 indexovaných</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="161" />
+        <location filename="../screens/SettingsScreen.qml" line="161"/>
         <source>%1 scraped</source>
         <translation>%1 zozbieraných</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270" />
+        <location filename="../screens/SettingsScreen.qml" line="266"/>
         <source>Cancel</source>
         <translation>Zrušiť</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270" />
+        <location filename="../screens/SettingsScreen.qml" line="266"/>
         <source>Start</source>
         <translation>Spustiť</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="272" />
+        <location filename="../screens/SettingsScreen.qml" line="268"/>
         <source>Upload</source>
         <translation>Nahrať</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="274" />
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
         <source>Open</source>
         <translation>Otvoriť</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="346" />
+        <location filename="../screens/SettingsScreen.qml" line="342"/>
         <source>English</source>
         <translation>Angličtina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="348" />
+        <location filename="../screens/SettingsScreen.qml" line="344"/>
         <source>Italian</source>
         <translation>Taliančina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="350" />
+        <location filename="../screens/SettingsScreen.qml" line="346"/>
         <source>German</source>
         <translation>Nemčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="352" />
+        <location filename="../screens/SettingsScreen.qml" line="348"/>
         <source>Greek</source>
         <translation>Gréčtina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="354" />
+        <location filename="../screens/SettingsScreen.qml" line="350"/>
         <source>Japanese</source>
         <translation>Japončina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="356" />
+        <location filename="../screens/SettingsScreen.qml" line="352"/>
         <source>Korean</source>
         <translation>Kórejčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="358" />
+        <location filename="../screens/SettingsScreen.qml" line="354"/>
         <source>Dutch</source>
         <translation>Holandčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="360" />
+        <location filename="../screens/SettingsScreen.qml" line="356"/>
         <source>Romanian</source>
         <translation>Rumunčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="362" />
+        <location filename="../screens/SettingsScreen.qml" line="358"/>
         <source>Slovak</source>
         <translation>Slovenčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="364" />
+        <location filename="../screens/SettingsScreen.qml" line="360"/>
         <source>Ukrainian</source>
         <translation>Ukrajinčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="366" />
+        <location filename="../screens/SettingsScreen.qml" line="362"/>
         <source>Chinese (Simplified)</source>
         <translation>Čínština (zjednodušená)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="368" />
+        <location filename="../screens/SettingsScreen.qml" line="364"/>
         <source>Hebrew</source>
         <translation>Hebrejčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="370" />
+        <location filename="../screens/SettingsScreen.qml" line="366"/>
         <source>Arabic</source>
-        <translation type="unfinished" />
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="372" />
+        <location filename="../screens/SettingsScreen.qml" line="368"/>
         <source>Hindi</source>
-        <translation type="unfinished" />
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="373" />
+        <location filename="../screens/SettingsScreen.qml" line="369"/>
         <source>Auto</source>
         <translation>Automaticky</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="378" />
+        <location filename="../screens/SettingsScreen.qml" line="374"/>
         <source>Detailed list view</source>
         <translation>Podrobné zobrazenie zoznamu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="379" />
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Grid view</source>
         <translation>Zobrazenie mriežky</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="384" />
+        <location filename="../screens/SettingsScreen.qml" line="380"/>
         <source>Style B</source>
         <translation>Štýl B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="386" />
+        <location filename="../screens/SettingsScreen.qml" line="382"/>
         <source>Style C</source>
         <translation>Štýl C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="388" />
+        <location filename="../screens/SettingsScreen.qml" line="384"/>
         <source>Style D</source>
         <translation>Štýl D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="389" />
+        <location filename="../screens/SettingsScreen.qml" line="385"/>
         <source>Style A</source>
         <translation>Štýl A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="326" />
+        <location filename="../screens/SettingsScreen.qml" line="322"/>
         <source>Default</source>
         <translation>Predvolené</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399" />
+        <location filename="../screens/SettingsScreen.qml" line="395"/>
         <source>Off</source>
         <translation>Vypnuté</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="401" />
+        <location filename="../screens/SettingsScreen.qml" line="397"/>
         <source>1 second (testing)</source>
         <translation>1 sekunda (test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="403" />
+        <location filename="../screens/SettingsScreen.qml" line="399"/>
         <source>1 minute</source>
         <translation>1 minúta</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405" />
+        <location filename="../screens/SettingsScreen.qml" line="401"/>
         <source>2 minutes</source>
         <translation>2 minúty</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="407" />
+        <location filename="../screens/SettingsScreen.qml" line="403"/>
         <source>5 minutes</source>
         <translation>5 minút</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="409" />
+        <location filename="../screens/SettingsScreen.qml" line="405"/>
         <source>10 minutes</source>
         <translation>10 minút</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="411" />
+        <location filename="../screens/SettingsScreen.qml" line="407"/>
         <source>15 minutes</source>
         <translation>15 minút</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="413" />
+        <location filename="../screens/SettingsScreen.qml" line="409"/>
         <source>30 minutes</source>
         <translation>30 minút</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="414" />
+        <location filename="../screens/SettingsScreen.qml" line="410"/>
         <source>%1 seconds</source>
         <translation>%1 sekúnd</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="427" />
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="423"/>
         <source>Resolution</source>
         <translation>Rozlíšenie</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="555" />
+        <location filename="../screens/SettingsScreen.qml" line="563"/>
         <source>Settings</source>
         <translation>Nastavenia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="745" />
+        <location filename="../screens/SettingsScreen.qml" line="755"/>
         <source>No settings available on this platform</source>
         <translation>Na tejto platforme nie sú dostupné žiadne nastavenia</translation>
     </message>
@@ -911,17 +998,23 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="182" />
+        <location filename="../screens/SystemsScreen.qml" line="185"/>
+        <location filename="../screens/SystemsScreen.qml" line="313"/>
         <source>%1 systems</source>
         <translation>%1 systémov</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="279" />
+        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SystemsScreen.qml" line="345"/>
         <source>No systems in this category</source>
         <translation>V tejto kategórii nie sú žiadne systémy</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="280" />
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>
@@ -929,7 +1022,7 @@
 <context>
     <name>TopStatusStrip</name>
     <message>
-        <location filename="../components/TopStatusStrip.qml" line="88" />
+        <location filename="../components/TopStatusStrip.qml" line="90"/>
         <source>Page %1 / %2</source>
         <translation>Stránka %1 / %2</translation>
     </message>

--- a/src/ui/translations/launcher_uk.ts
+++ b/src/ui/translations/launcher_uk.ts
@@ -90,38 +90,48 @@
         <translation type="unfinished">Завантаження…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="43"/>
+        <location filename="../components/BrowseDetailPane.qml" line="44"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="45"/>
+        <location filename="../components/BrowseDetailPane.qml" line="46"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <location filename="../components/BrowseDetailPane.qml" line="48"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <location filename="../components/BrowseDetailPane.qml" line="50"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <location filename="../components/BrowseDetailPane.qml" line="52"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <location filename="../components/BrowseDetailPane.qml" line="54"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="55"/>
-        <source>Filename</source>
+        <location filename="../components/BrowseDetailPane.qml" line="56"/>
+        <source>Category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="58"/>
+        <source>Release date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="60"/>
+        <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -245,12 +255,17 @@
         <translation>%1 записів</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="309"/>
+        <location filename="../screens/FavoritesScreen.qml" line="190"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/FavoritesScreen.qml" line="280"/>
         <source>No favorites yet</source>
         <translation>Поки немає вибраного</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="310"/>
+        <location filename="../screens/FavoritesScreen.qml" line="281"/>
         <source>Loading favorites…</source>
         <translation>Завантаження вибраного…</translation>
     </message>
@@ -324,33 +339,35 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="367"/>
-        <location filename="../screens/GamesScreen.qml" line="537"/>
+        <location filename="../screens/GamesScreen.qml" line="373"/>
+        <location filename="../screens/GamesScreen.qml" line="520"/>
         <source>%1 files</source>
         <translation>%1 файлів</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="437"/>
+        <location filename="../screens/GamesScreen.qml" line="409"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="554"/>
+        <location filename="../screens/GamesScreen.qml" line="382"/>
+        <location filename="../screens/GamesScreen.qml" line="537"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="570"/>
+        <location filename="../screens/GamesScreen.qml" line="553"/>
         <source>Loading games…</source>
         <translation>Завантаження ігор…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="592"/>
+        <location filename="../screens/GamesScreen.qml" line="378"/>
+        <location filename="../screens/GamesScreen.qml" line="575"/>
         <source>Loading more…</source>
         <translation>Завантаження ще…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="569"/>
+        <location filename="../screens/GamesScreen.qml" line="552"/>
         <source>No games in this system</source>
         <translation>У цій системі немає ігор</translation>
     </message>
@@ -672,12 +689,17 @@
         <translation>%1 записів</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="312"/>
+        <location filename="../screens/RecentsScreen.qml" line="191"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/RecentsScreen.qml" line="283"/>
         <source>Loading recently played…</source>
         <translation>Завантаження нещодавніх…</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="311"/>
+        <location filename="../screens/RecentsScreen.qml" line="282"/>
         <source>Nothing played yet</source>
         <translation>Поки нічого не грали</translation>
     </message>
@@ -999,22 +1021,23 @@
     <name>SystemsScreen</name>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="185"/>
-        <location filename="../screens/SystemsScreen.qml" line="313"/>
+        <location filename="../screens/SystemsScreen.qml" line="285"/>
         <source>%1 systems</source>
         <translation>%1 систем</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <location filename="../screens/SystemsScreen.qml" line="189"/>
+        <location filename="../screens/SystemsScreen.qml" line="302"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="345"/>
+        <location filename="../screens/SystemsScreen.qml" line="317"/>
         <source>No systems in this category</source>
         <translation>У цій категорії немає систем</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="318"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>
@@ -1022,7 +1045,7 @@
 <context>
     <name>TopStatusStrip</name>
     <message>
-        <location filename="../components/TopStatusStrip.qml" line="90"/>
+        <location filename="../components/TopStatusStrip.qml" line="91"/>
         <source>Page %1 / %2</source>
         <translation>Сторінка %1 / %2</translation>
     </message>

--- a/src/ui/translations/launcher_uk.ts
+++ b/src/ui/translations/launcher_uk.ts
@@ -1,59 +1,60 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
 <TS version="2.1" language="uk" sourcelanguage="en">
 <context>
     <name>AboutScreen</name>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="72" />
+        <location filename="../screens/AboutScreen.qml" line="71"/>
         <source>About / License</source>
         <translation>Про програму / Ліцензія</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="154" />
+        <location filename="../screens/AboutScreen.qml" line="153"/>
         <source>Zaparoo Launcher</source>
         <translation>Запускач Zaparoo</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="165" />
+        <location filename="../screens/AboutScreen.qml" line="164"/>
         <source>Version %1 · %2 · %3</source>
         <translation>Версія %1 · %2 · %3</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="178" />
+        <location filename="../screens/AboutScreen.qml" line="174"/>
         <source>Built %1</source>
         <translation>Зібрано %1</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="189" />
+        <location filename="../screens/AboutScreen.qml" line="185"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>Авторські права 2026 Wizzo Pty Ltd та учасники проєкту Zaparoo.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="200" />
+        <location filename="../screens/AboutScreen.qml" line="196"/>
         <source>Source available under the PolyForm Noncommercial License 1.0.0. Free for personal, non-commercial use. Commercial use or redistribution requires a separate license.</source>
         <translation>Вихідний код доступний за ліцензією PolyForm Noncommercial License 1.0.0. Безкоштовно для особистого некомерційного використання. Комерційне використання або розповсюдження потребує окремої ліцензії.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="211" />
+        <location filename="../screens/AboutScreen.qml" line="207"/>
         <source>Commercial licensing: legal@zaparoo.org</source>
         <translation>Комерційне ліцензування: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="222" />
+        <location filename="../screens/AboutScreen.qml" line="218"/>
         <source>Project: https://zaparoo.org</source>
         <translation>Проєкт: https://zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="232" />
+        <location filename="../screens/AboutScreen.qml" line="228"/>
         <source>Created by</source>
         <translation>Створено</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="256" />
+        <location filename="../screens/AboutScreen.qml" line="252"/>
         <source>Translations</source>
         <translation>Переклади</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="280" />
+        <location filename="../screens/AboutScreen.qml" line="276"/>
         <source>Full license text in COPYING.</source>
         <translation>Повний текст ліцензії у файлі COPYING.</translation>
     </message>
@@ -61,60 +62,103 @@
 <context>
     <name>BootOverlay</name>
     <message>
-        <location filename="../components/BootOverlay.qml" line="76" />
-        <source>Can't reach Zaparoo Core. Check your connection.</source>
-        <translation>Не вдається з'єднатися з Zaparoo Core. Перевірте з'єднання.</translation>
+        <location filename="../components/BootOverlay.qml" line="76"/>
+        <source>Can&apos;t reach Zaparoo Core. Check your connection.</source>
+        <translation>Не вдається з&apos;єднатися з Zaparoo Core. Перевірте з&apos;єднання.</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="78" />
+        <location filename="../components/BootOverlay.qml" line="78"/>
         <source>Reconnecting…</source>
         <translation>Повторне підключення…</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="80" />
+        <location filename="../components/BootOverlay.qml" line="80"/>
         <source>Loading library…</source>
         <translation>Завантаження бібліотеки…</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="85" />
+        <location filename="../components/BootOverlay.qml" line="85"/>
         <source>Connecting to Zaparoo Core…</source>
         <translation>Підключення до Zaparoo Core…</translation>
     </message>
 </context>
 <context>
+    <name>BrowseDetailPane</name>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="22"/>
+        <source>Loading…</source>
+        <translation type="unfinished">Завантаження…</translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="43"/>
+        <source>Year</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="45"/>
+        <source>Genre</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <source>Players</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <source>Developer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <source>Publisher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <source>Rating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="55"/>
+        <source>Filename</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommercialNoticeModal</name>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="59" />
+        <location filename="../components/CommercialNoticeModal.qml" line="59"/>
         <source>Welcome to Zaparoo Launcher</source>
         <translation>Ласкаво просимо до Zaparoo Launcher</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="68" />
+        <location filename="../components/CommercialNoticeModal.qml" line="68"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>Авторські права 2026 Wizzo Pty Ltd та учасники проєкту Zaparoo.</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="79" />
+        <location filename="../components/CommercialNoticeModal.qml" line="79"/>
         <source>This free source-available build is for personal and non-commercial use only. Commercial use or redistribution requires a license.</source>
         <translation>Ця безкоштовна збірка призначена лише для особистого та некомерційного використання. Комерційне використання або розповсюдження потребує ліцензії.</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="90" />
+        <location filename="../components/CommercialNoticeModal.qml" line="90"/>
         <source>Contact: legal@zaparoo.org</source>
         <translation>Контакт: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="101" />
+        <location filename="../components/CommercialNoticeModal.qml" line="101"/>
         <source>Full details available any time under Settings &gt; About / License.</source>
         <translation>Повні відомості доступні в будь-який час у Налаштуваннях &gt; Про програму / Ліцензія.</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="119" />
+        <location filename="../components/CommercialNoticeModal.qml" line="119"/>
         <source>Created by</source>
         <translation>Створено</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="162" />
+        <location filename="../components/CommercialNoticeModal.qml" line="162"/>
         <source>I understand</source>
         <translation>Я розумію</translation>
     </message>
@@ -122,68 +166,68 @@
 <context>
     <name>CoreStatusPill</name>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="44" />
-        <location filename="../components/CoreStatusPill.qml" line="50" />
+        <location filename="../components/CoreStatusPill.qml" line="44"/>
+        <location filename="../components/CoreStatusPill.qml" line="50"/>
         <source>Disconnected</source>
         <translation>Відключено</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="47" />
+        <location filename="../components/CoreStatusPill.qml" line="47"/>
         <source>Reconnecting…</source>
         <translation>Повторне підключення…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="53" />
+        <location filename="../components/CoreStatusPill.qml" line="53"/>
         <source>Connecting…</source>
         <translation>Підключення…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="56" />
+        <location filename="../components/CoreStatusPill.qml" line="56"/>
         <source>Core error</source>
         <translation>Помилка Core</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="60" />
+        <location filename="../components/CoreStatusPill.qml" line="60"/>
         <source>Optimizing database</source>
         <translation>Оптимізація бази даних</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="67" />
+        <location filename="../components/CoreStatusPill.qml" line="67"/>
         <source>Indexing paused</source>
         <translation>Індексування призупинено</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="70" />
+        <location filename="../components/CoreStatusPill.qml" line="70"/>
         <source>Indexing %1/%2 - %3</source>
         <translation>Індексування %1/%2 – %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="86" />
+        <location filename="../components/CoreStatusPill.qml" line="86"/>
         <source>Scraping %1/%2 - %3</source>
         <translation>Скрейпінг %1/%2 – %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="73" />
+        <location filename="../components/CoreStatusPill.qml" line="73"/>
         <source>Indexing %1/%2</source>
         <translation>Індексування %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="75" />
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
         <source>Indexing…</source>
         <translation>Індексування…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="83" />
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Scrape paused</source>
         <translation>Скрейпінг призупинено</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="89" />
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
         <source>Scraping %1/%2</source>
         <translation>Скрейпінг %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="91" />
+        <location filename="../components/CoreStatusPill.qml" line="91"/>
         <source>Scraping…</source>
         <translation>Скрейпінг…</translation>
     </message>
@@ -191,22 +235,22 @@
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="182" />
+        <location filename="../screens/FavoritesScreen.qml" line="183"/>
         <source>Favorites</source>
         <translation>Вибране</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="185" />
+        <location filename="../screens/FavoritesScreen.qml" line="186"/>
         <source>%1 entries</source>
         <translation>%1 записів</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="283" />
+        <location filename="../screens/FavoritesScreen.qml" line="309"/>
         <source>No favorites yet</source>
         <translation>Поки немає вибраного</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="284" />
+        <location filename="../screens/FavoritesScreen.qml" line="310"/>
         <source>Loading favorites…</source>
         <translation>Завантаження вибраного…</translation>
     </message>
@@ -214,75 +258,99 @@
 <context>
     <name>FirstRunIndexModal</name>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="127" />
+        <location filename="../components/FirstRunIndexModal.qml" line="127"/>
         <source>First-time setup</source>
         <translation>Початкове налаштування</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="136" />
+        <location filename="../components/FirstRunIndexModal.qml" line="136"/>
         <source>Zaparoo needs to scan your games before you can use the launcher. This usually takes a few minutes.</source>
         <translation>Zaparoo потрібно відсканувати ваші ігри перед використанням лаунчера. Зазвичай це займає кілька хвилин.</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="211" />
+        <location filename="../components/FirstRunIndexModal.qml" line="211"/>
         <source>Indexing paused</source>
         <translation>Індексування призупинено</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="158" />
+        <location filename="../components/FirstRunIndexModal.qml" line="158"/>
         <source>Optimizing database - almost done</source>
         <translation>Оптимізація бази даних – майже готово</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="213" />
+        <location filename="../components/FirstRunIndexModal.qml" line="213"/>
         <source>Step %1 of %2 - %3</source>
         <translation>Крок %1 з %2 – %3</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="215" />
+        <location filename="../components/FirstRunIndexModal.qml" line="215"/>
         <source>Step %1 of %2</source>
         <translation>Крок %1 з %2</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="216" />
+        <location filename="../components/FirstRunIndexModal.qml" line="216"/>
         <source>Preparing…</source>
         <translation>Підготовка…</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="233" />
+        <location filename="../components/FirstRunIndexModal.qml" line="233"/>
         <source>Done. %1 files indexed.</source>
         <translation>Готово. Проіндексовано %1 файлів.</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="263" />
+        <location filename="../components/FirstRunIndexModal.qml" line="263"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="263" />
+        <location filename="../components/FirstRunIndexModal.qml" line="263"/>
         <source>Start scan</source>
         <translation>Почати сканування</translation>
     </message>
 </context>
 <context>
+    <name>GameInfoModal</name>
+    <message>
+        <location filename="../components/GameInfoModal.qml" line="86"/>
+        <source>Back to close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/GameInfoModal.qml" line="114"/>
+        <source>Loading details…</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="363" />
+        <location filename="../screens/GamesScreen.qml" line="367"/>
+        <location filename="../screens/GamesScreen.qml" line="537"/>
         <source>%1 files</source>
         <translation>%1 файлів</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="534" />
+        <location filename="../screens/GamesScreen.qml" line="437"/>
+        <source>Loading game…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/GamesScreen.qml" line="554"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/GamesScreen.qml" line="570"/>
         <source>Loading games…</source>
         <translation>Завантаження ігор…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="556" />
+        <location filename="../screens/GamesScreen.qml" line="592"/>
         <source>Loading more…</source>
         <translation>Завантаження ще…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="533" />
+        <location filename="../screens/GamesScreen.qml" line="569"/>
         <source>No games in this system</source>
         <translation>У цій системі немає ігор</translation>
     </message>
@@ -290,22 +358,22 @@
 <context>
     <name>HubScreen</name>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91" />
+        <location filename="../screens/HubScreen.qml" line="91"/>
         <source>Favorites</source>
         <translation>Вибране</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="96" />
+        <location filename="../screens/HubScreen.qml" line="96"/>
         <source>Recently Played</source>
         <translation>Нещодавно зіграні</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="101" />
+        <location filename="../screens/HubScreen.qml" line="101"/>
         <source>Settings</source>
         <translation>Налаштування</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="537" />
+        <location filename="../screens/HubScreen.qml" line="537"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Немає доступних систем. Запустіть Оновлення бази даних з Налаштувань.</translation>
     </message>
@@ -313,7 +381,7 @@
 <context>
     <name>LoadingIndicator</name>
     <message>
-        <location filename="../components/LoadingIndicator.qml" line="26" />
+        <location filename="../components/LoadingIndicator.qml" line="26"/>
         <source>Loading…</source>
         <translation>Завантаження…</translation>
     </message>
@@ -321,32 +389,32 @@
 <context>
     <name>LogUploadModal</name>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="87" />
+        <location filename="../components/LogUploadModal.qml" line="87"/>
         <source>Upload log file</source>
         <translation>Завантажити файл журналу</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="97" />
+        <location filename="../components/LogUploadModal.qml" line="97"/>
         <source>Uploading log file - this may take a moment.</source>
         <translation>Завантаження файлу журналу – це може зайняти хвилину.</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197" />
+        <location filename="../components/LogUploadModal.qml" line="197"/>
         <source>Upload failed: %1</source>
         <translation>Помилка завантаження: %1</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197" />
+        <location filename="../components/LogUploadModal.qml" line="197"/>
         <source>Upload failed.</source>
         <translation>Помилка завантаження.</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="227" />
+        <location filename="../components/LogUploadModal.qml" line="227"/>
         <source>Retry</source>
         <translation>Повторити</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="227" />
+        <location filename="../components/LogUploadModal.qml" line="227"/>
         <source>Done</source>
         <translation>Готово</translation>
     </message>
@@ -354,58 +422,64 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="723" />
+        <location filename="../app/Main.qml" line="753"/>
         <source>Launch core</source>
         <translation>Запустити core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="741" />
+        <location filename="../app/Main.qml" line="761"/>
+        <location filename="../app/Main.qml" line="781"/>
+        <source>More info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="785"/>
         <source>Remove from favorites</source>
         <translation>Видалити з вибраного</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="741" />
+        <location filename="../app/Main.qml" line="785"/>
         <source>Add to favorites</source>
         <translation>Додати до вибраного</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="747" />
+        <location filename="../app/Main.qml" line="790"/>
         <source>Write to NFC token</source>
         <translation>Записати на NFC-токен</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="751" />
+        <location filename="../app/Main.qml" line="794"/>
         <source>QR code</source>
         <translation>QR-код</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="731" />
-        <location filename="../app/Main.qml" line="755" />
+        <location filename="../app/Main.qml" line="765"/>
+        <location filename="../app/Main.qml" line="804"/>
         <source>Launch game</source>
         <translation>Запустити гру</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1437" />
+        <location filename="../app/Main.qml" line="1652"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1441" />
+        <location filename="../app/Main.qml" line="1656"/>
         <source>Loading favorites…</source>
         <translation>Завантаження вибраного…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1439" />
+        <location filename="../app/Main.qml" line="1654"/>
         <source>Loading games…</source>
         <translation>Завантаження ігор…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1443" />
+        <location filename="../app/Main.qml" line="1658"/>
         <source>Loading recently played…</source>
         <translation>Завантаження нещодавніх…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1445" />
+        <location filename="../app/Main.qml" line="1660"/>
         <source>Loading…</source>
         <translation>Завантаження…</translation>
     </message>
@@ -413,144 +487,151 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="127" />
+        <location filename="../app/MainLayout.qml" line="141"/>
         <source>Zaparoo Launcher</source>
         <translation>Запускач Zaparoo</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="475" />
+        <location filename="../app/MainLayout.qml" line="545"/>
         <source>Writing failed</source>
         <translation>Помилка запису</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="475" />
+        <location filename="../app/MainLayout.qml" line="545"/>
         <source>Put a writable card near the reader</source>
         <translation>Прикладіть картку для запису до зчитувача</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="540" />
+        <location filename="../app/MainLayout.qml" line="556"/>
+        <source>Quit and restart Zaparoo Launcher?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="557"/>
+        <source>In order to apply this setting we need to restart the launcher.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="632"/>
         <source>Quit Zaparoo Launcher?</source>
         <translation>Вийти із Zaparoo Launcher?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="541" />
+        <location filename="../app/MainLayout.qml" line="633"/>
         <source>Are you sure you want to exit?</source>
         <translation>Ви впевнені, що хочете вийти?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="617" />
-        <location filename="../app/MainLayout.qml" line="689" />
-        <location filename="../app/MainLayout.qml" line="704" />
+        <location filename="../app/MainLayout.qml" line="709"/>
+        <location filename="../app/MainLayout.qml" line="781"/>
         <source>Select</source>
         <translation>Вибрати</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="621" />
-        <location filename="../app/MainLayout.qml" line="625" />
-        <location filename="../app/MainLayout.qml" line="639" />
-        <location filename="../app/MainLayout.qml" line="652" />
-        <location filename="../app/MainLayout.qml" line="663" />
+        <location filename="../app/MainLayout.qml" line="713"/>
+        <location filename="../app/MainLayout.qml" line="717"/>
+        <location filename="../app/MainLayout.qml" line="731"/>
+        <location filename="../app/MainLayout.qml" line="744"/>
+        <location filename="../app/MainLayout.qml" line="755"/>
         <source>Close</source>
         <translation>Закрити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="632" />
-        <location filename="../app/MainLayout.qml" line="670" />
-        <location filename="../app/MainLayout.qml" line="693" />
-        <location filename="../app/MainLayout.qml" line="708" />
-        <location filename="../app/MainLayout.qml" line="719" />
+        <location filename="../app/MainLayout.qml" line="724"/>
+        <location filename="../app/MainLayout.qml" line="762"/>
+        <location filename="../app/MainLayout.qml" line="785"/>
+        <location filename="../app/MainLayout.qml" line="796"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="648" />
+        <location filename="../app/MainLayout.qml" line="740"/>
         <source>Done</source>
         <translation>Готово</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="678" />
+        <location filename="../app/MainLayout.qml" line="770"/>
         <source>I understand</source>
         <translation>Я розумію</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="727" />
+        <location filename="../app/MainLayout.qml" line="804"/>
         <source>Start</source>
         <translation>Почати</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="896" />
+        <location filename="../app/MainLayout.qml" line="973"/>
         <source>Scroll</source>
         <translation>Прокрутка</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="613" />
-        <location filename="../app/MainLayout.qml" line="685" />
-        <location filename="../app/MainLayout.qml" line="700" />
-        <location filename="../app/MainLayout.qml" line="743" />
-        <location filename="../app/MainLayout.qml" line="772" />
-        <location filename="../app/MainLayout.qml" line="819" />
-        <location filename="../app/MainLayout.qml" line="860" />
-        <location filename="../app/MainLayout.qml" line="924" />
+        <location filename="../app/MainLayout.qml" line="705"/>
+        <location filename="../app/MainLayout.qml" line="777"/>
+        <location filename="../app/MainLayout.qml" line="820"/>
+        <location filename="../app/MainLayout.qml" line="849"/>
+        <location filename="../app/MainLayout.qml" line="896"/>
+        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="1001"/>
         <source>Move</source>
         <translation>Переміщення</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="747" />
-        <location filename="../app/MainLayout.qml" line="782" />
-        <location filename="../app/MainLayout.qml" line="829" />
-        <location filename="../app/MainLayout.qml" line="934" />
+        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="859"/>
+        <location filename="../app/MainLayout.qml" line="906"/>
+        <location filename="../app/MainLayout.qml" line="1011"/>
         <source>Open</source>
         <translation>Відкрити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="751" />
+        <location filename="../app/MainLayout.qml" line="828"/>
         <source>Quit</source>
         <translation>Вийти</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="760" />
-        <location filename="../app/MainLayout.qml" line="788" />
-        <location filename="../app/MainLayout.qml" line="799" />
-        <location filename="../app/MainLayout.qml" line="811" />
-        <location filename="../app/MainLayout.qml" line="838" />
-        <location filename="../app/MainLayout.qml" line="849" />
-        <location filename="../app/MainLayout.qml" line="884" />
-        <location filename="../app/MainLayout.qml" line="900" />
-        <location filename="../app/MainLayout.qml" line="909" />
-        <location filename="../app/MainLayout.qml" line="943" />
-        <location filename="../app/MainLayout.qml" line="954" />
+        <location filename="../app/MainLayout.qml" line="837"/>
+        <location filename="../app/MainLayout.qml" line="865"/>
+        <location filename="../app/MainLayout.qml" line="876"/>
+        <location filename="../app/MainLayout.qml" line="888"/>
+        <location filename="../app/MainLayout.qml" line="915"/>
+        <location filename="../app/MainLayout.qml" line="926"/>
+        <location filename="../app/MainLayout.qml" line="961"/>
+        <location filename="../app/MainLayout.qml" line="977"/>
+        <location filename="../app/MainLayout.qml" line="986"/>
+        <location filename="../app/MainLayout.qml" line="1020"/>
+        <location filename="../app/MainLayout.qml" line="1031"/>
         <source>Back</source>
         <translation>Назад</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="778" />
-        <location filename="../app/MainLayout.qml" line="825" />
-        <location filename="../app/MainLayout.qml" line="930" />
+        <location filename="../app/MainLayout.qml" line="855"/>
+        <location filename="../app/MainLayout.qml" line="902"/>
+        <location filename="../app/MainLayout.qml" line="1007"/>
         <source>Page</source>
         <translation>Сторінка</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="785" />
-        <location filename="../app/MainLayout.qml" line="834" />
-        <location filename="../app/MainLayout.qml" line="939" />
+        <location filename="../app/MainLayout.qml" line="862"/>
+        <location filename="../app/MainLayout.qml" line="911"/>
+        <location filename="../app/MainLayout.qml" line="1016"/>
         <source>Options</source>
         <translation>Параметри</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="659" />
-        <location filename="../app/MainLayout.qml" line="795" />
-        <location filename="../app/MainLayout.qml" line="845" />
-        <location filename="../app/MainLayout.qml" line="950" />
+        <location filename="../app/MainLayout.qml" line="751"/>
+        <location filename="../app/MainLayout.qml" line="872"/>
+        <location filename="../app/MainLayout.qml" line="922"/>
+        <location filename="../app/MainLayout.qml" line="1027"/>
         <source>Retry</source>
         <translation>Повторити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="869" />
+        <location filename="../app/MainLayout.qml" line="946"/>
         <source>Change</source>
         <translation>Змінити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="875" />
+        <location filename="../app/MainLayout.qml" line="952"/>
         <source>Toggle</source>
         <translation>Перемкнути</translation>
     </message>
@@ -558,22 +639,22 @@
 <context>
     <name>Modal</name>
     <message>
-        <location filename="../components/Modal.qml" line="49" />
+        <location filename="../components/Modal.qml" line="49"/>
         <source>OK</source>
         <translation>Гаразд</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="50" />
+        <location filename="../components/Modal.qml" line="50"/>
         <source>Yes</source>
         <translation>Так</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="51" />
+        <location filename="../components/Modal.qml" line="51"/>
         <source>No</source>
         <translation>Ні</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="198" />
+        <location filename="../components/Modal.qml" line="198"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
@@ -581,22 +662,22 @@
 <context>
     <name>RecentsScreen</name>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="183" />
+        <location filename="../screens/RecentsScreen.qml" line="184"/>
         <source>Recently Played</source>
         <translation>Нещодавно зіграні</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="186" />
+        <location filename="../screens/RecentsScreen.qml" line="187"/>
         <source>%1 entries</source>
         <translation>%1 записів</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="282" />
+        <location filename="../screens/RecentsScreen.qml" line="312"/>
         <source>Loading recently played…</source>
         <translation>Завантаження нещодавніх…</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="281" />
+        <location filename="../screens/RecentsScreen.qml" line="311"/>
         <source>Nothing played yet</source>
         <translation>Поки нічого не грали</translation>
     </message>
@@ -604,17 +685,17 @@
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="26" />
+        <location filename="../components/ScreenStateOverlay.qml" line="26"/>
         <source>Nothing here</source>
         <translation>Тут нічого немає</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27" />
+        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
         <source>Loading…</source>
         <translation>Завантаження…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="57" />
+        <location filename="../components/ScreenStateOverlay.qml" line="57"/>
         <source>Failed to load</source>
         <translation>Не вдалося завантажити</translation>
     </message>
@@ -622,288 +703,294 @@
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78" />
-        <location filename="../screens/SettingsScreen.qml" line="436" />
+        <location filename="../screens/SettingsScreen.qml" line="73"/>
+        <location filename="../screens/SettingsScreen.qml" line="432"/>
         <source>Language</source>
         <translation>Мова</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83" />
-        <location filename="../screens/SettingsScreen.qml" line="445" />
+        <location filename="../screens/SettingsScreen.qml" line="78"/>
+        <location filename="../screens/SettingsScreen.qml" line="441"/>
         <source>Browsing layout</source>
         <translation>Режим перегляду</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116" />
+        <location filename="../screens/SettingsScreen.qml" line="116"/>
         <source>Mouse support</source>
         <translation>Підтримка миші</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102" />
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
         <source>Update media database</source>
         <translation>Оновити базу медіа</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="61" />
+        <location filename="../screens/SettingsScreen.qml" line="61"/>
         <source>General</source>
         <translation>Загальні</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88" />
-        <location filename="../screens/SettingsScreen.qml" line="454" />
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="450"/>
         <source>Button style</source>
         <translation>Стиль кнопок</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="93" />
-        <location filename="../screens/SettingsScreen.qml" line="463" />
+        <location filename="../screens/SettingsScreen.qml" line="88"/>
+        <location filename="../screens/SettingsScreen.qml" line="459"/>
         <source>Screensaver</source>
         <translation>Заставка</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97" />
+        <location filename="../screens/SettingsScreen.qml" line="92"/>
         <source>Library</source>
         <translation>Бібліотека</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="107" />
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <source>Discover arcade alternate versions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="107"/>
         <source>Scrape metadata</source>
         <translation>Отримати метадані</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111" />
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
         <source>Advanced</source>
         <translation>Розширені</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121" />
+        <location filename="../screens/SettingsScreen.qml" line="121"/>
         <source>Debug logging</source>
         <translation>Журнал відлагодження</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126" />
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Upload log file</source>
         <translation>Завантажити файл журналу</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131" />
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
         <source>About / License</source>
         <translation>Про програму / Ліцензія</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147" />
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
         <source>Optimizing</source>
         <translation>Оптимізація</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149" />
-        <location filename="../screens/SettingsScreen.qml" line="158" />
+        <location filename="../screens/SettingsScreen.qml" line="149"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
         <source>Paused</source>
         <translation>Призупинено</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149" />
-        <location filename="../screens/SettingsScreen.qml" line="158" />
+        <location filename="../screens/SettingsScreen.qml" line="149"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
         <source>In progress</source>
         <translation>Виконується</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152" />
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>%1 indexed</source>
         <translation>%1 проіндексовано</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="161" />
+        <location filename="../screens/SettingsScreen.qml" line="161"/>
         <source>%1 scraped</source>
         <translation>%1 зібрано</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270" />
+        <location filename="../screens/SettingsScreen.qml" line="266"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270" />
+        <location filename="../screens/SettingsScreen.qml" line="266"/>
         <source>Start</source>
         <translation>Почати</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="272" />
+        <location filename="../screens/SettingsScreen.qml" line="268"/>
         <source>Upload</source>
         <translation>Вивантажити</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="274" />
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
         <source>Open</source>
         <translation>Відкрити</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="346" />
+        <location filename="../screens/SettingsScreen.qml" line="342"/>
         <source>English</source>
         <translation>Англійська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="348" />
+        <location filename="../screens/SettingsScreen.qml" line="344"/>
         <source>Italian</source>
         <translation>Італійська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="350" />
+        <location filename="../screens/SettingsScreen.qml" line="346"/>
         <source>German</source>
         <translation>Німецька</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="352" />
+        <location filename="../screens/SettingsScreen.qml" line="348"/>
         <source>Greek</source>
         <translation>Грецька</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="354" />
+        <location filename="../screens/SettingsScreen.qml" line="350"/>
         <source>Japanese</source>
         <translation>Японська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="356" />
+        <location filename="../screens/SettingsScreen.qml" line="352"/>
         <source>Korean</source>
         <translation>Корейська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="358" />
+        <location filename="../screens/SettingsScreen.qml" line="354"/>
         <source>Dutch</source>
         <translation>Нідерландська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="360" />
+        <location filename="../screens/SettingsScreen.qml" line="356"/>
         <source>Romanian</source>
         <translation>Румунська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="362" />
+        <location filename="../screens/SettingsScreen.qml" line="358"/>
         <source>Slovak</source>
         <translation>Словацька</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="364" />
+        <location filename="../screens/SettingsScreen.qml" line="360"/>
         <source>Ukrainian</source>
         <translation>Українська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="366" />
+        <location filename="../screens/SettingsScreen.qml" line="362"/>
         <source>Chinese (Simplified)</source>
         <translation>Китайська (спрощена)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="368" />
+        <location filename="../screens/SettingsScreen.qml" line="364"/>
         <source>Hebrew</source>
         <translation>Іврит</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="370" />
+        <location filename="../screens/SettingsScreen.qml" line="366"/>
         <source>Arabic</source>
-        <translation type="unfinished" />
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="372" />
+        <location filename="../screens/SettingsScreen.qml" line="368"/>
         <source>Hindi</source>
-        <translation type="unfinished" />
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="373" />
+        <location filename="../screens/SettingsScreen.qml" line="369"/>
         <source>Auto</source>
         <translation>Автоматично</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="378" />
+        <location filename="../screens/SettingsScreen.qml" line="374"/>
         <source>Detailed list view</source>
         <translation>Детальний перегляд списку</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="379" />
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Grid view</source>
         <translation>Перегляд сіткою</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="384" />
+        <location filename="../screens/SettingsScreen.qml" line="380"/>
         <source>Style B</source>
         <translation>Стиль B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="386" />
+        <location filename="../screens/SettingsScreen.qml" line="382"/>
         <source>Style C</source>
         <translation>Стиль C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="388" />
+        <location filename="../screens/SettingsScreen.qml" line="384"/>
         <source>Style D</source>
         <translation>Стиль D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="389" />
+        <location filename="../screens/SettingsScreen.qml" line="385"/>
         <source>Style A</source>
         <translation>Стиль A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="326" />
+        <location filename="../screens/SettingsScreen.qml" line="322"/>
         <source>Default</source>
         <translation>Типовий</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399" />
+        <location filename="../screens/SettingsScreen.qml" line="395"/>
         <source>Off</source>
         <translation>Вимкнено</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="401" />
+        <location filename="../screens/SettingsScreen.qml" line="397"/>
         <source>1 second (testing)</source>
         <translation>1 секунда (тест)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="403" />
+        <location filename="../screens/SettingsScreen.qml" line="399"/>
         <source>1 minute</source>
         <translation>1 хвилина</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405" />
+        <location filename="../screens/SettingsScreen.qml" line="401"/>
         <source>2 minutes</source>
         <translation>2 хвилини</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="407" />
+        <location filename="../screens/SettingsScreen.qml" line="403"/>
         <source>5 minutes</source>
         <translation>5 хвилин</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="409" />
+        <location filename="../screens/SettingsScreen.qml" line="405"/>
         <source>10 minutes</source>
         <translation>10 хвилин</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="411" />
+        <location filename="../screens/SettingsScreen.qml" line="407"/>
         <source>15 minutes</source>
         <translation>15 хвилин</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="413" />
+        <location filename="../screens/SettingsScreen.qml" line="409"/>
         <source>30 minutes</source>
         <translation>30 хвилин</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="414" />
+        <location filename="../screens/SettingsScreen.qml" line="410"/>
         <source>%1 seconds</source>
         <translation>%1 секунд</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="427" />
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="423"/>
         <source>Resolution</source>
         <translation>Роздільна здатність</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="555" />
+        <location filename="../screens/SettingsScreen.qml" line="563"/>
         <source>Settings</source>
         <translation>Налаштування</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="745" />
+        <location filename="../screens/SettingsScreen.qml" line="755"/>
         <source>No settings available on this platform</source>
         <translation>На цій платформі налаштування недоступні</translation>
     </message>
@@ -911,17 +998,23 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="182" />
+        <location filename="../screens/SystemsScreen.qml" line="185"/>
+        <location filename="../screens/SystemsScreen.qml" line="313"/>
         <source>%1 systems</source>
         <translation>%1 систем</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="279" />
+        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SystemsScreen.qml" line="345"/>
         <source>No systems in this category</source>
         <translation>У цій категорії немає систем</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="280" />
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>
@@ -929,7 +1022,7 @@
 <context>
     <name>TopStatusStrip</name>
     <message>
-        <location filename="../components/TopStatusStrip.qml" line="88" />
+        <location filename="../components/TopStatusStrip.qml" line="90"/>
         <source>Page %1 / %2</source>
         <translation>Сторінка %1 / %2</translation>
     </message>

--- a/src/ui/translations/launcher_uk.ts
+++ b/src/ui/translations/launcher_uk.ts
@@ -245,27 +245,27 @@
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="183"/>
+        <location filename="../screens/FavoritesScreen.qml" line="225"/>
         <source>Favorites</source>
         <translation>Вибране</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="186"/>
+        <location filename="../screens/FavoritesScreen.qml" line="228"/>
         <source>%1 entries</source>
         <translation>%1 записів</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="190"/>
+        <location filename="../screens/FavoritesScreen.qml" line="232"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="280"/>
+        <location filename="../screens/FavoritesScreen.qml" line="334"/>
         <source>No favorites yet</source>
         <translation>Поки немає вибраного</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="281"/>
+        <location filename="../screens/FavoritesScreen.qml" line="335"/>
         <source>Loading favorites…</source>
         <translation>Завантаження вибраного…</translation>
     </message>
@@ -326,13 +326,13 @@
 <context>
     <name>GameInfoModal</name>
     <message>
-        <location filename="../components/GameInfoModal.qml" line="86"/>
-        <source>Back to close</source>
+        <location filename="../components/GameInfoModal.qml" line="104"/>
+        <source>Loading details…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/GameInfoModal.qml" line="114"/>
-        <source>Loading details…</source>
+        <location filename="../components/GameInfoModal.qml" line="174"/>
+        <source>Loading image…</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -444,12 +444,6 @@
         <translation>Запустити core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="781"/>
-        <source>More info</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../app/Main.qml" line="785"/>
         <source>Remove from favorites</source>
         <translation>Видалити з вибраного</translation>
@@ -474,6 +468,12 @@
         <location filename="../app/Main.qml" line="804"/>
         <source>Launch game</source>
         <translation>Запустити гру</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="761"/>
+        <location filename="../app/Main.qml" line="781"/>
+        <source>View details</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1652"/>
@@ -679,27 +679,27 @@
 <context>
     <name>RecentsScreen</name>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="184"/>
+        <location filename="../screens/RecentsScreen.qml" line="226"/>
         <source>Recently Played</source>
         <translation>Нещодавно зіграні</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="187"/>
+        <location filename="../screens/RecentsScreen.qml" line="229"/>
         <source>%1 entries</source>
         <translation>%1 записів</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="191"/>
+        <location filename="../screens/RecentsScreen.qml" line="233"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="283"/>
+        <location filename="../screens/RecentsScreen.qml" line="337"/>
         <source>Loading recently played…</source>
         <translation>Завантаження нещодавніх…</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="282"/>
+        <location filename="../screens/RecentsScreen.qml" line="336"/>
         <source>Nothing played yet</source>
         <translation>Поки нічого не грали</translation>
     </message>

--- a/src/ui/translations/launcher_zh_CN.ts
+++ b/src/ui/translations/launcher_zh_CN.ts
@@ -90,38 +90,48 @@
         <translation type="unfinished">正在加载…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="43"/>
+        <location filename="../components/BrowseDetailPane.qml" line="44"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="45"/>
+        <location filename="../components/BrowseDetailPane.qml" line="46"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <location filename="../components/BrowseDetailPane.qml" line="48"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <location filename="../components/BrowseDetailPane.qml" line="50"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <location filename="../components/BrowseDetailPane.qml" line="52"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <location filename="../components/BrowseDetailPane.qml" line="54"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="55"/>
-        <source>Filename</source>
+        <location filename="../components/BrowseDetailPane.qml" line="56"/>
+        <source>Category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="58"/>
+        <source>Release date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="60"/>
+        <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -245,12 +255,17 @@
         <translation>%1 个条目</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="309"/>
+        <location filename="../screens/FavoritesScreen.qml" line="190"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/FavoritesScreen.qml" line="280"/>
         <source>No favorites yet</source>
         <translation>还没有收藏</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="310"/>
+        <location filename="../screens/FavoritesScreen.qml" line="281"/>
         <source>Loading favorites…</source>
         <translation>正在加载收藏…</translation>
     </message>
@@ -324,33 +339,35 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="367"/>
-        <location filename="../screens/GamesScreen.qml" line="537"/>
+        <location filename="../screens/GamesScreen.qml" line="373"/>
+        <location filename="../screens/GamesScreen.qml" line="520"/>
         <source>%1 files</source>
         <translation>%1 个文件</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="437"/>
+        <location filename="../screens/GamesScreen.qml" line="409"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="554"/>
+        <location filename="../screens/GamesScreen.qml" line="382"/>
+        <location filename="../screens/GamesScreen.qml" line="537"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="569"/>
+        <location filename="../screens/GamesScreen.qml" line="552"/>
         <source>No games in this system</source>
         <translation>此系统中没有游戏</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="570"/>
+        <location filename="../screens/GamesScreen.qml" line="553"/>
         <source>Loading games…</source>
         <translation>正在加载游戏…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="592"/>
+        <location filename="../screens/GamesScreen.qml" line="378"/>
+        <location filename="../screens/GamesScreen.qml" line="575"/>
         <source>Loading more…</source>
         <translation>正在加载更多…</translation>
     </message>
@@ -672,12 +689,17 @@
         <translation>%1 个条目</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="311"/>
+        <location filename="../screens/RecentsScreen.qml" line="191"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/RecentsScreen.qml" line="282"/>
         <source>Nothing played yet</source>
         <translation>还没有游玩记录</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="312"/>
+        <location filename="../screens/RecentsScreen.qml" line="283"/>
         <source>Loading recently played…</source>
         <translation>正在加载最近游玩…</translation>
     </message>
@@ -999,22 +1021,23 @@
     <name>SystemsScreen</name>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="185"/>
-        <location filename="../screens/SystemsScreen.qml" line="313"/>
+        <location filename="../screens/SystemsScreen.qml" line="285"/>
         <source>%1 systems</source>
         <translation>%1 个系统</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <location filename="../screens/SystemsScreen.qml" line="189"/>
+        <location filename="../screens/SystemsScreen.qml" line="302"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="345"/>
+        <location filename="../screens/SystemsScreen.qml" line="317"/>
         <source>No systems in this category</source>
         <translation>此类别中没有系统</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="318"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>
@@ -1022,7 +1045,7 @@
 <context>
     <name>TopStatusStrip</name>
     <message>
-        <location filename="../components/TopStatusStrip.qml" line="90"/>
+        <location filename="../components/TopStatusStrip.qml" line="91"/>
         <source>Page %1 / %2</source>
         <translation>第 %1 / %2 页</translation>
     </message>

--- a/src/ui/translations/launcher_zh_CN.ts
+++ b/src/ui/translations/launcher_zh_CN.ts
@@ -245,27 +245,27 @@
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="183"/>
+        <location filename="../screens/FavoritesScreen.qml" line="225"/>
         <source>Favorites</source>
         <translation>收藏</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="186"/>
+        <location filename="../screens/FavoritesScreen.qml" line="228"/>
         <source>%1 entries</source>
         <translation>%1 个条目</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="190"/>
+        <location filename="../screens/FavoritesScreen.qml" line="232"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="280"/>
+        <location filename="../screens/FavoritesScreen.qml" line="334"/>
         <source>No favorites yet</source>
         <translation>还没有收藏</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="281"/>
+        <location filename="../screens/FavoritesScreen.qml" line="335"/>
         <source>Loading favorites…</source>
         <translation>正在加载收藏…</translation>
     </message>
@@ -326,13 +326,13 @@
 <context>
     <name>GameInfoModal</name>
     <message>
-        <location filename="../components/GameInfoModal.qml" line="86"/>
-        <source>Back to close</source>
+        <location filename="../components/GameInfoModal.qml" line="104"/>
+        <source>Loading details…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/GameInfoModal.qml" line="114"/>
-        <source>Loading details…</source>
+        <location filename="../components/GameInfoModal.qml" line="174"/>
+        <source>Loading image…</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -446,7 +446,7 @@
     <message>
         <location filename="../app/Main.qml" line="761"/>
         <location filename="../app/Main.qml" line="781"/>
-        <source>More info</source>
+        <source>View details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -679,27 +679,27 @@
 <context>
     <name>RecentsScreen</name>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="184"/>
+        <location filename="../screens/RecentsScreen.qml" line="226"/>
         <source>Recently Played</source>
         <translation>最近游玩</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="187"/>
+        <location filename="../screens/RecentsScreen.qml" line="229"/>
         <source>%1 entries</source>
         <translation>%1 个条目</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="191"/>
+        <location filename="../screens/RecentsScreen.qml" line="233"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="282"/>
+        <location filename="../screens/RecentsScreen.qml" line="336"/>
         <source>Nothing played yet</source>
         <translation>还没有游玩记录</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="283"/>
+        <location filename="../screens/RecentsScreen.qml" line="337"/>
         <source>Loading recently played…</source>
         <translation>正在加载最近游玩…</translation>
     </message>

--- a/src/ui/translations/launcher_zh_CN.ts
+++ b/src/ui/translations/launcher_zh_CN.ts
@@ -1,59 +1,60 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
 <TS version="2.1" language="zh_CN" sourcelanguage="en">
 <context>
     <name>AboutScreen</name>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="72" />
+        <location filename="../screens/AboutScreen.qml" line="71"/>
         <source>About / License</source>
         <translation>关于 / 许可</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="154" />
+        <location filename="../screens/AboutScreen.qml" line="153"/>
         <source>Zaparoo Launcher</source>
         <translation>Zaparoo 启动器</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="165" />
+        <location filename="../screens/AboutScreen.qml" line="164"/>
         <source>Version %1 · %2 · %3</source>
         <translation>版本 %1 · %2 · %3</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="178" />
+        <location filename="../screens/AboutScreen.qml" line="174"/>
         <source>Built %1</source>
         <translation>构建于 %1</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="189" />
+        <location filename="../screens/AboutScreen.qml" line="185"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>版权所有 2026 Wizzo Pty Ltd 及 Zaparoo Project 贡献者。</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="200" />
+        <location filename="../screens/AboutScreen.qml" line="196"/>
         <source>Source available under the PolyForm Noncommercial License 1.0.0. Free for personal, non-commercial use. Commercial use or redistribution requires a separate license.</source>
         <translation>源码依据 PolyForm Noncommercial License 1.0.0 提供。可免费用于个人和非商业用途。商业使用或重新分发需要单独许可。</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="211" />
+        <location filename="../screens/AboutScreen.qml" line="207"/>
         <source>Commercial licensing: legal@zaparoo.org</source>
         <translation>商业许可：legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="222" />
+        <location filename="../screens/AboutScreen.qml" line="218"/>
         <source>Project: https://zaparoo.org</source>
         <translation>项目：https://zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="232" />
+        <location filename="../screens/AboutScreen.qml" line="228"/>
         <source>Created by</source>
         <translation>创作者</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="256" />
+        <location filename="../screens/AboutScreen.qml" line="252"/>
         <source>Translations</source>
         <translation>翻译</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="280" />
+        <location filename="../screens/AboutScreen.qml" line="276"/>
         <source>Full license text in COPYING.</source>
         <translation>完整许可文本见 COPYING。</translation>
     </message>
@@ -61,60 +62,103 @@
 <context>
     <name>BootOverlay</name>
     <message>
-        <location filename="../components/BootOverlay.qml" line="76" />
-        <source>Can't reach Zaparoo Core. Check your connection.</source>
+        <location filename="../components/BootOverlay.qml" line="76"/>
+        <source>Can&apos;t reach Zaparoo Core. Check your connection.</source>
         <translation>无法连接到 Zaparoo Core。请检查连接。</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="78" />
+        <location filename="../components/BootOverlay.qml" line="78"/>
         <source>Reconnecting…</source>
         <translation>正在重新连接…</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="80" />
+        <location filename="../components/BootOverlay.qml" line="80"/>
         <source>Loading library…</source>
         <translation>正在加载库…</translation>
     </message>
     <message>
-        <location filename="../components/BootOverlay.qml" line="85" />
+        <location filename="../components/BootOverlay.qml" line="85"/>
         <source>Connecting to Zaparoo Core…</source>
         <translation>正在连接到 Zaparoo Core…</translation>
     </message>
 </context>
 <context>
+    <name>BrowseDetailPane</name>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="22"/>
+        <source>Loading…</source>
+        <translation type="unfinished">正在加载…</translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="43"/>
+        <source>Year</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="45"/>
+        <source>Genre</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <source>Players</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <source>Developer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <source>Publisher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <source>Rating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="55"/>
+        <source>Filename</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CommercialNoticeModal</name>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="59" />
+        <location filename="../components/CommercialNoticeModal.qml" line="59"/>
         <source>Welcome to Zaparoo Launcher</source>
         <translation>欢迎使用 Zaparoo Launcher</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="68" />
+        <location filename="../components/CommercialNoticeModal.qml" line="68"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>版权所有 2026 Wizzo Pty Ltd 及 Zaparoo Project 贡献者。</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="79" />
+        <location filename="../components/CommercialNoticeModal.qml" line="79"/>
         <source>This free source-available build is for personal and non-commercial use only. Commercial use or redistribution requires a license.</source>
         <translation>此免费源码可用版本仅限个人和非商业用途。商业使用或重新分发需要许可。</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="90" />
+        <location filename="../components/CommercialNoticeModal.qml" line="90"/>
         <source>Contact: legal@zaparoo.org</source>
         <translation>联系：legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="101" />
+        <location filename="../components/CommercialNoticeModal.qml" line="101"/>
         <source>Full details available any time under Settings &gt; About / License.</source>
         <translation>完整详情可随时在“设置 &gt; 关于 / 许可”中查看。</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="119" />
+        <location filename="../components/CommercialNoticeModal.qml" line="119"/>
         <source>Created by</source>
         <translation>创作者</translation>
     </message>
     <message>
-        <location filename="../components/CommercialNoticeModal.qml" line="162" />
+        <location filename="../components/CommercialNoticeModal.qml" line="162"/>
         <source>I understand</source>
         <translation>我明白了</translation>
     </message>
@@ -122,68 +166,68 @@
 <context>
     <name>CoreStatusPill</name>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="44" />
-        <location filename="../components/CoreStatusPill.qml" line="50" />
+        <location filename="../components/CoreStatusPill.qml" line="44"/>
+        <location filename="../components/CoreStatusPill.qml" line="50"/>
         <source>Disconnected</source>
         <translation>已断开</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="47" />
+        <location filename="../components/CoreStatusPill.qml" line="47"/>
         <source>Reconnecting…</source>
         <translation>正在重新连接…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="53" />
+        <location filename="../components/CoreStatusPill.qml" line="53"/>
         <source>Connecting…</source>
         <translation>正在连接…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="56" />
+        <location filename="../components/CoreStatusPill.qml" line="56"/>
         <source>Core error</source>
         <translation>Core 错误</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="60" />
+        <location filename="../components/CoreStatusPill.qml" line="60"/>
         <source>Optimizing database</source>
         <translation>正在优化数据库</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="67" />
+        <location filename="../components/CoreStatusPill.qml" line="67"/>
         <source>Indexing paused</source>
         <translation>索引已暂停</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="70" />
+        <location filename="../components/CoreStatusPill.qml" line="70"/>
         <source>Indexing %1/%2 - %3</source>
         <translation>正在索引 %1/%2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="73" />
+        <location filename="../components/CoreStatusPill.qml" line="73"/>
         <source>Indexing %1/%2</source>
         <translation>正在索引 %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="75" />
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
         <source>Indexing…</source>
         <translation>正在索引…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="83" />
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Scrape paused</source>
         <translation>抓取已暂停</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="86" />
+        <location filename="../components/CoreStatusPill.qml" line="86"/>
         <source>Scraping %1/%2 - %3</source>
         <translation>正在抓取 %1/%2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="89" />
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
         <source>Scraping %1/%2</source>
         <translation>正在抓取 %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="91" />
+        <location filename="../components/CoreStatusPill.qml" line="91"/>
         <source>Scraping…</source>
         <translation>正在抓取…</translation>
     </message>
@@ -191,22 +235,22 @@
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="182" />
+        <location filename="../screens/FavoritesScreen.qml" line="183"/>
         <source>Favorites</source>
         <translation>收藏</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="185" />
+        <location filename="../screens/FavoritesScreen.qml" line="186"/>
         <source>%1 entries</source>
         <translation>%1 个条目</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="283" />
+        <location filename="../screens/FavoritesScreen.qml" line="309"/>
         <source>No favorites yet</source>
         <translation>还没有收藏</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="284" />
+        <location filename="../screens/FavoritesScreen.qml" line="310"/>
         <source>Loading favorites…</source>
         <translation>正在加载收藏…</translation>
     </message>
@@ -214,75 +258,99 @@
 <context>
     <name>FirstRunIndexModal</name>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="127" />
+        <location filename="../components/FirstRunIndexModal.qml" line="127"/>
         <source>First-time setup</source>
         <translation>首次设置</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="136" />
+        <location filename="../components/FirstRunIndexModal.qml" line="136"/>
         <source>Zaparoo needs to scan your games before you can use the launcher. This usually takes a few minutes.</source>
         <translation>在使用启动器前，Zaparoo 需要扫描您的游戏。这通常只需几分钟。</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="158" />
+        <location filename="../components/FirstRunIndexModal.qml" line="158"/>
         <source>Optimizing database - almost done</source>
         <translation>正在优化数据库 - 即将完成</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="211" />
+        <location filename="../components/FirstRunIndexModal.qml" line="211"/>
         <source>Indexing paused</source>
         <translation>索引已暂停</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="213" />
+        <location filename="../components/FirstRunIndexModal.qml" line="213"/>
         <source>Step %1 of %2 - %3</source>
         <translation>第 %1 / %2 步 - %3</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="215" />
+        <location filename="../components/FirstRunIndexModal.qml" line="215"/>
         <source>Step %1 of %2</source>
         <translation>第 %1 / %2 步</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="216" />
+        <location filename="../components/FirstRunIndexModal.qml" line="216"/>
         <source>Preparing…</source>
         <translation>正在准备…</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="233" />
+        <location filename="../components/FirstRunIndexModal.qml" line="233"/>
         <source>Done. %1 files indexed.</source>
         <translation>完成。已索引 %1 个文件。</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="263" />
+        <location filename="../components/FirstRunIndexModal.qml" line="263"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../components/FirstRunIndexModal.qml" line="263" />
+        <location filename="../components/FirstRunIndexModal.qml" line="263"/>
         <source>Start scan</source>
         <translation>开始扫描</translation>
     </message>
 </context>
 <context>
+    <name>GameInfoModal</name>
+    <message>
+        <location filename="../components/GameInfoModal.qml" line="86"/>
+        <source>Back to close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/GameInfoModal.qml" line="114"/>
+        <source>Loading details…</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="363" />
+        <location filename="../screens/GamesScreen.qml" line="367"/>
+        <location filename="../screens/GamesScreen.qml" line="537"/>
         <source>%1 files</source>
         <translation>%1 个文件</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="533" />
+        <location filename="../screens/GamesScreen.qml" line="437"/>
+        <source>Loading game…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/GamesScreen.qml" line="554"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/GamesScreen.qml" line="569"/>
         <source>No games in this system</source>
         <translation>此系统中没有游戏</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="534" />
+        <location filename="../screens/GamesScreen.qml" line="570"/>
         <source>Loading games…</source>
         <translation>正在加载游戏…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="556" />
+        <location filename="../screens/GamesScreen.qml" line="592"/>
         <source>Loading more…</source>
         <translation>正在加载更多…</translation>
     </message>
@@ -290,22 +358,22 @@
 <context>
     <name>HubScreen</name>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91" />
+        <location filename="../screens/HubScreen.qml" line="91"/>
         <source>Favorites</source>
         <translation>收藏</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="96" />
+        <location filename="../screens/HubScreen.qml" line="96"/>
         <source>Recently Played</source>
         <translation>最近游玩</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="101" />
+        <location filename="../screens/HubScreen.qml" line="101"/>
         <source>Settings</source>
         <translation>设置</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="537" />
+        <location filename="../screens/HubScreen.qml" line="537"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>没有可用系统。请在“设置”中运行“更新媒体数据库”。</translation>
     </message>
@@ -313,7 +381,7 @@
 <context>
     <name>LoadingIndicator</name>
     <message>
-        <location filename="../components/LoadingIndicator.qml" line="26" />
+        <location filename="../components/LoadingIndicator.qml" line="26"/>
         <source>Loading…</source>
         <translation>正在加载…</translation>
     </message>
@@ -321,32 +389,32 @@
 <context>
     <name>LogUploadModal</name>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="87" />
+        <location filename="../components/LogUploadModal.qml" line="87"/>
         <source>Upload log file</source>
         <translation>上传日志文件</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="97" />
+        <location filename="../components/LogUploadModal.qml" line="97"/>
         <source>Uploading log file - this may take a moment.</source>
         <translation>正在上传日志文件 - 这可能需要一点时间。</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197" />
+        <location filename="../components/LogUploadModal.qml" line="197"/>
         <source>Upload failed: %1</source>
         <translation>上传失败：%1</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197" />
+        <location filename="../components/LogUploadModal.qml" line="197"/>
         <source>Upload failed.</source>
         <translation>上传失败。</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="227" />
+        <location filename="../components/LogUploadModal.qml" line="227"/>
         <source>Retry</source>
         <translation>重试</translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="227" />
+        <location filename="../components/LogUploadModal.qml" line="227"/>
         <source>Done</source>
         <translation>完成</translation>
     </message>
@@ -354,58 +422,64 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="723" />
+        <location filename="../app/Main.qml" line="753"/>
         <source>Launch core</source>
         <translation>启动核心</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="731" />
-        <location filename="../app/Main.qml" line="755" />
+        <location filename="../app/Main.qml" line="761"/>
+        <location filename="../app/Main.qml" line="781"/>
+        <source>More info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="765"/>
+        <location filename="../app/Main.qml" line="804"/>
         <source>Launch game</source>
         <translation>启动游戏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="741" />
+        <location filename="../app/Main.qml" line="785"/>
         <source>Remove from favorites</source>
         <translation>从收藏中移除</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="741" />
+        <location filename="../app/Main.qml" line="785"/>
         <source>Add to favorites</source>
         <translation>添加到收藏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="747" />
+        <location filename="../app/Main.qml" line="790"/>
         <source>Write to NFC token</source>
         <translation>写入 NFC 令牌</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="751" />
+        <location filename="../app/Main.qml" line="794"/>
         <source>QR code</source>
         <translation>二维码</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1437" />
+        <location filename="../app/Main.qml" line="1652"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1439" />
+        <location filename="../app/Main.qml" line="1654"/>
         <source>Loading games…</source>
         <translation>正在加载游戏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1441" />
+        <location filename="../app/Main.qml" line="1656"/>
         <source>Loading favorites…</source>
         <translation>正在加载收藏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1443" />
+        <location filename="../app/Main.qml" line="1658"/>
         <source>Loading recently played…</source>
         <translation>正在加载最近游玩…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1445" />
+        <location filename="../app/Main.qml" line="1660"/>
         <source>Loading…</source>
         <translation>正在加载…</translation>
     </message>
@@ -413,144 +487,151 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="127" />
+        <location filename="../app/MainLayout.qml" line="141"/>
         <source>Zaparoo Launcher</source>
         <translation>Zaparoo 启动器</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="475" />
+        <location filename="../app/MainLayout.qml" line="545"/>
         <source>Writing failed</source>
         <translation>写入失败</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="475" />
+        <location filename="../app/MainLayout.qml" line="545"/>
         <source>Put a writable card near the reader</source>
         <translation>将可写卡片放在读卡器附近</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="540" />
+        <location filename="../app/MainLayout.qml" line="556"/>
+        <source>Quit and restart Zaparoo Launcher?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="557"/>
+        <source>In order to apply this setting we need to restart the launcher.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="632"/>
         <source>Quit Zaparoo Launcher?</source>
         <translation>要退出 Zaparoo Launcher 吗？</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="541" />
+        <location filename="../app/MainLayout.qml" line="633"/>
         <source>Are you sure you want to exit?</source>
         <translation>确定要退出吗？</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="613" />
-        <location filename="../app/MainLayout.qml" line="685" />
-        <location filename="../app/MainLayout.qml" line="700" />
-        <location filename="../app/MainLayout.qml" line="743" />
-        <location filename="../app/MainLayout.qml" line="772" />
-        <location filename="../app/MainLayout.qml" line="819" />
-        <location filename="../app/MainLayout.qml" line="860" />
-        <location filename="../app/MainLayout.qml" line="924" />
+        <location filename="../app/MainLayout.qml" line="705"/>
+        <location filename="../app/MainLayout.qml" line="777"/>
+        <location filename="../app/MainLayout.qml" line="820"/>
+        <location filename="../app/MainLayout.qml" line="849"/>
+        <location filename="../app/MainLayout.qml" line="896"/>
+        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="1001"/>
         <source>Move</source>
         <translation>移动</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="617" />
-        <location filename="../app/MainLayout.qml" line="689" />
-        <location filename="../app/MainLayout.qml" line="704" />
+        <location filename="../app/MainLayout.qml" line="709"/>
+        <location filename="../app/MainLayout.qml" line="781"/>
         <source>Select</source>
         <translation>选择</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="621" />
-        <location filename="../app/MainLayout.qml" line="625" />
-        <location filename="../app/MainLayout.qml" line="639" />
-        <location filename="../app/MainLayout.qml" line="652" />
-        <location filename="../app/MainLayout.qml" line="663" />
+        <location filename="../app/MainLayout.qml" line="713"/>
+        <location filename="../app/MainLayout.qml" line="717"/>
+        <location filename="../app/MainLayout.qml" line="731"/>
+        <location filename="../app/MainLayout.qml" line="744"/>
+        <location filename="../app/MainLayout.qml" line="755"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="632" />
-        <location filename="../app/MainLayout.qml" line="670" />
-        <location filename="../app/MainLayout.qml" line="693" />
-        <location filename="../app/MainLayout.qml" line="708" />
-        <location filename="../app/MainLayout.qml" line="719" />
+        <location filename="../app/MainLayout.qml" line="724"/>
+        <location filename="../app/MainLayout.qml" line="762"/>
+        <location filename="../app/MainLayout.qml" line="785"/>
+        <location filename="../app/MainLayout.qml" line="796"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="648" />
+        <location filename="../app/MainLayout.qml" line="740"/>
         <source>Done</source>
         <translation>完成</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="659" />
-        <location filename="../app/MainLayout.qml" line="795" />
-        <location filename="../app/MainLayout.qml" line="845" />
-        <location filename="../app/MainLayout.qml" line="950" />
+        <location filename="../app/MainLayout.qml" line="751"/>
+        <location filename="../app/MainLayout.qml" line="872"/>
+        <location filename="../app/MainLayout.qml" line="922"/>
+        <location filename="../app/MainLayout.qml" line="1027"/>
         <source>Retry</source>
         <translation>重试</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="678" />
+        <location filename="../app/MainLayout.qml" line="770"/>
         <source>I understand</source>
         <translation>我明白了</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="727" />
+        <location filename="../app/MainLayout.qml" line="804"/>
         <source>Start</source>
         <translation>开始</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="747" />
-        <location filename="../app/MainLayout.qml" line="782" />
-        <location filename="../app/MainLayout.qml" line="829" />
-        <location filename="../app/MainLayout.qml" line="934" />
+        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="859"/>
+        <location filename="../app/MainLayout.qml" line="906"/>
+        <location filename="../app/MainLayout.qml" line="1011"/>
         <source>Open</source>
         <translation>打开</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="751" />
+        <location filename="../app/MainLayout.qml" line="828"/>
         <source>Quit</source>
         <translation>退出</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="760" />
-        <location filename="../app/MainLayout.qml" line="788" />
-        <location filename="../app/MainLayout.qml" line="799" />
-        <location filename="../app/MainLayout.qml" line="811" />
-        <location filename="../app/MainLayout.qml" line="838" />
-        <location filename="../app/MainLayout.qml" line="849" />
-        <location filename="../app/MainLayout.qml" line="884" />
-        <location filename="../app/MainLayout.qml" line="900" />
-        <location filename="../app/MainLayout.qml" line="909" />
-        <location filename="../app/MainLayout.qml" line="943" />
-        <location filename="../app/MainLayout.qml" line="954" />
+        <location filename="../app/MainLayout.qml" line="837"/>
+        <location filename="../app/MainLayout.qml" line="865"/>
+        <location filename="../app/MainLayout.qml" line="876"/>
+        <location filename="../app/MainLayout.qml" line="888"/>
+        <location filename="../app/MainLayout.qml" line="915"/>
+        <location filename="../app/MainLayout.qml" line="926"/>
+        <location filename="../app/MainLayout.qml" line="961"/>
+        <location filename="../app/MainLayout.qml" line="977"/>
+        <location filename="../app/MainLayout.qml" line="986"/>
+        <location filename="../app/MainLayout.qml" line="1020"/>
+        <location filename="../app/MainLayout.qml" line="1031"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="778" />
-        <location filename="../app/MainLayout.qml" line="825" />
-        <location filename="../app/MainLayout.qml" line="930" />
+        <location filename="../app/MainLayout.qml" line="855"/>
+        <location filename="../app/MainLayout.qml" line="902"/>
+        <location filename="../app/MainLayout.qml" line="1007"/>
         <source>Page</source>
         <translation>页面</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="785" />
-        <location filename="../app/MainLayout.qml" line="834" />
-        <location filename="../app/MainLayout.qml" line="939" />
+        <location filename="../app/MainLayout.qml" line="862"/>
+        <location filename="../app/MainLayout.qml" line="911"/>
+        <location filename="../app/MainLayout.qml" line="1016"/>
         <source>Options</source>
         <translation>选项</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="869" />
+        <location filename="../app/MainLayout.qml" line="946"/>
         <source>Change</source>
         <translation>更改</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="875" />
+        <location filename="../app/MainLayout.qml" line="952"/>
         <source>Toggle</source>
         <translation>切换</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="896" />
+        <location filename="../app/MainLayout.qml" line="973"/>
         <source>Scroll</source>
         <translation>滚动</translation>
     </message>
@@ -558,22 +639,22 @@
 <context>
     <name>Modal</name>
     <message>
-        <location filename="../components/Modal.qml" line="49" />
+        <location filename="../components/Modal.qml" line="49"/>
         <source>OK</source>
         <translation>确定</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="50" />
+        <location filename="../components/Modal.qml" line="50"/>
         <source>Yes</source>
         <translation>是</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="51" />
+        <location filename="../components/Modal.qml" line="51"/>
         <source>No</source>
         <translation>否</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="198" />
+        <location filename="../components/Modal.qml" line="198"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
@@ -581,22 +662,22 @@
 <context>
     <name>RecentsScreen</name>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="183" />
+        <location filename="../screens/RecentsScreen.qml" line="184"/>
         <source>Recently Played</source>
         <translation>最近游玩</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="186" />
+        <location filename="../screens/RecentsScreen.qml" line="187"/>
         <source>%1 entries</source>
         <translation>%1 个条目</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="281" />
+        <location filename="../screens/RecentsScreen.qml" line="311"/>
         <source>Nothing played yet</source>
         <translation>还没有游玩记录</translation>
     </message>
     <message>
-        <location filename="../screens/RecentsScreen.qml" line="282" />
+        <location filename="../screens/RecentsScreen.qml" line="312"/>
         <source>Loading recently played…</source>
         <translation>正在加载最近游玩…</translation>
     </message>
@@ -604,17 +685,17 @@
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="26" />
+        <location filename="../components/ScreenStateOverlay.qml" line="26"/>
         <source>Nothing here</source>
         <translation>这里什么都没有</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27" />
+        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
         <source>Loading…</source>
         <translation>正在加载…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="57" />
+        <location filename="../components/ScreenStateOverlay.qml" line="57"/>
         <source>Failed to load</source>
         <translation>加载失败</translation>
     </message>
@@ -622,288 +703,294 @@
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="61" />
+        <location filename="../screens/SettingsScreen.qml" line="61"/>
         <source>General</source>
         <translation>常规</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78" />
-        <location filename="../screens/SettingsScreen.qml" line="436" />
+        <location filename="../screens/SettingsScreen.qml" line="73"/>
+        <location filename="../screens/SettingsScreen.qml" line="432"/>
         <source>Language</source>
         <translation>语言</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83" />
-        <location filename="../screens/SettingsScreen.qml" line="445" />
+        <location filename="../screens/SettingsScreen.qml" line="78"/>
+        <location filename="../screens/SettingsScreen.qml" line="441"/>
         <source>Browsing layout</source>
         <translation>浏览布局</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88" />
-        <location filename="../screens/SettingsScreen.qml" line="454" />
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="450"/>
         <source>Button style</source>
         <translation>按钮样式</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="93" />
-        <location filename="../screens/SettingsScreen.qml" line="463" />
+        <location filename="../screens/SettingsScreen.qml" line="88"/>
+        <location filename="../screens/SettingsScreen.qml" line="459"/>
         <source>Screensaver</source>
         <translation>屏幕保护程序</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97" />
+        <location filename="../screens/SettingsScreen.qml" line="92"/>
         <source>Library</source>
         <translation>资料库</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102" />
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <source>Discover arcade alternate versions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
         <source>Update media database</source>
         <translation>更新媒体数据库</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="107" />
+        <location filename="../screens/SettingsScreen.qml" line="107"/>
         <source>Scrape metadata</source>
         <translation>抓取元数据</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111" />
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
         <source>Advanced</source>
         <translation>高级</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116" />
+        <location filename="../screens/SettingsScreen.qml" line="116"/>
         <source>Mouse support</source>
         <translation>鼠标支持</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121" />
+        <location filename="../screens/SettingsScreen.qml" line="121"/>
         <source>Debug logging</source>
         <translation>调试日志</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126" />
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Upload log file</source>
         <translation>上传日志文件</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131" />
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
         <source>About / License</source>
         <translation>关于 / 许可</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147" />
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
         <source>Optimizing</source>
         <translation>正在优化</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149" />
-        <location filename="../screens/SettingsScreen.qml" line="158" />
+        <location filename="../screens/SettingsScreen.qml" line="149"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
         <source>Paused</source>
         <translation>已暂停</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149" />
-        <location filename="../screens/SettingsScreen.qml" line="158" />
+        <location filename="../screens/SettingsScreen.qml" line="149"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
         <source>In progress</source>
         <translation>进行中</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152" />
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>%1 indexed</source>
         <translation>已索引 %1 个</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="161" />
+        <location filename="../screens/SettingsScreen.qml" line="161"/>
         <source>%1 scraped</source>
         <translation>已抓取 %1 个</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270" />
+        <location filename="../screens/SettingsScreen.qml" line="266"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270" />
+        <location filename="../screens/SettingsScreen.qml" line="266"/>
         <source>Start</source>
         <translation>开始</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="272" />
+        <location filename="../screens/SettingsScreen.qml" line="268"/>
         <source>Upload</source>
         <translation>上传</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="274" />
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
         <source>Open</source>
         <translation>打开</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="326" />
+        <location filename="../screens/SettingsScreen.qml" line="322"/>
         <source>Default</source>
         <translation>默认</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="346" />
+        <location filename="../screens/SettingsScreen.qml" line="342"/>
         <source>English</source>
         <translation>英语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="348" />
+        <location filename="../screens/SettingsScreen.qml" line="344"/>
         <source>Italian</source>
         <translation>意大利语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="350" />
+        <location filename="../screens/SettingsScreen.qml" line="346"/>
         <source>German</source>
         <translation>德语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="352" />
+        <location filename="../screens/SettingsScreen.qml" line="348"/>
         <source>Greek</source>
         <translation>希腊语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="354" />
+        <location filename="../screens/SettingsScreen.qml" line="350"/>
         <source>Japanese</source>
         <translation>日语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="356" />
+        <location filename="../screens/SettingsScreen.qml" line="352"/>
         <source>Korean</source>
         <translation>韩语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="358" />
+        <location filename="../screens/SettingsScreen.qml" line="354"/>
         <source>Dutch</source>
         <translation>荷兰语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="360" />
+        <location filename="../screens/SettingsScreen.qml" line="356"/>
         <source>Romanian</source>
         <translation>罗马尼亚语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="362" />
+        <location filename="../screens/SettingsScreen.qml" line="358"/>
         <source>Slovak</source>
         <translation>斯洛伐克语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="364" />
+        <location filename="../screens/SettingsScreen.qml" line="360"/>
         <source>Ukrainian</source>
         <translation>乌克兰语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="366" />
+        <location filename="../screens/SettingsScreen.qml" line="362"/>
         <source>Chinese (Simplified)</source>
         <translation>简体中文</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="368" />
+        <location filename="../screens/SettingsScreen.qml" line="364"/>
         <source>Hebrew</source>
         <translation>希伯来语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="370" />
+        <location filename="../screens/SettingsScreen.qml" line="366"/>
         <source>Arabic</source>
-        <translation type="unfinished" />
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="372" />
+        <location filename="../screens/SettingsScreen.qml" line="368"/>
         <source>Hindi</source>
-        <translation type="unfinished" />
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="373" />
+        <location filename="../screens/SettingsScreen.qml" line="369"/>
         <source>Auto</source>
         <translation>自动</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="378" />
+        <location filename="../screens/SettingsScreen.qml" line="374"/>
         <source>Detailed list view</source>
         <translation>详细列表视图</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="379" />
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Grid view</source>
         <translation>网格视图</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="384" />
+        <location filename="../screens/SettingsScreen.qml" line="380"/>
         <source>Style B</source>
         <translation>样式 B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="386" />
+        <location filename="../screens/SettingsScreen.qml" line="382"/>
         <source>Style C</source>
         <translation>样式 C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="388" />
+        <location filename="../screens/SettingsScreen.qml" line="384"/>
         <source>Style D</source>
         <translation>样式 D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="389" />
+        <location filename="../screens/SettingsScreen.qml" line="385"/>
         <source>Style A</source>
         <translation>样式 A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399" />
+        <location filename="../screens/SettingsScreen.qml" line="395"/>
         <source>Off</source>
         <translation>关闭</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="401" />
+        <location filename="../screens/SettingsScreen.qml" line="397"/>
         <source>1 second (testing)</source>
         <translation>1 秒（测试）</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="403" />
+        <location filename="../screens/SettingsScreen.qml" line="399"/>
         <source>1 minute</source>
         <translation>1 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405" />
+        <location filename="../screens/SettingsScreen.qml" line="401"/>
         <source>2 minutes</source>
         <translation>2 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="407" />
+        <location filename="../screens/SettingsScreen.qml" line="403"/>
         <source>5 minutes</source>
         <translation>5 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="409" />
+        <location filename="../screens/SettingsScreen.qml" line="405"/>
         <source>10 minutes</source>
         <translation>10 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="411" />
+        <location filename="../screens/SettingsScreen.qml" line="407"/>
         <source>15 minutes</source>
         <translation>15 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="413" />
+        <location filename="../screens/SettingsScreen.qml" line="409"/>
         <source>30 minutes</source>
         <translation>30 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="414" />
+        <location filename="../screens/SettingsScreen.qml" line="410"/>
         <source>%1 seconds</source>
         <translation>%1 秒</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="427" />
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="423"/>
         <source>Resolution</source>
         <translation>分辨率</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="555" />
+        <location filename="../screens/SettingsScreen.qml" line="563"/>
         <source>Settings</source>
         <translation>设置</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="745" />
+        <location filename="../screens/SettingsScreen.qml" line="755"/>
         <source>No settings available on this platform</source>
         <translation>此平台上没有可用设置</translation>
     </message>
@@ -911,17 +998,23 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="182" />
+        <location filename="../screens/SystemsScreen.qml" line="185"/>
+        <location filename="../screens/SystemsScreen.qml" line="313"/>
         <source>%1 systems</source>
         <translation>%1 个系统</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="279" />
+        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SystemsScreen.qml" line="345"/>
         <source>No systems in this category</source>
         <translation>此类别中没有系统</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="280" />
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>
@@ -929,7 +1022,7 @@
 <context>
     <name>TopStatusStrip</name>
     <message>
-        <location filename="../components/TopStatusStrip.qml" line="88" />
+        <location filename="../components/TopStatusStrip.qml" line="90"/>
         <source>Page %1 / %2</source>
         <translation>第 %1 / %2 页</translation>
     </message>

--- a/tests/ui/tst_navigation.qml
+++ b/tests/ui/tst_navigation.qml
@@ -400,35 +400,35 @@ TestCase {
     function test_context_menu_games_no_reader_omits_write_card(): void {
         // qmllint disable compiler
         const entries = main.buildContextMenuEntries("games", "media", false, false);
-        compare(_idsOf(entries), ["more_info", "toggle_favorite", "qr_code", "launch_game"], "Write to NFC token must be hidden when no reader is reported");
+        compare(_idsOf(entries), ["toggle_favorite", "qr_code", "launch_game"], "Write to NFC token must be hidden when no reader is reported");
     // qmllint enable compiler
     }
 
     function test_context_menu_games_with_reader_includes_write_card(): void {
         // qmllint disable compiler
         const entries = main.buildContextMenuEntries("games", "media", true, false);
-        compare(_idsOf(entries), ["more_info", "toggle_favorite", "write_card", "qr_code", "launch_game"]);
+        compare(_idsOf(entries), ["toggle_favorite", "write_card", "qr_code", "launch_game"]);
     // qmllint enable compiler
     }
 
     function test_context_menu_favorites_matches_games_media_entries(): void {
         // qmllint disable compiler
         const entries = main.buildContextMenuEntries("favorites", "", true, true);
-        compare(_idsOf(entries), ["more_info", "toggle_favorite", "write_card", "qr_code", "launch_game"]);
+        compare(_idsOf(entries), ["toggle_favorite", "write_card", "qr_code", "launch_game"]);
     // qmllint enable compiler
     }
 
     function test_context_menu_favorites_no_reader_omits_write_card(): void {
         // qmllint disable compiler
         const entries = main.buildContextMenuEntries("favorites", "", false, true);
-        compare(_idsOf(entries), ["more_info", "toggle_favorite", "qr_code", "launch_game"]);
+        compare(_idsOf(entries), ["toggle_favorite", "qr_code", "launch_game"]);
     // qmllint enable compiler
     }
 
-    function test_context_menu_recents_includes_more_info(): void {
+    function test_context_menu_recents_omits_more_info(): void {
         // qmllint disable compiler
         const entries = main.buildContextMenuEntries("recents", "", false, false);
-        compare(_idsOf(entries), ["more_info", "launch_game"]);
+        compare(_idsOf(entries), ["launch_game"]);
     // qmllint enable compiler
     }
 
@@ -436,11 +436,11 @@ TestCase {
         // qmllint disable compiler
         const addEntries = main.buildContextMenuEntries("games", "media", false, false);
         const removeEntries = main.buildContextMenuEntries("games", "media", false, true);
-        compare(addEntries[1].id, "toggle_favorite");
-        compare(removeEntries[1].id, "toggle_favorite");
-        verify(addEntries[1].label.length > 0);
-        verify(removeEntries[1].label.length > 0);
-        verify(addEntries[1].label !== removeEntries[1].label);
+        compare(addEntries[0].id, "toggle_favorite");
+        compare(removeEntries[0].id, "toggle_favorite");
+        verify(addEntries[0].label.length > 0);
+        verify(removeEntries[0].label.length > 0);
+        verify(addEntries[0].label !== removeEntries[0].label);
     // qmllint enable compiler
     }
 

--- a/tests/ui/tst_navigation.qml
+++ b/tests/ui/tst_navigation.qml
@@ -400,28 +400,35 @@ TestCase {
     function test_context_menu_games_no_reader_omits_write_card(): void {
         // qmllint disable compiler
         const entries = main.buildContextMenuEntries("games", "media", false, false);
-        compare(_idsOf(entries), ["toggle_favorite", "qr_code", "launch_game"], "Write to NFC token must be hidden when no reader is reported");
+        compare(_idsOf(entries), ["more_info", "toggle_favorite", "qr_code", "launch_game"], "Write to NFC token must be hidden when no reader is reported");
     // qmllint enable compiler
     }
 
     function test_context_menu_games_with_reader_includes_write_card(): void {
         // qmllint disable compiler
         const entries = main.buildContextMenuEntries("games", "media", true, false);
-        compare(_idsOf(entries), ["toggle_favorite", "write_card", "qr_code", "launch_game"]);
+        compare(_idsOf(entries), ["more_info", "toggle_favorite", "write_card", "qr_code", "launch_game"]);
     // qmllint enable compiler
     }
 
     function test_context_menu_favorites_matches_games_media_entries(): void {
         // qmllint disable compiler
         const entries = main.buildContextMenuEntries("favorites", "", true, true);
-        compare(_idsOf(entries), ["toggle_favorite", "write_card", "qr_code", "launch_game"]);
+        compare(_idsOf(entries), ["more_info", "toggle_favorite", "write_card", "qr_code", "launch_game"]);
     // qmllint enable compiler
     }
 
     function test_context_menu_favorites_no_reader_omits_write_card(): void {
         // qmllint disable compiler
         const entries = main.buildContextMenuEntries("favorites", "", false, true);
-        compare(_idsOf(entries), ["toggle_favorite", "qr_code", "launch_game"]);
+        compare(_idsOf(entries), ["more_info", "toggle_favorite", "qr_code", "launch_game"]);
+    // qmllint enable compiler
+    }
+
+    function test_context_menu_recents_includes_more_info(): void {
+        // qmllint disable compiler
+        const entries = main.buildContextMenuEntries("recents", "", false, false);
+        compare(_idsOf(entries), ["more_info", "launch_game"]);
     // qmllint enable compiler
     }
 
@@ -429,11 +436,11 @@ TestCase {
         // qmllint disable compiler
         const addEntries = main.buildContextMenuEntries("games", "media", false, false);
         const removeEntries = main.buildContextMenuEntries("games", "media", false, true);
-        compare(addEntries[0].id, "toggle_favorite");
-        compare(removeEntries[0].id, "toggle_favorite");
-        verify(addEntries[0].label.length > 0);
-        verify(removeEntries[0].label.length > 0);
-        verify(addEntries[0].label !== removeEntries[0].label);
+        compare(addEntries[1].id, "toggle_favorite");
+        compare(removeEntries[1].id, "toggle_favorite");
+        verify(addEntries[1].label.length > 0);
+        verify(removeEntries[1].label.length > 0);
+        verify(addEntries[1].label !== removeEntries[1].label);
     // qmllint enable compiler
     }
 


### PR DESCRIPTION
## Summary
- add a shared game info modal reachable from playable game context menus
- card and tighten list/detail metadata panes with compact ordered metadata
- add loading states for game metadata and ignore local .pi state

## Validation
- just fmt
- just lint
- just test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "View details" context action and a Game Details modal with metadata, cover images, image cycling, and load/clear controls
  * New unified list+detail component for list layouts

* **UI Improvements**
  * Refreshed selection visuals, chrome toggle, padded card layout, refined detail pane sizing/tag table, new divider and loading indicator, improved status strip override and context-menu placement

* **Bug Fixes**
  * More robust media/image fetching with connection-down handling and soft-no-image policy; better detail-image resynchronization

* **Localization**
  * Updated translation catalogs across many languages with added strings and placeholders

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ZaparooProject/zaparoo-launcher/pull/137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->