### PR TITLE
feat(): Refactor tweaks and positions

### DIFF
--- a/scripts/run-macos-mister-core.sh
+++ b/scripts/run-macos-mister-core.sh
@@ -17,5 +17,5 @@ fi
 
 export ZAPAROO_CORE_ENDPOINT="ws://192.168.1.176:7497/api/v0.1"
 export ZAPAROO_CRT_PREVIEW_SCALE=3
-exec "${FRONTEND}"
+exec "${FRONTEND}" --crt
 # exec "${FRONTEND}" --crt

--- a/src/ui/app/MainLayout.qml
+++ b/src/ui/app/MainLayout.qml
@@ -292,9 +292,17 @@ ApplicationWindow {
     readonly property string recentsScreenState: Browse.RecentsModel.loading ? "loading" : ((Browse.RecentsModel.error_message ?? "") !== "" ? "error" : (Browse.RecentsModel.count === 0 ? "empty" : "ready"))
     readonly property string displayOrientation: Browse.Settings.current_orientation
     readonly property bool _sceneRotated: root.displayOrientation === "cw" || root.displayOrientation === "ccw"
-    readonly property bool _crtGridBrowseLayout: root.crtNativePath && Browse.Settings.current_browse_layout !== "list"
-    readonly property var _browseTileLayout: root.crtNativePath ? BrowseLayouts.crtTile : BrowseLayouts.defaultTile
-    readonly property var _contextMenuLayout: root.crtNativePath ? BrowseLayouts.crtTile : BrowseLayouts.defaultTile
+    readonly property bool _browseListLayout: Browse.Settings.current_browse_layout === "list"
+    readonly property bool _browseTateListLayout: root._browseListLayout && root.displayOrientation !== "horizontal"
+    readonly property string _browseViewId: {
+        if (root.activeScreen === root.screenSystems)
+            return root._browseListLayout ? (root._browseTateListLayout ? "systemsListTate" : "systemsList") : "systemsGrid";
+        if (root.activeScreen === root.screenGames || root.activeScreen === root.screenFavorites || root.activeScreen === root.screenRecents)
+            return root._browseListLayout ? (root._browseTateListLayout ? "gamesListTate" : "gamesList") : "gamesGrid";
+        return "gamesGrid";
+    }
+    readonly property string _browseThemeId: BrowseLayouts.currentThemeId
+    readonly property var _browseViewProfile: BrowseLayouts.themeProfile(root._browseThemeId, root._browseViewId)
     readonly property string _crtGamesHeaderTitle: {
         const sid = Browse.GamesModel.current_system_id;
         if (sid === "")
@@ -452,7 +460,7 @@ ApplicationWindow {
             anchors.right: parent.right
             anchors.top: parent.top
             anchors.topMargin: Sizing.headerTopMargin
-            layoutProfile: root._browseTileLayout
+            layoutProfile: root._browseViewProfile
             browseTitle: root.browseHeaderTitle
             browseProgressText: root.browseHeaderProgressText
             z: 200
@@ -593,7 +601,7 @@ ApplicationWindow {
             open: root.contextMenuVisible
             anchorRect: root.contextMenuAnchor
             entries: root.contextMenuEntries
-            bottomUnsafeHeight: root._contextMenuLayout.bottomUnsafeHeight
+            bottomUnsafeHeight: BrowseLayouts.numberValue(root._browseViewProfile, "footer.bottomUnsafeHeight", Sizing.pctH(6) + Sizing.pctH(2))
             onAccepted: id => root.contextMenuAccepted(id)
             onCloseRequested: root.contextMenuCloseRequested()
         }

--- a/src/ui/components/BrowseDetailPane.qml
+++ b/src/ui/components/BrowseDetailPane.qml
@@ -23,35 +23,52 @@ Item {
     property string loadingText: qsTr("Loading…")
     property var layoutProfile: null
 
-    readonly property int _cardPaddingLeft: root.layoutProfile && root.layoutProfile.detailPanePaddingLeft !== undefined ? root.layoutProfile.detailPanePaddingLeft : Sizing.pctW(2)
-    readonly property int _cardPaddingRight: root.layoutProfile && root.layoutProfile.detailPanePaddingRight !== undefined ? root.layoutProfile.detailPanePaddingRight : Sizing.pctW(2)
-    readonly property int _cardPaddingTop: root.layoutProfile && root.layoutProfile.detailPanePaddingTop !== undefined ? root.layoutProfile.detailPanePaddingTop : Sizing.pctH(2)
-    readonly property int _cardPaddingBottom: root.layoutProfile && root.layoutProfile.detailPanePaddingBottom !== undefined ? root.layoutProfile.detailPanePaddingBottom : Sizing.pctH(2)
+    readonly property var _detail: root.layoutProfile && root.layoutProfile.detail ? root.layoutProfile.detail : null
+    readonly property var _surface: root.layoutProfile && root.layoutProfile.surface ? root.layoutProfile.surface : null
+    readonly property int _panePaddingLeft: root._detail ? root._detail.panePaddingLeft : Sizing.pctW(2)
+    readonly property int _panePaddingRight: root._detail ? root._detail.panePaddingRight : Sizing.pctW(2)
+    readonly property int _panePaddingTop: root._detail ? root._detail.panePaddingTop : Sizing.pctH(2)
+    readonly property int _panePaddingBottom: root._detail ? root._detail.panePaddingBottom : Sizing.pctH(2)
+    readonly property int _imagePaddingLeft: root._detail ? root._detail.imagePaddingLeft : 0
+    readonly property int _imagePaddingRight: root._detail ? root._detail.imagePaddingRight : 0
+    readonly property int _imagePaddingTop: root._detail ? root._detail.imagePaddingTop : 0
+    readonly property int _imagePaddingBottom: root._detail ? root._detail.imagePaddingBottom : 0
+    readonly property int _metadataPaddingLeft: root._detail ? root._detail.metadataPaddingLeft : 0
+    readonly property int _metadataPaddingRight: root._detail ? root._detail.metadataPaddingRight : 0
+    readonly property int _metadataPaddingTop: root._detail ? root._detail.metadataPaddingTop : 0
+    readonly property int _metadataPaddingBottom: root._detail ? root._detail.metadataPaddingBottom : 0
+    readonly property int _metadataTopMargin: root._detail && root._detail.metadataTopMargin !== undefined ? root._detail.metadataTopMargin : 0
+    readonly property int _metadataLeftMargin: root._detail && root._detail.metadataLeftMargin !== undefined ? root._detail.metadataLeftMargin : 0
+    readonly property int _metadataRightMargin: root._detail && root._detail.metadataRightMargin !== undefined ? root._detail.metadataRightMargin : 0
+    readonly property int _metadataHeightAdjustment: root._detail && root._detail.metadataHeightAdjustment !== undefined ? root._detail.metadataHeightAdjustment : 0
+    readonly property int _sectionGap: root._detail ? root._detail.sectionGap : Sizing.pctH(2)
+    readonly property bool _horizontalSections: root._detail && root._detail.contentAxis === "horizontal"
+    readonly property real _imageShare: root._detail && root._detail.imageShare !== undefined ? root._detail.imageShare : 1
+    readonly property real _metadataShare: root._detail && root._detail.metadataShare !== undefined ? root._detail.metadataShare : 1
+    readonly property real _shareTotal: Math.max(1, root._imageShare + root._metadataShare)
+    readonly property int _tagRowHeight: root._detail ? root._detail.tagRowHeight : Sizing.pctH(3)
+    readonly property int _tagRowSpacing: root._detail ? root._detail.tagRowSpacing : Sizing.pctH(0.55)
+    readonly property bool _metadataBottomAligned: root._detail && root._detail.metadataBottomAligned === true
+    readonly property int _titleBottomMargin: root._detail ? root._detail.titleBottomMargin : Sizing.pctH(2)
+    readonly property real _imageHeightRatioWithTitle: root._detail && root._detail.imageHeightRatioWithTitle !== undefined ? root._detail.imageHeightRatioWithTitle : 48
+    readonly property int _imageReservedWidth: root._detail && root._detail.imageReservedWidth !== undefined ? root._detail.imageReservedWidth : 0
+    readonly property int _imageReservedHeight: root._detail && root._detail.imageReservedHeight !== undefined ? root._detail.imageReservedHeight : 0
+    readonly property int _imageBottomMargin: root._detail && root._detail.imageBottomMargin !== undefined ? root._detail.imageBottomMargin : 0
+    readonly property int _cardRadius: root._surface ? root._surface.cornerRadius : Sizing.cornerRadius
     readonly property int _carouselGutter: (canPreviousImage || canNextImage) ? Sizing.pctW(4) : 0
-    property int _labelColumnWidth: 0
-    readonly property int _tagTextSize: Sizing.fontSize(2.2)
-    readonly property int _tagLabelGap: Sizing.pctW(1.4)
-    readonly property var _detailRows: _parseDetailTags(detailTags)
-    readonly property int _tagRowCount: _detailRows.length
-    readonly property int _tagRowHeight: root.layoutProfile && root.layoutProfile.detailTagRowHeight !== undefined ? root.layoutProfile.detailTagRowHeight : Sizing.pctH(3)
-    readonly property int _tagRowSpacing: root.layoutProfile && root.layoutProfile.detailTagRowSpacing !== undefined ? root.layoutProfile.detailTagRowSpacing : Sizing.pctH(0.55)
-    readonly property int _metadataNaturalHeight: _tagRowCount <= 0 ? 0 : (_tagRowCount * _tagRowHeight) + ((_tagRowCount - 1) * _tagRowSpacing)
-    readonly property int _compactDetailHeight: Math.min(Sizing.px(content.height * 0.38), _metadataNaturalHeight)
     readonly property bool _coverPending: coverKey === "icons/Loading"
     readonly property url _coverSource: _coverPending ? "" : Resources.coverUrl(coverKey)
     readonly property bool _paneLoading: root.loading
     readonly property bool _detailVisible: !root._paneLoading && !root.detailSuppressed
     readonly property bool _suppressedPlaceholderCover: root.detailSuppressed && coverKey.startsWith("icons/") && root._coverSource !== ""
-    readonly property int _metadataYOffset: root.layoutProfile && root.layoutProfile.detailMetadataYOffset !== undefined ? root.layoutProfile.detailMetadataYOffset : 0
-    readonly property int _metadataExtraHeight: root.layoutProfile && root.layoutProfile.detailMetadataExtraHeight !== undefined ? root.layoutProfile.detailMetadataExtraHeight : 0
-    readonly property int _metadataLeftInset: root.layoutProfile && root.layoutProfile.detailMetadataLeftInset !== undefined ? root.layoutProfile.detailMetadataLeftInset : 0
-    readonly property int _metadataRightInset: root.layoutProfile && root.layoutProfile.detailMetadataRightInset !== undefined ? root.layoutProfile.detailMetadataRightInset : 0
-    readonly property int _imageXOffset: root.layoutProfile && root.layoutProfile.detailImageXOffset !== undefined ? root.layoutProfile.detailImageXOffset : 0
-    readonly property int _imageLeftInset: root.layoutProfile && root.layoutProfile.detailImageLeftInset !== undefined ? root.layoutProfile.detailImageLeftInset : 0
-    readonly property int _imageRightInset: root.layoutProfile && root.layoutProfile.detailImageRightInset !== undefined ? root.layoutProfile.detailImageRightInset : 0
-    readonly property int _imageExtraWidth: root.layoutProfile && root.layoutProfile.detailImageExtraWidth !== undefined ? root.layoutProfile.detailImageExtraWidth : 0
-    readonly property int _imageExtraHeight: root.layoutProfile && root.layoutProfile.detailImageExtraHeight !== undefined ? root.layoutProfile.detailImageExtraHeight : 0
-    readonly property int _imageBottomGap: root.layoutProfile && root.layoutProfile.detailImageBottomGap !== undefined ? root.layoutProfile.detailImageBottomGap : 0
+    readonly property var _detailRows: _parseDetailTags(detailTags)
+    readonly property int _tagRowCount: _detailRows.length
+    readonly property int _tagTextSize: Sizing.fontSize(2.2)
+    readonly property int _tagLabelGap: Sizing.pctW(1.4)
+    readonly property int _metadataNaturalHeight: _tagRowCount <= 0 ? 0 : (_tagRowCount * _tagRowHeight) + ((_tagRowCount - 1) * _tagRowSpacing)
+    readonly property int _compactMetadataHeight: Math.min(Sizing.px(content.height * 0.38), _metadataNaturalHeight)
+
+    property int _labelColumnWidth: 0
 
     onDetailTagsChanged: root._labelColumnWidth = 0
 
@@ -96,7 +113,7 @@ Item {
         color: Theme.surfaceCard
         border.width: Sizing.stroke(1)
         border.color: Theme.borderMid
-        radius: Sizing.cornerRadius
+        radius: root._cardRadius
         visible: root.showChrome
     }
 
@@ -104,48 +121,76 @@ Item {
         id: content
 
         anchors.fill: parent
-        anchors.leftMargin: root._cardPaddingLeft
-        anchors.rightMargin: root._cardPaddingRight
-        anchors.topMargin: root._cardPaddingTop
-        anchors.bottomMargin: root._cardPaddingBottom
+        anchors.leftMargin: root._panePaddingLeft
+        anchors.rightMargin: root._panePaddingRight
+        anchors.topMargin: root._panePaddingTop
+        anchors.bottomMargin: root._panePaddingBottom
         clip: true
+
+        readonly property int primarySpan: root._horizontalSections ? Math.floor((width - root._sectionGap) * root._imageShare / root._shareTotal) : Math.floor((height - root._sectionGap) * root._imageShare / root._shareTotal)
+        readonly property int secondarySpan: root._horizontalSections ? Math.max(0, width - primarySpan - root._sectionGap) : Math.max(0, height - imageSlotHeight - root._sectionGap)
+        readonly property int imageSlotX: root._horizontalSections ? root._carouselGutter : root._imagePaddingLeft + root._carouselGutter
+        readonly property int imageSlotY: 0
+        readonly property int imageSlotWidth: {
+            if (root._horizontalSections)
+                return Math.max(0, primarySpan - (2 * root._carouselGutter));
+            const availableWidth = Math.max(0, width - (2 * root._carouselGutter) - root._imagePaddingLeft - root._imagePaddingRight);
+            const maxWidth = Math.max(0, width - root._imagePaddingLeft - root._imagePaddingRight);
+            return Math.max(0, Math.min(maxWidth, availableWidth + root._imageReservedWidth));
+        }
+        readonly property int imageSlotHeight: {
+            if (root._horizontalSections)
+                return height;
+            const availableWidth = Math.max(0, width - (2 * root._carouselGutter) - root._imagePaddingLeft - root._imagePaddingRight);
+            const imageLimit = titleText.visible ? Math.floor((height * root._imageHeightRatioWithTitle) / 100) : Math.max(0, height - root._compactMetadataHeight - root._imageBottomMargin);
+            return Math.max(0, Math.min(height, Math.min(availableWidth, imageLimit) + root._imageReservedHeight));
+        }
+        readonly property int metadataX: root._horizontalSections ? primarySpan + root._sectionGap : 0
+        readonly property int metadataY: root._horizontalSections ? 0 : imageSlotHeight + root._sectionGap
+        readonly property int metadataWidth: root._horizontalSections ? secondarySpan : width
+        readonly property int metadataHeight: root._horizontalSections ? height : secondarySpan
 
         Item {
             id: imageSlot
 
-            readonly property int availableWidth: Math.max(0, parent.width - root._imageLeftInset - root._imageRightInset - (2 * root._carouselGutter))
-            readonly property int availableHeight: Math.max(0, root.showTitle ? Sizing.px(parent.height * 0.48) : detailBody.y - root._imageBottomGap)
-            readonly property int slotWidth: Math.min(parent.width - root._imageLeftInset - root._imageRightInset, availableWidth + root._imageExtraWidth)
-            readonly property int slotHeight: Math.min(parent.height, Math.min(availableWidth, availableHeight) + root._imageExtraHeight)
+            x: content.imageSlotX
+            y: content.imageSlotY
+            width: content.imageSlotWidth
+            height: content.imageSlotHeight
+            clip: true
 
-            x: root._imageLeftInset + root._carouselGutter + root._imageXOffset
-            anchors.top: parent.top
-            width: Math.max(0, slotWidth)
-            height: slotHeight
-
-            Image {
-                id: cover
+            Item {
                 anchors.fill: parent
-                source: root._coverSource
-                fillMode: Image.PreserveAspectFit
-                sourceSize.width: 512
-                smooth: true
-                asynchronous: true
-                visible: !root._paneLoading && root._coverSource !== "" && status === Image.Ready && (!root.detailSuppressed || root._suppressedPlaceholderCover)
-            }
+                anchors.leftMargin: root._horizontalSections ? root._imagePaddingLeft : 0
+                anchors.rightMargin: root._horizontalSections ? root._imagePaddingRight : 0
+                anchors.topMargin: root._imagePaddingTop
+                anchors.bottomMargin: root._imagePaddingBottom
 
-            Image {
-                x: Sizing.center(parent.width, width)
-                y: Sizing.center(parent.height, height)
-                width: Math.min(Sizing.pctH(10), parent.width, parent.height)
-                height: width
-                source: Resources.iconUrl(root._coverPending || cover.status === Image.Loading ? "Loading" : "File")
-                sourceSize.width: Sizing.px(width)
-                sourceSize.height: Sizing.px(height)
-                fillMode: Image.PreserveAspectFit
-                smooth: true
-                asynchronous: false
-                visible: !root._paneLoading && !root._suppressedPlaceholderCover && (root.detailSuppressed || root._coverPending || cover.status === Image.Loading || root._coverSource === "" || cover.status === Image.Error)
+                Image {
+                    id: cover
+
+                    anchors.fill: parent
+                    source: root._coverSource
+                    fillMode: Image.PreserveAspectFit
+                    sourceSize.width: 512
+                    smooth: true
+                    asynchronous: true
+                    visible: !root._paneLoading && root._coverSource !== "" && status === Image.Ready && (!root.detailSuppressed || root._suppressedPlaceholderCover)
+                }
+
+                Image {
+                    x: Sizing.center(parent.width, width)
+                    y: Sizing.center(parent.height, height)
+                    width: Math.min(Sizing.pctH(10), parent.width, parent.height)
+                    height: width
+                    source: Resources.iconUrl(root._coverPending || cover.status === Image.Loading ? "Loading" : "File")
+                    sourceSize.width: Sizing.px(width)
+                    sourceSize.height: Sizing.px(height)
+                    fillMode: Image.PreserveAspectFit
+                    smooth: true
+                    asynchronous: false
+                    visible: !root._paneLoading && !root._suppressedPlaceholderCover && (root.detailSuppressed || root._coverPending || cover.status === Image.Loading || root._coverSource === "" || cover.status === Image.Error)
+                }
             }
         }
 
@@ -171,101 +216,123 @@ Item {
             visible: root._detailVisible && root.canNextImage
         }
 
-        Text {
-            id: titleText
-
-            anchors.left: parent.left
-            anchors.right: parent.right
-            anchors.top: imageSlot.bottom
-            anchors.topMargin: Sizing.pctH(2)
-            text: root.title
-            color: Theme.textPrimary
-            font.family: Theme.fontUi
-            font.pixelSize: Sizing.fontSize(3.2)
-            wrapMode: Text.Wrap
-            maximumLineCount: 3
-            elide: Text.ElideRight
-            horizontalAlignment: Text.AlignLeft
-            renderType: Text.NativeRendering
-            visible: root._detailVisible && root.showTitle && root.title !== ""
-        }
-
         Item {
-            id: detailBody
+            id: metadataSlot
 
-            readonly property int _bodyY: Math.round(root.showTitle ? (titleText.visible ? titleText.y + titleText.height : imageSlot.y + imageSlot.height) + Sizing.pctH(2) : parent.height - height)
-
-            x: root._metadataLeftInset
-            y: _bodyY + root._metadataYOffset
-            width: Math.max(0, parent.width - root._metadataLeftInset - root._metadataRightInset)
-            height: root.showTitle ? Math.round(Math.max(0, parent.height - y + root._metadataExtraHeight)) : root._compactDetailHeight
+            x: content.metadataX
+            y: content.metadataY
+            width: content.metadataWidth
+            height: content.metadataHeight
             clip: true
 
-            Column {
-                id: tagTable
+            Item {
+                id: metadataInner
 
-                visible: root._detailVisible && root._detailRows.length > 0
                 anchors.fill: parent
-                spacing: root._tagRowSpacing
+                anchors.leftMargin: root._horizontalSections ? root._metadataPaddingLeft : root._metadataLeftMargin
+                anchors.rightMargin: root._horizontalSections ? root._metadataPaddingRight : root._metadataRightMargin
+                anchors.topMargin: root._horizontalSections ? root._metadataPaddingTop : 0
+                anchors.bottomMargin: root._horizontalSections ? root._metadataPaddingBottom : 0
                 clip: true
 
-                Repeater {
-                    model: root._detailRows
+                Text {
+                    id: titleText
 
-                    delegate: Item {
-                        id: tagRow
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.top: parent.top
+                    text: root.title
+                    color: Theme.textPrimary
+                    font.family: Theme.fontUi
+                    font.pixelSize: Sizing.fontSize(3.2)
+                    wrapMode: Text.Wrap
+                    maximumLineCount: 3
+                    elide: Text.ElideRight
+                    horizontalAlignment: Text.AlignLeft
+                    renderType: Text.NativeRendering
+                    visible: root._detailVisible && root.showTitle && root.title !== ""
+                }
 
-                        required property var modelData
+                Item {
+                    id: detailBody
 
-                        width: tagTable.width
-                        height: root._tagRowHeight
+                    x: 0
+                    y: titleText.visible ? titleText.y + titleText.height + root._titleBottomMargin + root._metadataTopMargin : (root._horizontalSections ? 0 : root._metadataTopMargin)
+                    width: parent.width
+                    height: {
+                        if (root._horizontalSections)
+                            return Math.max(0, parent.height - y);
+                        if (titleText.visible)
+                            return Math.max(0, parent.height - y + root._metadataHeightAdjustment);
+                        return root._compactMetadataHeight;
+                    }
+                    clip: true
 
-                        readonly property string rawLabel: modelData.rawLabel ?? ""
-                        readonly property string label: modelData.label ?? ""
-                        readonly property string value: modelData.value ?? ""
+                    Column {
+                        id: tagTable
 
-                        TextMetrics {
-                            id: labelMetrics
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.top: root._metadataBottomAligned && !titleText.visible ? undefined : parent.top
+                        anchors.bottom: root._metadataBottomAligned && !titleText.visible ? parent.bottom : undefined
+                        spacing: root._tagRowSpacing
+                        clip: true
+                        visible: root._detailVisible && root._detailRows.length > 0
 
-                            text: tagRow.label
-                            font.family: Theme.fontUi
-                            font.pixelSize: root._tagTextSize
-                            onAdvanceWidthChanged: root._labelColumnWidth = Math.max(root._labelColumnWidth, Math.ceil(advanceWidth))
-                        }
+                        Repeater {
+                            model: root._detailRows
 
-                        Component.onCompleted: root._labelColumnWidth = Math.max(root._labelColumnWidth, Math.ceil(labelMetrics.advanceWidth))
+                            delegate: Item {
+                                id: tagRow
 
-                        Text {
-                            id: tagType
+                                required property var modelData
 
-                            anchors.left: parent.left
-                            anchors.top: parent.top
-                            width: root._labelColumnWidth
-                            text: tagRow.label
-                            color: Theme.textLabel
-                            font.family: Theme.fontUi
-                            font.pixelSize: root._tagTextSize
-                            elide: Text.ElideRight
-                            horizontalAlignment: Text.AlignRight
-                            renderType: Text.NativeRendering
-                        }
+                                width: tagTable.width
+                                height: root._tagRowHeight
 
-                        Text {
-                            id: tagValue
+                                readonly property string label: modelData.label ?? ""
+                                readonly property string value: modelData.value ?? ""
 
-                            anchors.left: parent.left
-                            anchors.leftMargin: root._labelColumnWidth + root._tagLabelGap
-                            anchors.right: parent.right
-                            anchors.top: parent.top
-                            text: tagRow.value
-                            color: Theme.textPrimary
-                            font.family: Theme.fontUi
-                            font.pixelSize: root._tagTextSize
-                            wrapMode: Text.NoWrap
-                            maximumLineCount: 1
-                            elide: Text.ElideRight
-                            horizontalAlignment: Text.AlignLeft
-                            renderType: Text.NativeRendering
+                                TextMetrics {
+                                    id: labelMetrics
+
+                                    text: tagRow.label
+                                    font.family: Theme.fontUi
+                                    font.pixelSize: root._tagTextSize
+                                    onAdvanceWidthChanged: root._labelColumnWidth = Math.max(root._labelColumnWidth, Math.ceil(advanceWidth))
+                                }
+
+                                Component.onCompleted: root._labelColumnWidth = Math.max(root._labelColumnWidth, Math.ceil(labelMetrics.advanceWidth))
+
+                                Text {
+                                    anchors.left: parent.left
+                                    anchors.top: parent.top
+                                    width: root._labelColumnWidth
+                                    text: tagRow.label
+                                    color: Theme.textLabel
+                                    font.family: Theme.fontUi
+                                    font.pixelSize: root._tagTextSize
+                                    elide: Text.ElideRight
+                                    horizontalAlignment: Text.AlignRight
+                                    renderType: Text.NativeRendering
+                                }
+
+                                Text {
+                                    anchors.left: parent.left
+                                    anchors.leftMargin: root._labelColumnWidth + root._tagLabelGap
+                                    anchors.right: parent.right
+                                    anchors.top: parent.top
+                                    text: tagRow.value
+                                    color: Theme.textPrimary
+                                    font.family: Theme.fontUi
+                                    font.pixelSize: root._tagTextSize
+                                    wrapMode: Text.NoWrap
+                                    maximumLineCount: 1
+                                    elide: Text.ElideRight
+                                    horizontalAlignment: Text.AlignLeft
+                                    renderType: Text.NativeRendering
+                                }
+                            }
                         }
                     }
                 }

--- a/src/ui/components/BrowseList.qml
+++ b/src/ui/components/BrowseList.qml
@@ -18,34 +18,37 @@ Item {
     property bool showFileStem: false
     property bool showChrome: true
     property var layoutProfile: null
+    readonly property var _list: root.layoutProfile && root.layoutProfile.list ? root.layoutProfile.list : null
+    readonly property var _grid: root.layoutProfile && root.layoutProfile.grid ? root.layoutProfile.grid : null
+    readonly property var _surface: root.layoutProfile && root.layoutProfile.surface ? root.layoutProfile.surface : null
     readonly property int itemCount: listView.count
     readonly property int totalItems: totalItemsOverride >= 0 ? totalItemsOverride : itemCount
     readonly property bool _portraitNonCrt: !Theme.crtNativePath && Sizing.screenWidth < Sizing.screenHeight
-    readonly property int _selectionRadius: root.layoutProfile ? root.layoutProfile.tileCornerRadius : Sizing.cornerRadius
-    readonly property int cardPaddingLeft: root.layoutProfile ? root.layoutProfile.listCardPaddingLeft : Sizing.pctW(2)
-    readonly property int cardPaddingRight: root.layoutProfile ? root.layoutProfile.listCardPaddingRight : Sizing.pctW(2)
-    readonly property int cardPaddingTop: root.layoutProfile ? root.layoutProfile.listCardPaddingTop : Sizing.pctH(2)
-    readonly property int cardPaddingBottom: root.layoutProfile ? root.layoutProfile.listCardPaddingBottom : Sizing.pctH(2)
-    readonly property int rowSpacing: root.layoutProfile ? root.layoutProfile.listRowSpacing : (root._portraitNonCrt ? Sizing.pctH(0.3) : Sizing.pctH(0.7))
+    readonly property int _selectionRadius: root._surface ? root._surface.cornerRadius : Sizing.cornerRadius
+    readonly property int cardPaddingLeft: root._list ? root._list.cardPaddingLeft : Sizing.pctW(2)
+    readonly property int cardPaddingRight: root._list ? root._list.cardPaddingRight : Sizing.pctW(2)
+    readonly property int cardPaddingTop: root._list ? root._list.cardPaddingTop : Sizing.pctH(2)
+    readonly property int cardPaddingBottom: root._list ? root._list.cardPaddingBottom : Sizing.pctH(2)
+    readonly property int rowSpacing: root._list ? root._list.rowSpacing : (root._portraitNonCrt ? Sizing.pctH(0.3) : Sizing.pctH(0.7))
     readonly property int contentHeight: Math.max(0, height - cardPaddingTop - cardPaddingBottom)
-    readonly property int rowHeight: root.layoutProfile && root.layoutProfile.listRowHeight > 0 ? root.layoutProfile.listRowHeight : (targetVisibleRowCount > 0 ? Math.max(Sizing.pctH(3), Math.floor((contentHeight - (rowSpacing * (targetVisibleRowCount - 1))) / targetVisibleRowCount)) : Sizing.pctH(6))
+    readonly property int rowHeight: root._list && root._list.rowHeight > 0 ? root._list.rowHeight : (targetVisibleRowCount > 0 ? Math.max(Sizing.pctH(3), Math.floor((contentHeight - (rowSpacing * (targetVisibleRowCount - 1))) / targetVisibleRowCount)) : Sizing.pctH(6))
     readonly property int rowStride: rowHeight + rowSpacing
     readonly property int visibleRowCount: targetVisibleRowCount > 0 ? targetVisibleRowCount : Math.max(1, Math.floor((contentHeight + rowSpacing) / rowStride))
-    readonly property int _centerSlot: root.layoutProfile && root.layoutProfile.listCenterSlot >= 0 ? Math.max(0, Math.min(visibleRowCount - 1, root.layoutProfile.listCenterSlot)) : Math.max(0, Math.floor((visibleRowCount - 1) / 2))
+    readonly property int _centerSlot: root._list && root._list.centerSlot >= 0 ? Math.max(0, Math.min(visibleRowCount - 1, root._list.centerSlot)) : Math.max(0, Math.floor((visibleRowCount - 1) / 2))
     readonly property int _maxViewTopIndex: Math.max(0, itemCount - visibleRowCount)
     readonly property int _viewTopIndex: Math.max(0, Math.min(_maxViewTopIndex, currentIndex - _centerSlot))
     readonly property int _targetContentY: _viewTopIndex * rowStride
     readonly property int _maxScrollTopIndex: Math.max(0, totalItems - visibleRowCount)
-    readonly property int _gutterWidth: root.layoutProfile ? root.layoutProfile.gridGutterWidth : Sizing.pctW(3)
-    readonly property int _gutterGap: root.layoutProfile && root.layoutProfile.listScrollbarGap !== undefined ? root.layoutProfile.listScrollbarGap : (root.layoutProfile ? root.layoutProfile.gridGutterGap : Sizing.pctW(1.5))
-    readonly property int _scrollThumbWidth: root.layoutProfile ? root.layoutProfile.scrollThumbWidth : Sizing.pctW(1.2)
-    readonly property int _scrollThumbRightInset: root.layoutProfile ? root.layoutProfile.scrollThumbRightInset : 0
-    readonly property bool _scrollThumbRightAligned: root.layoutProfile && root.layoutProfile.scrollThumbRightAligned !== undefined ? root.layoutProfile.scrollThumbRightAligned : false
-    readonly property int _scrollArrowSize: root.layoutProfile ? root.layoutProfile.scrollArrowSize : Math.min(root._gutterWidth, Sizing.pctH(4))
-    readonly property int _selectionAccentWidth: root.layoutProfile && root.layoutProfile.listSelectionAccentWidth !== undefined ? root.layoutProfile.listSelectionAccentWidth : Sizing.pctW(0.45)
-    readonly property int _rowTextLeftPadding: root.layoutProfile ? root.layoutProfile.listRowTextLeftPadding : Sizing.pctW(1.6)
-    readonly property int _rowTextRightPadding: root.layoutProfile ? root.layoutProfile.listRowTextRightPadding : Sizing.pctW(1.6)
-    readonly property int _favoriteRightPadding: root.layoutProfile ? root.layoutProfile.listFavoriteRightPadding : Sizing.pctW(1.6)
+    readonly property int _gutterWidth: root._grid ? root._grid.gutterWidth : Sizing.pctW(3)
+    readonly property int _gutterGap: root._list && root._list.scrollbarGap !== undefined ? root._list.scrollbarGap : (root._grid ? root._grid.gutterGap : Sizing.pctW(1.5))
+    readonly property int _scrollThumbWidth: root._grid ? root._grid.scrollThumbWidth : Sizing.pctW(1.2)
+    readonly property int _scrollThumbRightInset: root._grid ? root._grid.scrollThumbRightInset : 0
+    readonly property bool _scrollThumbRightAligned: root._grid && root._grid.scrollThumbRightAligned !== undefined ? root._grid.scrollThumbRightAligned : false
+    readonly property int _scrollArrowSize: root._grid ? root._grid.scrollArrowSize : Math.min(root._gutterWidth, Sizing.pctH(4))
+    readonly property int _selectionAccentWidth: root._list && root._list.selectionAccentWidth !== undefined ? root._list.selectionAccentWidth : Sizing.pctW(0.45)
+    readonly property int _rowTextLeftPadding: root._list ? root._list.rowTextLeftPadding : Sizing.pctW(1.6)
+    readonly property int _rowTextRightPadding: root._list ? root._list.rowTextRightPadding : Sizing.pctW(1.6)
+    readonly property int _favoriteRightPadding: root._list ? root._list.favoriteRightPadding : Sizing.pctW(1.6)
 
     signal itemHovered(int index)
     signal itemClicked(int index)
@@ -78,7 +81,7 @@ Item {
         color: Theme.surfaceCard
         border.width: Sizing.stroke(1)
         border.color: Theme.borderMid
-        radius: Sizing.cornerRadius
+        radius: root._selectionRadius
         visible: root.showChrome
     }
 

--- a/src/ui/components/BrowseListDetailView.qml
+++ b/src/ui/components/BrowseListDetailView.qml
@@ -30,8 +30,18 @@ Item {
     property alias detailSuppressed: detailPane.detailSuppressed
     property alias detailCanPreviousImage: detailPane.canPreviousImage
     property alias detailCanNextImage: detailPane.canNextImage
-    readonly property int _cardRadius: root.layoutProfile ? root.layoutProfile.tileCornerRadius : Sizing.cornerRadius
-    readonly property int _dividerOffsetX: root.layoutProfile && root.layoutProfile.listDividerOffsetX !== undefined ? root.layoutProfile.listDividerOffsetX : 0
+
+    property var _listProfile: root.layoutProfile && root.layoutProfile.list ? root.layoutProfile.list : null
+    property var _surfaceProfile: root.layoutProfile && root.layoutProfile.surface ? root.layoutProfile.surface : null
+    readonly property bool _verticalSplit: root._listProfile && root._listProfile.contentAxis === "vertical"
+    readonly property int _dividerWidth: root._listProfile && root._listProfile.dividerWidth !== undefined ? root._listProfile.dividerWidth : Sizing.stroke(1)
+    readonly property int _dividerMargin: root._listProfile && root._listProfile.dividerMargin !== undefined ? root._listProfile.dividerMargin : 0
+    readonly property real _listShare: root._listProfile && root._listProfile.listShare !== undefined ? root._listProfile.listShare : 2
+    readonly property real _detailShare: root._listProfile && root._listProfile.detailShare !== undefined ? root._listProfile.detailShare : 1
+    readonly property real _shareTotal: Math.max(1, root._listShare + root._detailShare)
+    readonly property int _listSpan: root._verticalSplit ? Math.max(0, Math.floor((height - root._dividerWidth) * root._listShare / root._shareTotal) + root._dividerMargin) : Math.max(0, Math.floor((width - root._dividerWidth) * root._listShare / root._shareTotal) + root._dividerMargin)
+    readonly property int _detailSpan: root._verticalSplit ? Math.max(0, height - root._listSpan - root._dividerWidth) : Math.max(0, width - root._listSpan - root._dividerWidth)
+    readonly property int _cardRadius: root._surfaceProfile ? root._surfaceProfile.cornerRadius : Sizing.cornerRadius
 
     signal itemHovered(int index)
     signal itemClicked(int index)
@@ -51,21 +61,13 @@ Item {
         radius: root._cardRadius
     }
 
-    CardDivider {
-        id: listDivider
-
-        x: Sizing.px(parent.width * 2 / 3) + root._dividerOffsetX
-        anchors.top: parent.top
-        anchors.bottom: parent.bottom
-    }
-
     BrowseList {
         id: browseList
 
-        anchors.left: parent.left
-        anchors.right: listDivider.left
-        anchors.top: parent.top
-        anchors.bottom: parent.bottom
+        x: 0
+        y: 0
+        width: root._verticalSplit ? parent.width : root._listSpan
+        height: root._verticalSplit ? root._listSpan : parent.height
         layoutProfile: root.layoutProfile
         showChrome: false
         onItemHovered: index => root.itemHovered(index)
@@ -75,13 +77,21 @@ Item {
         onPageWheelRequested: delta => root.pageWheelRequested(delta)
     }
 
+    Rectangle {
+        x: root._verticalSplit ? 0 : browseList.width
+        y: root._verticalSplit ? browseList.height : 0
+        width: root._verticalSplit ? parent.width : root._dividerWidth
+        height: root._verticalSplit ? root._dividerWidth : parent.height
+        color: Theme.borderMid
+    }
+
     BrowseDetailPane {
         id: detailPane
 
-        anchors.left: listDivider.right
-        anchors.right: parent.right
-        anchors.top: parent.top
-        anchors.bottom: parent.bottom
+        x: root._verticalSplit ? 0 : browseList.width + root._dividerWidth
+        y: root._verticalSplit ? browseList.height + root._dividerWidth : 0
+        width: root._verticalSplit ? parent.width : root._detailSpan
+        height: root._verticalSplit ? root._detailSpan : parent.height
         layoutProfile: root.layoutProfile
         showChrome: false
     }

--- a/src/ui/components/HeaderBar.qml
+++ b/src/ui/components/HeaderBar.qml
@@ -25,6 +25,7 @@ Item {
     // the bouncing copy at exactly the same position.
     property alias logoItem: logo
     property var layoutProfile: null
+    readonly property var _headerProfile: header.layoutProfile && header.layoutProfile.header ? header.layoutProfile.header : null
     property string browseTitle: ""
     property string browseProgressText: ""
 
@@ -80,8 +81,8 @@ Item {
     Row {
         id: topHud
 
-        anchors.top: header.layoutProfile && header.layoutProfile.headerHudBottomAligned ? undefined : parent.top
-        anchors.bottom: header.layoutProfile && header.layoutProfile.headerHudBottomAligned ? parent.bottom : undefined
+        anchors.top: header._headerProfile && header._headerProfile.hudBottomAligned ? undefined : parent.top
+        anchors.bottom: header._headerProfile && header._headerProfile.hudBottomAligned ? parent.bottom : undefined
         anchors.right: parent.right
         anchors.rightMargin: Sizing.headerSideMargin
         spacing: Sizing.pctW(1)
@@ -161,7 +162,7 @@ Item {
     Text {
         id: crtTitleLabel
 
-        visible: header.layoutProfile && header.layoutProfile.showHeaderTitleInHeader && header.browseTitle !== ""
+        visible: header._headerProfile && header._headerProfile.titleInHeader && header.browseTitle !== ""
         x: Sizing.center(parent.width, width)
         y: parent.height - height
         width: Math.min(Math.floor(parent.width / 3), Math.ceil(Math.max(crtTitleMetrics.advanceWidth, crtTitleMetrics.boundingRect.width)))
@@ -183,8 +184,8 @@ Item {
     // idle, but its slot stays reserved by the header's fixed height
     // so the logo and the surrounding layout don't shift.
     CoreStatusPill {
-        anchors.top: header.layoutProfile && header.layoutProfile.headerStatusPillPinnedTop ? parent.top : topHud.bottom
+        anchors.top: header._headerProfile && header._headerProfile.statusPillPinnedTop ? parent.top : topHud.bottom
         anchors.right: topHud.right
-        anchors.topMargin: header.layoutProfile && header.layoutProfile.headerStatusPillPinnedTop ? 0 : Sizing.headerStackGap
+        anchors.topMargin: header._headerProfile && header._headerProfile.statusPillPinnedTop ? 0 : Sizing.headerStackGap
     }
 }

--- a/src/ui/components/PagedGrid.qml
+++ b/src/ui/components/PagedGrid.qml
@@ -51,6 +51,7 @@ Item {
     // untouched.
     property bool focused: true
     property var layoutProfile: null
+    readonly property var _gridProfile: root.layoutProfile && root.layoutProfile.grid ? root.layoutProfile.grid : null
 
     // Emitted when the user is sitting on the last loaded page after a
     // selection move. Models with more data fetch the next page in
@@ -164,20 +165,20 @@ Item {
     // not as another cell, so a full inter-cell gap looks like wasted
     // space next to it. The gutter stays reserved on a single page
     // (just hidden) so cells don't reflow when paging activates.
-    readonly property int leftInset: root.layoutProfile ? root.layoutProfile.gridLeftInset : Sizing.pctW(5)
-    readonly property int rightInset: root.layoutProfile ? root.layoutProfile.gridRightInset : Sizing.pctW(5)
-    readonly property int gutterWidth: root.layoutProfile ? root.layoutProfile.gridGutterWidth : Sizing.pctW(3)
-    readonly property int gutterGap: root.layoutProfile ? root.layoutProfile.gridGutterGap : Sizing.pctW(1.5)
-    readonly property int scrollThumbWidth: root.layoutProfile ? root.layoutProfile.scrollThumbWidth : Sizing.pctW(1.2)
-    readonly property int scrollThumbRightInset: root.layoutProfile ? root.layoutProfile.scrollThumbRightInset : 0
-    readonly property bool scrollThumbRightAligned: root.layoutProfile && root.layoutProfile.scrollThumbRightAligned !== undefined ? root.layoutProfile.scrollThumbRightAligned : false
-    readonly property int scrollArrowSize: root.layoutProfile ? root.layoutProfile.scrollArrowSize : Math.min(gutterWidth, Sizing.pctH(4))
-    readonly property int topInset: root.layoutProfile ? root.layoutProfile.gridTopInset : Sizing.pctH(2)
-    readonly property int bottomInset: root.layoutProfile ? root.layoutProfile.gridBottomInset : Sizing.pctH(2)
-    readonly property int cellSpacingX: root.layoutProfile ? root.layoutProfile.gridColumnGap : Sizing.pctW(3)
-    readonly property int cellSpacingY: root.layoutProfile ? root.layoutProfile.gridRowGap : Sizing.pctH(4)
+    readonly property int leftInset: root._gridProfile ? root._gridProfile.leftInset : Sizing.pctW(5)
+    readonly property int rightInset: root._gridProfile ? root._gridProfile.rightInset : Sizing.pctW(5)
+    readonly property int gutterWidth: root._gridProfile ? root._gridProfile.gutterWidth : Sizing.pctW(3)
+    readonly property int gutterGap: root._gridProfile ? root._gridProfile.gutterGap : Sizing.pctW(1.5)
+    readonly property int scrollThumbWidth: root._gridProfile ? root._gridProfile.scrollThumbWidth : Sizing.pctW(1.2)
+    readonly property int scrollThumbRightInset: root._gridProfile ? root._gridProfile.scrollThumbRightInset : 0
+    readonly property bool scrollThumbRightAligned: root._gridProfile && root._gridProfile.scrollThumbRightAligned !== undefined ? root._gridProfile.scrollThumbRightAligned : false
+    readonly property int scrollArrowSize: root._gridProfile ? root._gridProfile.scrollArrowSize : Math.min(gutterWidth, Sizing.pctH(4))
+    readonly property int topInset: root._gridProfile ? root._gridProfile.topInset : Sizing.pctH(2)
+    readonly property int bottomInset: root._gridProfile ? root._gridProfile.bottomInset : Sizing.pctH(2)
+    readonly property int cellSpacingX: root._gridProfile ? root._gridProfile.columnGap : Sizing.pctW(3)
+    readonly property int cellSpacingY: root._gridProfile ? root._gridProfile.rowGap : Sizing.pctH(4)
     readonly property int _contentWidth: root.columns * root.cellWidth + (root.columns - 1) * root.cellSpacingX
-    readonly property int _scrollGutterX: root.layoutProfile && root.layoutProfile.packHorizontalRemainderAfterGutter ? root.leftInset + root._contentWidth + root.gutterGap : width - root.rightInset - root.gutterWidth
+    readonly property int _scrollGutterX: root._gridProfile && root._gridProfile.gutterFollowsContentWidth ? root.leftInset + root._contentWidth + root.gutterGap : width - root.rightInset - root.gutterWidth
 
     // Computed cell dimensions — fill the available area, divided by
     // gridColumns × gridRows. Callers don't override. The cell area

--- a/src/ui/components/Tile.qml
+++ b/src/ui/components/Tile.qml
@@ -71,6 +71,7 @@ Item {
     readonly property string delegateCoverKey: parent.coverKey
     readonly property bool delegateFavorite: parent.favorite !== 0
     property var layoutProfile: null
+    readonly property var _surfaceProfile: root.layoutProfile && root.layoutProfile.surface ? root.layoutProfile.surface : null
     // Opt-in per-tile name caption. Off by default so Hub and Systems
     // keep their full-bleed logo layout. Cover-art screens (Games,
     // Recents) flip this on at the delegate template.
@@ -87,7 +88,7 @@ Item {
     readonly property int _captionHeight: Sizing.pctH(5.5)
     readonly property int _captionGap: Sizing.pctH(0.4)
     readonly property int _captionTextSize: Sizing.fontSize(2.2)
-    readonly property int _tileCornerRadius: root.layoutProfile ? root.layoutProfile.tileCornerRadius : Sizing.cornerRadius
+    readonly property int _tileCornerRadius: root._surfaceProfile ? root._surfaceProfile.cornerRadius : Sizing.cornerRadius
     readonly property int _captionTextMaxWidth: Math.max(0, root.width - 2 * root._tileCornerRadius)
     readonly property int _textMeasureSlack: Theme.crtNativePath ? 0 : 2
     readonly property int _captionMeasuredWidth: Math.ceil(Math.max(captionMetrics.advanceWidth, captionMetrics.boundingRect.width) + root._textMeasureSlack)

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -28,7 +28,16 @@ MediaListScreen {
     readonly property int _listPageSize: games._portraitNonCrtList ? 16 : 10
     readonly property int _browsePageSize: games._listLayout ? Math.max(1, games.listCard.visibleRowCount) : games.gamesGrid.pageSize
     readonly property bool _crtGridLayout: Theme.crtNativePath && !games._listLayout
-    readonly property var _tileLayout: games._crtGridLayout ? BrowseLayouts.crtTile : BrowseLayouts.defaultTile
+    readonly property bool _tateListLayout: Browse.Settings.current_orientation !== "horizontal"
+    readonly property string _gridViewId: "gamesGrid"
+    readonly property string _listViewId: "gamesList"
+    readonly property string _tateListViewId: "gamesListTate"
+    readonly property string _activeViewId: games._listLayout ? (games._tateListLayout ? games._tateListViewId : games._listViewId) : games._gridViewId
+    readonly property string _browseThemeId: BrowseLayouts.currentThemeId
+    readonly property var _viewProfile: BrowseLayouts.themeProfile(games._browseThemeId, games._activeViewId)
+    readonly property var _headerProfile: games._viewProfile && games._viewProfile.header ? games._viewProfile.header : null
+    readonly property var _statusProfile: games._viewProfile && games._viewProfile.status ? games._viewProfile.status : null
+    readonly property var _footerProfile: games._viewProfile && games._viewProfile.footer ? games._viewProfile.footer : null
 
     mediaModel: Browse.GamesModel
     emptyText: qsTr("No games in this system")
@@ -60,6 +69,9 @@ MediaListScreen {
     linearMoveAction: delta => games._performLinearMove(delta)
     pageAction: delta => games._performPage(delta)
     onListLayoutEntered: () => games._fillListPage()
+    gridViewId: games._gridViewId
+    listViewId: games._listViewId
+    tateListViewId: games._tateListViewId
     listLeftAction: () => Browse.GamesModel.cycle_detail_image(-1)
     listRightAction: () => Browse.GamesModel.cycle_detail_image(1)
     contextMenuEnabledAt: index => {
@@ -95,10 +107,8 @@ MediaListScreen {
         else
             games.requestSystemsScreen();
     }
-    showTopStrip: games._tileLayout.showTopStrip
+    showTopStrip: games._statusProfile ? games._statusProfile.topStripVisible : true
     topStripTitleProvider: () => {
-        if (games._tileLayout.showHeaderTitleInHeader)
-            return "";
         const sid = Browse.GamesModel.current_system_id;
         if (sid === "")
             return "";
@@ -106,8 +116,8 @@ MediaListScreen {
         return idx >= 0 ? Browse.SystemsModel.system_name_at(idx) : sid;
     }
     topStripCurrentPageProvider: () => Math.floor(games.gamesGrid.currentIndex / games._browsePageSize)
-    topStripTotalPagesProvider: () => games._tileLayout.showBottomStatusRow ? 1 : Math.max(1, Math.ceil((Browse.GamesModel.dir_count + Browse.GamesModel.total_files) / games._browsePageSize))
-    topStripTotalTextProvider: () => games._listLayout || games._tileLayout.showBottomStatusRow ? "" : (Browse.GamesModel.total_files > 0 ? qsTr("%1 files").arg(Browse.GamesModel.total_files) : "")
+    topStripTotalPagesProvider: () => games._footerProfile && games._footerProfile.bottomStatusVisible ? 1 : Math.max(1, Math.ceil((Browse.GamesModel.dir_count + Browse.GamesModel.total_files) / games._browsePageSize))
+    topStripTotalTextProvider: () => games._listLayout || (games._footerProfile && games._footerProfile.bottomStatusVisible) ? "" : (Browse.GamesModel.total_files > 0 ? qsTr("%1 files").arg(Browse.GamesModel.total_files) : "")
     topStripRightTextProvider: () => {
         if (!games._listLayout)
             return "";
@@ -118,8 +128,7 @@ MediaListScreen {
         const total = Math.max(1, Browse.GamesModel.dir_count + Browse.GamesModel.total_files);
         return qsTr("%1 / %2").arg(games.gamesGrid.currentIndex + 1).arg(total);
     }
-    gridLayoutProfile: games._tileLayout
-    gridBottomMargin: games._tileLayout.showBottomStatusRow ? games._tileLayout.activeLabelBottomMargin + games._tileLayout.activeLabelHeight : Sizing.pctH(6) + games._tileLayout.activeLabelBottomMargin + games._tileLayout.activeLabelHeight
+    gridBottomMargin: games._footerProfile ? games._footerProfile.gridBottomMargin : (Sizing.pctH(6) + Sizing.pctH(8) + Sizing.pctH(7))
     gridTotalItemsOverride: Browse.GamesModel.dir_count + Browse.GamesModel.total_files
     gridHasMorePages: Browse.GamesModel.has_next_page
     gridLoadMoreAction: () => Browse.GamesModel.fetch_more()
@@ -131,15 +140,15 @@ MediaListScreen {
     }
     activeLabelTextProvider: () => games.gamesGrid.itemCount > 0 ? Browse.GamesModel.name_at(games.gamesGrid.currentIndex) : ""
     activeLabelAtBottom: true
-    activeLabelBottomMargin: games._tileLayout.activeLabelBottomMargin
-    activeLabelHeight: games._tileLayout.activeLabelHeight
-    showBottomStatusRow: games._tileLayout.showBottomStatusRow
-    bottomStatusLeftMargin: games._tileLayout.bottomStatusLeftMargin
-    bottomStatusRightMargin: games._tileLayout.bottomStatusRightMargin
-    bottomStatusLeftText: games._tileLayout.showBottomStatusRow && Browse.GamesModel.total_files > 0 ? qsTr("%1 files").arg(Browse.GamesModel.total_files) : ""
-    bottomStatusRightText: games._tileLayout.showBottomStatusRow && Math.ceil((Browse.GamesModel.dir_count + Browse.GamesModel.total_files) / games._browsePageSize) > 1 ? qsTr("%1 / %2").arg(Math.floor(games.gamesGrid.currentIndex / games._browsePageSize) + 1).arg(Math.max(1, Math.ceil((Browse.GamesModel.dir_count + Browse.GamesModel.total_files) / games._browsePageSize))) : ""
+    activeLabelBottomMargin: games._footerProfile ? games._footerProfile.activeLabelBottomMargin : Sizing.pctH(8)
+    activeLabelHeight: games._footerProfile ? games._footerProfile.activeLabelHeight : Sizing.pctH(7)
+    showBottomStatusRow: games._footerProfile ? games._footerProfile.bottomStatusVisible : false
+    bottomStatusLeftMargin: games._footerProfile ? games._footerProfile.bottomStatusLeftMargin : 0
+    bottomStatusRightMargin: games._footerProfile ? games._footerProfile.bottomStatusRightMargin : 0
+    bottomStatusLeftText: games._footerProfile && games._footerProfile.bottomStatusVisible && Browse.GamesModel.total_files > 0 ? qsTr("%1 files").arg(Browse.GamesModel.total_files) : ""
+    bottomStatusRightText: games._footerProfile && games._footerProfile.bottomStatusVisible && Math.ceil((Browse.GamesModel.dir_count + Browse.GamesModel.total_files) / games._browsePageSize) > 1 ? qsTr("%1 / %2").arg(Math.floor(games.gamesGrid.currentIndex / games._browsePageSize) + 1).arg(Math.max(1, Math.ceil((Browse.GamesModel.dir_count + Browse.GamesModel.total_files) / games._browsePageSize))) : ""
     pageLoadingVisible: !games._listLayout && Browse.GamesModel.loading_more && games.gamesGrid.hasPendingTarget
-    pageLoadingLeftMargin: games._tileLayout.showBottomStatusRow && games.bottomStatusLeftText !== "" ? Sizing.px(games.width / 3) : games.gamesGrid.leftInset
+    pageLoadingLeftMargin: games._footerProfile && games._footerProfile.bottomStatusVisible && games.bottomStatusLeftText !== "" ? Sizing.px(games.width / 3) : games.gamesGrid.leftInset
 
     Binding {
         target: Browse.GamesModel

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -34,10 +34,11 @@ MediaListScreen {
     readonly property string _tateListViewId: "gamesListTate"
     readonly property string _activeViewId: games._listLayout ? (games._tateListLayout ? games._tateListViewId : games._listViewId) : games._gridViewId
     readonly property string _browseThemeId: BrowseLayouts.currentThemeId
+    readonly property var _gridProfile: BrowseLayouts.themeProfile(games._browseThemeId, games._gridViewId)
     readonly property var _viewProfile: BrowseLayouts.themeProfile(games._browseThemeId, games._activeViewId)
     readonly property var _headerProfile: games._viewProfile && games._viewProfile.header ? games._viewProfile.header : null
     readonly property var _statusProfile: games._viewProfile && games._viewProfile.status ? games._viewProfile.status : null
-    readonly property var _footerProfile: games._viewProfile && games._viewProfile.footer ? games._viewProfile.footer : null
+    readonly property var _footerProfile: games._gridProfile && games._gridProfile.footer ? games._gridProfile.footer : null
 
     mediaModel: Browse.GamesModel
     emptyText: qsTr("No games in this system")

--- a/src/ui/screens/MediaListScreen.qml
+++ b/src/ui/screens/MediaListScreen.qml
@@ -56,6 +56,9 @@ Item {
     property var gridCurrentPageChangedAction: null
     property var gridCurrentIndexChangedAction: null
     property var gridLoadMoreAction: null
+    property string gridViewId: "gamesGrid"
+    property string listViewId: "gamesList"
+    property string tateListViewId: "gamesListTate"
 
     property alias mediaGrid: mediaGrid
     property alias topStrip: topStrip
@@ -69,7 +72,6 @@ Item {
     property bool renderGridLayout: true
     property bool showTopStrip: true
     property bool showBottomStatusRow: false
-    property bool showHeaderTitleInHeader: false
     property bool activeLabelAtBottom: false
     property int gridBottomMargin: Sizing.pctH(15)
     property int activeLabelBottomMargin: 0
@@ -80,13 +82,19 @@ Item {
     property bool pageLoadingVisible: false
     property string bottomStatusLeftText: ""
     property string bottomStatusRightText: ""
-    property var gridLayoutProfile: null
     property int gridTotalItemsOverride: -1
     property bool gridHasMorePages: false
     readonly property bool _listLayout: root.forceListLayout || Browse.Settings.current_browse_layout === "list"
+    readonly property bool _tateListLayout: root._listLayout && Browse.Settings.current_orientation !== "horizontal"
+    readonly property string _activeListViewId: root._tateListLayout ? root.tateListViewId : root.listViewId
+    readonly property string _browseThemeId: BrowseLayouts.currentThemeId
+    readonly property var _gridLayoutProfile: BrowseLayouts.themeProfile(root._browseThemeId, root.gridViewId)
+    readonly property var _listLayoutProfile: BrowseLayouts.themeProfile(root._browseThemeId, root._activeListViewId)
+    readonly property var _activeViewProfile: root._listLayout ? root._listLayoutProfile : root._gridLayoutProfile
+    readonly property var _statusProfile: root._activeViewProfile && root._activeViewProfile.status ? root._activeViewProfile.status : null
+    readonly property var _footerProfile: root._gridLayoutProfile && root._gridLayoutProfile.footer ? root._gridLayoutProfile.footer : null
     readonly property bool _crtListStrip: Theme.crtNativePath && root._listLayout
-    readonly property var _listLayoutProfile: Theme.crtNativePath ? BrowseLayouts.crtTile : BrowseLayouts.defaultTile
-    readonly property int _listOverlayBottomMargin: Sizing.pctH(15)
+    readonly property int _listOverlayBottomMargin: root._listLayoutProfile && root._listLayoutProfile.list ? root._listLayoutProfile.list.overlayBottomMargin : Sizing.pctH(15)
     readonly property bool _gateHide: root.transitioning || root._loading()
 
     signal requestHubScreen
@@ -285,13 +293,13 @@ Item {
 
     TopStatusStrip {
         id: topStrip
-        visible: !root._gateHide && (root.showTopStrip || root._crtListStrip)
+        visible: !root._gateHide && (root._statusProfile ? root._statusProfile.topStripVisible : root.showTopStrip)
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: parent.top
-        anchors.topMargin: Sizing.headerBottom + Sizing.pctH(1)
-        height: root._crtListStrip ? root._listLayoutProfile.listStripHeight : (root.showTopStrip ? Sizing.pctH(7) : 0)
-        slotMargin: root._crtListStrip ? root._listLayoutProfile.listStripSlotMargin : Sizing.pctW(5)
+        anchors.topMargin: Sizing.headerBottom + (root._statusProfile ? root._statusProfile.topMargin : Sizing.pctH(1))
+        height: root._statusProfile ? root._statusProfile.stripHeight : (root.showTopStrip ? Sizing.pctH(7) : 0)
+        slotMargin: root._statusProfile ? root._statusProfile.slotMargin : Sizing.pctW(5)
         title: typeof root.topStripTitleProvider === "function" ? root.topStripTitleProvider() : root.screenTitle
         currentPage: typeof root.topStripCurrentPageProvider === "function" ? root.topStripCurrentPageProvider() : mediaGrid.currentPage
         totalPages: typeof root.topStripTotalPagesProvider === "function" ? root.topStripTotalPagesProvider() : Math.max(1, Math.ceil(root._count() / mediaGrid.pageSize))
@@ -304,13 +312,13 @@ Item {
 
         visible: !root._gateHide && root._listLayout
         anchors.left: parent.left
-        anchors.leftMargin: root._listLayoutProfile.listCardSideMargin
+        anchors.leftMargin: root._listLayoutProfile && root._listLayoutProfile.list ? root._listLayoutProfile.list.cardSideMargin : Sizing.pctW(5)
         anchors.right: parent.right
-        anchors.rightMargin: root._listLayoutProfile.listCardSideMargin
+        anchors.rightMargin: root._listLayoutProfile && root._listLayoutProfile.list ? root._listLayoutProfile.list.cardSideMargin : Sizing.pctW(5)
         anchors.top: topStrip.bottom
-        anchors.topMargin: Sizing.pctH(2)
+        anchors.topMargin: root._listLayoutProfile && root._listLayoutProfile.list ? root._listLayoutProfile.list.cardTopMargin : Sizing.pctH(2)
         anchors.bottom: parent.bottom
-        anchors.bottomMargin: Sizing.pctH(8)
+        anchors.bottomMargin: root._listLayoutProfile && root._listLayoutProfile.list ? root._listLayoutProfile.list.cardBottomMargin : Sizing.pctH(8)
         layoutProfile: root._listLayoutProfile
         model: root.mediaModel
         totalItemsOverride: root.totalItemsOverride
@@ -352,10 +360,10 @@ Item {
         focused: root.gridFocused
         model: root.mediaModel
         delegate: Tile {
-            layoutProfile: root.gridLayoutProfile
+            layoutProfile: root._gridLayoutProfile
             showCaption: true
         }
-        layoutProfile: root.gridLayoutProfile
+        layoutProfile: root._gridLayoutProfile
         columnsOverride: Sizing.gamesGridColumns
         rowsOverride: Sizing.gamesGridRows
         totalItemsOverride: root.gridTotalItemsOverride

--- a/src/ui/screens/SystemsScreen.qml
+++ b/src/ui/screens/SystemsScreen.qml
@@ -27,6 +27,7 @@ Item {
     id: systems
 
     property alias systemsGrid: systemsGrid
+    property alias listCard: listCard
     property bool transitioning: false
     // Router-driven flag: `MainLayout` writes this to
     // `!ScreenManager.hasModal` so the focused tile's accent ring

--- a/src/ui/screens/SystemsScreen.qml
+++ b/src/ui/screens/SystemsScreen.qml
@@ -42,9 +42,10 @@ Item {
     readonly property bool _tateListLayout: systems._listLayout && Browse.Settings.current_orientation !== "horizontal"
     readonly property string _viewId: systems._listLayout ? (systems._tateListLayout ? "systemsListTate" : "systemsList") : "systemsGrid"
     readonly property string _browseThemeId: BrowseLayouts.currentThemeId
+    readonly property var _gridProfile: BrowseLayouts.themeProfile(systems._browseThemeId, "systemsGrid")
     readonly property var _viewProfile: BrowseLayouts.themeProfile(systems._browseThemeId, systems._viewId)
     readonly property var _statusProfile: systems._viewProfile && systems._viewProfile.status ? systems._viewProfile.status : null
-    readonly property var _footerProfile: systems._viewProfile && systems._viewProfile.footer ? systems._viewProfile.footer : null
+    readonly property var _footerProfile: systems._gridProfile && systems._gridProfile.footer ? systems._gridProfile.footer : null
     readonly property var _listProfile: systems._viewProfile && systems._viewProfile.list ? systems._viewProfile.list : null
     readonly property int _listOverlayBottomMargin: systems._listProfile ? systems._listProfile.overlayBottomMargin : Sizing.pctH(15)
 

--- a/src/ui/screens/SystemsScreen.qml
+++ b/src/ui/screens/SystemsScreen.qml
@@ -39,8 +39,14 @@ Item {
     readonly property bool _listLayout: Browse.Settings.current_browse_layout === "list"
     readonly property bool _crtGridLayout: Theme.crtNativePath && !systems._listLayout
     readonly property bool _crtListStrip: Theme.crtNativePath && systems._listLayout
-    readonly property var _tileLayout: Theme.crtNativePath ? BrowseLayouts.crtTile : BrowseLayouts.defaultTile
-    readonly property int _listOverlayBottomMargin: Sizing.pctH(6) + systems._tileLayout.activeLabelBottomMargin + systems._tileLayout.activeLabelHeight
+    readonly property bool _tateListLayout: systems._listLayout && Browse.Settings.current_orientation !== "horizontal"
+    readonly property string _viewId: systems._listLayout ? (systems._tateListLayout ? "systemsListTate" : "systemsList") : "systemsGrid"
+    readonly property string _browseThemeId: BrowseLayouts.currentThemeId
+    readonly property var _viewProfile: BrowseLayouts.themeProfile(systems._browseThemeId, systems._viewId)
+    readonly property var _statusProfile: systems._viewProfile && systems._viewProfile.status ? systems._viewProfile.status : null
+    readonly property var _footerProfile: systems._viewProfile && systems._viewProfile.footer ? systems._viewProfile.footer : null
+    readonly property var _listProfile: systems._viewProfile && systems._viewProfile.list ? systems._viewProfile.list : null
+    readonly property int _listOverlayBottomMargin: systems._listProfile ? systems._listProfile.overlayBottomMargin : Sizing.pctH(15)
 
     signal requestAccept(systemId: string)
     signal requestHubScreen
@@ -178,15 +184,15 @@ Item {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: parent.top
-        anchors.topMargin: Sizing.headerBottom + Sizing.pctH(1)
-        height: systems._crtListStrip ? systems._tileLayout.listStripHeight : (systems._tileLayout.showTopStrip ? Sizing.pctH(7) : 0)
-        slotMargin: systems._crtListStrip ? systems._tileLayout.listStripSlotMargin : Sizing.pctW(5)
-        title: systems._tileLayout.showHeaderTitleInHeader ? "" : Browse.SystemsModel.current_category
+        anchors.topMargin: Sizing.headerBottom + (systems._statusProfile ? systems._statusProfile.topMargin : Sizing.pctH(1))
+        height: systems._statusProfile ? systems._statusProfile.stripHeight : Sizing.pctH(7)
+        slotMargin: systems._statusProfile ? systems._statusProfile.slotMargin : Sizing.pctW(5)
+        title: Browse.SystemsModel.current_category
         currentPage: systemsGrid.currentPage
-        totalPages: systems._tileLayout.showBottomStatusRow ? 1 : Math.max(1, Math.ceil(Browse.SystemsModel.count / systemsGrid.pageSize))
+        totalPages: systems._footerProfile && systems._footerProfile.bottomStatusVisible ? 1 : Math.max(1, Math.ceil(Browse.SystemsModel.count / systemsGrid.pageSize))
         totalText: Theme.crtNativePath ? "" : (Browse.SystemsModel.count > 0 ? qsTr("%1 systems").arg(Browse.SystemsModel.count) : "")
         rightTextOverride: !systems._listLayout || systemsGrid.itemCount <= 0 ? "" : qsTr("%1 / %2").arg(systemsGrid.currentIndex + 1).arg(Math.max(1, Browse.SystemsModel.count))
-        visible: !systems.transitioning && (systems._tileLayout.showTopStrip || systems._crtListStrip)
+        visible: !systems.transitioning && (!systems._statusProfile || systems._statusProfile.topStripVisible)
     }
 
     BrowseListDetailView {
@@ -194,15 +200,16 @@ Item {
 
         visible: !systems.transitioning && systems._listLayout
         anchors.left: parent.left
-        anchors.leftMargin: systems._tileLayout.listCardSideMargin
+        anchors.leftMargin: systems._listProfile ? systems._listProfile.cardSideMargin : Sizing.pctW(5)
         anchors.right: parent.right
-        anchors.rightMargin: systems._tileLayout.listCardSideMargin
+        anchors.rightMargin: systems._listProfile ? systems._listProfile.cardSideMargin : Sizing.pctW(5)
         anchors.top: topStrip.bottom
-        anchors.topMargin: Sizing.pctH(2)
+        anchors.topMargin: systems._listProfile ? systems._listProfile.cardTopMargin : Sizing.pctH(2)
         anchors.bottom: parent.bottom
-        anchors.bottomMargin: Sizing.pctH(8)
+        anchors.bottomMargin: systems._listProfile ? systems._listProfile.cardBottomMargin : Sizing.pctH(8)
         model: Browse.SystemsModel
         currentIndex: systemsGrid.currentIndex
+        layoutProfile: systems._viewProfile
         detailTitle: listCard.currentName
         detailCoverKey: listCard.currentCoverKey
         detailTags: Browse.SystemsModel.count > 0 ? Browse.SystemsModel.detail_tags_at(systemsGrid.currentIndex) : ""
@@ -230,12 +237,12 @@ Item {
         anchors.right: parent.right
         anchors.top: topStrip.bottom
         anchors.bottom: parent.bottom
-        anchors.bottomMargin: systems._tileLayout.showBottomStatusRow ? systems._tileLayout.activeLabelBottomMargin + systems._tileLayout.activeLabelHeight : Sizing.pctH(6) + systems._tileLayout.activeLabelBottomMargin + systems._tileLayout.activeLabelHeight
+        anchors.bottomMargin: systems._footerProfile ? systems._footerProfile.gridBottomMargin : (Sizing.pctH(6) + Sizing.pctH(8) + Sizing.pctH(7))
         focused: systems.gridFocused
         model: Browse.SystemsModel
-        layoutProfile: systems._tileLayout
+        layoutProfile: systems._viewProfile
         delegate: Tile {
-            layoutProfile: systems._tileLayout
+            layoutProfile: systems._viewProfile
         }
         onItemHovered: index => systems._focusIndex(index)
         onItemClicked: index => {
@@ -264,18 +271,18 @@ Item {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.bottom: parent.bottom
-        anchors.bottomMargin: systems._tileLayout.activeLabelBottomMargin
-        height: systems._tileLayout.activeLabelHeight
+        anchors.bottomMargin: systems._footerProfile ? systems._footerProfile.activeLabelBottomMargin : Sizing.pctH(8)
+        height: systems._footerProfile ? systems._footerProfile.activeLabelHeight : Sizing.pctH(7)
         text: systemsGrid.itemCount > 0 ? Browse.SystemsModel.system_name_at(systemsGrid.currentIndex) : ""
         visible: !systems.transitioning && !systems._listLayout
     }
 
     Text {
-        visible: systems._tileLayout.showBottomStatusRow && !systems.transitioning && !systems._listLayout && Browse.SystemsModel.count > 0
+        visible: systems._footerProfile && systems._footerProfile.bottomStatusVisible && !systems.transitioning && !systems._listLayout && Browse.SystemsModel.count > 0
         anchors.left: parent.left
-        anchors.leftMargin: systems._tileLayout.bottomStatusLeftMargin
+        anchors.leftMargin: systems._footerProfile ? systems._footerProfile.bottomStatusLeftMargin : 0
         anchors.verticalCenter: activeLabel.verticalCenter
-        width: Sizing.px(parent.width / 3) - systems._tileLayout.bottomStatusLeftMargin
+        width: Sizing.px(parent.width / 3) - (systems._footerProfile ? systems._footerProfile.bottomStatusLeftMargin : 0)
         height: Sizing.fontSize(2.9)
         elide: Text.ElideRight
         horizontalAlignment: Text.AlignLeft
@@ -288,11 +295,11 @@ Item {
     }
 
     Text {
-        visible: systems._tileLayout.showBottomStatusRow && !systems.transitioning && !systems._listLayout && Math.ceil(Browse.SystemsModel.count / systemsGrid.pageSize) > 1
+        visible: systems._footerProfile && systems._footerProfile.bottomStatusVisible && !systems.transitioning && !systems._listLayout && Math.ceil(Browse.SystemsModel.count / systemsGrid.pageSize) > 1
         anchors.right: parent.right
-        anchors.rightMargin: systems._tileLayout.bottomStatusRightMargin
+        anchors.rightMargin: systems._footerProfile ? systems._footerProfile.bottomStatusRightMargin : 0
         anchors.verticalCenter: activeLabel.verticalCenter
-        width: Sizing.px(parent.width / 3) - systems._tileLayout.bottomStatusRightMargin
+        width: Sizing.px(parent.width / 3) - (systems._footerProfile ? systems._footerProfile.bottomStatusRightMargin : 0)
         height: Sizing.fontSize(2.9)
         elide: Text.ElideRight
         horizontalAlignment: Text.AlignRight

--- a/src/ui/theme/BrowseLayouts.qml
+++ b/src/ui/theme/BrowseLayouts.qml
@@ -3,126 +3,862 @@
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 pragma Singleton
 import QtQuick
+import Zaparoo.Theme
 
-// Shared browse-screen layout profiles. These only describe geometry and
-// slot placement; screen behavior stays in the screens/components that
-// consume them.
+// Built-in browse layout profiles. Data stays in one place, but does not rely
+// on runtime file loading. Values are semantic view tokens, resolved into
+// integer geometry through Sizing.
 QtObject {
-    readonly property QtObject defaultTile: QtObject {
-        readonly property bool showTopStrip: true
-        readonly property bool showHeaderTitleInHeader: false
-        readonly property bool showBottomStatusRow: false
-        readonly property bool headerHudBottomAligned: false
-        readonly property bool headerStatusPillPinnedTop: false
-        readonly property int gridLeftInset: Sizing.pctW(5)
-        readonly property int gridRightInset: Sizing.pctW(5)
-        readonly property int gridGutterWidth: Sizing.pctW(3)
-        readonly property int gridGutterGap: Sizing.pctW(1.5)
-        readonly property int gridColumnGap: Sizing.pctW(3)
-        readonly property int gridTopInset: Sizing.pctH(2)
-        readonly property int gridBottomInset: Sizing.pctH(2)
-        readonly property int gridRowGap: Sizing.pctH(4)
-        readonly property int scrollThumbWidth: Sizing.pctW(1.2)
-        readonly property int scrollThumbRightInset: 0
-        readonly property bool scrollThumbRightAligned: false
-        readonly property int scrollArrowSize: Math.min(gridGutterWidth, Sizing.pctH(4))
-        readonly property bool packHorizontalRemainderAfterGutter: false
-        readonly property int activeLabelHeight: Sizing.pctH(7)
-        readonly property int activeLabelBottomMargin: Sizing.pctH(8)
-        readonly property int bottomStatusLeftMargin: Sizing.pctW(5)
-        readonly property int bottomStatusRightMargin: Sizing.pctW(5)
-        readonly property int bottomUnsafeHeight: Sizing.pctH(6) + Sizing.pctH(2)
-        readonly property int tileCornerRadius: Sizing.cornerRadius
-        readonly property int listCardSideMargin: Sizing.pctW(5)
-        readonly property int listDividerOffsetX: 0
-        readonly property int listStripHeight: Sizing.pctH(7)
-        readonly property int listStripSlotMargin: Sizing.pctW(5)
-        readonly property int listCardPaddingLeft: Sizing.pctW(2)
-        readonly property int listCardPaddingRight: Sizing.pctW(2)
-        readonly property int listCardPaddingTop: Sizing.pctH(2)
-        readonly property int listCardPaddingBottom: Sizing.pctH(2)
-        readonly property int listRowHeight: 0
-        readonly property int listRowSpacing: Sizing.pctH(0.7)
-        readonly property int listCenterSlot: -1
-        readonly property int listScrollbarGap: Sizing.pctW(1.5)
-        readonly property int listSelectionAccentWidth: Sizing.pctW(0.45)
-        readonly property int detailMetadataYOffset: 0
-        readonly property int detailMetadataExtraHeight: 0
-        readonly property int detailMetadataLeftInset: 0
-        readonly property int detailMetadataRightInset: 0
-        readonly property int detailPanePaddingLeft: Sizing.pctW(2)
-        readonly property int detailPanePaddingRight: Sizing.pctW(2)
-        readonly property int detailPanePaddingTop: Sizing.pctH(2)
-        readonly property int detailPanePaddingBottom: Sizing.pctH(2)
-        readonly property int detailImageXOffset: 0
-        readonly property int detailImageLeftInset: 0
-        readonly property int detailImageRightInset: 0
-        readonly property int detailImageExtraWidth: 0
-        readonly property int detailImageExtraHeight: 0
-        readonly property int detailImageBottomGap: 0
-        readonly property int detailTagRowHeight: Sizing.pctH(3)
-        readonly property int detailTagRowSpacing: Sizing.pctH(0.55)
-        readonly property int listRowTextLeftPadding: Sizing.pctW(1.6)
-        readonly property int listRowTextRightPadding: Sizing.pctW(1.6)
-        readonly property int listFavoriteRightPadding: Sizing.pctW(1.6)
+    readonly property string currentThemeId: Theme.crtNativePath ? "crt" : "default"
+    readonly property var _themes: ({
+        "default": {
+            "systemsGrid": {
+                "header": {
+                    "titleInHeader": false,
+                    "hudBottomAligned": false,
+                    "statusPillPinnedTop": false
+                },
+                "status": {
+                    "topStripVisible": true,
+                    "stripHeight": "pctH:7",
+                    "slotMargin": "pctW:5",
+                    "topMargin": "pctH:1"
+                },
+                "grid": {
+                    "leftInset": "pctW:5",
+                    "rightInset": "pctW:5",
+                    "gutterWidth": "pctW:3",
+                    "gutterGap": "pctW:1.5",
+                    "columnGap": "pctW:3",
+                    "topInset": "pctH:2",
+                    "bottomInset": "pctH:2",
+                    "rowGap": "pctH:4",
+                    "scrollThumbWidth": "pctW:1.2",
+                    "scrollThumbRightInset": 0,
+                    "scrollThumbRightAligned": false,
+                    "scrollArrowSize": "min(pctW:3,pctH:4)",
+                    "gutterFollowsContentWidth": false
+                },
+                "footer": {
+                    "activeLabelHeight": "pctH:7",
+                    "activeLabelBottomMargin": "pctH:8",
+                    "bottomStatusVisible": false,
+                    "bottomStatusLeftMargin": "pctW:5",
+                    "bottomStatusRightMargin": "pctW:5",
+                    "gridBottomMargin": "sum(pctH:6,pctH:8,pctH:7)",
+                    "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
+                },
+                "surface": {
+                    "cornerRadius": "cornerRadius"
+                }
+            },
+            "systemsList": {
+                "header": {
+                    "titleInHeader": false,
+                    "hudBottomAligned": false,
+                    "statusPillPinnedTop": false
+                },
+                "status": {
+                    "topStripVisible": true,
+                    "stripHeight": "pctH:7",
+                    "slotMargin": "pctW:5",
+                    "topMargin": "pctH:1"
+                },
+                "list": {
+                    "contentAxis": "horizontal",
+                    "listShare": 2,
+                    "detailShare": 1,
+                    "dividerWidth": 1,
+                    "dividerMargin": 0,
+                    "cardSideMargin": "pctW:5",
+                    "cardTopMargin": "pctH:2",
+                    "cardBottomMargin": "pctH:8",
+                    "cardPaddingLeft": "pctW:2",
+                    "cardPaddingRight": "pctW:2",
+                    "cardPaddingTop": "pctH:2",
+                    "cardPaddingBottom": "pctH:2",
+                    "rowHeight": 0,
+                    "rowSpacing": "pctH:0.7",
+                    "centerSlot": -1,
+                    "scrollbarGap": "pctW:1.5",
+                    "selectionAccentWidth": "pctW:0.45",
+                    "rowTextLeftPadding": "pctW:1.6",
+                    "rowTextRightPadding": "pctW:1.6",
+                    "favoriteRightPadding": "pctW:1.6",
+                    "overlayBottomMargin": "pctH:15"
+                },
+                "detail": {
+                    "contentAxis": "vertical",
+                    "sectionGap": "pctH:2",
+                    "imageShare": 2,
+                    "metadataShare": 1,
+                    "imageHeightRatioWithTitle": 48,
+                    "imageReservedWidth": 0,
+                    "imageReservedHeight": 0,
+                    "imageBottomMargin": 0,
+                    "panePaddingLeft": "pctW:2",
+                    "panePaddingRight": "pctW:2",
+                    "panePaddingTop": "pctH:2",
+                    "panePaddingBottom": "pctH:2",
+                    "imagePaddingLeft": 0,
+                    "imagePaddingRight": 0,
+                    "imagePaddingTop": 0,
+                    "imagePaddingBottom": 0,
+                    "metadataPaddingLeft": 0,
+                    "metadataPaddingRight": 0,
+                    "metadataPaddingTop": 0,
+                    "metadataPaddingBottom": 0,
+                    "metadataTopMargin": 0,
+                    "metadataLeftMargin": 0,
+                    "metadataRightMargin": 0,
+                    "metadataHeightAdjustment": 0,
+                    "metadataBottomAligned": false,
+                    "titleBottomMargin": "pctH:2",
+                    "tagRowHeight": "pctH:3",
+                    "tagRowSpacing": "pctH:0.55"
+                },
+                "footer": {
+                    "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
+                },
+                "surface": {
+                    "cornerRadius": "cornerRadius"
+                }
+            },
+            "systemsListTate": {
+                "header": {
+                    "titleInHeader": false,
+                    "hudBottomAligned": false,
+                    "statusPillPinnedTop": false
+                },
+                "status": {
+                    "topStripVisible": true,
+                    "stripHeight": "pctH:7",
+                    "slotMargin": "pctW:5",
+                    "topMargin": "pctH:1"
+                },
+                "list": {
+                    "contentAxis": "vertical",
+                    "listShare": 9,
+                    "detailShare": 7,
+                    "dividerWidth": 1,
+                    "dividerMargin": 0,
+                    "cardSideMargin": "pctW:5",
+                    "cardTopMargin": "pctH:2",
+                    "cardBottomMargin": "pctH:8",
+                    "cardPaddingLeft": "pctW:2",
+                    "cardPaddingRight": "pctW:2",
+                    "cardPaddingTop": "pctH:2",
+                    "cardPaddingBottom": "pctH:2",
+                    "rowHeight": 0,
+                    "rowSpacing": "pctH:0.3",
+                    "centerSlot": -1,
+                    "scrollbarGap": "pctW:1.5",
+                    "selectionAccentWidth": "pctW:0.45",
+                    "rowTextLeftPadding": "pctW:1.6",
+                    "rowTextRightPadding": "pctW:1.6",
+                    "favoriteRightPadding": "pctW:1.6",
+                    "overlayBottomMargin": "pctH:15"
+                },
+                "detail": {
+                    "contentAxis": "horizontal",
+                    "sectionGap": "pctW:2",
+                    "imageShare": 5,
+                    "metadataShare": 7,
+                    "imageHeightRatioWithTitle": 48,
+                    "imageReservedWidth": 0,
+                    "imageReservedHeight": 0,
+                    "imageBottomMargin": 0,
+                    "panePaddingLeft": "pctW:2",
+                    "panePaddingRight": "pctW:2",
+                    "panePaddingTop": "pctH:2",
+                    "panePaddingBottom": "pctH:2",
+                    "imagePaddingLeft": 0,
+                    "imagePaddingRight": 0,
+                    "imagePaddingTop": 0,
+                    "imagePaddingBottom": 0,
+                    "metadataPaddingLeft": 0,
+                    "metadataPaddingRight": 0,
+                    "metadataPaddingTop": 0,
+                    "metadataPaddingBottom": 0,
+                    "metadataTopMargin": 0,
+                    "metadataLeftMargin": 0,
+                    "metadataRightMargin": 0,
+                    "metadataHeightAdjustment": 0,
+                    "metadataBottomAligned": false,
+                    "titleBottomMargin": "pctH:2",
+                    "tagRowHeight": "pctH:3",
+                    "tagRowSpacing": "pctH:0.55"
+                },
+                "footer": {
+                    "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
+                },
+                "surface": {
+                    "cornerRadius": "cornerRadius"
+                }
+            },
+            "gamesGrid": {
+                "header": {
+                    "titleInHeader": false,
+                    "hudBottomAligned": false,
+                    "statusPillPinnedTop": false
+                },
+                "status": {
+                    "topStripVisible": true,
+                    "stripHeight": "pctH:7",
+                    "slotMargin": "pctW:5",
+                    "topMargin": "pctH:1"
+                },
+                "grid": {
+                    "leftInset": "pctW:5",
+                    "rightInset": "pctW:5",
+                    "gutterWidth": "pctW:3",
+                    "gutterGap": "pctW:1.5",
+                    "columnGap": "pctW:3",
+                    "topInset": "pctH:2",
+                    "bottomInset": "pctH:2",
+                    "rowGap": "pctH:4",
+                    "scrollThumbWidth": "pctW:1.2",
+                    "scrollThumbRightInset": 0,
+                    "scrollThumbRightAligned": false,
+                    "scrollArrowSize": "min(pctW:3,pctH:4)",
+                    "gutterFollowsContentWidth": false
+                },
+                "footer": {
+                    "activeLabelHeight": "pctH:7",
+                    "activeLabelBottomMargin": "pctH:8",
+                    "bottomStatusVisible": false,
+                    "bottomStatusLeftMargin": "pctW:5",
+                    "bottomStatusRightMargin": "pctW:5",
+                    "gridBottomMargin": "sum(pctH:6,pctH:8,pctH:7)",
+                    "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
+                },
+                "surface": {
+                    "cornerRadius": "cornerRadius"
+                }
+            },
+            "gamesList": {
+                "header": {
+                    "titleInHeader": false,
+                    "hudBottomAligned": false,
+                    "statusPillPinnedTop": false
+                },
+                "status": {
+                    "topStripVisible": true,
+                    "stripHeight": "pctH:7",
+                    "slotMargin": "pctW:5",
+                    "topMargin": "pctH:1"
+                },
+                "list": {
+                    "contentAxis": "horizontal",
+                    "listShare": 2,
+                    "detailShare": 1,
+                    "dividerWidth": 1,
+                    "dividerMargin": 0,
+                    "cardSideMargin": "pctW:5",
+                    "cardTopMargin": "pctH:2",
+                    "cardBottomMargin": "pctH:8",
+                    "cardPaddingLeft": "pctW:2",
+                    "cardPaddingRight": "pctW:2",
+                    "cardPaddingTop": "pctH:2",
+                    "cardPaddingBottom": "pctH:2",
+                    "rowHeight": 0,
+                    "rowSpacing": "pctH:0.7",
+                    "centerSlot": -1,
+                    "scrollbarGap": "pctW:1.5",
+                    "selectionAccentWidth": "pctW:0.45",
+                    "rowTextLeftPadding": "pctW:1.6",
+                    "rowTextRightPadding": "pctW:1.6",
+                    "favoriteRightPadding": "pctW:1.6",
+                    "overlayBottomMargin": "pctH:15"
+                },
+                "detail": {
+                    "contentAxis": "vertical",
+                    "sectionGap": "pctH:2",
+                    "imageShare": 2,
+                    "metadataShare": 1,
+                    "imageHeightRatioWithTitle": 48,
+                    "imageReservedWidth": 0,
+                    "imageReservedHeight": 0,
+                    "imageBottomMargin": 0,
+                    "panePaddingLeft": "pctW:2",
+                    "panePaddingRight": "pctW:2",
+                    "panePaddingTop": "pctH:2",
+                    "panePaddingBottom": "pctH:2",
+                    "imagePaddingLeft": 0,
+                    "imagePaddingRight": 0,
+                    "imagePaddingTop": 0,
+                    "imagePaddingBottom": 0,
+                    "metadataPaddingLeft": 0,
+                    "metadataPaddingRight": 0,
+                    "metadataPaddingTop": 0,
+                    "metadataPaddingBottom": 0,
+                    "metadataTopMargin": 0,
+                    "metadataLeftMargin": 0,
+                    "metadataRightMargin": 0,
+                    "metadataHeightAdjustment": 0,
+                    "metadataBottomAligned": true,
+                    "titleBottomMargin": "pctH:2",
+                    "tagRowHeight": "pctH:3",
+                    "tagRowSpacing": "pctH:0.55"
+                },
+                "footer": {
+                    "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
+                },
+                "surface": {
+                    "cornerRadius": "cornerRadius"
+                }
+            },
+            "gamesListTate": {
+                "header": {
+                    "titleInHeader": false,
+                    "hudBottomAligned": false,
+                    "statusPillPinnedTop": false
+                },
+                "status": {
+                    "topStripVisible": true,
+                    "stripHeight": "pctH:7",
+                    "slotMargin": "pctW:5",
+                    "topMargin": "pctH:1"
+                },
+                "list": {
+                    "contentAxis": "vertical",
+                    "listShare": 9,
+                    "detailShare": 7,
+                    "dividerWidth": 1,
+                    "dividerMargin": 0,
+                    "cardSideMargin": "pctW:5",
+                    "cardTopMargin": "pctH:2",
+                    "cardBottomMargin": "pctH:8",
+                    "cardPaddingLeft": "pctW:2",
+                    "cardPaddingRight": "pctW:2",
+                    "cardPaddingTop": "pctH:2",
+                    "cardPaddingBottom": "pctH:2",
+                    "rowHeight": 0,
+                    "rowSpacing": "pctH:0.3",
+                    "centerSlot": -1,
+                    "scrollbarGap": "pctW:1.5",
+                    "selectionAccentWidth": "pctW:0.45",
+                    "rowTextLeftPadding": "pctW:1.6",
+                    "rowTextRightPadding": "pctW:1.6",
+                    "favoriteRightPadding": "pctW:1.6",
+                    "overlayBottomMargin": "pctH:15"
+                },
+                "detail": {
+                    "contentAxis": "horizontal",
+                    "sectionGap": "pctW:2",
+                    "imageShare": 5,
+                    "metadataShare": 7,
+                    "imageHeightRatioWithTitle": 48,
+                    "imageReservedWidth": 0,
+                    "imageReservedHeight": 0,
+                    "imageBottomMargin": 0,
+                    "panePaddingLeft": "pctW:2",
+                    "panePaddingRight": "pctW:2",
+                    "panePaddingTop": "pctH:2",
+                    "panePaddingBottom": "pctH:2",
+                    "imagePaddingLeft": 0,
+                    "imagePaddingRight": 0,
+                    "imagePaddingTop": 0,
+                    "imagePaddingBottom": 0,
+                    "metadataPaddingLeft": 0,
+                    "metadataPaddingRight": 0,
+                    "metadataPaddingTop": 0,
+                    "metadataPaddingBottom": 0,
+                    "metadataTopMargin": 0,
+                    "metadataLeftMargin": 0,
+                    "metadataRightMargin": 0,
+                    "metadataHeightAdjustment": 0,
+                    "metadataBottomAligned": false,
+                    "titleBottomMargin": "pctH:2",
+                    "tagRowHeight": "pctH:3",
+                    "tagRowSpacing": "pctH:0.55"
+                },
+                "footer": {
+                    "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
+                },
+                "surface": {
+                    "cornerRadius": "cornerRadius"
+                }
+            }
+        },
+        "crt": {
+            "systemsGrid": {
+                "header": {
+                    "titleInHeader": true,
+                    "hudBottomAligned": true,
+                    "statusPillPinnedTop": true
+                },
+                "status": {
+                    "topStripVisible": false,
+                    "stripHeight": 0,
+                    "slotMargin": "headerSideMargin",
+                    "topMargin": "pctH:1"
+                },
+                "grid": {
+                    "leftInset": 4,
+                    "rightInset": 0,
+                    "gutterWidth": 8,
+                    "gutterGap": 4,
+                    "columnGap": 4,
+                    "topInset": 2,
+                    "bottomInset": 4,
+                    "rowGap": 4,
+                    "scrollThumbWidth": 4,
+                    "scrollThumbRightInset": 2,
+                    "scrollThumbRightAligned": false,
+                    "scrollArrowSize": 8,
+                    "gutterFollowsContentWidth": true
+                },
+                "footer": {
+                    "activeLabelHeight": 8,
+                    "activeLabelBottomMargin": "pctH:6",
+                    "bottomStatusVisible": true,
+                    "bottomStatusLeftMargin": 4,
+                    "bottomStatusRightMargin": "pctW:5",
+                    "gridBottomMargin": "sum(pctH:6,8)",
+                    "bottomUnsafeHeight": 16
+                },
+                "surface": {
+                    "cornerRadius": 4
+                }
+            },
+            "systemsList": {
+                "header": {
+                    "titleInHeader": true,
+                    "hudBottomAligned": true,
+                    "statusPillPinnedTop": true
+                },
+                "status": {
+                    "topStripVisible": true,
+                    "stripHeight": 8,
+                    "slotMargin": "headerSideMargin",
+                    "topMargin": "pctH:1"
+                },
+                "list": {
+                    "contentAxis": "horizontal",
+                    "listShare": 2,
+                    "detailShare": 1,
+                    "dividerWidth": 1,
+                    "dividerMargin": -16,
+                    "cardSideMargin": 4,
+                    "cardTopMargin": "pctH:2",
+                    "cardBottomMargin": "pctH:8",
+                    "cardPaddingLeft": 3,
+                    "cardPaddingRight": 2,
+                    "cardPaddingTop": 3,
+                    "cardPaddingBottom": 2,
+                    "rowHeight": 12,
+                    "rowSpacing": 0,
+                    "centerSlot": 7,
+                    "scrollbarGap": 2,
+                    "selectionAccentWidth": 2,
+                    "rowTextLeftPadding": 4,
+                    "rowTextRightPadding": 2,
+                    "favoriteRightPadding": 2,
+                    "overlayBottomMargin": "pctH:14"
+                },
+                "detail": {
+                    "contentAxis": "vertical",
+                    "sectionGap": 2,
+                    "imageShare": 2,
+                    "metadataShare": 1,
+                    "imageHeightRatioWithTitle": 48,
+                    "imageReservedWidth": 16,
+                    "imageReservedHeight": 0,
+                    "imageBottomMargin": 2,
+                    "panePaddingLeft": 1,
+                    "panePaddingRight": 1,
+                    "panePaddingTop": 3,
+                    "panePaddingBottom": 2,
+                    "imagePaddingLeft": 2,
+                    "imagePaddingRight": 2,
+                    "imagePaddingTop": 0,
+                    "imagePaddingBottom": 2,
+                    "metadataPaddingLeft": 2,
+                    "metadataPaddingRight": 1,
+                    "metadataPaddingTop": 0,
+                    "metadataPaddingBottom": 0,
+                    "metadataTopMargin": -14,
+                    "metadataLeftMargin": 2,
+                    "metadataRightMargin": 1,
+                    "metadataHeightAdjustment": 2,
+                    "metadataBottomAligned": false,
+                    "titleBottomMargin": 2,
+                    "tagRowHeight": 9,
+                    "tagRowSpacing": 0
+                },
+                "footer": {
+                    "bottomUnsafeHeight": 16
+                },
+                "surface": {
+                    "cornerRadius": 4
+                }
+            },
+            "systemsListTate": {
+                "header": {
+                    "titleInHeader": true,
+                    "hudBottomAligned": true,
+                    "statusPillPinnedTop": true
+                },
+                "status": {
+                    "topStripVisible": true,
+                    "stripHeight": 8,
+                    "slotMargin": "headerSideMargin",
+                    "topMargin": "pctH:1"
+                },
+                "list": {
+                    "contentAxis": "vertical",
+                    "listShare": 9,
+                    "detailShare": 7,
+                    "dividerWidth": 1,
+                    "dividerMargin": 0,
+                    "cardSideMargin": 4,
+                    "cardTopMargin": "pctH:2",
+                    "cardBottomMargin": "pctH:8",
+                    "cardPaddingLeft": 3,
+                    "cardPaddingRight": 2,
+                    "cardPaddingTop": 3,
+                    "cardPaddingBottom": 2,
+                    "rowHeight": 12,
+                    "rowSpacing": 0,
+                    "centerSlot": 7,
+                    "scrollbarGap": 2,
+                    "selectionAccentWidth": 2,
+                    "rowTextLeftPadding": 4,
+                    "rowTextRightPadding": 2,
+                    "favoriteRightPadding": 2,
+                    "overlayBottomMargin": "pctH:14"
+                },
+                "detail": {
+                    "contentAxis": "horizontal",
+                    "sectionGap": 2,
+                    "imageShare": 5,
+                    "metadataShare": 7,
+                    "imageHeightRatioWithTitle": 48,
+                    "imageReservedWidth": 16,
+                    "imageReservedHeight": 0,
+                    "imageBottomMargin": 2,
+                    "panePaddingLeft": 1,
+                    "panePaddingRight": 1,
+                    "panePaddingTop": 3,
+                    "panePaddingBottom": 2,
+                    "imagePaddingLeft": 2,
+                    "imagePaddingRight": 2,
+                    "imagePaddingTop": 0,
+                    "imagePaddingBottom": 2,
+                    "metadataPaddingLeft": 2,
+                    "metadataPaddingRight": 1,
+                    "metadataPaddingTop": 0,
+                    "metadataPaddingBottom": 0,
+                    "metadataTopMargin": 0,
+                    "metadataLeftMargin": 0,
+                    "metadataRightMargin": 0,
+                    "metadataHeightAdjustment": 0,
+                    "metadataBottomAligned": false,
+                    "titleBottomMargin": 2,
+                    "tagRowHeight": 9,
+                    "tagRowSpacing": 0
+                },
+                "footer": {
+                    "bottomUnsafeHeight": 16
+                },
+                "surface": {
+                    "cornerRadius": 4
+                }
+            },
+            "gamesGrid": {
+                "header": {
+                    "titleInHeader": true,
+                    "hudBottomAligned": true,
+                    "statusPillPinnedTop": true
+                },
+                "status": {
+                    "topStripVisible": false,
+                    "stripHeight": 0,
+                    "slotMargin": "headerSideMargin",
+                    "topMargin": "pctH:1"
+                },
+                "grid": {
+                    "leftInset": 4,
+                    "rightInset": 0,
+                    "gutterWidth": 8,
+                    "gutterGap": 4,
+                    "columnGap": 4,
+                    "topInset": 2,
+                    "bottomInset": 4,
+                    "rowGap": 4,
+                    "scrollThumbWidth": 4,
+                    "scrollThumbRightInset": 2,
+                    "scrollThumbRightAligned": false,
+                    "scrollArrowSize": 8,
+                    "gutterFollowsContentWidth": true
+                },
+                "footer": {
+                    "activeLabelHeight": 8,
+                    "activeLabelBottomMargin": "pctH:6",
+                    "bottomStatusVisible": true,
+                    "bottomStatusLeftMargin": 4,
+                    "bottomStatusRightMargin": "pctW:5",
+                    "gridBottomMargin": "sum(pctH:6,8)",
+                    "bottomUnsafeHeight": 16
+                },
+                "surface": {
+                    "cornerRadius": 4
+                }
+            },
+            "gamesList": {
+                "header": {
+                    "titleInHeader": true,
+                    "hudBottomAligned": true,
+                    "statusPillPinnedTop": true
+                },
+                "status": {
+                    "topStripVisible": true,
+                    "stripHeight": 8,
+                    "slotMargin": "headerSideMargin",
+                    "topMargin": "pctH:1"
+                },
+                "list": {
+                    "contentAxis": "horizontal",
+                    "listShare": 2,
+                    "detailShare": 1,
+                    "dividerWidth": 1,
+                    "dividerMargin": -16,
+                    "cardSideMargin": 4,
+                    "cardTopMargin": "pctH:2",
+                    "cardBottomMargin": "pctH:8",
+                    "cardPaddingLeft": 3,
+                    "cardPaddingRight": 2,
+                    "cardPaddingTop": 3,
+                    "cardPaddingBottom": 2,
+                    "rowHeight": 12,
+                    "rowSpacing": 0,
+                    "centerSlot": 7,
+                    "scrollbarGap": 2,
+                    "selectionAccentWidth": 2,
+                    "rowTextLeftPadding": 4,
+                    "rowTextRightPadding": 2,
+                    "favoriteRightPadding": 2,
+                    "overlayBottomMargin": "pctH:14"
+                },
+                "detail": {
+                    "contentAxis": "vertical",
+                    "sectionGap": 2,
+                    "imageShare": 2,
+                    "metadataShare": 1,
+                    "imageHeightRatioWithTitle": 48,
+                    "imageReservedWidth": 16,
+                    "imageReservedHeight": 0,
+                    "imageBottomMargin": 2,
+                    "panePaddingLeft": 1,
+                    "panePaddingRight": 1,
+                    "panePaddingTop": 3,
+                    "panePaddingBottom": 2,
+                    "imagePaddingLeft": 2,
+                    "imagePaddingRight": 2,
+                    "imagePaddingTop": 0,
+                    "imagePaddingBottom": 2,
+                    "metadataPaddingLeft": 2,
+                    "metadataPaddingRight": 1,
+                    "metadataPaddingTop": 0,
+                    "metadataPaddingBottom": 0,
+                    "metadataTopMargin": -14,
+                    "metadataLeftMargin": 2,
+                    "metadataRightMargin": 1,
+                    "metadataHeightAdjustment": 2,
+                    "metadataBottomAligned": true,
+                    "titleBottomMargin": 2,
+                    "tagRowHeight": 9,
+                    "tagRowSpacing": 0
+                },
+                "footer": {
+                    "bottomUnsafeHeight": 16
+                },
+                "surface": {
+                    "cornerRadius": 4
+                }
+            },
+            "gamesListTate": {
+                "header": {
+                    "titleInHeader": true,
+                    "hudBottomAligned": true,
+                    "statusPillPinnedTop": true
+                },
+                "status": {
+                    "topStripVisible": true,
+                    "stripHeight": 8,
+                    "slotMargin": "headerSideMargin",
+                    "topMargin": "pctH:1"
+                },
+                "list": {
+                    "contentAxis": "vertical",
+                    "listShare": 9,
+                    "detailShare": 7,
+                    "dividerWidth": 1,
+                    "dividerMargin": 0,
+                    "cardSideMargin": 4,
+                    "cardTopMargin": "pctH:2",
+                    "cardBottomMargin": "pctH:8",
+                    "cardPaddingLeft": 3,
+                    "cardPaddingRight": 2,
+                    "cardPaddingTop": 3,
+                    "cardPaddingBottom": 2,
+                    "rowHeight": 12,
+                    "rowSpacing": 0,
+                    "centerSlot": 7,
+                    "scrollbarGap": 2,
+                    "selectionAccentWidth": 2,
+                    "rowTextLeftPadding": 4,
+                    "rowTextRightPadding": 2,
+                    "favoriteRightPadding": 2,
+                    "overlayBottomMargin": "pctH:14"
+                },
+                "detail": {
+                    "contentAxis": "horizontal",
+                    "sectionGap": 2,
+                    "imageShare": 5,
+                    "metadataShare": 7,
+                    "imageHeightRatioWithTitle": 48,
+                    "imageReservedWidth": 16,
+                    "imageReservedHeight": 0,
+                    "imageBottomMargin": 2,
+                    "panePaddingLeft": 1,
+                    "panePaddingRight": 1,
+                    "panePaddingTop": 3,
+                    "panePaddingBottom": 2,
+                    "imagePaddingLeft": 2,
+                    "imagePaddingRight": 2,
+                    "imagePaddingTop": 0,
+                    "imagePaddingBottom": 2,
+                    "metadataPaddingLeft": 2,
+                    "metadataPaddingRight": 1,
+                    "metadataPaddingTop": 0,
+                    "metadataPaddingBottom": 0,
+                    "metadataTopMargin": 0,
+                    "metadataLeftMargin": 0,
+                    "metadataRightMargin": 0,
+                    "metadataHeightAdjustment": 0,
+                    "metadataBottomAligned": false,
+                    "titleBottomMargin": 2,
+                    "tagRowHeight": 9,
+                    "tagRowSpacing": 0
+                },
+                "footer": {
+                    "bottomUnsafeHeight": 16
+                },
+                "surface": {
+                    "cornerRadius": 4
+                }
+            }
+        }
+    })
+
+    function currentProfile(viewId: string): var {
+        return BrowseLayouts.themeProfile(BrowseLayouts.currentThemeId, viewId);
     }
 
-    readonly property QtObject crtTile: QtObject {
-        readonly property bool showTopStrip: false
-        readonly property bool showHeaderTitleInHeader: true
-        readonly property bool showBottomStatusRow: true
-        readonly property bool headerHudBottomAligned: true
-        readonly property bool headerStatusPillPinnedTop: true
-        readonly property int gridLeftInset: 4
-        readonly property int gridRightInset: 0
-        readonly property int gridGutterWidth: 8
-        readonly property int gridGutterGap: 4
-        readonly property int gridColumnGap: 4
-        readonly property int gridTopInset: 2
-        readonly property int gridBottomInset: 4
-        readonly property int gridRowGap: 4
-        readonly property int scrollThumbWidth: 4
-        readonly property int scrollThumbRightInset: 2
-        readonly property bool scrollThumbRightAligned: false
-        readonly property int scrollArrowSize: 8
-        readonly property bool packHorizontalRemainderAfterGutter: true
-        readonly property int activeLabelHeight: 8
-        readonly property int activeLabelBottomMargin: Sizing.pctH(6)
-        readonly property int bottomStatusLeftMargin: 4
-        readonly property int bottomStatusRightMargin: Sizing.pctW(5)
-        readonly property int bottomUnsafeHeight: 16
-        readonly property int tileCornerRadius: 4
-        readonly property int listCardSideMargin: 4
-        readonly property int listDividerOffsetX: -16
-        readonly property int listStripHeight: 8
-        readonly property int listStripSlotMargin: Sizing.headerSideMargin
-        readonly property int listCardPaddingLeft: 3
-        readonly property int listCardPaddingRight: 2
-        readonly property int listCardPaddingTop: 3
-        readonly property int listCardPaddingBottom: 2
-        readonly property int listRowHeight: 12
-        readonly property int listRowSpacing: 0
-        readonly property int listCenterSlot: 7
-        readonly property int listScrollbarGap: 2
-        readonly property int listSelectionAccentWidth: 2
-        readonly property int detailMetadataYOffset: -14
-        readonly property int detailMetadataExtraHeight: 2
-        readonly property int detailMetadataLeftInset: 2
-        readonly property int detailMetadataRightInset: 1
-        readonly property int detailPanePaddingLeft: 1
-        readonly property int detailPanePaddingRight: 1
-        readonly property int detailPanePaddingTop: 3
-        readonly property int detailPanePaddingBottom: 2
-        readonly property int detailImageXOffset: 0
-        readonly property int detailImageLeftInset: 2
-        readonly property int detailImageRightInset: 2
-        readonly property int detailImageExtraWidth: 16
-        readonly property int detailImageExtraHeight: 0
-        readonly property int detailImageBottomGap: 2
-        readonly property int detailTagRowHeight: 9
-        readonly property int detailTagRowSpacing: 0
-        readonly property int listRowTextLeftPadding: 4
-        readonly property int listRowTextRightPadding: 2
-        readonly property int listFavoriteRightPadding: 2
+    function themeProfile(themeId: string, viewId: string): var {
+        const theme = BrowseLayouts._themes[themeId];
+        if (theme === undefined || theme === null || !(viewId in theme))
+            return null;
+        return BrowseLayouts._resolveValue(theme, theme[viewId], {});
+    }
+
+    function boolValue(profile: var, path: string, fallback: bool): bool {
+        const value = BrowseLayouts._lookup(profile, path);
+        return typeof value === "boolean" ? value : fallback;
+    }
+
+    function numberValue(profile: var, path: string, fallback: int): int {
+        const value = BrowseLayouts._lookup(profile, path);
+        return typeof value === "number" && isFinite(value) ? value : fallback;
+    }
+
+    function stringValue(profile: var, path: string, fallback: string): string {
+        const value = BrowseLayouts._lookup(profile, path);
+        return typeof value === "string" ? value : fallback;
+    }
+
+    function _lookup(object: var, path: string): var {
+        if (object === null || typeof object !== "object" || path === "")
+            return undefined;
+        const parts = path.split(".");
+        let current = object;
+        for (let i = 0; i < parts.length; i++) {
+            if (current === null || typeof current !== "object" || !(parts[i] in current))
+                return undefined;
+            current = current[parts[i]];
+        }
+        return current;
+    }
+
+    function _resolveValue(theme: var, value: var, seenRefs: var): var {
+        if (value === null || value === undefined)
+            return value;
+        if (Array.isArray(value))
+            return value.map(entry => BrowseLayouts._resolveValue(theme, entry, seenRefs));
+        if (typeof value === "object") {
+            const out = {};
+            for (const key in value)
+                out[key] = BrowseLayouts._resolveValue(theme, value[key], seenRefs);
+            return out;
+        }
+        if (typeof value !== "string")
+            return value;
+
+        if (value.startsWith("pctW:"))
+            return Sizing.pctW(Number(value.substring("pctW:".length)));
+        if (value.startsWith("pctH:"))
+            return Sizing.pctH(Number(value.substring("pctH:".length)));
+        if (value.startsWith("fontSize:"))
+            return Sizing.fontSize(Number(value.substring("fontSize:".length)));
+        if (value === "cornerRadius")
+            return Sizing.cornerRadius;
+        if (value === "headerSideMargin")
+            return Sizing.headerSideMargin;
+        if (value.startsWith("ref:")) {
+            const refPath = value.substring("ref:".length);
+            if (seenRefs[refPath] === true)
+                return undefined;
+            const nextSeen = Object.assign({}, seenRefs);
+            nextSeen[refPath] = true;
+            return BrowseLayouts._resolveValue(theme, BrowseLayouts._lookup(theme, refPath), nextSeen);
+        }
+
+        const fnMatch = value.match(/^([a-z]+)\((.*)\)$/);
+        if (fnMatch !== null) {
+            const fnName = fnMatch[1];
+            const args = BrowseLayouts._splitArgs(fnMatch[2]).map(arg => BrowseLayouts._resolveValue(theme, arg, seenRefs));
+            if (fnName === "min" && args.length === 2)
+                return Math.min(args[0], args[1]);
+            if (fnName === "max" && args.length === 2)
+                return Math.max(args[0], args[1]);
+            if (fnName === "sum")
+                return args.reduce((total, entry) => total + entry, 0);
+        }
+
+        const numeric = Number(value);
+        if (!isNaN(numeric))
+            return numeric;
+        return value;
+    }
+
+    function _splitArgs(text: string): var {
+        const parts = [];
+        let start = 0;
+        let depth = 0;
+        for (let i = 0; i < text.length; i++) {
+            const ch = text[i];
+            if (ch === "(")
+                depth++;
+            else if (ch === ")")
+                depth--;
+            else if (ch === "," && depth === 0) {
+                parts.push(text.substring(start, i).trim());
+                start = i + 1;
+            }
+        }
+        parts.push(text.substring(start).trim());
+        return parts;
     }
 }

--- a/src/ui/theme/browse-profiles/crt.json
+++ b/src/ui/theme/browse-profiles/crt.json
@@ -1,0 +1,370 @@
+{
+  "systemsGrid": {
+    "header": {
+      "titleInHeader": true,
+      "hudBottomAligned": true,
+      "statusPillPinnedTop": true
+    },
+    "status": {
+      "topStripVisible": false,
+      "stripHeight": 0,
+      "slotMargin": "headerSideMargin",
+      "topMargin": "pctH:1"
+    },
+    "grid": {
+      "leftInset": 4,
+      "rightInset": 0,
+      "gutterWidth": 8,
+      "gutterGap": 4,
+      "columnGap": 4,
+      "topInset": 2,
+      "bottomInset": 4,
+      "rowGap": 4,
+      "scrollThumbWidth": 4,
+      "scrollThumbRightInset": 2,
+      "scrollThumbRightAligned": false,
+      "scrollArrowSize": 8,
+      "gutterFollowsContentWidth": true
+    },
+    "footer": {
+      "activeLabelHeight": 8,
+      "activeLabelBottomMargin": "pctH:6",
+      "bottomStatusVisible": true,
+      "bottomStatusLeftMargin": 4,
+      "bottomStatusRightMargin": "pctW:5",
+      "gridBottomMargin": "sum(pctH:6,8)",
+      "bottomUnsafeHeight": 16
+    },
+    "surface": {
+      "cornerRadius": 4
+    }
+  },
+  "systemsList": {
+    "header": {
+      "titleInHeader": true,
+      "hudBottomAligned": true,
+      "statusPillPinnedTop": true
+    },
+    "status": {
+      "topStripVisible": true,
+      "stripHeight": 8,
+      "slotMargin": "headerSideMargin",
+      "topMargin": "pctH:1"
+    },
+    "list": {
+      "contentAxis": "horizontal",
+      "listShare": 2,
+      "detailShare": 1,
+      "dividerWidth": 1,
+      "dividerMargin": -16,
+      "cardSideMargin": 4,
+      "cardTopMargin": "pctH:2",
+      "cardBottomMargin": "pctH:8",
+      "cardPaddingLeft": 3,
+      "cardPaddingRight": 2,
+      "cardPaddingTop": 3,
+      "cardPaddingBottom": 2,
+      "rowHeight": 12,
+      "rowSpacing": 0,
+      "centerSlot": 7,
+      "scrollbarGap": 2,
+      "selectionAccentWidth": 2,
+      "rowTextLeftPadding": 4,
+      "rowTextRightPadding": 2,
+      "favoriteRightPadding": 2,
+      "overlayBottomMargin": "pctH:14"
+    },
+    "detail": {
+      "contentAxis": "vertical",
+      "sectionGap": 2,
+      "imageShare": 58,
+      "metadataShare": 42,
+      "imageHeightRatioWithTitle": 48,
+      "imageReservedWidth": 16,
+      "imageReservedHeight": 0,
+      "imageBottomMargin": 2,
+      "panePaddingLeft": 1,
+      "panePaddingRight": 1,
+      "panePaddingTop": 3,
+      "panePaddingBottom": 2,
+      "imagePaddingLeft": 2,
+      "imagePaddingRight": 2,
+      "imagePaddingTop": 0,
+      "imagePaddingBottom": 2,
+      "metadataPaddingLeft": 2,
+      "metadataPaddingRight": 1,
+      "metadataPaddingTop": 0,
+      "metadataPaddingBottom": 0,
+      "metadataTopMargin": -14,
+      "metadataLeftMargin": 2,
+      "metadataRightMargin": 1,
+      "metadataHeightAdjustment": 2,
+      "metadataBottomAligned": false,
+      "titleBottomMargin": 2,
+      "tagRowHeight": 9,
+      "tagRowSpacing": 0
+    },
+    "footer": {
+      "bottomUnsafeHeight": 16
+    },
+    "surface": {
+      "cornerRadius": 4
+    }
+  },
+  "systemsListTate": {
+    "header": {
+      "titleInHeader": true,
+      "hudBottomAligned": true,
+      "statusPillPinnedTop": true
+    },
+    "status": {
+      "topStripVisible": true,
+      "stripHeight": 8,
+      "slotMargin": "headerSideMargin",
+      "topMargin": "pctH:1"
+    },
+    "list": {
+      "contentAxis": "vertical",
+      "listShare": 9,
+      "detailShare": 7,
+      "dividerWidth": 1,
+      "dividerMargin": 0,
+      "cardSideMargin": 4,
+      "cardTopMargin": "pctH:2",
+      "cardBottomMargin": "pctH:8",
+      "cardPaddingLeft": 3,
+      "cardPaddingRight": 2,
+      "cardPaddingTop": 3,
+      "cardPaddingBottom": 2,
+      "rowHeight": 12,
+      "rowSpacing": 0,
+      "centerSlot": 7,
+      "scrollbarGap": 2,
+      "selectionAccentWidth": 2,
+      "rowTextLeftPadding": 4,
+      "rowTextRightPadding": 2,
+      "favoriteRightPadding": 2,
+      "overlayBottomMargin": "pctH:14"
+    },
+    "detail": {
+      "contentAxis": "horizontal",
+      "sectionGap": 2,
+      "imageShare": 5,
+      "metadataShare": 7,
+      "imageHeightRatioWithTitle": 48,
+      "imageReservedWidth": 16,
+      "imageReservedHeight": 0,
+      "imageBottomMargin": 2,
+      "panePaddingLeft": 1,
+      "panePaddingRight": 1,
+      "panePaddingTop": 3,
+      "panePaddingBottom": 2,
+      "imagePaddingLeft": 2,
+      "imagePaddingRight": 2,
+      "imagePaddingTop": 0,
+      "imagePaddingBottom": 2,
+      "metadataPaddingLeft": 2,
+      "metadataPaddingRight": 1,
+      "metadataPaddingTop": 0,
+      "metadataPaddingBottom": 0,
+      "metadataTopMargin": 0,
+      "metadataLeftMargin": 0,
+      "metadataRightMargin": 0,
+      "metadataHeightAdjustment": 0,
+      "metadataBottomAligned": false,
+      "titleBottomMargin": 2,
+      "tagRowHeight": 9,
+      "tagRowSpacing": 0
+    },
+    "footer": {
+      "bottomUnsafeHeight": 16
+    },
+    "surface": {
+      "cornerRadius": 4
+    }
+  },
+  "gamesGrid": {
+    "header": {
+      "titleInHeader": true,
+      "hudBottomAligned": true,
+      "statusPillPinnedTop": true
+    },
+    "status": {
+      "topStripVisible": false,
+      "stripHeight": 0,
+      "slotMargin": "headerSideMargin",
+      "topMargin": "pctH:1"
+    },
+    "grid": {
+      "leftInset": 4,
+      "rightInset": 0,
+      "gutterWidth": 8,
+      "gutterGap": 4,
+      "columnGap": 4,
+      "topInset": 2,
+      "bottomInset": 4,
+      "rowGap": 4,
+      "scrollThumbWidth": 4,
+      "scrollThumbRightInset": 2,
+      "scrollThumbRightAligned": false,
+      "scrollArrowSize": 8,
+      "gutterFollowsContentWidth": true
+    },
+    "footer": {
+      "activeLabelHeight": 8,
+      "activeLabelBottomMargin": "pctH:6",
+      "bottomStatusVisible": true,
+      "bottomStatusLeftMargin": 4,
+      "bottomStatusRightMargin": "pctW:5",
+      "gridBottomMargin": "sum(pctH:6,8)",
+      "bottomUnsafeHeight": 16
+    },
+    "surface": {
+      "cornerRadius": 4
+    }
+  },
+  "gamesList": {
+    "header": {
+      "titleInHeader": true,
+      "hudBottomAligned": true,
+      "statusPillPinnedTop": true
+    },
+    "status": {
+      "topStripVisible": true,
+      "stripHeight": 8,
+      "slotMargin": "headerSideMargin",
+      "topMargin": "pctH:1"
+    },
+    "list": {
+      "contentAxis": "horizontal",
+      "listShare": 2,
+      "detailShare": 1,
+      "dividerWidth": 1,
+      "dividerMargin": -16,
+      "cardSideMargin": 4,
+      "cardTopMargin": "pctH:2",
+      "cardBottomMargin": "pctH:8",
+      "cardPaddingLeft": 3,
+      "cardPaddingRight": 2,
+      "cardPaddingTop": 3,
+      "cardPaddingBottom": 2,
+      "rowHeight": 12,
+      "rowSpacing": 0,
+      "centerSlot": 7,
+      "scrollbarGap": 2,
+      "selectionAccentWidth": 2,
+      "rowTextLeftPadding": 4,
+      "rowTextRightPadding": 2,
+      "favoriteRightPadding": 2,
+      "overlayBottomMargin": "pctH:14"
+    },
+    "detail": {
+      "contentAxis": "vertical",
+      "sectionGap": 2,
+      "imageShare": 62,
+      "metadataShare": 38,
+      "imageHeightRatioWithTitle": 48,
+      "imageReservedWidth": 16,
+      "imageReservedHeight": 0,
+      "imageBottomMargin": 2,
+      "panePaddingLeft": 1,
+      "panePaddingRight": 1,
+      "panePaddingTop": 3,
+      "panePaddingBottom": 2,
+      "imagePaddingLeft": 2,
+      "imagePaddingRight": 2,
+      "imagePaddingTop": 0,
+      "imagePaddingBottom": 2,
+      "metadataPaddingLeft": 2,
+      "metadataPaddingRight": 1,
+      "metadataPaddingTop": 0,
+      "metadataPaddingBottom": 0,
+      "metadataTopMargin": -14,
+      "metadataLeftMargin": 2,
+      "metadataRightMargin": 1,
+      "metadataHeightAdjustment": 2,
+      "metadataBottomAligned": true,
+      "titleBottomMargin": 2,
+      "tagRowHeight": 9,
+      "tagRowSpacing": 0
+    },
+    "footer": {
+      "bottomUnsafeHeight": 16
+    },
+    "surface": {
+      "cornerRadius": 4
+    }
+  },
+  "gamesListTate": {
+    "header": {
+      "titleInHeader": true,
+      "hudBottomAligned": true,
+      "statusPillPinnedTop": true
+    },
+    "status": {
+      "topStripVisible": true,
+      "stripHeight": 8,
+      "slotMargin": "headerSideMargin",
+      "topMargin": "pctH:1"
+    },
+    "list": {
+      "contentAxis": "vertical",
+      "listShare": 9,
+      "detailShare": 7,
+      "dividerWidth": 1,
+      "dividerMargin": 0,
+      "cardSideMargin": 4,
+      "cardTopMargin": "pctH:2",
+      "cardBottomMargin": "pctH:8",
+      "cardPaddingLeft": 3,
+      "cardPaddingRight": 2,
+      "cardPaddingTop": 3,
+      "cardPaddingBottom": 2,
+      "rowHeight": 12,
+      "rowSpacing": 0,
+      "centerSlot": 7,
+      "scrollbarGap": 2,
+      "selectionAccentWidth": 2,
+      "rowTextLeftPadding": 4,
+      "rowTextRightPadding": 2,
+      "favoriteRightPadding": 2,
+      "overlayBottomMargin": "pctH:14"
+    },
+    "detail": {
+      "contentAxis": "horizontal",
+      "sectionGap": 2,
+      "imageShare": 5,
+      "metadataShare": 7,
+      "imageHeightRatioWithTitle": 48,
+      "imageReservedWidth": 16,
+      "imageReservedHeight": 0,
+      "imageBottomMargin": 2,
+      "panePaddingLeft": 1,
+      "panePaddingRight": 1,
+      "panePaddingTop": 3,
+      "panePaddingBottom": 2,
+      "imagePaddingLeft": 2,
+      "imagePaddingRight": 2,
+      "imagePaddingTop": 0,
+      "imagePaddingBottom": 2,
+      "metadataPaddingLeft": 2,
+      "metadataPaddingRight": 1,
+      "metadataPaddingTop": 0,
+      "metadataPaddingBottom": 0,
+      "metadataTopMargin": 0,
+      "metadataLeftMargin": 0,
+      "metadataRightMargin": 0,
+      "metadataHeightAdjustment": 0,
+      "metadataBottomAligned": false,
+      "titleBottomMargin": 2,
+      "tagRowHeight": 9,
+      "tagRowSpacing": 0
+    },
+    "footer": {
+      "bottomUnsafeHeight": 16
+    },
+    "surface": {
+      "cornerRadius": 4
+    }
+  }
+}

--- a/src/ui/theme/browse-profiles/default.json
+++ b/src/ui/theme/browse-profiles/default.json
@@ -1,0 +1,370 @@
+{
+  "systemsGrid": {
+    "header": {
+      "titleInHeader": false,
+      "hudBottomAligned": false,
+      "statusPillPinnedTop": false
+    },
+    "status": {
+      "topStripVisible": true,
+      "stripHeight": "pctH:7",
+      "slotMargin": "pctW:5",
+      "topMargin": "pctH:1"
+    },
+    "grid": {
+      "leftInset": "pctW:5",
+      "rightInset": "pctW:5",
+      "gutterWidth": "pctW:3",
+      "gutterGap": "pctW:1.5",
+      "columnGap": "pctW:3",
+      "topInset": "pctH:2",
+      "bottomInset": "pctH:2",
+      "rowGap": "pctH:4",
+      "scrollThumbWidth": "pctW:1.2",
+      "scrollThumbRightInset": 0,
+      "scrollThumbRightAligned": false,
+      "scrollArrowSize": "min(pctW:3,pctH:4)",
+      "gutterFollowsContentWidth": false
+    },
+    "footer": {
+      "activeLabelHeight": "pctH:7",
+      "activeLabelBottomMargin": "pctH:8",
+      "bottomStatusVisible": false,
+      "bottomStatusLeftMargin": "pctW:5",
+      "bottomStatusRightMargin": "pctW:5",
+      "gridBottomMargin": "sum(pctH:6,pctH:8,pctH:7)",
+      "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
+    },
+    "surface": {
+      "cornerRadius": "cornerRadius"
+    }
+  },
+  "systemsList": {
+    "header": {
+      "titleInHeader": false,
+      "hudBottomAligned": false,
+      "statusPillPinnedTop": false
+    },
+    "status": {
+      "topStripVisible": true,
+      "stripHeight": "pctH:7",
+      "slotMargin": "pctW:5",
+      "topMargin": "pctH:1"
+    },
+    "list": {
+      "contentAxis": "horizontal",
+      "listShare": 2,
+      "detailShare": 1,
+      "dividerWidth": 1,
+      "dividerMargin": 0,
+      "cardSideMargin": "pctW:5",
+      "cardTopMargin": "pctH:2",
+      "cardBottomMargin": "pctH:8",
+      "cardPaddingLeft": "pctW:2",
+      "cardPaddingRight": "pctW:2",
+      "cardPaddingTop": "pctH:2",
+      "cardPaddingBottom": "pctH:2",
+      "rowHeight": 0,
+      "rowSpacing": "pctH:0.7",
+      "centerSlot": -1,
+      "scrollbarGap": "pctW:1.5",
+      "selectionAccentWidth": "pctW:0.45",
+      "rowTextLeftPadding": "pctW:1.6",
+      "rowTextRightPadding": "pctW:1.6",
+      "favoriteRightPadding": "pctW:1.6",
+      "overlayBottomMargin": "pctH:15"
+    },
+    "detail": {
+      "contentAxis": "vertical",
+      "sectionGap": "pctH:2",
+      "imageShare": 48,
+      "metadataShare": 52,
+      "imageHeightRatioWithTitle": 48,
+      "imageReservedWidth": 0,
+      "imageReservedHeight": 0,
+      "imageBottomMargin": 0,
+      "panePaddingLeft": "pctW:2",
+      "panePaddingRight": "pctW:2",
+      "panePaddingTop": "pctH:2",
+      "panePaddingBottom": "pctH:2",
+      "imagePaddingLeft": 0,
+      "imagePaddingRight": 0,
+      "imagePaddingTop": 0,
+      "imagePaddingBottom": 0,
+      "metadataPaddingLeft": 0,
+      "metadataPaddingRight": 0,
+      "metadataPaddingTop": 0,
+      "metadataPaddingBottom": 0,
+      "metadataTopMargin": 0,
+      "metadataLeftMargin": 0,
+      "metadataRightMargin": 0,
+      "metadataHeightAdjustment": 0,
+      "metadataBottomAligned": false,
+      "titleBottomMargin": "pctH:2",
+      "tagRowHeight": "pctH:3",
+      "tagRowSpacing": "pctH:0.55"
+    },
+    "footer": {
+      "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
+    },
+    "surface": {
+      "cornerRadius": "cornerRadius"
+    }
+  },
+  "systemsListTate": {
+    "header": {
+      "titleInHeader": false,
+      "hudBottomAligned": false,
+      "statusPillPinnedTop": false
+    },
+    "status": {
+      "topStripVisible": true,
+      "stripHeight": "pctH:7",
+      "slotMargin": "pctW:5",
+      "topMargin": "pctH:1"
+    },
+    "list": {
+      "contentAxis": "vertical",
+      "listShare": 9,
+      "detailShare": 7,
+      "dividerWidth": 1,
+      "dividerMargin": 0,
+      "cardSideMargin": "pctW:5",
+      "cardTopMargin": "pctH:2",
+      "cardBottomMargin": "pctH:8",
+      "cardPaddingLeft": "pctW:2",
+      "cardPaddingRight": "pctW:2",
+      "cardPaddingTop": "pctH:2",
+      "cardPaddingBottom": "pctH:2",
+      "rowHeight": 0,
+      "rowSpacing": "pctH:0.3",
+      "centerSlot": -1,
+      "scrollbarGap": "pctW:1.5",
+      "selectionAccentWidth": "pctW:0.45",
+      "rowTextLeftPadding": "pctW:1.6",
+      "rowTextRightPadding": "pctW:1.6",
+      "favoriteRightPadding": "pctW:1.6",
+      "overlayBottomMargin": "pctH:15"
+    },
+    "detail": {
+      "contentAxis": "horizontal",
+      "sectionGap": "pctW:2",
+      "imageShare": 5,
+      "metadataShare": 7,
+      "imageHeightRatioWithTitle": 48,
+      "imageReservedWidth": 0,
+      "imageReservedHeight": 0,
+      "imageBottomMargin": 0,
+      "panePaddingLeft": "pctW:2",
+      "panePaddingRight": "pctW:2",
+      "panePaddingTop": "pctH:2",
+      "panePaddingBottom": "pctH:2",
+      "imagePaddingLeft": 0,
+      "imagePaddingRight": 0,
+      "imagePaddingTop": 0,
+      "imagePaddingBottom": 0,
+      "metadataPaddingLeft": 0,
+      "metadataPaddingRight": 0,
+      "metadataPaddingTop": 0,
+      "metadataPaddingBottom": 0,
+      "metadataTopMargin": 0,
+      "metadataLeftMargin": 0,
+      "metadataRightMargin": 0,
+      "metadataHeightAdjustment": 0,
+      "metadataBottomAligned": false,
+      "titleBottomMargin": "pctH:2",
+      "tagRowHeight": "pctH:3",
+      "tagRowSpacing": "pctH:0.55"
+    },
+    "footer": {
+      "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
+    },
+    "surface": {
+      "cornerRadius": "cornerRadius"
+    }
+  },
+  "gamesGrid": {
+    "header": {
+      "titleInHeader": false,
+      "hudBottomAligned": false,
+      "statusPillPinnedTop": false
+    },
+    "status": {
+      "topStripVisible": true,
+      "stripHeight": "pctH:7",
+      "slotMargin": "pctW:5",
+      "topMargin": "pctH:1"
+    },
+    "grid": {
+      "leftInset": "pctW:5",
+      "rightInset": "pctW:5",
+      "gutterWidth": "pctW:3",
+      "gutterGap": "pctW:1.5",
+      "columnGap": "pctW:3",
+      "topInset": "pctH:2",
+      "bottomInset": "pctH:2",
+      "rowGap": "pctH:4",
+      "scrollThumbWidth": "pctW:1.2",
+      "scrollThumbRightInset": 0,
+      "scrollThumbRightAligned": false,
+      "scrollArrowSize": "min(pctW:3,pctH:4)",
+      "gutterFollowsContentWidth": false
+    },
+    "footer": {
+      "activeLabelHeight": "pctH:7",
+      "activeLabelBottomMargin": "pctH:8",
+      "bottomStatusVisible": false,
+      "bottomStatusLeftMargin": "pctW:5",
+      "bottomStatusRightMargin": "pctW:5",
+      "gridBottomMargin": "sum(pctH:6,pctH:8,pctH:7)",
+      "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
+    },
+    "surface": {
+      "cornerRadius": "cornerRadius"
+    }
+  },
+  "gamesList": {
+    "header": {
+      "titleInHeader": false,
+      "hudBottomAligned": false,
+      "statusPillPinnedTop": false
+    },
+    "status": {
+      "topStripVisible": true,
+      "stripHeight": "pctH:7",
+      "slotMargin": "pctW:5",
+      "topMargin": "pctH:1"
+    },
+    "list": {
+      "contentAxis": "horizontal",
+      "listShare": 2,
+      "detailShare": 1,
+      "dividerWidth": 1,
+      "dividerMargin": 0,
+      "cardSideMargin": "pctW:5",
+      "cardTopMargin": "pctH:2",
+      "cardBottomMargin": "pctH:8",
+      "cardPaddingLeft": "pctW:2",
+      "cardPaddingRight": "pctW:2",
+      "cardPaddingTop": "pctH:2",
+      "cardPaddingBottom": "pctH:2",
+      "rowHeight": 0,
+      "rowSpacing": "pctH:0.7",
+      "centerSlot": -1,
+      "scrollbarGap": "pctW:1.5",
+      "selectionAccentWidth": "pctW:0.45",
+      "rowTextLeftPadding": "pctW:1.6",
+      "rowTextRightPadding": "pctW:1.6",
+      "favoriteRightPadding": "pctW:1.6",
+      "overlayBottomMargin": "pctH:15"
+    },
+    "detail": {
+      "contentAxis": "vertical",
+      "sectionGap": "pctH:2",
+      "imageShare": 62,
+      "metadataShare": 38,
+      "imageHeightRatioWithTitle": 48,
+      "imageReservedWidth": 0,
+      "imageReservedHeight": 0,
+      "imageBottomMargin": 0,
+      "panePaddingLeft": "pctW:2",
+      "panePaddingRight": "pctW:2",
+      "panePaddingTop": "pctH:2",
+      "panePaddingBottom": "pctH:2",
+      "imagePaddingLeft": 0,
+      "imagePaddingRight": 0,
+      "imagePaddingTop": 0,
+      "imagePaddingBottom": 0,
+      "metadataPaddingLeft": 0,
+      "metadataPaddingRight": 0,
+      "metadataPaddingTop": 0,
+      "metadataPaddingBottom": 0,
+      "metadataTopMargin": 0,
+      "metadataLeftMargin": 0,
+      "metadataRightMargin": 0,
+      "metadataHeightAdjustment": 0,
+      "metadataBottomAligned": true,
+      "titleBottomMargin": "pctH:2",
+      "tagRowHeight": "pctH:3",
+      "tagRowSpacing": "pctH:0.55"
+    },
+    "footer": {
+      "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
+    },
+    "surface": {
+      "cornerRadius": "cornerRadius"
+    }
+  },
+  "gamesListTate": {
+    "header": {
+      "titleInHeader": false,
+      "hudBottomAligned": false,
+      "statusPillPinnedTop": false
+    },
+    "status": {
+      "topStripVisible": true,
+      "stripHeight": "pctH:7",
+      "slotMargin": "pctW:5",
+      "topMargin": "pctH:1"
+    },
+    "list": {
+      "contentAxis": "vertical",
+      "listShare": 9,
+      "detailShare": 7,
+      "dividerWidth": 1,
+      "dividerMargin": 0,
+      "cardSideMargin": "pctW:5",
+      "cardTopMargin": "pctH:2",
+      "cardBottomMargin": "pctH:8",
+      "cardPaddingLeft": "pctW:2",
+      "cardPaddingRight": "pctW:2",
+      "cardPaddingTop": "pctH:2",
+      "cardPaddingBottom": "pctH:2",
+      "rowHeight": 0,
+      "rowSpacing": "pctH:0.3",
+      "centerSlot": -1,
+      "scrollbarGap": "pctW:1.5",
+      "selectionAccentWidth": "pctW:0.45",
+      "rowTextLeftPadding": "pctW:1.6",
+      "rowTextRightPadding": "pctW:1.6",
+      "favoriteRightPadding": "pctW:1.6",
+      "overlayBottomMargin": "pctH:15"
+    },
+    "detail": {
+      "contentAxis": "horizontal",
+      "sectionGap": "pctW:2",
+      "imageShare": 5,
+      "metadataShare": 7,
+      "imageHeightRatioWithTitle": 48,
+      "imageReservedWidth": 0,
+      "imageReservedHeight": 0,
+      "imageBottomMargin": 0,
+      "panePaddingLeft": "pctW:2",
+      "panePaddingRight": "pctW:2",
+      "panePaddingTop": "pctH:2",
+      "panePaddingBottom": "pctH:2",
+      "imagePaddingLeft": 0,
+      "imagePaddingRight": 0,
+      "imagePaddingTop": 0,
+      "imagePaddingBottom": 0,
+      "metadataPaddingLeft": 0,
+      "metadataPaddingRight": 0,
+      "metadataPaddingTop": 0,
+      "metadataPaddingBottom": 0,
+      "metadataTopMargin": 0,
+      "metadataLeftMargin": 0,
+      "metadataRightMargin": 0,
+      "metadataHeightAdjustment": 0,
+      "metadataBottomAligned": false,
+      "titleBottomMargin": "pctH:2",
+      "tagRowHeight": "pctH:3",
+      "tagRowSpacing": "pctH:0.55"
+    },
+    "footer": {
+      "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
+    },
+    "surface": {
+      "cornerRadius": "cornerRadius"
+    }
+  }
+}

--- a/tests/ui/tst_browse_layout_profiles.qml
+++ b/tests/ui/tst_browse_layout_profiles.qml
@@ -45,8 +45,8 @@ TestCase {
         main.crtNativePath = true;
         Browse.Settings.current_browse_layout = "grid";
 
-        compare(main.headerBar.layoutProfile.showHeaderTitleInHeader, true);
-        compare(main.systemsScreen.systemsGrid.layoutProfile.tileCornerRadius, 4);
+        compare(main.headerBar.layoutProfile.header.titleInHeader, true);
+        compare(main.systemsScreen.systemsGrid.layoutProfile.surface.cornerRadius, 4);
         compare(main.systemsScreen.systemsGrid.leftInset, 4);
         compare(main.systemsScreen.systemsGrid.gutterWidth, 8);
         compare(main.systemsScreen.systemsGrid.scrollArrowSize, 8);
@@ -56,9 +56,9 @@ TestCase {
         main.crtNativePath = true;
         Browse.Settings.current_browse_layout = "list";
 
-        compare(main.headerBar.layoutProfile.showHeaderTitleInHeader, true);
-        compare(main.systemsScreen.systemsGrid.layoutProfile.tileCornerRadius, 4);
-        compare(main.systemsScreen.systemsGrid.leftInset, 4);
-        compare(main.systemsScreen.systemsGrid.gutterWidth, 8);
+        compare(main.headerBar.layoutProfile.header.titleInHeader, true);
+        compare(main.systemsScreen.listCard.layoutProfile.surface.cornerRadius, 4);
+        compare(main.systemsScreen.listCard.layoutProfile.list.rowHeight, 12);
+        compare(main.systemsScreen.listCard.layoutProfile.list.scrollbarGap, 2);
     }
 }


### PR DESCRIPTION
<!-- Thanks for the pull request. Please fill this out before requesting review. -->

## Summary

replace #156 
close #152 

<!-- What changed, and why? One or two sentences is usually enough. -->

## Motivation

<!-- Link the issue or discussion that led to this. Delete this section if it does not apply. -->

## Screenshots / recordings

<!-- Required for visual changes. Include the FPS counter at 720p and, if possible, 240p. -->

## Test plan

<!-- How did you verify this? Manual steps and automated tests are both fine. -->

## Checklist

- [ ] `just lint` is green (zero warnings)
- [ ] `just test` passes
- [ ] If this touches QML, the FPS counter stays green (≥ 55) at 720p+ and ≥ 30 at 240p
- [ ] If this could affect the MiSTer build, I considered ARM32 implications (see `docs/architecture.md`)
- [ ] If this adds user-visible strings, they are wrapped in `qsTr()` (QML) or `tr()` (C++)
- [ ] I have signed the [CLA](../.github/CLA.md) (first-time contributors only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * macOS frontend can be launched in CRT preview mode via a new CRT flag.
  * Theme/profile-driven browse themes added (default and CRT) for flexible view variants.

* **Refactor**
  * Layout system redesigned to use dynamic, tokenized profiles for responsive rendering across browse screens, lists, tiles, detail panes, headers, and grids.

* **Tests**
  * UI tests updated to validate the new profile-based layout behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ZaparooProject/zaparoo-frontend/pull/170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->