### PR TITLE
chore: bump version to 1.0.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.22)
 
 project(
     zaparoo-frontend
-    VERSION 0.1.0
+    VERSION 1.0.2
     DESCRIPTION "Zaparoo Core frontend"
     HOMEPAGE_URL "https://zaparoo.org"
     LANGUAGES CXX

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -679,7 +679,7 @@ dependencies = [
 
 [[package]]
 name = "mock-core"
-version = "0.1.0"
+version = "1.0.2"
 dependencies = [
  "futures-util",
  "serde",
@@ -1629,7 +1629,7 @@ dependencies = [
 
 [[package]]
 name = "zaparoo-core"
-version = "0.1.0"
+version = "1.0.2"
 dependencies = [
  "dirs-next",
  "futures-util",
@@ -1649,7 +1649,7 @@ dependencies = [
 
 [[package]]
 name = "zaparoo-frontend-rs"
-version = "0.1.0"
+version = "1.0.2"
 dependencies = [
  "base64",
  "cxx",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ members = ["frontend", "mock-core", "zaparoo-core"]
 resolver = "2"
 
 [workspace.package]
-version      = "0.1.0"
+version      = "1.0.2"
 edition      = "2021"
 rust-version = "1.90"
 license      = "LicenseRef-PolyForm-Noncommercial-1.0.0"

--- a/scripts/package-macos-app.sh
+++ b/scripts/package-macos-app.sh
@@ -37,9 +37,9 @@ cat > "$APP_DIR/Contents/Info.plist" <<'PLIST'
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.1.0</string>
+  <string>1.0.2</string>
   <key>CFBundleVersion</key>
-  <string>0.1.0</string>
+  <string>1.0.2</string>
   <key>LSMinimumSystemVersion</key>
   <string>15.0</string>
   <key>NSHighResolutionCapable</key>

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -150,7 +150,7 @@ int main(int argc, char* argv[]) // NOLINT
     }
 
     QGuiApplication::setApplicationName("Zaparoo Frontend");
-    QGuiApplication::setApplicationVersion("0.1.0");
+    QGuiApplication::setApplicationVersion("1.0.2");
     QGuiApplication::setOrganizationName("Zaparoo");
     QGuiApplication::setOrganizationDomain("zaparoo.org");
 


### PR DESCRIPTION
## Summary
- bump frontend app/package versions to 1.0.2
- update generated Rust lockfile package versions
- update macOS bundle version metadata

## Validation
- just lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Version updated to 1.0.2 across build configuration and application metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ZaparooProject/zaparoo-frontend/pull/150?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->