### PR TITLE
Add per-system launcher selection

### DIFF
--- a/rust/launcher/build.rs
+++ b/rust/launcher/build.rs
@@ -4,6 +4,35 @@
 
 use cxx_qt_build::{CxxQtBuilder, QmlModule};
 
+const MODEL_FILES: &[&str] = &[
+    "src/models/alternate_versions.rs",
+    "src/models/categories.rs",
+    "src/models/systems.rs",
+    "src/models/game_info.rs",
+    "src/models/games.rs",
+    "src/models/favorites.rs",
+    "src/models/browse.rs",
+    "src/models/app_state.rs",
+    "src/models/build_info.rs",
+    "src/models/app_status.rs",
+    "src/models/hub_state.rs",
+    "src/models/systems_state.rs",
+    "src/models/games_state.rs",
+    "src/models/favorites_state.rs",
+    "src/models/input.rs",
+    "src/models/log_upload.rs",
+    "src/models/media_status.rs",
+    "src/models/notice.rs",
+    "src/models/platform.rs",
+    "src/models/qr_code.rs",
+    "src/models/recents.rs",
+    "src/models/recents_state.rs",
+    "src/models/runtime.rs",
+    "src/models/settings.rs",
+    "src/models/system_launchers.rs",
+    "src/models/system_status.rs",
+];
+
 fn main() {
     // cxx_qt_build compiles the CXX-Qt bridge code and registers the
     // Zaparoo.Browse QML module. Qt is located via the QMAKE env var
@@ -23,33 +52,7 @@ fn main() {
     .qt_module("Gui")
     .qt_module("Quick")
     .qt_module("QuickControls2")
-    .files([
-        "src/models/alternate_versions.rs",
-        "src/models/categories.rs",
-        "src/models/systems.rs",
-        "src/models/game_info.rs",
-        "src/models/games.rs",
-        "src/models/favorites.rs",
-        "src/models/browse.rs",
-        "src/models/app_state.rs",
-        "src/models/build_info.rs",
-        "src/models/app_status.rs",
-        "src/models/hub_state.rs",
-        "src/models/systems_state.rs",
-        "src/models/games_state.rs",
-        "src/models/favorites_state.rs",
-        "src/models/input.rs",
-        "src/models/log_upload.rs",
-        "src/models/media_status.rs",
-        "src/models/notice.rs",
-        "src/models/platform.rs",
-        "src/models/qr_code.rs",
-        "src/models/recents.rs",
-        "src/models/recents_state.rs",
-        "src/models/runtime.rs",
-        "src/models/settings.rs",
-        "src/models/system_status.rs",
-    ]);
+    .files(MODEL_FILES);
 
     // SAFETY: cc_builder is unsafe in 0.8 because cxx-qt makes no stability
     // guarantees about the cc::Build instance. We only adjust the include

--- a/rust/launcher/src/models/mod.rs
+++ b/rust/launcher/src/models/mod.rs
@@ -45,6 +45,7 @@ pub mod recents;
 pub mod recents_state;
 pub mod runtime;
 pub mod settings;
+pub mod system_launchers;
 pub mod system_status;
 pub mod systems;
 pub mod systems_state;

--- a/rust/launcher/src/models/system_launchers.rs
+++ b/rust/launcher/src/models/system_launchers.rs
@@ -1,0 +1,361 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+use crate::models::{global_handle, global_store};
+use cxx_qt::{CxxQtType, Initialize, Threading};
+use cxx_qt_lib::{QString, QStringList};
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use tracing::warn;
+use zaparoo_core::endpoints::launchers::LaunchersEndpoint;
+use zaparoo_core::endpoints::settings::SettingsEndpoint;
+use zaparoo_core::endpoints::system_launcher_default::{
+    SetSystemLauncherDefaultArgs, SetSystemLauncherDefaultMutation,
+};
+use zaparoo_core::media_types::{LauncherInfo, SettingsResult, SystemDefault};
+use zaparoo_core::remote_resource::ResourceStatus;
+
+const DEFAULT_LAUNCHER_ID: &str = "__default__";
+
+#[allow(
+    clippy::struct_excessive_bools,
+    reason = "QML state bag tracks independent endpoint/update flags"
+)]
+#[derive(Default)]
+pub struct SystemLaunchersRust {
+    loading: bool,
+    error_message: QString,
+    update_pending: bool,
+    update_error: QString,
+    picker_ids: QStringList,
+    picker_labels: QStringList,
+    current_launcher: QString,
+    launchers: Vec<LauncherInfo>,
+    system_defaults: Vec<SystemDefault>,
+    launchers_loading: bool,
+    settings_loading: bool,
+    launchers_error: String,
+    settings_error: String,
+    update_seq: Arc<AtomicU64>,
+}
+
+#[cxx_qt::bridge]
+pub mod ffi {
+    unsafe extern "C++" {
+        include!("model_includes.h");
+
+        type QString = cxx_qt_lib::QString;
+        type QStringList = cxx_qt_lib::QStringList;
+    }
+
+    unsafe extern "RustQt" {
+        #[qobject]
+        #[qml_element]
+        #[qml_singleton]
+        #[qproperty(bool, loading)]
+        #[qproperty(QString, error_message)]
+        #[qproperty(bool, update_pending)]
+        #[qproperty(QString, update_error)]
+        #[qproperty(QStringList, picker_ids)]
+        #[qproperty(QStringList, picker_labels)]
+        #[qproperty(QString, current_launcher)]
+        type SystemLaunchers = super::SystemLaunchersRust;
+
+        #[qinvokable]
+        fn prepare_system(self: Pin<&mut SystemLaunchers>, system_id: QString);
+
+        #[qinvokable]
+        fn launcher_count_for_system(self: &SystemLaunchers, system_id: &QString) -> i32;
+
+        #[qinvokable]
+        fn set_system_launcher(
+            self: Pin<&mut SystemLaunchers>,
+            system_id: QString,
+            launcher_id: QString,
+        );
+    }
+
+    impl cxx_qt::Initialize for SystemLaunchers {}
+    impl cxx_qt::Threading for SystemLaunchers {}
+}
+
+impl Initialize for ffi::SystemLaunchers {
+    fn initialize(mut self: Pin<&mut Self>) {
+        let store = global_store();
+        let mut launchers_rx = store.subscribe::<LaunchersEndpoint>(()).subscribe();
+        let mut settings_rx = store.subscribe::<SettingsEndpoint>(()).subscribe();
+
+        apply_launchers_state(
+            self.as_mut(),
+            project_launchers(&launchers_rx.borrow_and_update()),
+        );
+        apply_settings_state(
+            self.as_mut(),
+            project_settings(&settings_rx.borrow_and_update()),
+        );
+
+        let qt_thread = self.qt_thread();
+        global_handle().spawn(async move {
+            while launchers_rx.changed().await.is_ok() {
+                let projected = project_launchers(&launchers_rx.borrow_and_update());
+                let _ = qt_thread.queue(move |model| apply_launchers_state(model, projected));
+            }
+        });
+
+        let qt_thread = self.qt_thread();
+        global_handle().spawn(async move {
+            while settings_rx.changed().await.is_ok() {
+                let projected = project_settings(&settings_rx.borrow_and_update());
+                let _ = qt_thread.queue(move |model| apply_settings_state(model, projected));
+            }
+        });
+    }
+}
+
+fn project_launchers(
+    status: &ResourceStatus<zaparoo_core::media_types::LaunchersResult>,
+) -> (Option<Vec<LauncherInfo>>, bool, String) {
+    match status {
+        ResourceStatus::Ready(data) => (Some(data.launchers.clone()), false, String::new()),
+        ResourceStatus::Errored { message, .. } => (None, false, message.clone()),
+        ResourceStatus::Idle | ResourceStatus::Loading => (None, true, String::new()),
+    }
+}
+
+fn project_settings(
+    status: &ResourceStatus<SettingsResult>,
+) -> (Option<Vec<SystemDefault>>, bool, String) {
+    match status {
+        ResourceStatus::Ready(data) => (Some(data.system_defaults.clone()), false, String::new()),
+        ResourceStatus::Errored { message, .. } => (None, false, message.clone()),
+        ResourceStatus::Idle | ResourceStatus::Loading => (None, true, String::new()),
+    }
+}
+
+fn apply_launchers_state(
+    mut model: Pin<&mut ffi::SystemLaunchers>,
+    (launchers, loading, error): (Option<Vec<LauncherInfo>>, bool, String),
+) {
+    if let Some(launchers) = launchers {
+        model.as_mut().rust_mut().launchers = launchers;
+    }
+    model.as_mut().rust_mut().launchers_loading = loading;
+    model.as_mut().rust_mut().launchers_error = error;
+    refresh_status(model);
+}
+
+fn apply_settings_state(
+    mut model: Pin<&mut ffi::SystemLaunchers>,
+    (defaults, loading, error): (Option<Vec<SystemDefault>>, bool, String),
+) {
+    if let Some(defaults) = defaults {
+        model.as_mut().rust_mut().system_defaults = defaults;
+    }
+    model.as_mut().rust_mut().settings_loading = loading;
+    model.as_mut().rust_mut().settings_error = error;
+    refresh_status(model);
+}
+
+fn refresh_status(mut model: Pin<&mut ffi::SystemLaunchers>) {
+    let loading = model.rust().launchers_loading || model.rust().settings_loading;
+    if model.loading != loading {
+        model.as_mut().set_loading(loading);
+    }
+    let error = if model.rust().launchers_error.is_empty() {
+        model.rust().settings_error.clone()
+    } else {
+        model.rust().launchers_error.clone()
+    };
+    let qerr = QString::from(error.as_str());
+    if model.error_message != qerr {
+        model.as_mut().set_error_message(qerr);
+    }
+}
+
+impl ffi::SystemLaunchers {
+    #[allow(
+        clippy::needless_pass_by_value,
+        reason = "cxx-qt qinvokable signature requires QString by value"
+    )]
+    fn prepare_system(mut self: Pin<&mut Self>, system_id: QString) {
+        let system_id = system_id.to_string();
+        let current = current_launcher_for_system(&self.system_defaults, &system_id)
+            .unwrap_or_else(|| DEFAULT_LAUNCHER_ID.to_string());
+        let entries = picker_entries_for_system(&self.launchers, &self.system_defaults, &system_id);
+        let mut ids = QStringList::default();
+        let mut labels = QStringList::default();
+        for entry in entries {
+            ids.append(QString::from(entry.id.as_str()));
+            labels.append(QString::from(entry.label.as_str()));
+        }
+        self.as_mut().set_picker_ids(ids);
+        self.as_mut().set_picker_labels(labels);
+        self.as_mut()
+            .set_current_launcher(QString::from(current.as_str()));
+    }
+
+    fn launcher_count_for_system(&self, system_id: &QString) -> i32 {
+        launchers_for_system(&self.launchers, &system_id.to_string()).len() as i32
+    }
+
+    #[allow(
+        clippy::needless_pass_by_value,
+        reason = "cxx-qt qinvokable signature requires QString by value"
+    )]
+    fn set_system_launcher(mut self: Pin<&mut Self>, system_id: QString, launcher_id: QString) {
+        let launcher = launcher_id.to_string();
+        let launcher = if launcher == DEFAULT_LAUNCHER_ID {
+            String::new()
+        } else {
+            launcher
+        };
+        let system_id = system_id.to_string();
+        let store = global_store();
+        let seq = self.rust().update_seq.clone();
+        let ticket = seq.fetch_add(1, Ordering::SeqCst) + 1;
+        self.as_mut().set_update_error(QString::default());
+        self.as_mut().set_update_pending(true);
+        let qt_thread = self.qt_thread();
+        global_handle().spawn(async move {
+            let result = store
+                .run_mutation::<SetSystemLauncherDefaultMutation>(SetSystemLauncherDefaultArgs {
+                    system_id,
+                    launcher,
+                })
+                .await;
+            let _ = qt_thread.queue(move |mut model| {
+                if seq.load(Ordering::SeqCst) != ticket {
+                    return;
+                }
+                let error = match result {
+                    Ok(()) => QString::default(),
+                    Err(e) => {
+                        warn!("system launcher update failed: {}", e.message);
+                        QString::from(e.message.as_str())
+                    }
+                };
+                model.as_mut().set_update_error(error);
+                model.as_mut().set_update_pending(false);
+            });
+        });
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PickerEntry {
+    pub id: String,
+    pub label: String,
+}
+
+pub fn launchers_for_system(launchers: &[LauncherInfo], system_id: &str) -> Vec<LauncherInfo> {
+    launchers
+        .iter()
+        .filter(|launcher| launcher.system_id == system_id)
+        .cloned()
+        .collect()
+}
+
+pub fn current_launcher_for_system(defaults: &[SystemDefault], system_id: &str) -> Option<String> {
+    defaults
+        .iter()
+        .find(|default| default.system == system_id)
+        .and_then(|default| {
+            if default.launcher.is_empty() {
+                None
+            } else {
+                Some(default.launcher.clone())
+            }
+        })
+}
+
+pub fn picker_entries_for_system(
+    launchers: &[LauncherInfo],
+    defaults: &[SystemDefault],
+    system_id: &str,
+) -> Vec<PickerEntry> {
+    let mut entries = vec![PickerEntry {
+        id: DEFAULT_LAUNCHER_ID.into(),
+        label: "Default".into(),
+    }];
+    let matching = launchers_for_system(launchers, system_id);
+    for launcher in &matching {
+        entries.push(PickerEntry {
+            id: launcher.id.clone(),
+            label: launcher.id.clone(),
+        });
+    }
+    if let Some(current) = current_launcher_for_system(defaults, system_id) {
+        let known = matching.iter().any(|launcher| launcher.id == current);
+        if !known {
+            entries.push(PickerEntry {
+                id: current.clone(),
+                label: format!("Current: {current}"),
+            });
+        }
+    }
+    entries
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn launcher(id: &str, system_id: &str) -> LauncherInfo {
+        LauncherInfo {
+            id: id.into(),
+            system_id: system_id.into(),
+            ..LauncherInfo::default()
+        }
+    }
+
+    fn default(system: &str, launcher: &str) -> SystemDefault {
+        SystemDefault {
+            system: system.into(),
+            launcher: launcher.into(),
+            before_exit: String::new(),
+        }
+    }
+
+    #[test]
+    fn filters_launchers_by_exact_system_id() {
+        let launchers = vec![launcher("snes9x", "SNES"), launcher("nestopia", "NES")];
+        let filtered = launchers_for_system(&launchers, "SNES");
+        assert_eq!(filtered, vec![launcher("snes9x", "SNES")]);
+    }
+
+    #[test]
+    fn picker_entries_put_default_first() {
+        let entries = picker_entries_for_system(&[launcher("snes9x", "SNES")], &[], "SNES");
+        assert_eq!(entries[0].id, DEFAULT_LAUNCHER_ID);
+        assert_eq!(entries[0].label, "Default");
+        assert_eq!(entries[1].id, "snes9x");
+    }
+
+    #[test]
+    fn picker_entries_include_unknown_current_override() {
+        let entries = picker_entries_for_system(
+            &[launcher("snes9x", "SNES")],
+            &[default("SNES", "libretro")],
+            "SNES",
+        );
+        assert_eq!(
+            entries,
+            vec![
+                PickerEntry {
+                    id: DEFAULT_LAUNCHER_ID.into(),
+                    label: "Default".into()
+                },
+                PickerEntry {
+                    id: "snes9x".into(),
+                    label: "snes9x".into()
+                },
+                PickerEntry {
+                    id: "libretro".into(),
+                    label: "Current: libretro".into()
+                },
+            ]
+        );
+    }
+}

--- a/rust/mock-core/src/fixtures.rs
+++ b/rust/mock-core/src/fixtures.rs
@@ -9,11 +9,105 @@
 // into it.
 
 use serde_json::{json, Value};
+use std::sync::{Mutex, OnceLock};
+
+static SYSTEM_DEFAULTS: OnceLock<Mutex<Vec<SystemDefaultFixture>>> = OnceLock::new();
+
+#[derive(Clone)]
+struct SystemDefaultFixture {
+    system: String,
+    launcher: String,
+    before_exit: String,
+}
 
 pub fn version_response() -> Value {
     json!({
         "version": "mock-0.1.0",
         "platform": "mock",
+    })
+}
+
+pub fn launchers_response() -> Value {
+    json!({
+        "launchers": [
+            { "id": "nestopia",          "systemId": "NES",        "systemName": "Nintendo Entertainment System", "groups": ["libretro"] },
+            { "id": "fceumm",           "systemId": "NES",        "systemName": "Nintendo Entertainment System", "groups": ["libretro"] },
+            { "id": "snes9x",           "systemId": "SNES",       "systemName": "Super Nintendo",                "groups": ["libretro"] },
+            { "id": "bsnes",            "systemId": "SNES",       "systemName": "Super Nintendo",                "groups": ["libretro"] },
+            { "id": "genesis-plus-gx",  "systemId": "Genesis",    "systemName": "Sega Genesis",                  "groups": ["libretro"] },
+            { "id": "mupen64plus-next", "systemId": "Nintendo64", "systemName": "Nintendo 64",                   "groups": ["libretro"] },
+            { "id": "gambatte",         "systemId": "Gameboy",    "systemName": "Game Boy",                      "groups": ["libretro"] },
+            { "id": "mgba",             "systemId": "GBA",        "systemName": "Game Boy Advance",              "groups": ["libretro"] },
+            { "id": "mame",             "systemId": "MAME",       "systemName": "MAME",                          "groups": ["arcade"] },
+            { "id": "fbneo",            "systemId": "NeoGeo",     "systemName": "Neo Geo",                       "groups": ["arcade"] }
+        ]
+    })
+}
+
+pub fn settings_response() -> Value {
+    let defaults = system_defaults()
+        .lock()
+        .map(|defaults| defaults.clone())
+        .unwrap_or_default();
+    let system_defaults: Vec<Value> = defaults
+        .into_iter()
+        .map(|default| {
+            json!({
+                "system": default.system,
+                "launcher": default.launcher,
+                "beforeExit": default.before_exit,
+            })
+        })
+        .collect();
+    json!({
+        "runZapScript": true,
+        "debugLogging": false,
+        "audioScanFeedback": true,
+        "readersAutoDetect": true,
+        "readersScanMode": "tap",
+        "readersScanExitDelay": 0.0,
+        "readersScanIgnoreSystems": [],
+        "errorReporting": false,
+        "readersConnect": [],
+        "systemDefaults": system_defaults,
+    })
+}
+
+pub fn settings_update_response(params: &Value) -> Value {
+    if let Some(items) = params.get("systemDefaults").and_then(Value::as_array) {
+        let next = items
+            .iter()
+            .filter_map(|item| {
+                let system = item.get("system").and_then(Value::as_str)?;
+                Some(SystemDefaultFixture {
+                    system: system.to_string(),
+                    launcher: item
+                        .get("launcher")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_string(),
+                    before_exit: item
+                        .get("beforeExit")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_string(),
+                })
+            })
+            .collect();
+        if let Ok(mut defaults) = system_defaults().lock() {
+            *defaults = next;
+        }
+    }
+    Value::Null
+}
+
+fn system_defaults() -> &'static Mutex<Vec<SystemDefaultFixture>> {
+    SYSTEM_DEFAULTS.get_or_init(|| {
+        Mutex::new(vec![SystemDefaultFixture {
+            system: "SNES".into(),
+            launcher: "snes9x".into(),
+            before_exit: String::new(),
+        }])
     })
 }
 

--- a/rust/mock-core/src/handler.rs
+++ b/rust/mock-core/src/handler.rs
@@ -58,6 +58,9 @@ pub fn dispatch(text: &str) -> String {
 
     let result = match req.method.as_str() {
         "systems" => Some(fixtures::systems_response()),
+        "launchers" => Some(fixtures::launchers_response()),
+        "settings" => Some(fixtures::settings_response()),
+        "settings.update" => Some(fixtures::settings_update_response(&req.params)),
         "media.search" => Some(fixtures::media_search_response(&req.params)),
         "media.browse" => Some(fixtures::media_browse_response(&req.params)),
         "media.history" => Some(fixtures::media_history_response(&req.params)),
@@ -132,6 +135,29 @@ mod tests {
         let resp = parse(&dispatch(req));
         let systems = resp["result"]["systems"].as_array().expect("array");
         assert_eq!(systems.len(), 10);
+    }
+
+    #[test]
+    fn launchers_returns_fixture_launchers() {
+        let req = r#"{"jsonrpc":"2.0","id":"1","method":"launchers","params":{}}"#;
+        let resp = parse(&dispatch(req));
+        let launchers = resp["result"]["launchers"].as_array().expect("array");
+        assert!(!launchers.is_empty());
+        assert!(launchers.iter().any(|l| l["systemId"] == "SNES"));
+    }
+
+    #[test]
+    fn settings_update_replaces_system_defaults() {
+        let update = r#"{"jsonrpc":"2.0","id":"1","method":"settings.update","params":{"systemDefaults":[{"system":"NES","launcher":"nestopia"}]}}"#;
+        let resp = parse(&dispatch(update));
+        assert!(resp["result"].is_null());
+
+        let req = r#"{"jsonrpc":"2.0","id":"2","method":"settings","params":{}}"#;
+        let resp = parse(&dispatch(req));
+        let defaults = resp["result"]["systemDefaults"].as_array().expect("array");
+        assert_eq!(defaults.len(), 1);
+        assert_eq!(defaults[0]["system"], "NES");
+        assert_eq!(defaults[0]["launcher"], "nestopia");
     }
 
     #[test]

--- a/rust/zaparoo-core/src/client.rs
+++ b/rust/zaparoo-core/src/client.rs
@@ -14,13 +14,14 @@
 // instead of disappearing into a queue.
 
 use crate::media_types::{
-    MediaBrowseParams, MediaBrowseResult, MediaHistoryParams, MediaHistoryResult,
+    LaunchersResult, MediaBrowseParams, MediaBrowseResult, MediaHistoryParams, MediaHistoryResult,
     MediaHistoryTopParams, MediaHistoryTopResult, MediaImageBulkParams, MediaImageBulkResult,
     MediaImageParams, MediaImageResult, MediaIndexParams, MediaLookupParams, MediaLookupResult,
     MediaMetaParams, MediaMetaResult, MediaResult, MediaScrapeParams, MediaSearchParams,
     MediaSearchResult, MediaTagsParams, MediaTagsResult, MediaTagsUpdateParams,
     MediaTagsUpdateResult, ReadersResult, ReadersWriteParams, RunParams, ScrapersResult,
-    ScrapingStatusResponse, SystemsParams, SystemsResult, VersionResult,
+    ScrapingStatusResponse, SettingsResult, SystemsParams, SystemsResult, UpdateSettingsParams,
+    VersionResult,
 };
 use futures_util::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
@@ -484,6 +485,29 @@ impl Client {
         #[derive(Serialize)]
         struct P {}
         let val = self.call("readers", &P {}).await?;
+        serde_json::from_value(val).map_err(|e| ClientError {
+            message: e.to_string(),
+        })
+    }
+
+    pub async fn settings(&self) -> Result<SettingsResult, ClientError> {
+        #[derive(Serialize)]
+        struct P {}
+        let val = self.call("settings", &P {}).await?;
+        serde_json::from_value(val).map_err(|e| ClientError {
+            message: e.to_string(),
+        })
+    }
+
+    pub async fn settings_update(&self, params: UpdateSettingsParams) -> Result<(), ClientError> {
+        self.call("settings.update", &params).await?;
+        Ok(())
+    }
+
+    pub async fn launchers(&self) -> Result<LaunchersResult, ClientError> {
+        #[derive(Serialize)]
+        struct P {}
+        let val = self.call("launchers", &P {}).await?;
         serde_json::from_value(val).map_err(|e| ClientError {
             message: e.to_string(),
         })

--- a/rust/zaparoo-core/src/endpoints/launchers.rs
+++ b/rust/zaparoo-core/src/endpoints/launchers.rs
@@ -1,0 +1,29 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+use crate::client::{Client, ClientError};
+use crate::media_types::LaunchersResult;
+use crate::store::{Endpoint, Tag};
+use futures_util::future::BoxFuture;
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub struct LaunchersEndpoint;
+
+impl Endpoint for LaunchersEndpoint {
+    type Args = ();
+    type Output = LaunchersResult;
+    const NAME: &'static str = "Launchers";
+
+    fn fetch(
+        client: Arc<Client>,
+        _args: Self::Args,
+    ) -> BoxFuture<'static, Result<Self::Output, ClientError>> {
+        Box::pin(async move { client.launchers().await })
+    }
+
+    fn provides(_args: &Self::Args, _output: &Self::Output) -> Vec<Tag> {
+        vec![Tag::any(Self::NAME)]
+    }
+}

--- a/rust/zaparoo-core/src/endpoints/mod.rs
+++ b/rust/zaparoo-core/src/endpoints/mod.rs
@@ -7,6 +7,7 @@
 // invalidation system.
 
 pub mod catalog;
+pub mod launchers;
 pub mod media_browse;
 pub mod media_favorites;
 pub mod media_history;
@@ -15,3 +16,5 @@ pub mod media_tags_update;
 pub mod readers;
 pub mod readers_write;
 pub mod run;
+pub mod settings;
+pub mod system_launcher_default;

--- a/rust/zaparoo-core/src/endpoints/settings.rs
+++ b/rust/zaparoo-core/src/endpoints/settings.rs
@@ -1,0 +1,29 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+use crate::client::{Client, ClientError};
+use crate::media_types::SettingsResult;
+use crate::store::{Endpoint, Tag};
+use futures_util::future::BoxFuture;
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub struct SettingsEndpoint;
+
+impl Endpoint for SettingsEndpoint {
+    type Args = ();
+    type Output = SettingsResult;
+    const NAME: &'static str = "Settings";
+
+    fn fetch(
+        client: Arc<Client>,
+        _args: Self::Args,
+    ) -> BoxFuture<'static, Result<Self::Output, ClientError>> {
+        Box::pin(async move { client.settings().await })
+    }
+
+    fn provides(_args: &Self::Args, _output: &Self::Output) -> Vec<Tag> {
+        vec![Tag::any(Self::NAME)]
+    }
+}

--- a/rust/zaparoo-core/src/endpoints/system_launcher_default.rs
+++ b/rust/zaparoo-core/src/endpoints/system_launcher_default.rs
@@ -1,0 +1,109 @@
+// Zaparoo Launcher
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+use crate::client::{Client, ClientError};
+use crate::media_types::{SystemDefault, UpdateSettingsParams};
+use crate::store::{Mutation, Tag};
+use futures_util::future::BoxFuture;
+use std::sync::Arc;
+
+#[derive(Debug, Clone, Default)]
+pub struct SetSystemLauncherDefaultArgs {
+    pub system_id: String,
+    pub launcher: String,
+}
+
+#[derive(Debug)]
+pub struct SetSystemLauncherDefaultMutation;
+
+impl Mutation for SetSystemLauncherDefaultMutation {
+    type Args = SetSystemLauncherDefaultArgs;
+    type Output = ();
+
+    fn run(
+        client: Arc<Client>,
+        args: Self::Args,
+    ) -> BoxFuture<'static, Result<Self::Output, ClientError>> {
+        Box::pin(async move {
+            let settings = client.settings().await?;
+            let merged = merge_system_launcher_default(
+                settings.system_defaults,
+                &args.system_id,
+                &args.launcher,
+            );
+            client
+                .settings_update(UpdateSettingsParams {
+                    system_defaults: Some(merged),
+                })
+                .await
+        })
+    }
+
+    fn invalidates(_args: &Self::Args, _result: &Self::Output) -> Vec<Tag> {
+        vec![Tag::any("Settings")]
+    }
+}
+
+pub fn merge_system_launcher_default(
+    mut defaults: Vec<SystemDefault>,
+    system_id: &str,
+    launcher: &str,
+) -> Vec<SystemDefault> {
+    let launcher = launcher.trim();
+    if let Some(existing) = defaults.iter_mut().find(|d| d.system == system_id) {
+        existing.launcher = launcher.to_string();
+    } else if !launcher.is_empty() {
+        defaults.push(SystemDefault {
+            system: system_id.to_string(),
+            launcher: launcher.to_string(),
+            before_exit: String::new(),
+        });
+    }
+
+    defaults
+        .retain(|d| !(d.system == system_id && d.launcher.is_empty() && d.before_exit.is_empty()));
+    defaults
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn default(system: &str, launcher: &str, before_exit: &str) -> SystemDefault {
+        SystemDefault {
+            system: system.into(),
+            launcher: launcher.into(),
+            before_exit: before_exit.into(),
+        }
+    }
+
+    #[test]
+    fn merge_replaces_launcher_and_preserves_before_exit() {
+        let merged = merge_system_launcher_default(
+            vec![default("SNES", "snes9x", "echo bye")],
+            "SNES",
+            "retroarch",
+        );
+        assert_eq!(merged, vec![default("SNES", "retroarch", "echo bye")]);
+    }
+
+    #[test]
+    fn merge_appends_non_empty_launcher() {
+        let merged = merge_system_launcher_default(vec![], "SNES", "snes9x");
+        assert_eq!(merged, vec![default("SNES", "snes9x", "")]);
+    }
+
+    #[test]
+    fn merge_default_removes_row_without_before_exit() {
+        let merged = merge_system_launcher_default(vec![default("SNES", "snes9x", "")], "SNES", "");
+        assert!(merged.is_empty());
+    }
+
+    #[test]
+    fn merge_default_keeps_row_with_before_exit() {
+        let merged =
+            merge_system_launcher_default(vec![default("SNES", "snes9x", "echo bye")], "SNES", "");
+        assert_eq!(merged, vec![default("SNES", "", "echo bye")]);
+    }
+}

--- a/rust/zaparoo-core/src/media_types.rs
+++ b/rust/zaparoo-core/src/media_types.rs
@@ -812,6 +812,50 @@ pub struct ScrapersResult {
     pub scrapers: Vec<ScraperInfo>,
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SystemDefault {
+    pub system: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub launcher: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub before_exit: String,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SettingsResult {
+    #[serde(default)]
+    pub system_defaults: Vec<SystemDefault>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateSettingsParams {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system_defaults: Option<Vec<SystemDefault>>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct LauncherInfo {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub system_id: String,
+    #[serde(default)]
+    pub system_name: String,
+    #[serde(default)]
+    pub groups: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LaunchersResult {
+    #[serde(default)]
+    pub launchers: Vec<LauncherInfo>,
+}
+
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct RunParams {
     pub text: String,
@@ -892,13 +936,13 @@ mod tests {
     )]
 
     use super::{
-        BrowseEntry, IndexingStatusResponse, MediaBrowseParams, MediaBrowseResult,
+        BrowseEntry, IndexingStatusResponse, LaunchersResult, MediaBrowseParams, MediaBrowseResult,
         MediaHistoryParams, MediaHistoryResult, MediaHistoryTopParams, MediaHistoryTopResult,
         MediaImageBulkResult, MediaImageParams, MediaImageResult, MediaIndexParams,
         MediaLookupParams, MediaLookupResult, MediaMetaParams, MediaMetaResult, MediaResult,
         MediaScrapeParams, MediaSearchParams, MediaSearchResult, MediaTagsParams, MediaTagsResult,
-        ReaderInfo, ReadersResult, ScrapersResult, ScrapingStatusResponse, SystemsResult,
-        VersionResult,
+        ReaderInfo, ReadersResult, ScrapersResult, ScrapingStatusResponse, SettingsResult,
+        SystemDefault, SystemsResult, UpdateSettingsParams, VersionResult,
     };
 
     #[test]
@@ -1583,6 +1627,65 @@ mod tests {
     fn media_tags_result_handles_empty_envelope() {
         let result: MediaTagsResult = serde_json::from_str("{}").expect("parse");
         assert!(result.tags.is_empty());
+    }
+
+    #[test]
+    fn settings_result_parses_system_defaults() {
+        let json = r#"{
+            "systemDefaults": [
+                {"system":"SNES","launcher":"snes9x","beforeExit":"echo bye"},
+                {"system":"Genesis"}
+            ]
+        }"#;
+        let result: SettingsResult = serde_json::from_str(json).expect("parse");
+        assert_eq!(result.system_defaults.len(), 2);
+        assert_eq!(result.system_defaults[0].system, "SNES");
+        assert_eq!(result.system_defaults[0].launcher, "snes9x");
+        assert_eq!(result.system_defaults[0].before_exit, "echo bye");
+        assert_eq!(result.system_defaults[1].launcher, "");
+    }
+
+    #[test]
+    fn update_settings_params_serialises_system_defaults() {
+        let params = UpdateSettingsParams {
+            system_defaults: Some(vec![SystemDefault {
+                system: "SNES".into(),
+                launcher: "snes9x".into(),
+                before_exit: String::new(),
+            }]),
+        };
+        let json = serde_json::to_value(&params).expect("serialise");
+        let defaults = json
+            .get("systemDefaults")
+            .and_then(|v| v.as_array())
+            .expect("defaults array");
+        assert_eq!(defaults.len(), 1);
+        assert_eq!(
+            defaults[0].get("system").and_then(|v| v.as_str()),
+            Some("SNES")
+        );
+        assert_eq!(
+            defaults[0].get("launcher").and_then(|v| v.as_str()),
+            Some("snes9x")
+        );
+        assert!(!defaults[0]
+            .as_object()
+            .expect("object")
+            .contains_key("beforeExit"));
+    }
+
+    #[test]
+    fn launchers_result_parses_payload() {
+        let json = r#"{
+            "launchers": [
+                {"id":"snes9x","systemId":"SNES","systemName":"Super Nintendo","groups":["libretro"]}
+            ]
+        }"#;
+        let result: LaunchersResult = serde_json::from_str(json).expect("parse");
+        assert_eq!(result.launchers.len(), 1);
+        assert_eq!(result.launchers[0].id, "snes9x");
+        assert_eq!(result.launchers[0].system_id, "SNES");
+        assert_eq!(result.launchers[0].groups, vec!["libretro"]);
     }
 
     #[test]

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -51,6 +51,8 @@ MainLayout {
     property string _pendingResolutionSelection: ""
     property bool _discoverMenuPending: false
     property var _discoverParentEntries: []
+    property string _pendingLauncherSystemId: ""
+    property string _pendingLauncherSelectionId: ""
     property string cardWriteOwner: ""
     property string contextMenuMode: "main"
     property string contextMenuOwner: ""
@@ -745,14 +747,21 @@ MainLayout {
     // caller saw `entries.length === 0` despite the function pushing 3
     // items in. Plain `var` round-trips cleanly and silences the
     // "insufficiently annotated" coercion warning at the call site.
-    function buildContextMenuEntries(owner: string, entryType: string, hasNfc: bool, isFavorite: bool) {
+    function buildContextMenuEntries(owner: string, entryType: string, hasNfc: bool, isFavorite: bool, systemId: string) {
         if (owner === "systems") {
-            return [
+            const entries = [
                 {
                     id: "launch_system",
                     label: qsTr("Launch core")
                 }
             ];
+            if (!Browse.SystemLaunchers.loading && Browse.SystemLaunchers.error_message === "" && Browse.SystemLaunchers.launcher_count_for_system(systemId) > 0) {
+                entries.push({
+                    id: "change_launcher",
+                    label: qsTr("Change launcher")
+                });
+            }
+            return entries;
         }
         if (owner === "recents") {
             const entries = [
@@ -844,7 +853,12 @@ MainLayout {
             return;
         let entryType = "";
         let isFavorite = false;
-        if (owner === "games") {
+        let systemId = "";
+        if (owner === "systems") {
+            if (index >= Browse.SystemsModel.count)
+                return;
+            systemId = Browse.SystemsModel.system_id_at(index);
+        } else if (owner === "games") {
             if (index >= Browse.GamesModel.count)
                 return;
             entryType = Browse.GamesModel.entry_type_at(index);
@@ -857,7 +871,7 @@ MainLayout {
             if (index >= Browse.RecentsModel.count)
                 return;
         }
-        const entries = root.buildContextMenuEntries(owner, entryType, Browse.SystemStatus.has_nfc, isFavorite);
+        const entries = root.buildContextMenuEntries(owner, entryType, Browse.SystemStatus.has_nfc, isFavorite, systemId);
         if (entries.length === 0)
             return;
         root.contextMenuEntries = entries;
@@ -923,7 +937,23 @@ MainLayout {
             return;
         }
         root.closeContextMenu();
-        if (id.startsWith("alternate_version:")) {
+        if (id === "change_launcher") {
+            const systemId = Browse.SystemsModel.system_id_at(targetIndex);
+            if (systemId === "")
+                return;
+            Browse.SystemLaunchers.prepare_system(systemId);
+            const entries = [];
+            for (let i = 0; i < Browse.SystemLaunchers.picker_ids.length; i++) {
+                const launcherId = Browse.SystemLaunchers.picker_ids[i];
+                const label = Browse.SystemLaunchers.picker_labels[i];
+                entries.push({
+                    id: launcherId,
+                    label: launcherId === "__default__" ? qsTr("Default") : (label.indexOf("Current: ") === 0 ? qsTr("Current: %1").arg(launcherId) : label)
+                });
+            }
+            if (entries.length > 0)
+                root.openListPickerModal(qsTr("Change launcher"), entries, Browse.SystemLaunchers.current_launcher, "system_launcher:" + systemId);
+        } else if (id.startsWith("alternate_version:")) {
             const altIndex = Number(id.slice("alternate_version:".length));
             if (!Number.isNaN(altIndex))
                 Browse.AlternateVersions.launch_at(altIndex);
@@ -1191,7 +1221,72 @@ MainLayout {
         Qt.exit(1000);
     }
 
+    function beginSystemLauncherUpdate(systemId: string, selectedId: string): void {
+        root._pendingLauncherSystemId = systemId;
+        root._pendingLauncherSelectionId = selectedId;
+        root.listPickerTitle = qsTr("Saving launcher");
+        root.listPickerEntries = [
+            {
+                id: "saving",
+                label: qsTr("Saving…")
+            }
+        ];
+        root.listPickerInitialId = "saving";
+        root.listPickerFieldId = "system_launcher_pending";
+        Browse.SystemLaunchers.set_system_launcher(systemId, selectedId);
+    }
+
+    function clearPendingLauncherUpdate(): void {
+        root._pendingLauncherSystemId = "";
+        root._pendingLauncherSelectionId = "";
+    }
+
+    function showSystemLauncherUpdateError(): void {
+        root.listPickerTitle = qsTr("Launcher update failed");
+        root.listPickerEntries = [
+            {
+                id: "error",
+                label: qsTr("Error: %1").arg(Browse.SystemLaunchers.update_error)
+            },
+            {
+                id: "retry",
+                label: qsTr("Retry")
+            },
+            {
+                id: "cancel",
+                label: qsTr("Cancel")
+            }
+        ];
+        root.listPickerInitialId = "retry";
+        root.listPickerFieldId = "system_launcher_error";
+    }
+
+    function handleListPickerCloseRequested(): void {
+        if (root.listPickerFieldId === "system_launcher_pending")
+            return;
+        if (root.listPickerFieldId === "system_launcher_error")
+            root.clearPendingLauncherUpdate();
+        root.closeListPickerModal();
+    }
+
     onListPickerAccepted: (fieldId, selectedId) => {
+        if (fieldId === "system_launcher_pending")
+            return;
+        if (fieldId === "system_launcher_error") {
+            if (selectedId === "error")
+                return;
+            if (selectedId === "retry" && root._pendingLauncherSystemId !== "")
+                root.beginSystemLauncherUpdate(root._pendingLauncherSystemId, root._pendingLauncherSelectionId);
+            else {
+                root.clearPendingLauncherUpdate();
+                root.closeListPickerModal();
+            }
+            return;
+        }
+        if (fieldId.startsWith("system_launcher:")) {
+            root.beginSystemLauncherUpdate(fieldId.slice("system_launcher:".length), selectedId);
+            return;
+        }
         if (fieldId === "language") {
             root.closeListPickerModal();
             if (selectedId !== Browse.Settings.current_language)
@@ -1210,7 +1305,21 @@ MainLayout {
             Browse.Settings.set_screensaver_timeout(selectedId);
         root.closeListPickerModal();
     }
-    onListPickerCloseRequested: root.closeListPickerModal()
+    onListPickerCloseRequested: root.handleListPickerCloseRequested()
+
+    Connections {
+        target: Browse.SystemLaunchers
+        function onUpdate_pendingChanged(): void {
+            if (root._pendingLauncherSystemId === "" || Browse.SystemLaunchers.update_pending)
+                return;
+            if (Browse.SystemLaunchers.update_error === "") {
+                root.clearPendingLauncherUpdate();
+                root.closeListPickerModal();
+            } else {
+                root.showSystemLauncherUpdateError();
+            }
+        }
+    }
 
     Connections {
         target: Browse.AppStatus


### PR DESCRIPTION
Summary:
- expose Core settings/systemDefaults and launchers APIs in the launcher data layer
- add SystemLaunchers singleton and Systems context menu picker for changing launcher defaults
- keep save feedback visible with pending, retry, and error states
- update mock-core fixtures for launchers and settings updates

Validated:
- just test-rust
- just lint
- just test-qml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to change system launchers directly from the context menu.
  * Introduced launcher picker modal displaying available options with "Default" and current launcher override labels.
  * Added support for persisting and updating system default launcher preferences.
  * Implemented launcher information retrieval and management.

* **Tests**
  * Added unit tests validating launcher selection, filtering, and picker entry behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ZaparooProject/zaparoo-launcher/pull/142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->