### PR TITLE
feat(): Add support for TATE Mode

### DIFF
--- a/docs/tate-list-view-plan.md
+++ b/docs/tate-list-view-plan.md
@@ -1,0 +1,117 @@
+# TATE List View Plan
+
+Best path: do not fork whole list screen for TATE. Keep one shell, split layout into strategy/profile pieces.
+
+## Plan
+
+1. Add list-detail orientation mode, not special-case soup.
+   - New derived mode in `src/ui/screens/MediaListScreen.qml`: `standardList` vs `tateList`.
+   - Trigger from `Browse.Settings.current_orientation !== "horizontal"` and `_listLayout`.
+   - Keep input/state/detail loading in `MediaListScreen`; only geometry changes.
+
+2. Break `src/ui/components/BrowseListDetailView.qml` into 3 stable pieces.
+   - `BrowseListPane`
+   - `BrowseDetailPane`
+   - thin `BrowseListDetailView` compositor
+   - Reason: current component already mixes list + detail geometry. TATE will get messy if we keep one giant anchoring file.
+
+3. Introduce explicit layout profile object for list-detail composition.
+   - Today profile mostly tunes sizes.
+   - Expand it to include composition slots:
+     - `listDetailAxis: "horizontal" | "vertical"`
+     - `detailAxis: "horizontal" | "vertical"`
+     - `listShare`, `detailShare`
+     - `detailImageShare`, `detailMetadataShare`
+     - gaps, margins, panel heights
+   - Then theme can override profile values without rewriting component logic.
+
+## Target TATE Layout
+
+- Whole screen:
+  - top: list
+  - bottom: detail panel
+- Inside detail panel:
+  - left: preview image
+  - right: metadata/text
+- So:
+  - outer compositor = vertical split
+  - detail pane internals = horizontal split
+
+## Maintainable Component Shape
+
+- `MediaListScreen.qml`
+  - owns navigation, selection persistence, retry/accept/cancel, focused-detail controller
+  - decides which layout profile to pass down
+- `BrowseListDetailView.qml`
+  - only composes panes using profile
+  - no business logic
+- `BrowseListPane.qml`
+  - row rendering, hover/click/current rect
+- `BrowseDetailPane.qml`
+  - image, title, tags, description
+  - already close to reusable; keep pushing it there
+
+## Theming Rule
+
+Do theme with profiles, not `if (tate)` colors/fonts in components.
+
+Suggested profiles in `src/ui/theme/BrowseLayouts.qml`:
+- `defaultList`
+- `crtList`
+- `defaultTateList`
+- `crtTateList`
+
+Each profile defines only tokens. Components read tokens. No visual branching all over QML.
+
+## Why This Stays Sane
+
+- One navigation model
+- One detail-loading model
+- One list row implementation
+- Two composition profiles
+- TATE-specific work isolated to geometry/profile layer
+
+## Implementation Order
+
+1. Add `tateList` derived mode in `MediaListScreen`.
+2. Refactor `BrowseListDetailView` so outer split direction comes from profile.
+3. Refactor `BrowseDetailPane` so image/metadata split direction comes from profile.
+4. Add `defaultTateList` + `crtTateList` tokens.
+5. Tune text truncation/row count for portrait logical space.
+6. Only after that, decide if favorites/recents need small per-screen overrides.
+
+## Watchouts
+
+- Keep integer geometry through `Sizing`; rotated portrait space will expose rounding bugs fast.
+- In TATE, description area will shrink first. Make description optional/collapsible before shrinking metadata rows too hard.
+- Context-menu anchor should still come from list cell rect only; no TATE special case if pane ownership stays unchanged.
+
+## PR 156 Addition
+
+This plan is the intended follow-up for [ZaparooProject/zaparoo-frontend#156](https://github.com/ZaparooProject/zaparoo-frontend/pull/156) after TATE mode lands.
+
+- PR 156 is the right direction for theme/profile-driven tokens.
+- PR 156 is not enough by itself for TATE list-detail layout, because `BrowseListDetailView.qml` still hardcodes the outer split as list-left and detail-right.
+- After TATE merges, the refactor discussion for PR 156 should continue with one extra requirement: make the list/detail compositor profile-driven, not only size-driven.
+
+Required additions on top of PR 156:
+
+1. `BrowseListDetailView.qml` must support profile-driven outer axis selection.
+   - Normal mode: horizontal split
+   - TATE mode: vertical split
+2. `BrowseDetailPane.qml` must support profile-driven inner axis selection.
+   - Normal mode: current layout
+   - TATE mode: preview image left, metadata right
+3. `BrowseLayouts.qml` profiles should grow composition keys, not only spacing keys.
+   - `listDetailAxis`
+   - `listShare`
+   - `detailShare`
+   - `detailAxis`
+   - `detailImageShare`
+   - `detailMetadataShare`
+
+Conclusion:
+
+- Merge TATE mode first.
+- Keep PR 156 as the token/theme foundation.
+- Resume PR 156 with this TATE compositor refactor as the next steering point.

--- a/rust/frontend/src/models/settings.rs
+++ b/rust/frontend/src/models/settings.rs
@@ -22,6 +22,11 @@
 //   * `current_language` — READ + NOTIFY. Mirrors `[general].language`
 //     from frontend.toml and is also recorded in persisted state so the
 //     settings snapshot stays coherent.
+//   * `available_orientations` — CONSTANT. Three display transforms:
+//     horizontal (default), rotated clockwise, rotated counter-clockwise.
+//   * `current_orientation` — READ + NOTIFY, persisted. Applied live by
+//     the QML scene wrapper while also mirrored into frontend.toml so
+//     MiSTer survives `/tmp` resets.
 //   * `available_browse_layouts` — CONSTANT. The browsing layout picker
 //     choices. "grid" is the existing layout; "list" is the detailed list
 //     placeholder until the new browsing screen is built.
@@ -88,6 +93,8 @@ const LANGUAGES: &[&str] = &[
     "hi",
 ];
 const DEFAULT_LANGUAGE: &str = "auto";
+const ORIENTATIONS: &[&str] = &["horizontal", "cw", "ccw"];
+const DEFAULT_ORIENTATION: &str = "horizontal";
 const BROWSE_LAYOUTS: &[&str] = &["grid", "list"];
 const DEFAULT_BROWSE_LAYOUT: &str = "grid";
 const BUTTON_LAYOUTS: &[&str] = &["a", "b", "c", "d"];
@@ -118,6 +125,8 @@ pub struct SettingsRust {
     current_resolution: QString,
     available_languages: QStringList,
     current_language: QString,
+    available_orientations: QStringList,
+    current_orientation: QString,
     available_browse_layouts: QStringList,
     current_browse_layout: QString,
     available_button_layouts: QStringList,
@@ -147,6 +156,8 @@ pub mod ffi {
         #[qproperty(QString, current_resolution, READ, WRITE = set_resolution, NOTIFY)]
         #[qproperty(QStringList, available_languages, READ, CONSTANT)]
         #[qproperty(QString, current_language, READ, WRITE = set_language, NOTIFY)]
+        #[qproperty(QStringList, available_orientations, READ, CONSTANT)]
+        #[qproperty(QString, current_orientation, READ, WRITE = set_orientation, NOTIFY)]
         #[qproperty(QStringList, available_browse_layouts, READ, CONSTANT)]
         #[qproperty(QString, current_browse_layout, READ, WRITE = set_browse_layout, NOTIFY)]
         #[qproperty(QStringList, available_button_layouts, READ, CONSTANT)]
@@ -163,6 +174,9 @@ pub mod ffi {
 
         #[qinvokable]
         fn set_language(self: Pin<&mut Settings>, value: QString);
+
+        #[qinvokable]
+        fn set_orientation(self: Pin<&mut Settings>, value: QString);
 
         #[qinvokable]
         fn set_browse_layout(self: Pin<&mut Settings>, value: QString);
@@ -204,6 +218,8 @@ impl Initialize for ffi::Settings {
         self.as_mut().rust_mut().current_resolution = QString::from(merged.resolution.as_str());
         self.as_mut().rust_mut().available_languages = languages();
         self.as_mut().rust_mut().current_language = QString::from(merged.language.as_str());
+        self.as_mut().rust_mut().available_orientations = orientations();
+        self.as_mut().rust_mut().current_orientation = QString::from(merged.orientation.as_str());
         self.as_mut().rust_mut().available_browse_layouts = browse_layouts();
         self.as_mut().rust_mut().current_browse_layout =
             QString::from(merged.browse_layout.as_str());
@@ -248,6 +264,21 @@ impl ffi::Settings {
         mirror_settings_to_config(&config_file_path(), &snapshot.settings);
         self.as_mut().rust_mut().current_language = QString::from(value_str.as_str());
         self.as_mut().current_language_changed();
+    }
+
+    #[allow(
+        clippy::needless_pass_by_value,
+        reason = "cxx-qt qinvokable signature requires QString by value"
+    )]
+    fn set_orientation(mut self: Pin<&mut Self>, value: QString) {
+        let value_str = normalize_orientation(&value.to_string()).to_string();
+        if self.current_orientation.to_string() == value_str {
+            return;
+        }
+        let snapshot = persist_settings(|s| s.orientation.clone_from(&value_str));
+        mirror_settings_to_config(&config_file_path(), &snapshot.settings);
+        self.as_mut().rust_mut().current_orientation = QString::from(value_str.as_str());
+        self.as_mut().current_orientation_changed();
     }
 
     #[allow(
@@ -355,6 +386,7 @@ fn mirror_settings_to_config(config_path: &std::path::Path, settings: &SettingsS
         SettingsMirror {
             resolution: settings.resolution.as_str(),
             language: settings.language.as_str(),
+            orientation: settings.orientation.as_str(),
             browse_layout: settings.browse_layout.as_str(),
             button_layout: settings.button_layout.as_str(),
             mouse_enabled: settings.mouse_enabled,
@@ -378,6 +410,14 @@ fn merge_settings(snapshot: &SettingsState, config: &Config) -> SettingsState {
             String::new()
         },
         language: normalize_language(&config.language).to_string(),
+        orientation: normalize_orientation(
+            config
+                .settings
+                .orientation
+                .as_deref()
+                .unwrap_or(snapshot.orientation.as_str()),
+        )
+        .to_string(),
         browse_layout: normalize_browse_layout(
             config
                 .settings
@@ -440,6 +480,14 @@ fn browse_layouts() -> QStringList {
     list
 }
 
+fn orientations() -> QStringList {
+    let mut list = QStringList::default();
+    for orientation in ORIENTATIONS {
+        list.append(QString::from(*orientation));
+    }
+    list
+}
+
 fn languages() -> QStringList {
     let mut list = QStringList::default();
     for language in LANGUAGES {
@@ -470,6 +518,15 @@ fn normalize_language(value: &str) -> &str {
         .copied()
         .find(|language| *language == trimmed)
         .unwrap_or(DEFAULT_LANGUAGE)
+}
+
+fn normalize_orientation(value: &str) -> &'static str {
+    let trimmed = value.trim();
+    ORIENTATIONS
+        .iter()
+        .copied()
+        .find(|orientation| *orientation == trimmed)
+        .unwrap_or(DEFAULT_ORIENTATION)
 }
 
 fn normalize_browse_layout(value: &str) -> &'static str {
@@ -520,9 +577,9 @@ fn normalize_button_layout(value: &str) -> &'static str {
 mod tests {
     use super::{
         browse_layouts, button_layouts, curated_resolutions, languages, normalize_browse_layout,
-        normalize_button_layout, normalize_language, BROWSE_LAYOUTS, BUTTON_LAYOUTS,
-        DEFAULT_BROWSE_LAYOUT, DEFAULT_BUTTON_LAYOUT, DEFAULT_LANGUAGE, LANGUAGES,
-        MISTER_RESOLUTIONS,
+        normalize_button_layout, normalize_language, normalize_orientation, orientations,
+        BROWSE_LAYOUTS, BUTTON_LAYOUTS, DEFAULT_BROWSE_LAYOUT, DEFAULT_BUTTON_LAYOUT,
+        DEFAULT_LANGUAGE, DEFAULT_ORIENTATION, LANGUAGES, MISTER_RESOLUTIONS, ORIENTATIONS,
     };
 
     #[test]
@@ -562,6 +619,14 @@ mod tests {
     }
 
     #[test]
+    fn orientations_preserve_order() {
+        let list = orientations();
+        let collected: Vec<String> = list.iter().map(String::from).collect();
+        let expected: Vec<String> = ORIENTATIONS.iter().map(|s| (*s).to_string()).collect();
+        assert_eq!(collected, expected);
+    }
+
+    #[test]
     fn browse_layouts_preserve_order() {
         let list = browse_layouts();
         let collected: Vec<String> = list.iter().map(String::from).collect();
@@ -575,6 +640,15 @@ mod tests {
         assert_eq!(normalize_browse_layout("detail"), DEFAULT_BROWSE_LAYOUT);
         assert_eq!(normalize_browse_layout("grid"), "grid");
         assert_eq!(normalize_browse_layout("list"), "list");
+    }
+
+    #[test]
+    fn orientation_normalization_defaults_to_horizontal() {
+        assert_eq!(normalize_orientation(""), DEFAULT_ORIENTATION);
+        assert_eq!(normalize_orientation("sideways"), DEFAULT_ORIENTATION);
+        assert_eq!(normalize_orientation("horizontal"), "horizontal");
+        assert_eq!(normalize_orientation("cw"), "cw");
+        assert_eq!(normalize_orientation("ccw"), "ccw");
     }
 
     #[test]

--- a/rust/zaparoo-core/src/config.rs
+++ b/rust/zaparoo-core/src/config.rs
@@ -44,6 +44,7 @@ pub struct Config {
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct SettingsConfig {
+    pub orientation: Option<String>,
     pub browse_layout: Option<String>,
     pub button_layout: Option<String>,
     pub mouse_enabled: Option<bool>,
@@ -55,6 +56,7 @@ pub struct SettingsConfig {
 pub struct SettingsMirror<'a> {
     pub resolution: &'a str,
     pub language: &'a str,
+    pub orientation: &'a str,
     pub browse_layout: &'a str,
     pub button_layout: &'a str,
     pub mouse_enabled: bool,
@@ -131,6 +133,7 @@ struct RawInput {
 
 #[derive(Deserialize, Default)]
 struct RawSettings {
+    orientation: Option<String>,
     browse_layout: Option<String>,
     button_layout: Option<String>,
     mouse_enabled: Option<bool>,
@@ -201,6 +204,10 @@ pub fn load_config(path: &Path) -> Config {
         cfg.key_to_action = input_actions::invert(&merged);
     }
     cfg.settings = SettingsConfig {
+        orientation: raw
+            .settings
+            .orientation
+            .map(|value| value.trim().to_string()),
         browse_layout: raw
             .settings
             .browse_layout
@@ -273,6 +280,10 @@ pub fn save_settings_mirror(path: &Path, mirror: SettingsMirror<'_>) -> Result<(
             path.display()
         ));
     };
+    settings.insert(
+        "orientation".into(),
+        toml::Value::String(mirror.orientation.trim().to_string()),
+    );
     settings.insert(
         "browse_layout".into(),
         toml::Value::String(mirror.browse_layout.trim().to_string()),
@@ -427,6 +438,7 @@ mod tests {
         assert_eq!(cfg.video_height, 1080);
         assert!(!cfg.debug_logging);
         assert_eq!(cfg.language, "");
+        assert_eq!(cfg.settings.orientation, None);
         assert_eq!(cfg.settings.browse_layout, None);
         assert_eq!(cfg.settings.button_layout, None);
         assert_eq!(cfg.settings.mouse_enabled, None);
@@ -568,6 +580,7 @@ mod tests {
             debug = true
 
             [settings]
+            orientation = "cw"
             browse_layout = "list"
             button_layout = "c"
             mouse_enabled = false
@@ -579,6 +592,7 @@ mod tests {
         assert_eq!(cfg.video_width, 640);
         assert_eq!(cfg.video_height, 480);
         assert!(cfg.debug_logging);
+        assert_eq!(cfg.settings.orientation.as_deref(), Some("cw"));
         assert_eq!(cfg.settings.browse_layout.as_deref(), Some("list"));
         assert_eq!(cfg.settings.button_layout.as_deref(), Some("c"));
         assert_eq!(cfg.settings.mouse_enabled, Some(false));
@@ -600,6 +614,7 @@ mod tests {
             SettingsMirror {
                 resolution: "1280x720",
                 language: "it_IT",
+                orientation: "cw",
                 browse_layout: "list",
                 button_layout: "b",
                 mouse_enabled: false,
@@ -614,6 +629,7 @@ mod tests {
         assert_eq!(cfg.video_width, 1280);
         assert_eq!(cfg.video_height, 720);
         assert!(cfg.video_explicit);
+        assert_eq!(cfg.settings.orientation.as_deref(), Some("cw"));
         assert_eq!(cfg.settings.browse_layout.as_deref(), Some("list"));
         assert_eq!(cfg.settings.button_layout.as_deref(), Some("b"));
         assert_eq!(cfg.settings.mouse_enabled, Some(false));
@@ -632,6 +648,7 @@ mod tests {
             SettingsMirror {
                 resolution: "1280x720",
                 language: "en",
+                orientation: "horizontal",
                 browse_layout: "grid",
                 button_layout: "a",
                 mouse_enabled: true,
@@ -648,6 +665,7 @@ mod tests {
         assert_eq!(cfg.core_endpoint, "ws://example.com/api");
         assert_eq!(cfg.video_width, 1280);
         assert_eq!(cfg.video_height, 720);
+        assert_eq!(cfg.settings.orientation.as_deref(), Some("horizontal"));
         assert_eq!(cfg.settings.browse_layout.as_deref(), Some("grid"));
         assert_eq!(cfg.settings.button_layout.as_deref(), Some("a"));
         assert_eq!(cfg.settings.mouse_enabled, Some(true));
@@ -664,6 +682,7 @@ mod tests {
             SettingsMirror {
                 resolution: "",
                 language: "",
+                orientation: "ccw",
                 browse_layout: "list",
                 button_layout: "c",
                 mouse_enabled: false,
@@ -675,6 +694,7 @@ mod tests {
         .expect("save");
         let written = std::fs::read_to_string(f.path()).expect("read");
         assert!(written.contains("language = \"auto\""));
+        assert!(written.contains("orientation = \"ccw\""));
         assert!(written.contains("browse_layout = \"list\""));
         assert!(written.contains("button_layout = \"c\""));
         assert!(written.contains("mouse_enabled = false"));
@@ -684,6 +704,7 @@ mod tests {
         let cfg = load_config(f.path());
         assert_eq!(cfg.language, "");
         assert!(!cfg.video_explicit);
+        assert_eq!(cfg.settings.orientation.as_deref(), Some("ccw"));
         assert_eq!(cfg.settings.browse_layout.as_deref(), Some("list"));
         assert_eq!(cfg.settings.button_layout.as_deref(), Some("c"));
         assert_eq!(cfg.settings.mouse_enabled, Some(false));

--- a/rust/zaparoo-core/src/persist.rs
+++ b/rust/zaparoo-core/src/persist.rs
@@ -97,6 +97,8 @@ pub struct FavoritesState {
 pub struct SettingsState {
     pub resolution: String,
     pub language: String,
+    #[serde(default = "default_orientation")]
+    pub orientation: String,
     #[serde(default = "default_browse_layout")]
     pub browse_layout: String,
     #[serde(default = "default_button_layout")]
@@ -116,6 +118,7 @@ impl Default for SettingsState {
         Self {
             resolution: String::new(),
             language: String::new(),
+            orientation: default_orientation(),
             browse_layout: default_browse_layout(),
             button_layout: default_button_layout(),
             mouse_enabled: default_mouse_enabled(),
@@ -124,6 +127,10 @@ impl Default for SettingsState {
             screensaver_timeout: default_screensaver_timeout(),
         }
     }
+}
+
+fn default_orientation() -> String {
+    "horizontal".into()
 }
 
 fn default_browse_layout() -> String {
@@ -270,6 +277,7 @@ mod tests {
             settings: SettingsState {
                 resolution: "1920x1080".into(),
                 language: "it_IT".into(),
+                orientation: "cw".into(),
                 browse_layout: "list".into(),
                 button_layout: "b".into(),
                 mouse_enabled: false,

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -1292,6 +1292,8 @@ MainLayout {
             if (selectedId !== Browse.Settings.current_language)
                 root.stageSettingRestart(fieldId, selectedId);
             return;
+        } else if (fieldId === "orientation") {
+            Browse.Settings.set_orientation(selectedId);
         } else if (fieldId === "browseLayout")
             Browse.Settings.set_browse_layout(selectedId);
         else if (fieldId === "buttonLayout")

--- a/src/ui/app/MainLayout.qml
+++ b/src/ui/app/MainLayout.qml
@@ -192,6 +192,12 @@ ApplicationWindow {
         value: root.crtNativePath
     }
 
+    Binding {
+        target: Sizing
+        property: "swapPercentageAxes"
+        value: root._sceneRotated
+    }
+
     // Screen plumbing exposed for Main.qml's orchestration. Anything
     // inside the screens (categories row, systems/games grids) is
     // reached via root.hubScreen.* / root.systemsScreen.* /
@@ -214,10 +220,8 @@ ApplicationWindow {
     property alias headerBar: headerBar
     property alias screensaverOverlay: screensaverOverlay
     // Exposed so Main.qml binds Sizing.screenWidth/Height to the
-    // (logical) scene dimensions in CRT preview mode rather than the
-    // (physical) ApplicationWindow dimensions. Outside preview the
-    // scene fills the window, so the bindings produce the same values
-    // they did before this wrapper existed.
+    // logical scene dimensions. In rotated mode this is the swapped
+    // B x A layout space while the outer framebuffer still stays A x B.
     property alias scene: scene
 
     property bool cardWriteModalVisible: false
@@ -286,6 +290,8 @@ ApplicationWindow {
     readonly property string hubScreenState: (Browse.CategoriesModel.error_message ?? "") !== "" ? "error" : (Browse.CategoriesModel.count === 0 ? "empty" : "ready")
 
     readonly property string recentsScreenState: Browse.RecentsModel.loading ? "loading" : ((Browse.RecentsModel.error_message ?? "") !== "" ? "error" : (Browse.RecentsModel.count === 0 ? "empty" : "ready"))
+    readonly property string displayOrientation: Browse.Settings.current_orientation
+    readonly property bool _sceneRotated: root.displayOrientation === "cw" || root.displayOrientation === "ccw"
     readonly property bool _crtGridBrowseLayout: root.crtNativePath && Browse.Settings.current_browse_layout !== "list"
     readonly property var _browseTileLayout: root.crtNativePath ? BrowseLayouts.crtTile : BrowseLayouts.defaultTile
     readonly property var _contextMenuLayout: root.crtNativePath ? BrowseLayouts.crtTile : BrowseLayouts.defaultTile
@@ -362,12 +368,13 @@ ApplicationWindow {
     // and the GL backend's final logical-to-physical present step is
     // a no-op (no bilinear filtering smearing the integer upscale).
     Item {
-        id: scene
+        id: framebufferScene
 
         x: 0
         y: 0
         width: root._crtPreviewActive ? root.videoWidth : root.width
         height: root._crtPreviewActive ? root.videoHeight : root.height
+        clip: false
         transformOrigin: Item.TopLeft
         scale: root._crtPreviewActive ? root._crtPreviewEffectiveScale : 1
         // smooth/layer.smooth control the integer-upscale sampling on
@@ -393,6 +400,17 @@ ApplicationWindow {
         layer.enabled: root._crtPreviewActive
         layer.smooth: false
         layer.textureSize: root._crtPreviewActive ? Qt.size(root.videoWidth, root.videoHeight) : Qt.size(0, 0)
+
+        Item {
+            id: scene
+
+            x: Sizing.center(framebufferScene.width, width)
+            y: Sizing.center(framebufferScene.height, height)
+            width: root._sceneRotated ? framebufferScene.height : framebufferScene.width
+            height: root._sceneRotated ? framebufferScene.width : framebufferScene.height
+            clip: false
+            transformOrigin: Item.Center
+            rotation: root.displayOrientation === "cw" ? 90 : root.displayOrientation === "ccw" ? -90 : 0
 
         // ── Background ────────────────────────────────────────────────────────────
 
@@ -1114,6 +1132,7 @@ ApplicationWindow {
 
             anchors.fill: parent
             z: 500
+        }
         }
     }
 }

--- a/src/ui/components/BrowseList.qml
+++ b/src/ui/components/BrowseList.qml
@@ -20,12 +20,13 @@ Item {
     property var layoutProfile: null
     readonly property int itemCount: listView.count
     readonly property int totalItems: totalItemsOverride >= 0 ? totalItemsOverride : itemCount
+    readonly property bool _portraitNonCrt: !Theme.crtNativePath && Sizing.screenWidth < Sizing.screenHeight
     readonly property int _selectionRadius: root.layoutProfile ? root.layoutProfile.tileCornerRadius : Sizing.cornerRadius
     readonly property int cardPaddingLeft: root.layoutProfile ? root.layoutProfile.listCardPaddingLeft : Sizing.pctW(2)
     readonly property int cardPaddingRight: root.layoutProfile ? root.layoutProfile.listCardPaddingRight : Sizing.pctW(2)
     readonly property int cardPaddingTop: root.layoutProfile ? root.layoutProfile.listCardPaddingTop : Sizing.pctH(2)
     readonly property int cardPaddingBottom: root.layoutProfile ? root.layoutProfile.listCardPaddingBottom : Sizing.pctH(2)
-    readonly property int rowSpacing: root.layoutProfile ? root.layoutProfile.listRowSpacing : Sizing.pctH(0.7)
+    readonly property int rowSpacing: root.layoutProfile ? root.layoutProfile.listRowSpacing : (root._portraitNonCrt ? Sizing.pctH(0.3) : Sizing.pctH(0.7))
     readonly property int contentHeight: Math.max(0, height - cardPaddingTop - cardPaddingBottom)
     readonly property int rowHeight: root.layoutProfile && root.layoutProfile.listRowHeight > 0 ? root.layoutProfile.listRowHeight : (targetVisibleRowCount > 0 ? Math.max(Sizing.pctH(3), Math.floor((contentHeight - (rowSpacing * (targetVisibleRowCount - 1))) / targetVisibleRowCount)) : Sizing.pctH(6))
     readonly property int rowStride: rowHeight + rowSpacing

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -24,7 +24,8 @@ MediaListScreen {
 
     property alias gamesGrid: games.mediaGrid
 
-    readonly property int _listPageSize: 10
+    readonly property bool _portraitNonCrtList: !Theme.crtNativePath && Browse.Settings.current_orientation !== "horizontal"
+    readonly property int _listPageSize: games._portraitNonCrtList ? 16 : 10
     readonly property int _browsePageSize: games._listLayout ? Math.max(1, games.listCard.visibleRowCount) : games.gamesGrid.pageSize
     readonly property bool _crtGridLayout: Theme.crtNativePath && !games._listLayout
     readonly property var _tileLayout: games._crtGridLayout ? BrowseLayouts.crtTile : BrowseLayouts.defaultTile

--- a/src/ui/screens/SettingsScreen.qml
+++ b/src/ui/screens/SettingsScreen.qml
@@ -74,6 +74,11 @@ Item {
         });
         out.push({
             kind: "field",
+            id: "orientation",
+            label: qsTr("Orientation")
+        });
+        out.push({
+            kind: "field",
             id: "browseLayout",
             label: qsTr("Browsing layout")
         });
@@ -242,7 +247,7 @@ Item {
         if (!settings._isField(settings.currentIndex))
             return false;
         const id = settings.fields[settings.currentIndex].id;
-        return id === "language" || id === "browseLayout" || id === "buttonLayout" || id === "resolution";
+        return id === "language" || id === "orientation" || id === "browseLayout" || id === "buttonLayout" || id === "resolution" || id === "screensaverTimeout";
     }
     // True when the focused field is an action button (updateMediaDb,
     // runScraper, uploadLog, aboutLicense). Drives the help-bar Accept
@@ -337,6 +342,11 @@ Item {
         return raw === undefined || raw === null ? [] : raw;
     }
 
+    function _orientationList(): list<string> {
+        const raw = Browse.Settings.available_orientations;
+        return raw === undefined || raw === null ? [] : raw;
+    }
+
     function _languageDisplay(value: string): string {
         if (value === "en")
             return qsTr("English");
@@ -367,6 +377,14 @@ Item {
         if (value === "hi")
             return qsTr("Hindi");
         return qsTr("Auto");
+    }
+
+    function _orientationDisplay(value: string): string {
+        if (value === "cw")
+            return qsTr("Rotated CW");
+        if (value === "ccw")
+            return qsTr("Rotated CCW");
+        return qsTr("Horizontal");
     }
 
     function _browseLayoutDisplay(value: string): string {
@@ -437,6 +455,15 @@ Item {
                     label: settings._languageDisplay(list[i])
                 });
             initialId = Browse.Settings.current_language;
+        } else if (id === "orientation") {
+            title = qsTr("Orientation");
+            const list = settings._orientationList();
+            for (let i = 0; i < list.length; i++)
+                entries.push({
+                    id: list[i],
+                    label: settings._orientationDisplay(list[i])
+                });
+            initialId = Browse.Settings.current_orientation;
         } else if (id === "browseLayout") {
             title = qsTr("Browsing layout");
             const list = settings._browseLayoutList();
@@ -667,7 +694,7 @@ Item {
                         // `_triggerIndex`/`_triggerScrape`.
                         enabled: row.modelData.id === "updateMediaDb" ? !settings._scrapeBusy : row.modelData.id === "runScraper" ? !settings._indexBusy : true
                         label: row.modelData.label
-                        value: row.modelData.id === "resolution" ? settings._resolutionDisplay(Browse.Settings.current_resolution) : row.modelData.id === "language" ? settings._languageDisplay(Browse.Settings.current_language) : row.modelData.id === "browseLayout" ? settings._browseLayoutDisplay(Browse.Settings.current_browse_layout) : row.modelData.id === "buttonLayout" ? settings._buttonLayoutDisplay(Browse.Settings.current_button_layout) : row.modelData.id === "screensaverTimeout" ? settings._screensaverTimeoutDisplay(Browse.Settings.current_screensaver_timeout) : ""
+                        value: row.modelData.id === "resolution" ? settings._resolutionDisplay(Browse.Settings.current_resolution) : row.modelData.id === "language" ? settings._languageDisplay(Browse.Settings.current_language) : row.modelData.id === "orientation" ? settings._orientationDisplay(Browse.Settings.current_orientation) : row.modelData.id === "browseLayout" ? settings._browseLayoutDisplay(Browse.Settings.current_browse_layout) : row.modelData.id === "buttonLayout" ? settings._buttonLayoutDisplay(Browse.Settings.current_button_layout) : row.modelData.id === "screensaverTimeout" ? settings._screensaverTimeoutDisplay(Browse.Settings.current_screensaver_timeout) : ""
                         control: row.modelData.id === "mouseEnabled" || row.modelData.id === "discoverArcadeAlternateVersions" || row.modelData.id === "debugLogging" ? "toggle" : row.modelData.id === "aboutLicense" ? "navigate" : (row.modelData.id === "updateMediaDb" || row.modelData.id === "runScraper" || row.modelData.id === "uploadLog") ? "action" : "picker"
                         checked: row.modelData.id === "debugLogging" ? Browse.Settings.current_debug_logging : row.modelData.id === "discoverArcadeAlternateVersions" ? Browse.Settings.current_discover_arcade_alternate_versions : Browse.Settings.current_mouse_enabled
                         actionStatus: row.modelData.id === "updateMediaDb" ? settings._indexActionStatus() : row.modelData.id === "runScraper" ? settings._scrapeActionStatus() : ""

--- a/src/ui/theme/Sizing.qml
+++ b/src/ui/theme/Sizing.qml
@@ -14,6 +14,7 @@ QtObject {
     property real screenWidth: 640
     property real screenHeight: 480
     property bool crtNativePath: false
+    property bool swapPercentageAxes: false
 
     // Visible tile-row covers: fewer at very low resolution to avoid crowding.
     readonly property int visibleCovers: screenHeight < 300 ? 3 : 5
@@ -47,11 +48,11 @@ QtObject {
     readonly property int headerBottom: headerTopMargin + headerHeight
 
     function pctH(percent: real): int {
-        return Math.round(screenHeight * percent / 100);
+        return Math.round((swapPercentageAxes ? screenWidth : screenHeight) * percent / 100);
     }
 
     function pctW(percent: real): int {
-        return Math.round(screenWidth * percent / 100);
+        return Math.round((swapPercentageAxes ? screenHeight : screenWidth) * percent / 100);
     }
 
     function px(value: real): int {


### PR DESCRIPTION
<!-- Thanks for the pull request. Please fill this out before requesting review. -->

## Summary

This PR introduces TATE mode.
You can rotate the ui CW or CCW of 90 in order to see it correctly when you are playing tate mode games and you have a turned screen.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added display orientation setting with horizontal, clockwise, and counterclockwise options
  * Implemented scene rotation based on selected orientation
  * Responsive spacing and row layout calculations that adapt to orientation and display mode

* **Documentation**
  * Added planning documentation for list-detail layout refactor

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ZaparooProject/zaparoo-frontend/pull/169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->