### PR TITLE
Sync media browse with Core updates

### DIFF
--- a/rust/frontend/src/media_image_cache.rs
+++ b/rust/frontend/src/media_image_cache.rs
@@ -123,7 +123,7 @@ const CORE_DEFAULT_IMAGE_TYPES: &[&str] = &[
 const COVER_PREF_PREFIX: &str = "__pref:";
 
 fn current_cover_preference_marker() -> Option<Arc<str>> {
-    let value = crate::models::with_persist_read(|s| s.settings.media_image_type.clone());
+    let value = crate::models::try_with_persist_read(|s| s.settings.media_image_type.clone())?;
     let trimmed = value.trim();
     if trimmed.is_empty() || trimmed == "auto" {
         return None;

--- a/rust/frontend/src/media_image_cache.rs
+++ b/rust/frontend/src/media_image_cache.rs
@@ -108,6 +108,39 @@ const SUPPORTED_EXTS: &[(&str, &str)] = &[
 ];
 
 const SUPPORTED_PLAIN_EXTS: &[&str] = &["png", "jpg", "jpeg", "webp"];
+const CORE_DEFAULT_IMAGE_TYPES: &[&str] = &[
+    "image",
+    "thumbnail",
+    "boxart",
+    "boxart3d",
+    "screenshot",
+    "wheel",
+    "titleshot",
+    "map",
+    "marquee",
+    "fanart",
+];
+const COVER_PREF_PREFIX: &str = "__pref:";
+
+fn current_cover_preference_marker() -> Option<Arc<str>> {
+    let value = crate::models::with_persist_read(|s| s.settings.media_image_type.clone());
+    let trimmed = value.trim();
+    if trimmed.is_empty() || trimmed == "auto" {
+        return None;
+    }
+    Some(Arc::from(format!("{COVER_PREF_PREFIX}{trimmed}")))
+}
+
+fn preferred_image_types(preference: &str) -> Vec<String> {
+    let mut out = Vec::with_capacity(CORE_DEFAULT_IMAGE_TYPES.len() + 1);
+    out.push(preference.to_string());
+    for image_type in CORE_DEFAULT_IMAGE_TYPES {
+        if *image_type != preference {
+            out.push((*image_type).to_string());
+        }
+    }
+    out
+}
 
 fn ext_for_content_type(content_type: &str) -> Option<&'static str> {
     let head = content_type.split(';').next()?.trim().to_ascii_lowercase();
@@ -167,6 +200,24 @@ impl MediaKey {
             media_id: Some(media_id),
             image_type: None,
         }
+    }
+
+    pub fn with_current_cover_preference(mut self) -> Self {
+        if let Some(pref) = current_cover_preference_marker() {
+            self.image_type = Some(pref);
+        }
+        self
+    }
+
+    fn cover_preference(&self) -> Option<&str> {
+        self.image_type
+            .as_deref()
+            .and_then(|t| t.strip_prefix(COVER_PREF_PREFIX))
+            .filter(|t| !t.is_empty())
+    }
+
+    pub fn is_cover_key(&self) -> bool {
+        self.image_type.is_none() || self.cover_preference().is_some()
     }
 
     pub fn with_image_type(
@@ -1026,7 +1077,9 @@ async fn fetch_one(
             ),
         }
     };
-    if let Some(image_type) = key.image_type.as_ref() {
+    if let Some(preference) = key.cover_preference() {
+        params.image_types = preferred_image_types(preference);
+    } else if let Some(image_type) = key.image_type.as_ref() {
         params.image_types.push(image_type.to_string());
     }
     debug!(

--- a/rust/frontend/src/models/alternate_versions.rs
+++ b/rust/frontend/src/models/alternate_versions.rs
@@ -138,10 +138,14 @@ impl ffi::AlternateVersions {
             return;
         }
         let entry = &self.entries[index as usize];
-        if entry.zap_script.is_empty() {
+        let text = if entry.path.trim().is_empty() {
+            entry.zap_script.clone()
+        } else {
+            entry.path.clone()
+        };
+        if text.is_empty() {
             return;
         }
-        let text = entry.zap_script.clone();
         let name = entry.name.clone();
         let store = global_store();
         global_handle().spawn(async move {

--- a/rust/frontend/src/models/favorites.rs
+++ b/rust/frontend/src/models/favorites.rs
@@ -582,7 +582,8 @@ impl ffi::FavoritesModel {
         let detail_key = match media_id {
             Some(id) => MediaKey::with_media_id(system.clone(), path.clone(), id),
             None => MediaKey::new(system.clone(), path.clone()),
-        };
+        }
+        .with_current_cover_preference();
         self.as_mut().rust_mut().current_detail_media_key = Some(detail_key);
         self.as_mut().rust_mut().current_detail_media_id = media_id;
         sync_current_detail_image_key(self.as_mut());
@@ -891,7 +892,7 @@ fn cover_key_for_with(
 fn enqueue_favorites_covers(results: &[MediaItem]) {
     let cache = global_media_image_cache();
     for entry in results.iter().rev() {
-        if let Some(key) = media_key_for(entry) {
+        if let Some(key) = media_key_for(entry).map(MediaKey::with_current_cover_preference) {
             cache.enqueue_search_cover_with_media_id(key, entry.media_id, PAGE_SIZE);
         }
     }
@@ -996,7 +997,7 @@ where
 {
     entries
         .iter()
-        .filter_map(media_key_for)
+        .filter_map(|entry| media_key_for(entry).map(MediaKey::with_current_cover_preference))
         .filter(|k| !is_cached(k) && !is_negative(k))
         .collect()
 }

--- a/rust/frontend/src/models/favorites.rs
+++ b/rust/frontend/src/models/favorites.rs
@@ -19,7 +19,8 @@
 //
 // Search is flat (no folder navigation, no auto-nav) so this model
 // stays a fraction of the size of `GamesModel`. Card-write isn't wired
-// here yet — favorites launches by `run`-ing the entry's ZapScript.
+// here yet — runtime launches prefer the exact indexed path, while
+// QR/card-write payloads prefer Core's portable ZapScript.
 
 use crate::media_image_cache::{global_media_image_cache, MediaImageCache, MediaKey};
 use crate::models::{global_handle, global_store};
@@ -435,7 +436,7 @@ impl ffi::FavoritesModel {
         if index < 0 || index >= self.count {
             return QString::default();
         }
-        QString::from(self.entries[index as usize].zap_script.as_str())
+        QString::from(portable_text_for_entry(&self.entries[index as usize]).as_str())
     }
 
     fn write_card_at(mut self: Pin<&mut Self>, index: i32) {
@@ -446,13 +447,13 @@ impl ffi::FavoritesModel {
             return;
         }
         let entry = &self.entries[index as usize];
-        if entry.zap_script.is_empty() {
+        let text = portable_text_for_entry(entry);
+        if text.is_empty() {
             self.as_mut()
-                .set_card_write_error(QString::from("missing zap script"));
+                .set_card_write_error(QString::from("missing launch payload"));
             self.as_mut().set_card_write_pending(false);
             return;
         }
-        let text = entry.zap_script.clone();
         let name = entry.name.clone();
         let store = global_store();
         let seq = self.rust().card_write_seq.clone();
@@ -663,7 +664,7 @@ fn cover_key_for(entry: &MediaItem) -> String {
     if entry.system.id.is_empty() {
         return "icons/File".to_string();
     }
-    let media_key = media_key_for(entry);
+    let media_key = media_key_for(entry).map(MediaKey::with_current_cover_preference);
     let cache = global_media_image_cache();
     let cached = media_key.as_ref().is_some_and(|k| cache.is_cached(k));
     let negative = media_key.as_ref().is_some_and(|k| cache.is_negative(k));
@@ -910,9 +911,12 @@ fn notify_cover_update(mut model: Pin<&mut ffi::FavoritesModel>, key: &MediaKey)
         .entries
         .iter()
         .enumerate()
-        .filter(|(_, e)| match (key.media_id, e.media_id) {
-            (Some(a), Some(b)) => a == b,
-            _ => e.path == *key.path && e.system.id == *key.system_id,
+        .filter(|(_, e)| {
+            key.is_cover_key()
+                && match (key.media_id, e.media_id) {
+                    (Some(a), Some(b)) => a == b,
+                    _ => e.path == *key.path && e.system.id == *key.system_id,
+                }
         })
         .filter_map(|(i, _)| i32::try_from(i).ok())
         .collect();
@@ -1069,10 +1073,20 @@ fn release_cover_gate_after_timeout(mut model: Pin<&mut ffi::FavoritesModel>) {
 }
 
 /// Build the `text` payload sent to Core's `run` for a search entry.
-/// Search entries carry a Core-built `ZapScript` command, so use it
-/// directly and suppress the run when it is empty.
+/// Runtime launches prefer exact paths to avoid title/ZapScript
+/// ambiguity; portable write/QR paths prefer Core's `ZapScript`.
 fn launch_text_for(entry: &MediaItem) -> String {
+    if !entry.path.trim().is_empty() {
+        return entry.path.clone();
+    }
     entry.zap_script.clone()
+}
+
+fn portable_text_for_entry(entry: &MediaItem) -> String {
+    if !entry.zap_script.trim().is_empty() {
+        return entry.zap_script.clone();
+    }
+    entry.path.clone()
 }
 
 fn position_of_path(entries: &[MediaItem], needle: &str) -> i32 {

--- a/rust/frontend/src/models/game_info.rs
+++ b/rust/frontend/src/models/game_info.rs
@@ -303,21 +303,32 @@ fn image_type_from_property_key(key: &str) -> Option<String> {
 }
 
 fn detail_image_keys_from_meta(meta: &MediaMeta, system: &str, path: &str) -> Vec<MediaKey> {
-    let mut types = BTreeSet::<String>::new();
-    for key in meta
-        .title
-        .properties
-        .keys()
-        .chain(meta.properties.keys())
-        .filter_map(|key| image_type_from_property_key(key))
+    let mut seen = BTreeSet::<String>::new();
+    let mut ordered = Vec::<String>::new();
+    for image_type in meta
+        .available_image_types
+        .iter()
+        .chain(meta.title.available_image_types.iter())
     {
-        types.insert(key);
+        if !image_type.trim().is_empty() && seen.insert(image_type.clone()) {
+            ordered.push(image_type.clone());
+        }
     }
-    let mut ordered = Vec::new();
-    if types.remove("image") {
-        ordered.push("image".to_string());
+    if ordered.is_empty() {
+        for key in meta
+            .title
+            .properties
+            .keys()
+            .chain(meta.properties.keys())
+            .filter_map(|key| image_type_from_property_key(key))
+        {
+            seen.insert(key);
+        }
+        if seen.remove("image") {
+            ordered.push("image".to_string());
+        }
+        ordered.extend(seen);
     }
-    ordered.extend(types);
     ordered
         .into_iter()
         .map(|image_type| MediaKey::with_image_type(system, path, image_type))

--- a/rust/frontend/src/models/games.rs
+++ b/rust/frontend/src/models/games.rs
@@ -379,6 +379,9 @@ pub mod ffi {
         fn entry_type_at(self: &GamesModel, index: i32) -> QString;
 
         #[qinvokable]
+        fn is_media_capable_at(self: &GamesModel, index: i32) -> bool;
+
+        #[qinvokable]
         fn index_for_game_path(self: &GamesModel, path: &QString) -> i32;
 
         #[inherit]
@@ -605,10 +608,10 @@ impl ffi::GamesModel {
             return;
         }
         let entry = &self.entries[index as usize];
-        if entry.zap_script.is_empty() {
+        let text = run_text_for_entry(entry);
+        if text.is_empty() {
             return;
         }
-        let text = entry.zap_script.clone();
         let name = entry.name.clone();
         let store = global_store();
         global_handle().spawn(async move {
@@ -622,7 +625,7 @@ impl ffi::GamesModel {
         if index < 0 || index >= self.count {
             return QString::default();
         }
-        QString::from(self.entries[index as usize].zap_script.as_str())
+        QString::from(portable_text_for_entry(&self.entries[index as usize]).as_str())
     }
 
     fn write_card_at(mut self: Pin<&mut Self>, index: i32) {
@@ -633,13 +636,13 @@ impl ffi::GamesModel {
             return;
         }
         let entry = &self.entries[index as usize];
-        if entry.zap_script.is_empty() {
+        let text = portable_text_for_entry(entry);
+        if text.is_empty() {
             self.as_mut()
-                .set_card_write_error(QString::from("missing zap script"));
+                .set_card_write_error(QString::from("missing launch payload"));
             self.as_mut().set_card_write_pending(false);
             return;
         }
-        let text = entry.zap_script.clone();
         let name = entry.name.clone();
         let store = global_store();
         let seq = self.rust().card_write_seq.clone();
@@ -673,7 +676,7 @@ impl ffi::GamesModel {
             return;
         }
         let entry = &self.entries[index as usize];
-        if entry.is_folder() {
+        if !is_media_capable_entry(entry) {
             return;
         }
         let Some(params) = favorite_params_for_entry(entry, !has_favorite_tag(&entry.tags)) else {
@@ -756,7 +759,7 @@ impl ffi::GamesModel {
         }
 
         let entry = &self.entries[index as usize];
-        if entry.is_folder() {
+        if !is_media_capable_entry(entry) {
             self.as_mut().set_current_detail_loading(false);
             self.as_mut().set_current_description(QString::default());
             self.as_mut().set_current_detail_tags(QString::default());
@@ -819,6 +822,13 @@ impl ffi::GamesModel {
             return QString::default();
         }
         QString::from(self.entries[index as usize].entry_type.as_str())
+    }
+
+    fn is_media_capable_at(&self, index: i32) -> bool {
+        if index < 0 || index >= self.count {
+            return false;
+        }
+        is_media_capable_entry(&self.entries[index as usize])
     }
 
     fn index_for_game_path(&self, path: &QString) -> i32 {
@@ -990,6 +1000,28 @@ fn entry_system_id(entry: &BrowseEntry) -> String {
     entry.system_ids.first().cloned().unwrap_or_default()
 }
 
+fn is_media_capable_entry(entry: &BrowseEntry) -> bool {
+    entry.entry_type == "media"
+        || (entry.entry_type == "directory"
+            && (entry.media_id.is_some()
+                || !entry.zap_script.is_empty()
+                || !entry.system_id.is_empty()))
+}
+
+fn run_text_for_entry(entry: &BrowseEntry) -> String {
+    if !entry.path.trim().is_empty() {
+        return entry.path.clone();
+    }
+    entry.zap_script.clone()
+}
+
+fn portable_text_for_entry(entry: &BrowseEntry) -> String {
+    if !entry.zap_script.trim().is_empty() {
+        return entry.zap_script.clone();
+    }
+    entry.path.clone()
+}
+
 fn detail_tags_from_entry(entry: &BrowseEntry) -> String {
     detail_tags_from_tags(entry.tags.as_slice())
 }
@@ -1131,7 +1163,7 @@ fn sync_current_detail_image_key_with_page_size(
 }
 
 fn cover_placeholder_for(entry: &BrowseEntry) -> String {
-    if entry.is_folder() {
+    if !is_media_capable_entry(entry) && entry.is_folder() {
         "icons/Folder".to_string()
     } else {
         "icons/File".to_string()
@@ -1139,10 +1171,10 @@ fn cover_placeholder_for(entry: &BrowseEntry) -> String {
 }
 
 fn cover_key_for(entry: &BrowseEntry, page_size: u32) -> String {
-    if entry.is_folder() {
+    if !is_media_capable_entry(entry) && entry.is_folder() {
         return "icons/Folder".to_string();
     }
-    let media_key = media_key_for(entry);
+    let media_key = media_key_for(entry).map(MediaKey::with_current_cover_preference);
     let cache = global_media_image_cache();
     let cached = media_key.as_ref().is_some_and(|k| cache.is_cached(k));
     let negative = media_key.as_ref().is_some_and(|k| cache.is_negative(k));
@@ -1170,7 +1202,7 @@ fn cover_key_for(entry: &BrowseEntry, page_size: u32) -> String {
 /// entry. Returns `None` for entries the cache cannot key on (folder
 /// roots, unattributed entries, browse roots without a path).
 fn media_key_for(entry: &BrowseEntry) -> Option<MediaKey> {
-    if entry.is_folder() || entry.path.is_empty() {
+    if !is_media_capable_entry(entry) || entry.path.is_empty() {
         return None;
     }
     let system_id = entry_system_id(entry);
@@ -1218,11 +1250,11 @@ fn prefetch_around_plan(
             return;
         }
         let entry = &entries[idx];
-        if entry.is_folder() {
+        if !is_media_capable_entry(entry) {
             return;
         }
         if let Some(key) = media_key_for(entry) {
-            plan.push((key, entry.media_id));
+            plan.push((key.with_current_cover_preference(), entry.media_id));
         }
     };
     for row in (next_start..next_end).rev() {
@@ -1308,7 +1340,7 @@ fn cover_key_for_with(
     cached: bool,
     unavailable: bool,
 ) -> String {
-    if entry.is_folder() {
+    if !is_media_capable_entry(entry) && entry.is_folder() {
         return "icons/Folder".to_string();
     }
     match key {
@@ -1333,8 +1365,8 @@ fn notify_cover_update(mut model: Pin<&mut ffi::GamesModel>, key: &MediaKey) {
         .iter()
         .enumerate()
         .filter(|(_, e)| {
-            key.image_type.is_none()
-                && !e.is_folder()
+            key.is_cover_key()
+                && is_media_capable_entry(e)
                 && match (key.media_id, e.media_id) {
                     (Some(a), Some(b)) => a == b,
                     _ => e.path == *key.path && entry_system_id(e) == *key.system_id,

--- a/rust/frontend/src/models/games.rs
+++ b/rust/frontend/src/models/games.rs
@@ -1072,7 +1072,7 @@ fn is_media_capable_entry(entry: &BrowseEntry) -> bool {
         || (entry.entry_type == "directory"
             && (entry.media_id.is_some()
                 || !entry.zap_script.is_empty()
-                || !entry.system_id.is_empty()))
+                || !entry_system_id(entry).is_empty()))
 }
 
 fn run_text_for_entry(entry: &BrowseEntry) -> String {
@@ -1598,7 +1598,7 @@ where
 {
     entries
         .iter()
-        .filter_map(media_key_for)
+        .filter_map(|entry| media_key_for(entry).map(MediaKey::with_current_cover_preference))
         .filter(|k| !is_cached(k) && !is_negative(k))
         .collect()
 }

--- a/rust/frontend/src/models/games.rs
+++ b/rust/frontend/src/models/games.rs
@@ -36,7 +36,7 @@ use cxx_qt::{CxxQtType, Threading};
 use cxx_qt_lib::{
     QByteArray, QHash, QHashPair_i32_QByteArray, QList, QModelIndex, QString, QVariant,
 };
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashSet};
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -50,8 +50,8 @@ use zaparoo_core::endpoints::media_tags_update::MediaTagsUpdateMutation;
 use zaparoo_core::endpoints::readers_write::ReadersWriteMutation;
 use zaparoo_core::endpoints::run::RunMutation;
 use zaparoo_core::media_types::{
-    BrowseEntry, MediaBrowseParams, MediaBrowseResult, MediaTagsUpdateParams, ReadersWriteParams,
-    RunParams, TagInfo,
+    BrowseEntry, MediaBrowseParams, MediaBrowseResult, MediaMeta, MediaMetaParams,
+    MediaTagsUpdateParams, ReadersWriteParams, RunParams, TagInfo,
 };
 use zaparoo_core::platform::{self, Platform};
 use zaparoo_core::remote_resource::ResourceStatus;
@@ -608,13 +608,31 @@ impl ffi::GamesModel {
             return;
         }
         let entry = &self.entries[index as usize];
-        let text = run_text_for_entry(entry);
-        if text.is_empty() {
+        let fallback_text = run_text_for_entry(entry);
+        if fallback_text.is_empty() {
             return;
         }
+        let params = singleton_directory_needs_launch_resolution(entry)
+            .then(|| meta_params_for_entry(entry))
+            .flatten();
         let name = entry.name.clone();
         let store = global_store();
         global_handle().spawn(async move {
+            let text = if let Some(params) = params {
+                match store.client().media_meta(params).await {
+                    Ok(result) if !result.media.path.trim().is_empty() => result.media.path,
+                    Ok(_) => fallback_text.clone(),
+                    Err(e) => {
+                        warn!(
+                            "singleton launch path resolve failed for {name}: {}",
+                            e.message
+                        );
+                        fallback_text.clone()
+                    }
+                }
+            } else {
+                fallback_text.clone()
+            };
             if let Err(e) = store.run_mutation::<RunMutation>(RunParams { text }).await {
                 warn!("run failed for {name}: {}", e.message);
             }
@@ -746,10 +764,12 @@ impl ffi::GamesModel {
     }
 
     fn load_description_at(mut self: Pin<&mut Self>, index: i32) {
-        self.as_mut()
+        let ticket = self
+            .as_mut()
             .rust_mut()
             .description_seq
-            .fetch_add(1, Ordering::SeqCst);
+            .fetch_add(1, Ordering::SeqCst)
+            + 1;
         if index < 0 || index >= self.count {
             self.as_mut().set_current_detail_loading(false);
             self.as_mut().set_current_description(QString::default());
@@ -770,14 +790,61 @@ impl ffi::GamesModel {
         let description = entry.description.clone();
         let detail_tags = detail_tags_from_entry(entry);
         let detail_image_key = media_key_for(entry);
+        let Some(params) = meta_params_for_entry(entry) else {
+            self.as_mut().set_current_detail_loading(false);
+            self.as_mut()
+                .set_current_description(QString::from(description.as_str()));
+            self.as_mut()
+                .set_current_detail_tags(QString::from(detail_tags.as_str()));
+            set_single_detail_image_key(self.as_mut(), detail_image_key);
+            return;
+        };
 
         self.as_mut().set_current_detail_loading(true);
         self.as_mut()
             .set_current_description(QString::from(description.as_str()));
         self.as_mut()
             .set_current_detail_tags(QString::from(detail_tags.as_str()));
-        set_detail_image_keys(self.as_mut(), detail_image_key);
-        self.as_mut().set_current_detail_loading(false);
+        set_single_detail_image_key(self.as_mut(), detail_image_key);
+
+        let seq = self.rust().description_seq.clone();
+        let qt_thread = self.qt_thread();
+        let store = global_store();
+        global_handle().spawn(async move {
+            let result = store.client().media_meta(params).await;
+            let _ = qt_thread.queue(move |mut model| {
+                if seq.load(Ordering::SeqCst) != ticket {
+                    return;
+                }
+                match result {
+                    Ok(result) => {
+                        let meta = result.media;
+                        let description = description_from_meta(&meta);
+                        if !description.is_empty() {
+                            model
+                                .as_mut()
+                                .set_current_description(QString::from(description.as_str()));
+                        }
+                        model.as_mut().set_current_detail_tags(QString::from(
+                            detail_tags_from_meta(&meta).as_str(),
+                        ));
+                        let mut detail_keys = detail_image_keys_from_meta(
+                            &meta,
+                            meta.title.system.id.as_str(),
+                            meta.path.as_str(),
+                        );
+                        if detail_keys.is_empty() {
+                            if let Some(key) = media_key_for(&model.entries[index as usize]) {
+                                detail_keys.push(key);
+                            }
+                        }
+                        set_detail_image_keys(model.as_mut(), detail_keys);
+                    }
+                    Err(e) => warn!("games detail fetch failed: {}", e.message),
+                }
+                model.as_mut().set_current_detail_loading(false);
+            });
+        });
     }
 
     fn clear_current_detail(mut self: Pin<&mut Self>) {
@@ -1015,6 +1082,81 @@ fn run_text_for_entry(entry: &BrowseEntry) -> String {
     entry.zap_script.clone()
 }
 
+fn meta_params_for_entry(entry: &BrowseEntry) -> Option<MediaMetaParams> {
+    if let Some(media_id) = entry.media_id {
+        return Some(MediaMetaParams::for_media_id(media_id));
+    }
+    let system_id = entry_system_id(entry);
+    if system_id.trim().is_empty() || entry.path.trim().is_empty() {
+        return None;
+    }
+    Some(MediaMetaParams::for_media(system_id, entry.path.clone()))
+}
+
+fn singleton_directory_needs_launch_resolution(entry: &BrowseEntry) -> bool {
+    entry.entry_type == "directory" && entry.media_id.is_some()
+}
+
+fn description_from_meta(meta: &MediaMeta) -> String {
+    meta.title
+        .properties
+        .get("property:description")
+        .or_else(|| meta.properties.get("property:description"))
+        .map(|property| property.text.trim().to_string())
+        .filter(|text| !text.is_empty())
+        .unwrap_or_default()
+}
+
+fn detail_tags_from_meta(meta: &MediaMeta) -> String {
+    let source = if meta.title.tags.is_empty() {
+        meta.tags.as_slice()
+    } else {
+        meta.title.tags.as_slice()
+    };
+    detail_tags_from_tags(source)
+}
+
+fn image_type_from_property_key(key: &str) -> Option<String> {
+    let suffix = key.strip_prefix("property:image")?;
+    if suffix.is_empty() {
+        return Some("image".to_string());
+    }
+    Some(suffix.trim_start_matches('-').to_string()).filter(|image_type| !image_type.is_empty())
+}
+
+fn detail_image_keys_from_meta(meta: &MediaMeta, system: &str, path: &str) -> Vec<MediaKey> {
+    let mut seen = BTreeSet::<String>::new();
+    let mut ordered = Vec::<String>::new();
+    for image_type in meta
+        .available_image_types
+        .iter()
+        .chain(meta.title.available_image_types.iter())
+    {
+        if !image_type.trim().is_empty() && seen.insert(image_type.clone()) {
+            ordered.push(image_type.clone());
+        }
+    }
+    if ordered.is_empty() {
+        for key in meta
+            .title
+            .properties
+            .keys()
+            .chain(meta.properties.keys())
+            .filter_map(|key| image_type_from_property_key(key))
+        {
+            seen.insert(key);
+        }
+        if seen.remove("image") {
+            ordered.push("image".to_string());
+        }
+        ordered.extend(seen);
+    }
+    ordered
+        .into_iter()
+        .map(|image_type| MediaKey::with_image_type(system, path, image_type))
+        .collect()
+}
+
 fn portable_text_for_entry(entry: &BrowseEntry) -> String {
     if !entry.zap_script.trim().is_empty() {
         return entry.zap_script.clone();
@@ -1092,17 +1234,18 @@ fn clear_detail_images(mut model: Pin<&mut ffi::GamesModel>) {
     model.as_mut().set_current_detail_image_can_next(false);
 }
 
-fn set_detail_image_keys(mut model: Pin<&mut ffi::GamesModel>, key: Option<MediaKey>) {
-    model.as_mut().rust_mut().detail_image_keys.clear();
-    if let Some(key) = key {
-        model.as_mut().rust_mut().detail_image_keys.push(key);
-    }
+fn set_detail_image_keys(mut model: Pin<&mut ffi::GamesModel>, keys: Vec<MediaKey>) {
+    model.as_mut().rust_mut().detail_image_keys = keys;
     model.as_mut().set_current_detail_image_index(0);
     let count = i32::try_from(model.detail_image_keys.len()).unwrap_or(i32::MAX);
     model.as_mut().set_current_detail_image_count(count);
     model.as_mut().set_current_detail_image_can_prev(false);
     model.as_mut().set_current_detail_image_can_next(count > 1);
     sync_current_detail_image_key_with_page_size(model, 1);
+}
+
+fn set_single_detail_image_key(model: Pin<&mut ffi::GamesModel>, key: Option<MediaKey>) {
+    set_detail_image_keys(model, key.into_iter().collect());
 }
 
 fn set_detail_image_index(mut model: Pin<&mut ffi::GamesModel>, index: i32) {
@@ -2167,7 +2310,8 @@ mod tests {
         chunk_for_subbatching, compute_unresolved_keys, cover_key_for_with, cover_placeholder_for,
         decide_initial, dedup_roots_drop_ancestors, detail_tags_from_tags, display_name,
         entry_system_id, is_strict_ancestor_path, leading_dir_count, media_key_for,
-        position_of_game_path, prefetch_around_plan, project_status, transform_entries,
+        meta_params_for_entry, position_of_game_path, prefetch_around_plan, project_status,
+        run_text_for_entry, singleton_directory_needs_launch_resolution, transform_entries,
         InitialAction, Projection,
     };
     use crate::media_image_cache::{MediaImageCache, MediaKey};
@@ -2669,6 +2813,35 @@ mod tests {
         let key = media_key_for(&media("smb", "/p/smb", "NES")).expect("ok");
         assert_eq!(key.system_id.as_ref(), "NES");
         assert_eq!(key.path.as_ref(), "/p/smb");
+    }
+
+    #[test]
+    fn singleton_directory_uses_media_id_for_meta_but_container_as_fallback_run_text() {
+        let entry = BrowseEntry {
+            media_id: Some(42),
+            name: "Archive".into(),
+            path: "/roms/NES/archive.zip".into(),
+            entry_type: "directory".into(),
+            system_id: "NES".into(),
+            zap_script: "@NES/Super Mario Bros.".into(),
+            ..BrowseEntry::default()
+        };
+        assert!(singleton_directory_needs_launch_resolution(&entry));
+        let params = meta_params_for_entry(&entry).expect("meta params");
+        assert_eq!(params.media_id, Some(42));
+        assert!(params.system.is_empty());
+        assert!(params.path.is_empty());
+        assert_eq!(run_text_for_entry(&entry), "/roms/NES/archive.zip");
+    }
+
+    #[test]
+    fn normal_media_does_not_need_launch_resolution() {
+        let entry = BrowseEntry {
+            media_id: Some(7),
+            ..media("smb", "/roms/NES/smb.nes", "NES")
+        };
+        assert!(!singleton_directory_needs_launch_resolution(&entry));
+        assert_eq!(run_text_for_entry(&entry), "/roms/NES/smb.nes");
     }
 
     #[test]

--- a/rust/frontend/src/models/media_status.rs
+++ b/rust/frontend/src/models/media_status.rs
@@ -59,6 +59,11 @@ pub struct MediaStatusRust {
     scrape_total_scraped: i32,
     scrape_system_id: QString,
     scrape_scraper_id: QString,
+    scrape_state: QString,
+    scrape_error: QString,
+    scrape_current_step: i32,
+    scrape_total_steps: i32,
+    scrape_current_step_display: QString,
 }
 
 #[cxx_qt::bridge]
@@ -93,6 +98,11 @@ pub mod ffi {
         #[qproperty(i32, scrape_total_scraped)]
         #[qproperty(QString, scrape_system_id)]
         #[qproperty(QString, scrape_scraper_id)]
+        #[qproperty(QString, scrape_state)]
+        #[qproperty(QString, scrape_error)]
+        #[qproperty(i32, scrape_current_step)]
+        #[qproperty(i32, scrape_total_steps)]
+        #[qproperty(QString, scrape_current_step_display)]
         type MediaStatus = super::MediaStatusRust;
 
         #[qinvokable]
@@ -102,7 +112,7 @@ pub mod ffi {
         fn cancel_index(self: Pin<&mut MediaStatus>);
 
         #[qinvokable]
-        fn start_scrape(self: Pin<&mut MediaStatus>);
+        fn start_scrape(self: Pin<&mut MediaStatus>, force: bool);
 
         #[qinvokable]
         fn cancel_scrape(self: Pin<&mut MediaStatus>);
@@ -142,6 +152,11 @@ struct Snapshot {
     scrape_total_scraped: i32,
     scrape_system_id: QString,
     scrape_scraper_id: QString,
+    scrape_state: QString,
+    scrape_error: QString,
+    scrape_current_step: i32,
+    scrape_total_steps: i32,
+    scrape_current_step_display: QString,
 }
 
 fn project(state: &MediaStatusState) -> Snapshot {
@@ -166,6 +181,11 @@ fn project(state: &MediaStatusState) -> Snapshot {
         scrape_total_scraped: state.scrape_total_scraped,
         scrape_system_id: QString::from(state.scrape_system_id.as_str()),
         scrape_scraper_id: QString::from(state.scrape_scraper_id.as_str()),
+        scrape_state: QString::from(state.scrape_state.as_str()),
+        scrape_error: QString::from(state.scrape_error.as_str()),
+        scrape_current_step: state.scrape_current_step,
+        scrape_total_steps: state.scrape_total_steps,
+        scrape_current_step_display: QString::from(state.scrape_current_step_display.as_str()),
     }
 }
 
@@ -204,10 +224,11 @@ impl ffi::MediaStatus {
         });
     }
 
-    fn start_scrape(self: Pin<&mut Self>) {
+    fn start_scrape(self: Pin<&mut Self>, force: bool) {
         let resource = crate::models::global_store().media_status();
         crate::models::global_handle().spawn(async move {
-            // ES gamelist.xml across every indexed system, no re-scrape.
+            // ES gamelist.xml across every indexed system. `force` is
+            // a one-shot UI toggle for re-scraping existing metadata.
             // Core ships this scraper in-tree (see `pkg/api/server.go`
             // wiring `gamelistxml.NewGamelistXMLScraper`) and validates
             // `scraperId` as `min=1` — there is no server-side "default"
@@ -218,7 +239,7 @@ impl ffi::MediaStatus {
             let params = MediaScrapeParams {
                 scraper_id: "gamelist.xml".into(),
                 systems: Vec::new(),
-                force: false,
+                force,
             };
             if let Err(e) = resource.start_scrape(params).await {
                 warn!("media_status: start_scrape failed: {}", e.message);
@@ -305,6 +326,25 @@ fn apply(mut model: Pin<&mut ffi::MediaStatus>, s: Snapshot) {
     if model.scrape_scraper_id != s.scrape_scraper_id {
         model.as_mut().set_scrape_scraper_id(s.scrape_scraper_id);
     }
+    if model.scrape_state != s.scrape_state {
+        model.as_mut().set_scrape_state(s.scrape_state);
+    }
+    if model.scrape_error != s.scrape_error {
+        model.as_mut().set_scrape_error(s.scrape_error);
+    }
+    if model.scrape_current_step != s.scrape_current_step {
+        model
+            .as_mut()
+            .set_scrape_current_step(s.scrape_current_step);
+    }
+    if model.scrape_total_steps != s.scrape_total_steps {
+        model.as_mut().set_scrape_total_steps(s.scrape_total_steps);
+    }
+    if model.scrape_current_step_display != s.scrape_current_step_display {
+        model
+            .as_mut()
+            .set_scrape_current_step_display(s.scrape_current_step_display);
+    }
 }
 
 #[cfg(test)]
@@ -336,6 +376,11 @@ mod tests {
             scrape_total_scraped: 0,
             scrape_system_id: String::new(),
             scrape_scraper_id: String::new(),
+            scrape_state: String::new(),
+            scrape_error: String::new(),
+            scrape_current_step: 0,
+            scrape_total_steps: 0,
+            scrape_current_step_display: String::new(),
         };
         let snapshot = project(&state);
         assert!(snapshot.seeded);
@@ -362,6 +407,10 @@ mod tests {
             scrape_total_scraped: 50,
             scrape_system_id: "SNES".into(),
             scrape_scraper_id: "screenscraper".into(),
+            scrape_state: "running".into(),
+            scrape_current_step: 2,
+            scrape_total_steps: 5,
+            scrape_current_step_display: "Super Nintendo".into(),
             ..MediaStatusState::default()
         };
         let snapshot = project(&state);
@@ -373,6 +422,13 @@ mod tests {
         assert_eq!(snapshot.scrape_total_scraped, 50);
         assert_eq!(snapshot.scrape_system_id, QString::from("SNES"));
         assert_eq!(snapshot.scrape_scraper_id, QString::from("screenscraper"));
+        assert_eq!(snapshot.scrape_state, QString::from("running"));
+        assert_eq!(snapshot.scrape_current_step, 2);
+        assert_eq!(snapshot.scrape_total_steps, 5);
+        assert_eq!(
+            snapshot.scrape_current_step_display,
+            QString::from("Super Nintendo"),
+        );
     }
 
     #[test]

--- a/rust/frontend/src/models/mod.rs
+++ b/rust/frontend/src/models/mod.rs
@@ -157,6 +157,15 @@ pub fn persist_state() -> Arc<Mutex<PersistedState>> {
         .clone()
 }
 
+pub fn try_with_persist_read<R>(f: impl FnOnce(&PersistedState) -> R) -> Option<R> {
+    let shared = PERSIST_STATE.get()?.clone();
+    let guard = shared
+        .lock()
+        .inspect_err(|e| error!("persist mutex poisoned: {e}"))
+        .expect("persist mutex poisoned");
+    Some(f(&guard))
+}
+
 /// Read the persisted state under a closure. Centralises the
 /// lock + log + panic-on-poison chain so the 5+ persist call sites
 /// can't drift in their error message or skip the log breadcrumb.

--- a/rust/frontend/src/models/recents.rs
+++ b/rust/frontend/src/models/recents.rs
@@ -453,7 +453,8 @@ impl ffi::RecentsModel {
         let detail_key = match media_id {
             Some(id) => MediaKey::with_media_id(system.clone(), path.clone(), id),
             None => MediaKey::new(system.clone(), path.clone()),
-        };
+        }
+        .with_current_cover_preference();
         self.as_mut().rust_mut().current_detail_media_key = Some(detail_key);
         self.as_mut().rust_mut().current_detail_media_id = media_id;
         sync_current_detail_image_key(self.as_mut());
@@ -708,7 +709,7 @@ fn file_stem_or_name(path: &str, name: &str) -> String {
 fn enqueue_recents_covers(entries: &[MediaHistoryEntry]) {
     let cache = global_media_image_cache();
     for entry in entries.iter().rev() {
-        if let Some(key) = media_key_for(entry) {
+        if let Some(key) = media_key_for(entry).map(MediaKey::with_current_cover_preference) {
             cache.enqueue_search_cover_with_media_id(key, entry.media_id, PAGE_SIZE);
         }
     }
@@ -813,7 +814,7 @@ where
 {
     entries
         .iter()
-        .filter_map(media_key_for)
+        .filter_map(|entry| media_key_for(entry).map(MediaKey::with_current_cover_preference))
         .filter(|k| !is_cached(k) && !is_negative(k))
         .collect()
 }
@@ -1045,52 +1046,35 @@ mod tests {
     }
 
     #[test]
-    fn launch_text_uses_launch_with_launcher_override_when_known() {
+    fn launch_text_uses_raw_media_path_when_launcher_known() {
         let e = entry("smb", "/p/smb.nes", "NES", "NES");
-        assert_eq!(launch_text_for(&e), "**launch:\"/p/smb.nes\"?launcher=NES");
+        assert_eq!(launch_text_for(&e), "/p/smb.nes");
     }
 
     #[test]
-    fn launch_text_falls_back_to_bare_launch_when_launcher_missing() {
+    fn launch_text_uses_raw_media_path_when_launcher_missing() {
         let e = entry("smb", "/p/smb.nes", "NES", "");
-        assert_eq!(launch_text_for(&e), "**launch:\"/p/smb.nes\"");
+        assert_eq!(launch_text_for(&e), "/p/smb.nes");
     }
 
     #[test]
-    fn launch_text_quotes_path_with_spaces_and_metacharacters() {
-        // Real-world path that fails to launch unquoted because of
-        // spaces, parens, and commas — exactly the regression the
-        // user reported when running from Recently Played.
-        let e = entry(
-            "bob",
-            "/media/fat/cifs/games/Genesis/1 US - A-F/B.O.B. (USA,Europe) (Rev A).md",
-            "Genesis",
-            "Genesis",
-        );
-        assert_eq!(
-            launch_text_for(&e),
-            "**launch:\"/media/fat/cifs/games/Genesis/1 US - A-F/B.O.B. (USA,Europe) (Rev A).md\"?launcher=Genesis"
-        );
+    fn launch_text_preserves_path_with_spaces_and_metacharacters() {
+        let path = "/media/fat/cifs/games/Genesis/1 US - A-F/B.O.B. (USA,Europe) (Rev A).md";
+        let e = entry("bob", path, "Genesis", "Genesis");
+        assert_eq!(launch_text_for(&e), path);
     }
 
     #[test]
-    fn launch_text_escapes_backslashes_and_quotes_in_path() {
-        // Windows-host paths reach Core with backslash separators, and
-        // a stray `"` in a filename would otherwise close the quoted
-        // arg early. Both must be ZapScript-escaped so
-        // `parseQuotedArg` decodes them back to the original path.
-        let e = entry("weird", r#"C:\Games\say "hi".rom"#, "DOS", "DOS");
-        assert_eq!(
-            launch_text_for(&e),
-            r#"**launch:"C:\\Games\\say \"hi\".rom"?launcher=DOS"#
-        );
+    fn launch_text_preserves_backslashes_and_quotes_in_path() {
+        let path = r#"C:\Games\say "hi".rom"#;
+        let e = entry("weird", path, "DOS", "DOS");
+        assert_eq!(launch_text_for(&e), path);
     }
 
     #[test]
     fn launch_text_is_empty_when_path_missing_and_launcher_present() {
-        // A history row with a launcher id but no path is malformed —
-        // `**launch:?launcher=NES` would just confuse Core. Empty here
-        // suppresses the run entirely.
+        // A history row with a launcher id but no path is malformed.
+        // Empty here suppresses the run entirely.
         let e = entry("ghost", "", "NES", "NES");
         assert_eq!(launch_text_for(&e), "");
     }

--- a/rust/frontend/src/models/recents.rs
+++ b/rust/frontend/src/models/recents.rs
@@ -535,7 +535,7 @@ fn cover_key_for(entry: &MediaHistoryEntry) -> String {
     if entry.system_id.is_empty() {
         return "icons/File".to_string();
     }
-    let media_key = media_key_for(entry);
+    let media_key = media_key_for(entry).map(MediaKey::with_current_cover_preference);
     let cache = global_media_image_cache();
     let cached = media_key.as_ref().is_some_and(|k| cache.is_cached(k));
     let negative = media_key.as_ref().is_some_and(|k| cache.is_negative(k));
@@ -728,9 +728,12 @@ fn notify_cover_update(mut model: Pin<&mut ffi::RecentsModel>, key: &MediaKey) {
         .entries
         .iter()
         .enumerate()
-        .filter(|(_, e)| match (key.media_id, e.media_id) {
-            (Some(a), Some(b)) => a == b,
-            _ => e.media_path == *key.path && e.system_id == *key.system_id,
+        .filter(|(_, e)| {
+            key.is_cover_key()
+                && match (key.media_id, e.media_id) {
+                    (Some(a), Some(b)) => a == b,
+                    _ => e.media_path == *key.path && e.system_id == *key.system_id,
+                }
         })
         .filter_map(|(i, _)| i32::try_from(i).ok())
         .collect();
@@ -887,32 +890,11 @@ fn release_cover_gate_after_timeout(mut model: Pin<&mut ffi::RecentsModel>) {
 }
 
 /// Build the `text` payload sent to Core's `run` for a history entry.
-/// History entries don't carry a synthesised `zap_script` (Core surfaces
-/// only the raw fields), so compose `**launch:"<path>"` from the row's
-/// `mediaPath`, with `?launcher=<id>` appended when `launcherId` is known
-/// so Core picks the same launcher the entry originally ran under. An
-/// empty path yields an empty string, suppressing the run entirely —
-/// `**launch.system:<id>` would just boot the core without a game.
-///
-/// The path is always wrapped in double quotes so spaces and shell
-/// metacharacters (parens, commas) survive Core's argument parsing —
-/// real-world paths like
-/// `/media/fat/cifs/games/Genesis/1 US - A-F/B.O.B. (USA,Europe) (Rev A).md`
-/// fail to launch unquoted. Embedded backslashes and double quotes are
-/// escaped per `ZapScript`'s `parseQuotedArg` rules (backslash first so
-/// the quote-escape's leading `\` doesn't get re-escaped) — Windows-host
-/// paths and the rare filename containing a literal `"` would otherwise
-/// produce a malformed token.
+/// Runtime relaunches prefer the exact path Core recorded; portable
+/// `ZapScript` is not available on history rows and launcher affinity is
+/// less important than avoiding title-resolution ambiguity.
 fn launch_text_for(entry: &MediaHistoryEntry) -> String {
-    if entry.media_path.is_empty() {
-        return String::new();
-    }
-    let escaped = entry.media_path.replace('\\', "\\\\").replace('"', "\\\"");
-    if entry.launcher_id.is_empty() {
-        format!("**launch:\"{escaped}\"")
-    } else {
-        format!("**launch:\"{escaped}\"?launcher={}", entry.launcher_id)
-    }
+    entry.media_path.clone()
 }
 
 fn position_of_path(entries: &[MediaHistoryEntry], needle: &str) -> i32 {

--- a/rust/frontend/src/models/settings.rs
+++ b/rust/frontend/src/models/settings.rs
@@ -105,6 +105,22 @@ const DEFAULT_BUTTON_LAYOUT: &str = "a";
 // is long enough that idle browsing does not trip it.
 const SCREENSAVER_TIMEOUTS: &[&str] = &["off", "60", "120", "300", "600", "900", "1800"];
 const DEFAULT_SCREENSAVER_TIMEOUT: &str = "300";
+const MEDIA_IMAGE_TYPES: &[&str] = &[
+    "auto",
+    "image",
+    "thumbnail",
+    "boxart",
+    "boxart3d",
+    "screenshot",
+    "wheel",
+    "titleshot",
+    "map",
+    "marquee",
+    "fanart",
+    "boxartside",
+    "boxartback",
+];
+const DEFAULT_MEDIA_IMAGE_TYPE: &str = "auto";
 
 // Debug-only QA shortcut so the activation path can be exercised
 // without waiting for the production timer. Only appears in debug
@@ -136,6 +152,8 @@ pub struct SettingsRust {
     current_debug_logging: bool,
     available_screensaver_timeouts: QStringList,
     current_screensaver_timeout: QString,
+    available_media_image_types: QStringList,
+    current_media_image_type: QString,
 }
 
 #[cxx_qt::bridge]
@@ -167,6 +185,8 @@ pub mod ffi {
         #[qproperty(bool, current_debug_logging, READ, WRITE = set_debug_logging, NOTIFY)]
         #[qproperty(QStringList, available_screensaver_timeouts, READ, CONSTANT)]
         #[qproperty(QString, current_screensaver_timeout, READ, WRITE = set_screensaver_timeout, NOTIFY)]
+        #[qproperty(QStringList, available_media_image_types, READ, CONSTANT)]
+        #[qproperty(QString, current_media_image_type, READ, WRITE = set_media_image_type, NOTIFY)]
         type Settings = super::SettingsRust;
 
         #[qinvokable]
@@ -195,6 +215,9 @@ pub mod ffi {
 
         #[qinvokable]
         fn set_screensaver_timeout(self: Pin<&mut Settings>, value: QString);
+
+        #[qinvokable]
+        fn set_media_image_type(self: Pin<&mut Settings>, value: QString);
     }
 
     impl cxx_qt::Initialize for Settings {}
@@ -234,6 +257,9 @@ impl Initialize for ffi::Settings {
         self.as_mut().rust_mut().available_screensaver_timeouts = screensaver_timeouts();
         self.as_mut().rust_mut().current_screensaver_timeout =
             QString::from(merged.screensaver_timeout.as_str());
+        self.as_mut().rust_mut().available_media_image_types = media_image_types();
+        self.as_mut().rust_mut().current_media_image_type =
+            QString::from(merged.media_image_type.as_str());
     }
 }
 
@@ -358,6 +384,21 @@ impl ffi::Settings {
         self.as_mut().rust_mut().current_screensaver_timeout = QString::from(value_str.as_str());
         self.as_mut().current_screensaver_timeout_changed();
     }
+
+    #[allow(
+        clippy::needless_pass_by_value,
+        reason = "cxx-qt qinvokable signature requires QString by value"
+    )]
+    fn set_media_image_type(mut self: Pin<&mut Self>, value: QString) {
+        let value_str = normalize_media_image_type(&value.to_string()).to_string();
+        if self.current_media_image_type.to_string() == value_str {
+            return;
+        }
+        let snapshot = persist_settings(|s| s.media_image_type.clone_from(&value_str));
+        mirror_settings_to_config(&config_file_path(), &snapshot.settings);
+        self.as_mut().rust_mut().current_media_image_type = QString::from(value_str.as_str());
+        self.as_mut().current_media_image_type_changed();
+    }
 }
 
 fn persist_settings<F: FnOnce(&mut SettingsState)>(mutator: F) -> persist::PersistedState {
@@ -393,6 +434,7 @@ fn mirror_settings_to_config(config_path: &std::path::Path, settings: &SettingsS
             discover_arcade_alternate_versions: settings.discover_arcade_alternate_versions,
             debug_logging: settings.debug_logging,
             screensaver_timeout: settings.screensaver_timeout.as_str(),
+            media_image_type: settings.media_image_type.as_str(),
         },
     ) {
         warn!(
@@ -453,6 +495,14 @@ fn merge_settings(snapshot: &SettingsState, config: &Config) -> SettingsState {
                 .unwrap_or(snapshot.screensaver_timeout.as_str()),
         )
         .to_string(),
+        media_image_type: normalize_media_image_type(
+            config
+                .settings
+                .media_image_type
+                .as_deref()
+                .unwrap_or(snapshot.media_image_type.as_str()),
+        )
+        .to_string(),
     }
 }
 
@@ -508,6 +558,14 @@ fn screensaver_timeouts() -> QStringList {
     list
 }
 
+fn media_image_types() -> QStringList {
+    let mut list = QStringList::default();
+    for value in MEDIA_IMAGE_TYPES {
+        list.append(QString::from(*value));
+    }
+    list
+}
+
 fn normalize_language(value: &str) -> &str {
     let trimmed = value.trim();
     if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("auto") {
@@ -553,6 +611,15 @@ fn normalize_screensaver_timeout(value: &str) -> &'static str {
         .copied()
         .find(|v| *v == trimmed)
         .unwrap_or(DEFAULT_SCREENSAVER_TIMEOUT)
+}
+
+fn normalize_media_image_type(value: &str) -> &'static str {
+    let trimmed = value.trim();
+    MEDIA_IMAGE_TYPES
+        .iter()
+        .copied()
+        .find(|v| *v == trimmed)
+        .unwrap_or(DEFAULT_MEDIA_IMAGE_TYPE)
 }
 
 fn normalize_button_layout(value: &str) -> &'static str {

--- a/rust/zaparoo-core/src/client.rs
+++ b/rust/zaparoo-core/src/client.rs
@@ -566,8 +566,9 @@ impl Client {
 
     /// Fetches the full metadata graph for a single media row —
     /// ROM-level + title-level tags and scraped properties. Identified
-    /// by `(system, path)`; the canonical indexed media path from
-    /// `media.search`/`media.browse` is required. Property values
+    /// by `mediaId` when available, otherwise `(system, path)` with the
+    /// canonical indexed media path from `media.search`/`media.browse`.
+    /// Property values
     /// surface their MIME type and extension when binary-backed, so
     /// callers can render or cache them without sniffing.
     pub async fn media_meta(

--- a/rust/zaparoo-core/src/config.rs
+++ b/rust/zaparoo-core/src/config.rs
@@ -50,6 +50,7 @@ pub struct SettingsConfig {
     pub mouse_enabled: Option<bool>,
     pub discover_arcade_alternate_versions: Option<bool>,
     pub screensaver_timeout: Option<String>,
+    pub media_image_type: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -63,6 +64,7 @@ pub struct SettingsMirror<'a> {
     pub discover_arcade_alternate_versions: bool,
     pub debug_logging: bool,
     pub screensaver_timeout: &'a str,
+    pub media_image_type: &'a str,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -139,6 +141,7 @@ struct RawSettings {
     mouse_enabled: Option<bool>,
     discover_arcade_alternate_versions: Option<bool>,
     screensaver_timeout: Option<String>,
+    media_image_type: Option<String>,
 }
 
 #[derive(Deserialize, Default)]
@@ -222,6 +225,10 @@ pub fn load_config(path: &Path) -> Config {
             .settings
             .screensaver_timeout
             .map(|value| value.trim().to_string()),
+        media_image_type: raw
+            .settings
+            .media_image_type
+            .map(|value| value.trim().to_string()),
     };
     cfg.notice = NoticeConfig {
         commercial_ack: raw.notice.commercial_ack.unwrap_or(false),
@@ -303,6 +310,10 @@ pub fn save_settings_mirror(path: &Path, mirror: SettingsMirror<'_>) -> Result<(
     settings.insert(
         "screensaver_timeout".into(),
         toml::Value::String(mirror.screensaver_timeout.trim().to_string()),
+    );
+    settings.insert(
+        "media_image_type".into(),
+        toml::Value::String(mirror.media_image_type.trim().to_string()),
     );
 
     let logging_value = table
@@ -621,6 +632,7 @@ mod tests {
                 discover_arcade_alternate_versions: true,
                 debug_logging: true,
                 screensaver_timeout: "300",
+                media_image_type: "auto",
             },
         )
         .expect("save");
@@ -655,6 +667,7 @@ mod tests {
                 discover_arcade_alternate_versions: false,
                 debug_logging: false,
                 screensaver_timeout: "60",
+                media_image_type: "auto",
             },
         )
         .expect("save");
@@ -689,6 +702,7 @@ mod tests {
                 discover_arcade_alternate_versions: true,
                 debug_logging: true,
                 screensaver_timeout: "off",
+                media_image_type: "auto",
             },
         )
         .expect("save");

--- a/rust/zaparoo-core/src/media_types.rs
+++ b/rust/zaparoo-core/src/media_types.rs
@@ -185,8 +185,9 @@ pub struct MediaBrowseParams {
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BrowseEntry {
-    /// Opaque media database row ID. Present on `media` entries only.
-    /// Treat as ephemeral — valid only for the current Core session.
+    /// Opaque media database row ID. Present on `media` entries and
+    /// singleton media-container `directory` entries on zip-as-directory
+    /// platforms. Treat as ephemeral — valid only for the current Core session.
     #[serde(default)]
     pub media_id: Option<i64>,
     pub name: String,
@@ -207,8 +208,8 @@ pub struct BrowseEntry {
     pub group: String,
     #[serde(default)]
     pub description: String,
-    /// Tags attached to a media entry. Empty for non-media (`directory`,
-    /// `root`) entries. Core only populates this on media leaves.
+    /// Tags attached to media-capable entries. Empty for normal folders;
+    /// Core can populate this on singleton media-container directories.
     #[serde(default)]
     pub tags: Vec<TagInfo>,
 }
@@ -415,6 +416,8 @@ pub struct MediaMeta {
     #[serde(default)]
     pub properties: HashMap<String, MediaMetaProperty>,
     #[serde(default)]
+    pub available_image_types: Vec<String>,
+    #[serde(default)]
     pub title: MediaMetaTitle,
 }
 
@@ -441,6 +444,8 @@ pub struct MediaMetaTitle {
     /// title slug.
     #[serde(default)]
     pub properties: HashMap<String, MediaMetaProperty>,
+    #[serde(default)]
+    pub available_image_types: Vec<String>,
 }
 
 /// One scraped property attached to a media row or title. Binary
@@ -661,16 +666,46 @@ pub struct IndexingStatusResponse {
     pub paused: bool,
 }
 
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScrapeSystemProgressResponse {
+    #[serde(default)]
+    pub system_id: String,
+    #[serde(default)]
+    pub system_name: String,
+    #[serde(default)]
+    pub processed: i32,
+    #[serde(default)]
+    pub total: i32,
+    #[serde(default)]
+    pub matched: i32,
+    #[serde(default)]
+    pub skipped: i32,
+}
+
 /// Snapshot of Core's scraper progress. Mirrors `ScrapingStatusResponse`
-/// from upstream. `scraper_id` and `system_id` carry the in-flight job's
-/// identifiers; the counters are cumulative for the run.
+/// from upstream. `total_steps` / `current_step` carry whole-run system
+/// progress; flat counters remain the per-current-system compatibility
+/// surface.
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ScrapingStatusResponse {
     #[serde(default)]
+    pub current_step: Option<i32>,
+    #[serde(default)]
+    pub current_step_display: Option<String>,
+    #[serde(default)]
+    pub total_steps: Option<i32>,
+    #[serde(default)]
+    pub current_system: Option<ScrapeSystemProgressResponse>,
+    #[serde(default)]
     pub scraper_id: String,
     #[serde(default)]
     pub system_id: String,
+    #[serde(default)]
+    pub state: String,
+    #[serde(default)]
+    pub error: String,
     #[serde(default)]
     pub processed: i32,
     #[serde(default)]
@@ -1780,6 +1815,11 @@ mod tests {
         let json = r#"{
             "scraperId": "screenscraper",
             "systemId": "SNES",
+            "state": "running",
+            "totalSteps": 5,
+            "currentStep": 2,
+            "currentStepDisplay": "Super Nintendo",
+            "currentSystem": {"systemId": "SNES", "systemName": "Super Nintendo", "processed": 12, "total": 200, "matched": 10, "skipped": 2},
             "processed": 12,
             "total": 200,
             "matched": 10,
@@ -1792,6 +1832,17 @@ mod tests {
         let result: ScrapingStatusResponse = serde_json::from_str(json).expect("parse");
         assert_eq!(result.scraper_id, "screenscraper");
         assert_eq!(result.system_id, "SNES");
+        assert_eq!(result.state, "running");
+        assert_eq!(result.total_steps, Some(5));
+        assert_eq!(result.current_step, Some(2));
+        assert_eq!(
+            result.current_step_display.as_deref(),
+            Some("Super Nintendo")
+        );
+        let current = result.current_system.as_ref().expect("current system");
+        assert_eq!(current.system_id, "SNES");
+        assert_eq!(current.system_name, "Super Nintendo");
+        assert_eq!(current.processed, 12);
         assert_eq!(result.processed, 12);
         assert_eq!(result.total, 200);
         assert_eq!(result.matched, 10);

--- a/rust/zaparoo-core/src/media_types.rs
+++ b/rust/zaparoo-core/src/media_types.rs
@@ -374,22 +374,35 @@ pub struct MediaImageResult {
     pub type_tag: String,
 }
 
-/// Parameters for `media.meta`. Identifies the media row by `(system,
-/// path)`. The result includes ROM-level and title-level metadata —
-/// tags, properties (text or binary with `extension` + `contentType`),
-/// and the shared title block.
+/// Parameters for `media.meta`. Identifies the media row by `media_id`
+/// when available, otherwise by `(system, path)`. The result includes
+/// ROM-level and title-level metadata — tags, properties (text or
+/// binary with `extension` + `contentType`), and the shared title block.
 #[derive(Debug, Clone, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MediaMetaParams {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub media_id: Option<i64>,
+    #[serde(skip_serializing_if = "String::is_empty")]
     pub system: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
     pub path: String,
 }
 
 impl MediaMetaParams {
     pub fn for_media(system: impl Into<String>, path: impl Into<String>) -> Self {
         Self {
+            media_id: None,
             system: system.into(),
             path: path.into(),
+        }
+    }
+
+    pub fn for_media_id(media_id: i64) -> Self {
+        Self {
+            media_id: Some(media_id),
+            system: String::new(),
+            path: String::new(),
         }
     }
 }
@@ -1376,6 +1389,20 @@ mod tests {
             object.get("path").and_then(|v| v.as_str()),
             Some("/roms/snes/x.sfc")
         );
+        assert!(!object.contains_key("mediaId"));
+    }
+
+    #[test]
+    fn media_meta_params_for_media_id_serialises_id_only() {
+        let params = MediaMetaParams::for_media_id(42);
+        let json = serde_json::to_value(&params).expect("serialise");
+        let object = json.as_object().expect("object");
+        assert_eq!(
+            object.get("mediaId").and_then(serde_json::Value::as_i64),
+            Some(42),
+        );
+        assert!(!object.contains_key("system"));
+        assert!(!object.contains_key("path"));
     }
 
     #[test]

--- a/rust/zaparoo-core/src/persist.rs
+++ b/rust/zaparoo-core/src/persist.rs
@@ -111,6 +111,8 @@ pub struct SettingsState {
     pub debug_logging: bool,
     #[serde(default = "default_screensaver_timeout")]
     pub screensaver_timeout: String,
+    #[serde(default = "default_media_image_type")]
+    pub media_image_type: String,
 }
 
 impl Default for SettingsState {
@@ -125,6 +127,7 @@ impl Default for SettingsState {
             discover_arcade_alternate_versions: false,
             debug_logging: false,
             screensaver_timeout: default_screensaver_timeout(),
+            media_image_type: default_media_image_type(),
         }
     }
 }
@@ -150,6 +153,10 @@ fn default_mouse_enabled() -> bool {
 
 fn default_screensaver_timeout() -> String {
     "300".into()
+}
+
+fn default_media_image_type() -> String {
+    "auto".into()
 }
 
 pub fn load() -> PersistedState {
@@ -284,6 +291,7 @@ mod tests {
                 discover_arcade_alternate_versions: true,
                 debug_logging: true,
                 screensaver_timeout: "300".into(),
+                media_image_type: "auto".into(),
             },
         };
         save_to(&path, &original);

--- a/rust/zaparoo-core/src/store/media_status.rs
+++ b/rust/zaparoo-core/src/store/media_status.rs
@@ -68,6 +68,11 @@ pub struct MediaStatusState {
     pub scrape_total_scraped: i32,
     pub scrape_system_id: String,
     pub scrape_scraper_id: String,
+    pub scrape_state: String,
+    pub scrape_error: String,
+    pub scrape_current_step: i32,
+    pub scrape_total_steps: i32,
+    pub scrape_current_step_display: String,
 }
 
 impl MediaStatusState {
@@ -98,6 +103,15 @@ impl MediaStatusState {
         self.scrape_total_scraped = status.total_scraped;
         self.scrape_system_id.clone_from(&status.system_id);
         self.scrape_scraper_id.clone_from(&status.scraper_id);
+        self.scrape_state.clone_from(&status.state);
+        self.scrape_error.clone_from(&status.error);
+        self.scrape_current_step = status.current_step.unwrap_or(0);
+        self.scrape_total_steps = status.total_steps.unwrap_or(0);
+        status
+            .current_step_display
+            .as_deref()
+            .unwrap_or_default()
+            .clone_into(&mut self.scrape_current_step_display);
     }
 }
 
@@ -359,6 +373,8 @@ mod tests {
         let tx = Arc::new(tx);
         let payload = json!({
             "scraperId": "screenscraper", "systemId": "SNES",
+            "state": "running", "currentStep": 2, "totalSteps": 5,
+            "currentStepDisplay": "Super Nintendo",
             "processed": 12, "total": 200, "matched": 10, "skipped": 2,
             "totalScraped": 50, "scraping": true, "done": false, "paused": false
         });
@@ -374,6 +390,10 @@ mod tests {
         assert_eq!(snapshot.scrape_processed, 12);
         assert_eq!(snapshot.scrape_total, 200);
         assert_eq!(snapshot.scrape_system_id, "SNES");
+        assert_eq!(snapshot.scrape_state, "running");
+        assert_eq!(snapshot.scrape_current_step, 2);
+        assert_eq!(snapshot.scrape_total_steps, 5);
+        assert_eq!(snapshot.scrape_current_step_display, "Super Nintendo");
         // `scraped`-side notifications must not flip the indexing
         // `seeded` flag — that's the `media` query's job.
         assert!(!snapshot.seeded);

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -739,7 +739,7 @@ MainLayout {
         }
     }
 
-    // Pure helper — owner/entryType/hasNfc/isFavorite → list of `{id,label}` entries.
+    // Pure helper — owner/entryType/mediaCapable/hasNfc/isFavorite → list of `{id,label}` entries.
     // Empty list = no menu (caller bails out of openContextMenu).
     //
     // Annotated as `: var` (not `list<var>`): MiSTer's AOT-compiled
@@ -747,7 +747,7 @@ MainLayout {
     // caller saw `entries.length === 0` despite the function pushing 3
     // items in. Plain `var` round-trips cleanly and silences the
     // "insufficiently annotated" coercion warning at the call site.
-    function buildContextMenuEntries(owner: string, entryType: string, hasNfc: bool, isFavorite: bool, systemId: string) {
+    function buildContextMenuEntries(owner: string, entryType: string, mediaCapable: bool, hasNfc: bool, isFavorite: bool, systemId: string) {
         if (owner === "systems") {
             const entries = [
                 {
@@ -778,7 +778,7 @@ MainLayout {
             return entries;
         }
         if (owner === "games" || owner === "favorites") {
-            if (entryType === "directory" || entryType === "root")
+            if ((entryType === "directory" || entryType === "root") && !mediaCapable)
                 return [];
             const entries = [];
             entries.push({
@@ -854,6 +854,7 @@ MainLayout {
         let entryType = "";
         let isFavorite = false;
         let systemId = "";
+        let mediaCapable = false;
         if (owner === "systems") {
             if (index >= Browse.SystemsModel.count)
                 return;
@@ -862,16 +863,18 @@ MainLayout {
             if (index >= Browse.GamesModel.count)
                 return;
             entryType = Browse.GamesModel.entry_type_at(index);
+            mediaCapable = Browse.GamesModel.is_media_capable_at(index);
             isFavorite = Browse.GamesModel.is_favorite_at(index);
         } else if (owner === "favorites") {
             if (index >= Browse.FavoritesModel.count)
                 return;
+            mediaCapable = true;
             isFavorite = Browse.FavoritesModel.is_favorite_at(index);
         } else if (owner === "recents") {
             if (index >= Browse.RecentsModel.count)
                 return;
         }
-        const entries = root.buildContextMenuEntries(owner, entryType, Browse.SystemStatus.has_nfc, isFavorite, systemId);
+        const entries = root.buildContextMenuEntries(owner, entryType, mediaCapable, Browse.SystemStatus.has_nfc, isFavorite, systemId);
         if (entries.length === 0)
             return;
         root.contextMenuEntries = entries;
@@ -1305,6 +1308,8 @@ MainLayout {
             return;
         } else if (fieldId === "screensaverTimeout")
             Browse.Settings.set_screensaver_timeout(selectedId);
+        else if (fieldId === "mediaImageType")
+            Browse.Settings.set_media_image_type(selectedId);
         root.closeListPickerModal();
     }
     onListPickerCloseRequested: root.handleListPickerCloseRequested()

--- a/src/ui/app/MainLayout.qml
+++ b/src/ui/app/MainLayout.qml
@@ -420,367 +420,488 @@ ApplicationWindow {
             transformOrigin: Item.Center
             rotation: root.displayOrientation === "cw" ? 90 : root.displayOrientation === "ccw" ? -90 : 0
 
-        // ── Background ────────────────────────────────────────────────────────────
+            // ── Background ────────────────────────────────────────────────────────────
 
-        Rectangle {
-            anchors.fill: parent
-            color: Theme.bgDeep
-        }
-
-        // Faint circuit-trace texture, tiled across the whole window. The
-        // PNG is pre-rendered from resources/images/bg-circuit.svg at the
-        // source pattern's native 304×304 size, with white at ~8 % alpha
-        // baked into the pixmap so QtSvg isn't needed at runtime. Sits
-        // between bgDeep and the rest of the tree so logos, captions, and
-        // selection cards stay fully legible. `Image.Tile` is software-
-        // rendered, so this is MiSTer-safe; `cache: true` keeps the
-        // pixmap in QPixmapCache after first decode.
-        Image {
-            anchors.fill: parent
-            source: "qrc:/qt/qml/Zaparoo/App/resources/images/bg-circuit.png"
-            fillMode: Image.Tile
-            cache: true
-            smooth: false        // 1:1 tile — filtering would just blur the lines
-            // Synchronous so the first frame paints with the texture instead
-            // of flashing the bare bgDeep underneath. One small PNG decode
-            // at startup is cheap.
-            asynchronous: false
-        }
-
-        // ── Top header (logo + status row + status pill) ───────────────────────────
-
-        // Single component owning the brand mark, host status icons +
-        // clock, and Core status pill. Height is fixed (Sizing.headerHeight)
-        // so the pill's slot stays reserved when idle and the logo always
-        // matches the stacked rows. Screens clear `Sizing.headerBottom`.
-        HeaderBar {
-            id: headerBar
-
-            anchors.left: parent.left
-            anchors.right: parent.right
-            anchors.top: parent.top
-            anchors.topMargin: Sizing.headerTopMargin
-            layoutProfile: root._browseViewProfile
-            browseTitle: root.browseHeaderTitle
-            browseProgressText: root.browseHeaderProgressText
-            z: 200
-        }
-
-        // ── Screen containers ─────────────────────────────────────────────────────
-
-        // Stacked container — only the active screen paints. Hub →
-        // Systems → Games drill-downs (and Esc back) are instant cuts:
-        // bind `visible` directly on the live `activeScreen` and let
-        // Qt's scene graph swap which screen paints in one frame.
-        //
-        // Earlier iterations tried a horizontal slide, then a direct
-        // opacity fade on the screen container, then an overlay-rectangle
-        // fade. All three were structurally too expensive for Qt Quick's
-        // Software adaptation when the destination screen is a dense
-        // grid. Translucent overlays don't subtract from the renderer's
-        // dirty region, so every cell underneath re-rasterises per frame
-        // throughout the fade — text labels, cover images, card bodies.
-        // Instant cuts paint the new screen exactly once. See
-        // docs/qml-gotchas.md → "Software-renderer animation costs"
-        // for the full reasoning.
-        //
-        // No additional cue on screen change: the help-bar text changes
-        // instantly, the screen body swaps, and the user just pressed
-        // OK or Esc — the action is deliberate and the feedback is
-        // immediate. The page-dot pulse inside `PagedGrid` is the only
-        // animated transition cue in the frontend.
-        //
-        // The wrapper `Item` stays for grouping clarity; with no fade
-        // machinery it carries no buffered state. Model bindings stay
-        // live across deactivations so Esc back to systems doesn't
-        // re-instantiate the whole delegate tree — Items with
-        // `visible: false` skip painting but keep their scene graph
-        // alive and their decoded covers warm.
-        Item {
-            id: stackedScreens
-
-            anchors.fill: parent
-            // Screens stay hidden until the catalog has loaded for the
-            // first time. BootOverlay holds the window in the meantime;
-            // see the `bootComplete` property declaration above.
-            visible: root.bootComplete
-
-            HubScreen {
-                id: hubScreen
+            Rectangle {
                 anchors.fill: parent
-                visible: root.activeScreen === root.screenHub
-                transitioning: root.pendingTransition !== ""
+                color: Theme.bgDeep
             }
 
-            SystemsScreen {
-                id: systemsScreen
+            // Faint circuit-trace texture, tiled across the whole window. The
+            // PNG is pre-rendered from resources/images/bg-circuit.svg at the
+            // source pattern's native 304×304 size, with white at ~8 % alpha
+            // baked into the pixmap so QtSvg isn't needed at runtime. Sits
+            // between bgDeep and the rest of the tree so logos, captions, and
+            // selection cards stay fully legible. `Image.Tile` is software-
+            // rendered, so this is MiSTer-safe; `cache: true` keeps the
+            // pixmap in QPixmapCache after first decode.
+            Image {
                 anchors.fill: parent
-                visible: root.activeScreen === root.screenSystems
-                transitioning: root.pendingTransition !== ""
+                source: "qrc:/qt/qml/Zaparoo/App/resources/images/bg-circuit.png"
+                fillMode: Image.Tile
+                cache: true
+                smooth: false        // 1:1 tile — filtering would just blur the lines
+                // Synchronous so the first frame paints with the texture instead
+                // of flashing the bare bgDeep underneath. One small PNG decode
+                // at startup is cheap.
+                asynchronous: false
             }
 
-            GamesScreen {
-                id: gamesScreen
-                anchors.fill: parent
-                visible: root.activeScreen === root.screenGames
-                transitioning: root.pendingTransition !== ""
+            // ── Top header (logo + status row + status pill) ───────────────────────────
+
+            // Single component owning the brand mark, host status icons +
+            // clock, and Core status pill. Height is fixed (Sizing.headerHeight)
+            // so the pill's slot stays reserved when idle and the logo always
+            // matches the stacked rows. Screens clear `Sizing.headerBottom`.
+            HeaderBar {
+                id: headerBar
+
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.top: parent.top
+                anchors.topMargin: Sizing.headerTopMargin
+                layoutProfile: root._browseViewProfile
+                browseTitle: root.browseHeaderTitle
+                browseProgressText: root.browseHeaderProgressText
+                z: 200
             }
 
-            FavoritesScreen {
-                id: favoritesScreen
-                anchors.fill: parent
-                visible: root.activeScreen === root.screenFavorites
-                transitioning: root.pendingTransition !== ""
-            }
+            // ── Screen containers ─────────────────────────────────────────────────────
 
-            RecentsScreen {
-                id: recentsScreen
-                anchors.fill: parent
-                visible: root.activeScreen === root.screenRecents
-                transitioning: root.pendingTransition !== ""
-            }
-
-            SettingsScreen {
-                id: settingsScreen
-                anchors.fill: parent
-                visible: root.activeScreen === root.screenSettings
-                transitioning: root.pendingTransition !== ""
-            }
-
-            AboutScreen {
-                id: aboutScreen
-                anchors.fill: parent
-                visible: root.activeScreen === root.screenAbout
-                transitioning: root.pendingTransition !== ""
-            }
-        }
-
-        // ── Boot overlay ─────────────────────────────────────────────────────────
-        //
-        // Painted between the screens and the modal layer; unmounts itself
-        // the first time `bootComplete` flips true. Loader (rather than
-        // `visible: false`) so the overlay leaves the scene graph after
-        // dismissal — a subsequent disconnect must not bring it back over
-        // the user's cached catalog.
-
-        Loader {
-            anchors.fill: parent
-            active: !root.bootComplete
-            z: 50
-            sourceComponent: BootOverlay {}
-        }
-
-        // ── Card writer modal ────────────────────────────────────────────────────
-
-        Modal {
-            id: cardWriteModal
-
-            open: root.cardWriteModalVisible
-            kind: "transient"
-            failed: root.cardWriteFailed
-            title: root.cardWriteFailed ? qsTr("Writing failed") : qsTr("Put a writable card near the reader")
-            onCancelRequested: root.cancelCardWriteRequested()
-        }
-
-        // ── Setting restart prompt modal ────────────────────────────────────────────────────
-
-        Modal {
-            id: settingNeedsRestartModal
-
-            open: root.settingNeedsRestartModalVisible
-            kind: "confirm"
-            title: qsTr("Quit and restart Zaparoo Frontend?")
-            body: qsTr("In order to apply this setting we need to restart the frontend.")
-            onConfirmed: root.acceptRestart()
-            onCancelRequested: root.cancelRestart()
-        }
-
-        ContextMenu {
-            id: contextMenu
-
-            open: root.contextMenuVisible
-            anchorRect: root.contextMenuAnchor
-            entries: root.contextMenuEntries
-            bottomUnsafeHeight: BrowseLayouts.numberValue(root._browseViewProfile, "footer.bottomUnsafeHeight", Sizing.pctH(6) + Sizing.pctH(2))
-            onAccepted: id => root.contextMenuAccepted(id)
-            onCloseRequested: root.contextMenuCloseRequested()
-        }
-
-        QrCodeModal {
-            id: qrCodeModal
-
-            anchors.fill: parent
-            open: root.qrCodeModalVisible
-        }
-
-        GameInfoModal {
-            id: gameInfoModal
-
-            anchors.fill: parent
-            open: root.gameInfoModalVisible
-            onCloseRequested: root.closeGameInfoRequested()
-        }
-
-        // First-run mediadb index modal. Pushed by Main.qml the first time
-        // we connect to a Core whose mediadb is empty. Blocks the screens
-        // beneath until the initial scan completes (or the user cancels and
-        // tries again).
-        FirstRunIndexModal {
-            id: firstRunIndexModal
-
-            anchors.fill: parent
-            open: root.firstRunIndexModalVisible
-            onCloseRequested: root.closeFirstRunIndexRequested()
-        }
-
-        // Commercial-use notice. Sits above every other modal (z: 310) so
-        // it always paints first on a fresh install. Once the user acks,
-        // `Browse.Notice.commercial_ack` flips to true on disk and the
-        // modal stays closed for the rest of this install.
-        CommercialNoticeModal {
-            id: commercialNoticeModal
-
-            anchors.fill: parent
-            open: root.commercialNoticeModalVisible
-            onCloseRequested: root.closeCommercialNoticeRequested()
-        }
-
-        // Log-upload modal. Pushed by Main.qml when the user triggers the
-        // "Upload log" action in Settings. Owns its own three-phase view
-        // (uploading / success / error) — the router only sees open / close.
-        LogUploadModal {
-            id: logUploadModal
-
-            anchors.fill: parent
-            open: root.logUploadModalVisible
-            onCloseRequested: root.closeLogUploadRequested()
-        }
-
-        // Quit-confirm modal. Pushed by Main.qml when the user presses
-        // cancel on Hub. Default focus is "No" so an accidental press
-        // can't quit; "Yes" routes through `quitConfirmAccepted` and the
-        // router calls Qt.quit().
-        Modal {
-            id: quitConfirmModal
-
-            open: root.quitConfirmModalVisible
-            kind: "confirm"
-            title: qsTr("Quit Zaparoo Frontend?")
-            body: qsTr("Are you sure you want to exit?")
-            onConfirmed: root.quitConfirmAccepted()
-            onCancelRequested: root.closeQuitConfirmRequested()
-        }
-
-        // List-picker modal. Settings opens this for picker rows
-        // (Language, Browsing layout, Button style, Resolution). The
-        // fieldId round-trip lets the router dispatch the chosen id
-        // back to the matching Browse.Settings.set_X without parsing
-        // the title.
-        ListPickerModal {
-            id: listPickerModal
-
-            anchors.fill: parent
-            open: root.listPickerModalVisible
-            title: root.listPickerTitle
-            entries: root.listPickerEntries
-            initialId: root.listPickerInitialId
-            onAccepted: id => root.listPickerAccepted(root.listPickerFieldId, id)
-            onCloseRequested: root.listPickerCloseRequested(root.listPickerFieldId)
-        }
-
-        // ── Instructions bar ──────────────────────────────────────────────────────
-
-        Rectangle {
-            id: instructionsBar
-
-            anchors.left: parent.left
-            anchors.right: parent.right
-            anchors.bottom: parent.bottom
-            height: Sizing.pctH(6)
-            // Sits above every modal scrim (modals max out at z: 310 — see
-            // CommercialNoticeModal) so the help cue stays readable while a
-            // dialog is open. The bar's content is already modal-aware
-            // (helpEntries above branches per topModal), so the cue under
-            // the modal is the right one.
-            z: 400
-            color: Theme.bgBar
-            border.width: Sizing.stroke(1)
-            border.color: Theme.borderSubtle
-
-            // (activeScreen, screenState, modal?)-keyed lookup. The modal
-            // row wins outright; otherwise per-screen entries vary with
-            // the screen's data-state (Loading / Error / Empty / Ready).
-            // Error and Empty share the retry-or-back row on Systems and
-            // Games (both wire `accept` to re-fire `set_category` /
-            // `set_system` in non-Ready state). Hub has no retry handler
-            // — CategoriesModel binds eagerly via bind_to_endpoint! and
-            // recovers automatically — so its non-Ready row drops the
-            // Retry entry rather than promising behavior the screen
-            // doesn't implement.
+            // Stacked container — only the active screen paints. Hub →
+            // Systems → Games drill-downs (and Esc back) are instant cuts:
+            // bind `visible` directly on the live `activeScreen` and let
+            // Qt's scene graph swap which screen paints in one frame.
             //
-            // During a forward transition (`pendingTransition !== ""`)
-            // the router's input gate swallows every press — including
-            // cancel — so the bar blanks rather than advertising
-            // buttons that won't respond. Modals still win outright;
-            // they run on top of the input gate.
+            // Earlier iterations tried a horizontal slide, then a direct
+            // opacity fade on the screen container, then an overlay-rectangle
+            // fade. All three were structurally too expensive for Qt Quick's
+            // Software adaptation when the destination screen is a dense
+            // grid. Translucent overlays don't subtract from the renderer's
+            // dirty region, so every cell underneath re-rasterises per frame
+            // throughout the fade — text labels, cover images, card bodies.
+            // Instant cuts paint the new screen exactly once. See
+            // docs/qml-gotchas.md → "Software-renderer animation costs"
+            // for the full reasoning.
             //
-            // Each entry resolves to a button glyph (Dpad / ButtonA /
-            // ButtonB / ButtonX) plus a label. The button names are routed
-            // through Resources.iconUrl(), which owns the qrc path rules.
+            // No additional cue on screen change: the help-bar text changes
+            // instantly, the screen body swaps, and the user just pressed
+            // OK or Esc — the action is deliberate and the feedback is
+            // immediate. The page-dot pulse inside `PagedGrid` is the only
+            // animated transition cue in the frontend.
             //
-            // Label vocabulary is deliberately minimal: D-pad is always
-            // "Move"; A is "Open" for both drill-downs and launches (the
-            // tile and screen title carry the specific identity, so the
-            // verb doesn't need to repeat that); B is "Back" except on
-            // the Hub root, where it's "Quit". Sentence case throughout.
-            readonly property var helpEntries: {
-                if (root.contextMenuVisible)
-                    return [
-                        {
-                            button: "Dpad",
-                            label: qsTr("Move")
-                        },
-                        {
-                            button: "ButtonA",
-                            label: qsTr("Select")
-                        },
-                        {
-                            button: "ButtonB",
-                            label: qsTr("Close")
-                        },
-                        {
-                            button: "ButtonX",
-                            label: qsTr("Close")
-                        }
-                    ];
-                if (root.cardWriteModalVisible)
-                    return [
-                        {
-                            button: "ButtonB",
-                            label: qsTr("Cancel")
-                        }
-                    ];
-                if (root.qrCodeModalVisible || root.gameInfoModalVisible)
-                    return [
-                        {
-                            button: "ButtonB",
-                            label: qsTr("Close")
-                        }
-                    ];
-                if (root.logUploadModalVisible) {
-                    const phase = root.logUploadModal.phase;
-                    if (phase === root.logUploadModal._stateSuccess)
+            // The wrapper `Item` stays for grouping clarity; with no fade
+            // machinery it carries no buffered state. Model bindings stay
+            // live across deactivations so Esc back to systems doesn't
+            // re-instantiate the whole delegate tree — Items with
+            // `visible: false` skip painting but keep their scene graph
+            // alive and their decoded covers warm.
+            Item {
+                id: stackedScreens
+
+                anchors.fill: parent
+                // Screens stay hidden until the catalog has loaded for the
+                // first time. BootOverlay holds the window in the meantime;
+                // see the `bootComplete` property declaration above.
+                visible: root.bootComplete
+
+                HubScreen {
+                    id: hubScreen
+                    anchors.fill: parent
+                    visible: root.activeScreen === root.screenHub
+                    transitioning: root.pendingTransition !== ""
+                }
+
+                SystemsScreen {
+                    id: systemsScreen
+                    anchors.fill: parent
+                    visible: root.activeScreen === root.screenSystems
+                    transitioning: root.pendingTransition !== ""
+                }
+
+                GamesScreen {
+                    id: gamesScreen
+                    anchors.fill: parent
+                    visible: root.activeScreen === root.screenGames
+                    transitioning: root.pendingTransition !== ""
+                }
+
+                FavoritesScreen {
+                    id: favoritesScreen
+                    anchors.fill: parent
+                    visible: root.activeScreen === root.screenFavorites
+                    transitioning: root.pendingTransition !== ""
+                }
+
+                RecentsScreen {
+                    id: recentsScreen
+                    anchors.fill: parent
+                    visible: root.activeScreen === root.screenRecents
+                    transitioning: root.pendingTransition !== ""
+                }
+
+                SettingsScreen {
+                    id: settingsScreen
+                    anchors.fill: parent
+                    visible: root.activeScreen === root.screenSettings
+                    transitioning: root.pendingTransition !== ""
+                }
+
+                AboutScreen {
+                    id: aboutScreen
+                    anchors.fill: parent
+                    visible: root.activeScreen === root.screenAbout
+                    transitioning: root.pendingTransition !== ""
+                }
+            }
+
+            // ── Boot overlay ─────────────────────────────────────────────────────────
+            //
+            // Painted between the screens and the modal layer; unmounts itself
+            // the first time `bootComplete` flips true. Loader (rather than
+            // `visible: false`) so the overlay leaves the scene graph after
+            // dismissal — a subsequent disconnect must not bring it back over
+            // the user's cached catalog.
+
+            Loader {
+                anchors.fill: parent
+                active: !root.bootComplete
+                z: 50
+                sourceComponent: BootOverlay {}
+            }
+
+            // ── Card writer modal ────────────────────────────────────────────────────
+
+            Modal {
+                id: cardWriteModal
+
+                open: root.cardWriteModalVisible
+                kind: "transient"
+                failed: root.cardWriteFailed
+                title: root.cardWriteFailed ? qsTr("Writing failed") : qsTr("Put a writable card near the reader")
+                onCancelRequested: root.cancelCardWriteRequested()
+            }
+
+            // ── Setting restart prompt modal ────────────────────────────────────────────────────
+
+            Modal {
+                id: settingNeedsRestartModal
+
+                open: root.settingNeedsRestartModalVisible
+                kind: "confirm"
+                title: qsTr("Quit and restart Zaparoo Frontend?")
+                body: qsTr("In order to apply this setting we need to restart the frontend.")
+                onConfirmed: root.acceptRestart()
+                onCancelRequested: root.cancelRestart()
+            }
+
+            ContextMenu {
+                id: contextMenu
+
+                open: root.contextMenuVisible
+                anchorRect: root.contextMenuAnchor
+                entries: root.contextMenuEntries
+                bottomUnsafeHeight: BrowseLayouts.numberValue(root._browseViewProfile, "footer.bottomUnsafeHeight", Sizing.pctH(6) + Sizing.pctH(2))
+                onAccepted: id => root.contextMenuAccepted(id)
+                onCloseRequested: root.contextMenuCloseRequested()
+            }
+
+            QrCodeModal {
+                id: qrCodeModal
+
+                anchors.fill: parent
+                open: root.qrCodeModalVisible
+            }
+
+            GameInfoModal {
+                id: gameInfoModal
+
+                anchors.fill: parent
+                open: root.gameInfoModalVisible
+                onCloseRequested: root.closeGameInfoRequested()
+            }
+
+            // First-run mediadb index modal. Pushed by Main.qml the first time
+            // we connect to a Core whose mediadb is empty. Blocks the screens
+            // beneath until the initial scan completes (or the user cancels and
+            // tries again).
+            FirstRunIndexModal {
+                id: firstRunIndexModal
+
+                anchors.fill: parent
+                open: root.firstRunIndexModalVisible
+                onCloseRequested: root.closeFirstRunIndexRequested()
+            }
+
+            // Commercial-use notice. Sits above every other modal (z: 310) so
+            // it always paints first on a fresh install. Once the user acks,
+            // `Browse.Notice.commercial_ack` flips to true on disk and the
+            // modal stays closed for the rest of this install.
+            CommercialNoticeModal {
+                id: commercialNoticeModal
+
+                anchors.fill: parent
+                open: root.commercialNoticeModalVisible
+                onCloseRequested: root.closeCommercialNoticeRequested()
+            }
+
+            // Log-upload modal. Pushed by Main.qml when the user triggers the
+            // "Upload log" action in Settings. Owns its own three-phase view
+            // (uploading / success / error) — the router only sees open / close.
+            LogUploadModal {
+                id: logUploadModal
+
+                anchors.fill: parent
+                open: root.logUploadModalVisible
+                onCloseRequested: root.closeLogUploadRequested()
+            }
+
+            // Quit-confirm modal. Pushed by Main.qml when the user presses
+            // cancel on Hub. Default focus is "No" so an accidental press
+            // can't quit; "Yes" routes through `quitConfirmAccepted` and the
+            // router calls Qt.quit().
+            Modal {
+                id: quitConfirmModal
+
+                open: root.quitConfirmModalVisible
+                kind: "confirm"
+                title: qsTr("Quit Zaparoo Frontend?")
+                body: qsTr("Are you sure you want to exit?")
+                onConfirmed: root.quitConfirmAccepted()
+                onCancelRequested: root.closeQuitConfirmRequested()
+            }
+
+            // List-picker modal. Settings opens this for picker rows
+            // (Language, Browsing layout, Button style, Resolution). The
+            // fieldId round-trip lets the router dispatch the chosen id
+            // back to the matching Browse.Settings.set_X without parsing
+            // the title.
+            ListPickerModal {
+                id: listPickerModal
+
+                anchors.fill: parent
+                open: root.listPickerModalVisible
+                title: root.listPickerTitle
+                entries: root.listPickerEntries
+                initialId: root.listPickerInitialId
+                onAccepted: id => root.listPickerAccepted(root.listPickerFieldId, id)
+                onCloseRequested: root.listPickerCloseRequested(root.listPickerFieldId)
+            }
+
+            // ── Instructions bar ──────────────────────────────────────────────────────
+
+            Rectangle {
+                id: instructionsBar
+
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.bottom: parent.bottom
+                height: Sizing.pctH(6)
+                // Sits above every modal scrim (modals max out at z: 310 — see
+                // CommercialNoticeModal) so the help cue stays readable while a
+                // dialog is open. The bar's content is already modal-aware
+                // (helpEntries above branches per topModal), so the cue under
+                // the modal is the right one.
+                z: 400
+                color: Theme.bgBar
+                border.width: Sizing.stroke(1)
+                border.color: Theme.borderSubtle
+
+                // (activeScreen, screenState, modal?)-keyed lookup. The modal
+                // row wins outright; otherwise per-screen entries vary with
+                // the screen's data-state (Loading / Error / Empty / Ready).
+                // Error and Empty share the retry-or-back row on Systems and
+                // Games (both wire `accept` to re-fire `set_category` /
+                // `set_system` in non-Ready state). Hub has no retry handler
+                // — CategoriesModel binds eagerly via bind_to_endpoint! and
+                // recovers automatically — so its non-Ready row drops the
+                // Retry entry rather than promising behavior the screen
+                // doesn't implement.
+                //
+                // During a forward transition (`pendingTransition !== ""`)
+                // the router's input gate swallows every press — including
+                // cancel — so the bar blanks rather than advertising
+                // buttons that won't respond. Modals still win outright;
+                // they run on top of the input gate.
+                //
+                // Each entry resolves to a button glyph (Dpad / ButtonA /
+                // ButtonB / ButtonX) plus a label. The button names are routed
+                // through Resources.iconUrl(), which owns the qrc path rules.
+                //
+                // Label vocabulary is deliberately minimal: D-pad is always
+                // "Move"; A is "Open" for both drill-downs and launches (the
+                // tile and screen title carry the specific identity, so the
+                // verb doesn't need to repeat that); B is "Back" except on
+                // the Hub root, where it's "Quit". Sentence case throughout.
+                readonly property var helpEntries: {
+                    if (root.contextMenuVisible)
                         return [
                             {
-                                button: "ButtonA",
-                                label: qsTr("Done")
+                                button: "Dpad",
+                                label: qsTr("Move")
                             },
+                            {
+                                button: "ButtonA",
+                                label: qsTr("Select")
+                            },
+                            {
+                                button: "ButtonB",
+                                label: qsTr("Close")
+                            },
+                            {
+                                button: "ButtonX",
+                                label: qsTr("Close")
+                            }
+                        ];
+                    if (root.cardWriteModalVisible)
+                        return [
+                            {
+                                button: "ButtonB",
+                                label: qsTr("Cancel")
+                            }
+                        ];
+                    if (root.qrCodeModalVisible || root.gameInfoModalVisible)
+                        return [
                             {
                                 button: "ButtonB",
                                 label: qsTr("Close")
                             }
                         ];
-                    if (phase === root.logUploadModal._stateError)
+                    if (root.logUploadModalVisible) {
+                        const phase = root.logUploadModal.phase;
+                        if (phase === root.logUploadModal._stateSuccess)
+                            return [
+                                {
+                                    button: "ButtonA",
+                                    label: qsTr("Done")
+                                },
+                                {
+                                    button: "ButtonB",
+                                    label: qsTr("Close")
+                                }
+                            ];
+                        if (phase === root.logUploadModal._stateError)
+                            return [
+                                {
+                                    button: "ButtonA",
+                                    label: qsTr("Retry")
+                                },
+                                {
+                                    button: "ButtonB",
+                                    label: qsTr("Close")
+                                }
+                            ];
+                        // Idle / uploading: only Cancel.
+                        return [
+                            {
+                                button: "ButtonB",
+                                label: qsTr("Cancel")
+                            }
+                        ];
+                    }
+                    if (root.commercialNoticeModalVisible)
+                        return [
+                            {
+                                button: "ButtonA",
+                                label: qsTr("I understand")
+                            }
+                        ];
+                    if (root.quitConfirmModalVisible || root.settingNeedsRestartModalVisible || root.listPickerModalVisible)
+                        return [
+                            {
+                                button: "Dpad",
+                                label: qsTr("Move")
+                            },
+                            {
+                                button: "ButtonA",
+                                label: qsTr("Select")
+                            },
+                            {
+                                button: "ButtonB",
+                                label: qsTr("Cancel")
+                            }
+                        ];
+                    if (!root.bootComplete)
+                        return [];
+                    if (root.firstRunIndexModalVisible) {
+                        const phase = root.firstRunIndexModal.phase;
+                        if (phase === "running")
+                            return [
+                                {
+                                    button: "ButtonB",
+                                    label: qsTr("Cancel")
+                                }
+                            ];
+                        if (phase === "completed")
+                            return [];
+                        return [
+                            {
+                                button: "ButtonA",
+                                label: qsTr("Start")
+                            }
+                        ];
+                    }
+                    if (root.pendingTransition !== "")
+                        return [];
+                    if (root.activeScreen === root.screenHub) {
+                        // Hub always has the actions row (Recently Played /
+                        // Settings), so Move/Open/Quit applies even when the
+                        // categories row is empty (0 systems indexed) — the
+                        // help bar must reflect that the actions row is
+                        // navigable, otherwise the user reads "Quit only"
+                        // and misses the Settings tile entirely.
+                        return [
+                            {
+                                button: "Dpad",
+                                label: qsTr("Move")
+                            },
+                            {
+                                button: "ButtonA",
+                                label: qsTr("Open")
+                            },
+                            {
+                                button: "ButtonB",
+                                label: qsTr("Quit")
+                            }
+                        ];
+                    }
+                    if (root.activeScreen === root.screenSystems) {
+                        if (root.systemsScreenState === "loading")
+                            return [
+                                {
+                                    button: "ButtonB",
+                                    label: qsTr("Back")
+                                }
+                            ];
+                        if (root.systemsScreenState === "ready") {
+                            // L/R shoulders page jump; only advertise the cue
+                            // when there's a second page to jump to, so we
+                            // don't promise a press that no-ops on a single
+                            // page of systems.
+                            const pages = root.systemsScreen.systemsGrid.pageCount;
+                            let row = [
+                                {
+                                    button: "Dpad",
+                                    label: qsTr("Move")
+                                }
+                            ];
+                            if (pages > 1)
+                                row.push({
+                                    buttons: ["ButtonL", "ButtonR"],
+                                    label: qsTr("Page")
+                                });
+                            row.push({
+                                button: "ButtonA",
+                                label: qsTr("Open")
+                            }, {
+                                button: "ButtonX",
+                                label: qsTr("Options")
+                            }, {
+                                button: "ButtonB",
+                                label: qsTr("Back")
+                            });
+                            return row;
+                        }
                         return [
                             {
                                 button: "ButtonA",
@@ -788,144 +909,128 @@ ApplicationWindow {
                             },
                             {
                                 button: "ButtonB",
-                                label: qsTr("Close")
+                                label: qsTr("Back")
                             }
                         ];
-                    // Idle / uploading: only Cancel.
-                    return [
-                        {
-                            button: "ButtonB",
-                            label: qsTr("Cancel")
+                    }
+                    if (root.activeScreen === root.screenFavorites || root.activeScreen === root.screenRecents) {
+                        const isFavorites = root.activeScreen === root.screenFavorites;
+                        const state = isFavorites ? root.favoritesScreenState : root.recentsScreenState;
+                        const grid = isFavorites ? root.favoritesScreen.favoritesGrid : root.recentsScreen.recentsGrid;
+                        if (state === "loading")
+                            return [
+                                {
+                                    button: "ButtonB",
+                                    label: qsTr("Back")
+                                }
+                            ];
+                        if (state === "ready") {
+                            const pages = grid.pageCount;
+                            let row = [
+                                {
+                                    button: "Dpad",
+                                    label: qsTr("Move")
+                                }
+                            ];
+                            if (pages > 1)
+                                row.push({
+                                    buttons: ["ButtonL", "ButtonR"],
+                                    label: qsTr("Page")
+                                });
+                            row.push({
+                                button: "ButtonA",
+                                label: qsTr("Open")
+                            });
+                            if (isFavorites)
+                                row.push({
+                                    button: "ButtonX",
+                                    label: qsTr("Options")
+                                });
+                            row.push({
+                                button: "ButtonB",
+                                label: qsTr("Back")
+                            });
+                            return row;
                         }
-                    ];
-                }
-                if (root.commercialNoticeModalVisible)
-                    return [
-                        {
-                            button: "ButtonA",
-                            label: qsTr("I understand")
-                        }
-                    ];
-                if (root.quitConfirmModalVisible || root.settingNeedsRestartModalVisible || root.listPickerModalVisible)
-                    return [
-                        {
-                            button: "Dpad",
-                            label: qsTr("Move")
-                        },
-                        {
-                            button: "ButtonA",
-                            label: qsTr("Select")
-                        },
-                        {
-                            button: "ButtonB",
-                            label: qsTr("Cancel")
-                        }
-                    ];
-                if (!root.bootComplete)
-                    return [];
-                if (root.firstRunIndexModalVisible) {
-                    const phase = root.firstRunIndexModal.phase;
-                    if (phase === "running")
                         return [
                             {
-                                button: "ButtonB",
-                                label: qsTr("Cancel")
-                            }
-                        ];
-                    if (phase === "completed")
-                        return [];
-                    return [
-                        {
-                            button: "ButtonA",
-                            label: qsTr("Start")
-                        }
-                    ];
-                }
-                if (root.pendingTransition !== "")
-                    return [];
-                if (root.activeScreen === root.screenHub) {
-                    // Hub always has the actions row (Recently Played /
-                    // Settings), so Move/Open/Quit applies even when the
-                    // categories row is empty (0 systems indexed) — the
-                    // help bar must reflect that the actions row is
-                    // navigable, otherwise the user reads "Quit only"
-                    // and misses the Settings tile entirely.
-                    return [
-                        {
-                            button: "Dpad",
-                            label: qsTr("Move")
-                        },
-                        {
-                            button: "ButtonA",
-                            label: qsTr("Open")
-                        },
-                        {
-                            button: "ButtonB",
-                            label: qsTr("Quit")
-                        }
-                    ];
-                }
-                if (root.activeScreen === root.screenSystems) {
-                    if (root.systemsScreenState === "loading")
-                        return [
+                                button: "ButtonA",
+                                label: qsTr("Retry")
+                            },
                             {
                                 button: "ButtonB",
                                 label: qsTr("Back")
                             }
                         ];
-                    if (root.systemsScreenState === "ready") {
-                        // L/R shoulders page jump; only advertise the cue
-                        // when there's a second page to jump to, so we
-                        // don't promise a press that no-ops on a single
-                        // page of systems.
-                        const pages = root.systemsScreen.systemsGrid.pageCount;
-                        let row = [
-                            {
-                                button: "Dpad",
-                                label: qsTr("Move")
-                            }
-                        ];
-                        if (pages > 1)
+                    }
+                    if (root.activeScreen === root.screenSettings) {
+                        let row = [];
+                        // Up/Down moves between fields; only useful when there
+                        // are 2+ fields.
+                        if (root.settingsScreen.fieldCount > 1) {
                             row.push({
-                                buttons: ["ButtonL", "ButtonR"],
-                                label: qsTr("Page")
+                                buttons: ["DpadUp", "DpadDown"],
+                                label: qsTr("Move")
+                            });
+                        }
+                        // Left/Right cycles the focused field's value. Skip
+                        // the cue when the focused field is an action row
+                        // (no left/right binding) or there are no fields.
+                        if (root.settingsScreen.fieldCount > 0 && !root.settingsScreen.focusedFieldIsAction) {
+                            row.push({
+                                buttons: ["DpadLeft", "DpadRight"],
+                                label: qsTr("Change")
+                            });
+                        }
+                        if (root.settingsScreen.focusedFieldIsToggle)
+                            row.push({
+                                button: "ButtonA",
+                                label: qsTr("Toggle")
+                            });
+                        else if (root.settingsScreen.focusedFieldIsAction && !root.settingsScreen.focusedActionDisabled)
+                            row.push({
+                                button: "ButtonA",
+                                label: root.settingsScreen.focusedActionLabel
                             });
                         row.push({
-                            button: "ButtonA",
-                            label: qsTr("Open")
-                        }, {
-                            button: "ButtonX",
-                            label: qsTr("Options")
-                        }, {
                             button: "ButtonB",
                             label: qsTr("Back")
                         });
                         return row;
                     }
-                    return [
-                        {
-                            button: "ButtonA",
-                            label: qsTr("Retry")
-                        },
-                        {
+                    if (root.activeScreen === root.screenAbout) {
+                        let row = [];
+                        // Up/Down only meaningful when the body actually
+                        // overflows the viewport (per the minimal help-bar
+                        // policy — never advertise a press that no-ops).
+                        if (root.aboutScreen.contentOverflows)
+                            row.push({
+                                buttons: ["DpadUp", "DpadDown"],
+                                label: qsTr("Scroll")
+                            });
+                        row.push({
                             button: "ButtonB",
                             label: qsTr("Back")
-                        }
-                    ];
-                }
-                if (root.activeScreen === root.screenFavorites || root.activeScreen === root.screenRecents) {
-                    const isFavorites = root.activeScreen === root.screenFavorites;
-                    const state = isFavorites ? root.favoritesScreenState : root.recentsScreenState;
-                    const grid = isFavorites ? root.favoritesScreen.favoritesGrid : root.recentsScreen.recentsGrid;
-                    if (state === "loading")
+                        });
+                        return row;
+                    }
+                    // games
+                    if (root.gamesScreenState === "loading")
                         return [
                             {
                                 button: "ButtonB",
                                 label: qsTr("Back")
                             }
                         ];
-                    if (state === "ready") {
-                        const pages = grid.pageCount;
+                    if (root.gamesScreenState === "ready") {
+                        const pages = root.gamesScreen.gamesGrid.pageCount;
+                        // Options menu is only meaningful on media leaves —
+                        // folder/root entries open via Accept and have no
+                        // per-entry actions. Drop the X cue so the bar
+                        // doesn't promise a press that no-ops.
+                        const idx = root.gamesScreen.gamesGrid.currentIndex;
+                        const entryType = Browse.GamesModel.entry_type_at(idx);
+                        const isFolder = entryType === "directory" || entryType === "root";
                         let row = [
                             {
                                 button: "Dpad",
@@ -941,7 +1046,7 @@ ApplicationWindow {
                             button: "ButtonA",
                             label: qsTr("Open")
                         });
-                        if (isFavorites)
+                        if (!isFolder)
                             row.push({
                                 button: "ButtonX",
                                 label: qsTr("Options")
@@ -963,184 +1068,79 @@ ApplicationWindow {
                         }
                     ];
                 }
-                if (root.activeScreen === root.screenSettings) {
-                    let row = [];
-                    // Up/Down moves between fields; only useful when there
-                    // are 2+ fields.
-                    if (root.settingsScreen.fieldCount > 1) {
-                        row.push({
-                            buttons: ["DpadUp", "DpadDown"],
-                            label: qsTr("Move")
-                        });
-                    }
-                    // Left/Right cycles the focused field's value. Skip
-                    // the cue when the focused field is an action row
-                    // (no left/right binding) or there are no fields.
-                    if (root.settingsScreen.fieldCount > 0 && !root.settingsScreen.focusedFieldIsAction) {
-                        row.push({
-                            buttons: ["DpadLeft", "DpadRight"],
-                            label: qsTr("Change")
-                        });
-                    }
-                    if (root.settingsScreen.focusedFieldIsToggle)
-                        row.push({
-                            button: "ButtonA",
-                            label: qsTr("Toggle")
-                        });
-                    else if (root.settingsScreen.focusedFieldIsAction && !root.settingsScreen.focusedActionDisabled)
-                        row.push({
-                            button: "ButtonA",
-                            label: root.settingsScreen.focusedActionLabel
-                        });
-                    row.push({
-                        button: "ButtonB",
-                        label: qsTr("Back")
-                    });
-                    return row;
-                }
-                if (root.activeScreen === root.screenAbout) {
-                    let row = [];
-                    // Up/Down only meaningful when the body actually
-                    // overflows the viewport (per the minimal help-bar
-                    // policy — never advertise a press that no-ops).
-                    if (root.aboutScreen.contentOverflows)
-                        row.push({
-                            buttons: ["DpadUp", "DpadDown"],
-                            label: qsTr("Scroll")
-                        });
-                    row.push({
-                        button: "ButtonB",
-                        label: qsTr("Back")
-                    });
-                    return row;
-                }
-                // games
-                if (root.gamesScreenState === "loading")
-                    return [
-                        {
-                            button: "ButtonB",
-                            label: qsTr("Back")
-                        }
-                    ];
-                if (root.gamesScreenState === "ready") {
-                    const pages = root.gamesScreen.gamesGrid.pageCount;
-                    // Options menu is only meaningful on media leaves —
-                    // folder/root entries open via Accept and have no
-                    // per-entry actions. Drop the X cue so the bar
-                    // doesn't promise a press that no-ops.
-                    const idx = root.gamesScreen.gamesGrid.currentIndex;
-                    const entryType = Browse.GamesModel.entry_type_at(idx);
-                    const isFolder = entryType === "directory" || entryType === "root";
-                    let row = [
-                        {
-                            button: "Dpad",
-                            label: qsTr("Move")
-                        }
-                    ];
-                    if (pages > 1)
-                        row.push({
-                            buttons: ["ButtonL", "ButtonR"],
-                            label: qsTr("Page")
-                        });
-                    row.push({
-                        button: "ButtonA",
-                        label: qsTr("Open")
-                    });
-                    if (!isFolder)
-                        row.push({
-                            button: "ButtonX",
-                            label: qsTr("Options")
-                        });
-                    row.push({
-                        button: "ButtonB",
-                        label: qsTr("Back")
-                    });
-                    return row;
-                }
-                return [
-                    {
-                        button: "ButtonA",
-                        label: qsTr("Retry")
-                    },
-                    {
-                        button: "ButtonB",
-                        label: qsTr("Back")
-                    }
-                ];
-            }
 
-            Row {
-                x: Sizing.center(parent.width, width)
-                y: Sizing.center(parent.height, height)
-                spacing: Sizing.pctW(2)
+                Row {
+                    x: Sizing.center(parent.width, width)
+                    y: Sizing.center(parent.height, height)
+                    spacing: Sizing.pctW(2)
 
-                Repeater {
-                    model: instructionsBar.helpEntries
+                    Repeater {
+                        model: instructionsBar.helpEntries
 
-                    // Each entry is either a single-glyph cue
-                    // (`{ button: "ButtonA", label: "Open" }`) or a
-                    // multi-glyph cue rendered as N icons in a row before
-                    // the label (`{ buttons: ["DpadLeft", "DpadRight"],
-                    // label: "Change" }`). The Settings screen uses the
-                    // multi-glyph form to disambiguate "left/right cycles
-                    // the value" from "up/down moves between fields".
-                    delegate: Row {
-                        id: helpEntry
-                        required property var modelData
-                        spacing: Sizing.pctW(0.6)
+                        // Each entry is either a single-glyph cue
+                        // (`{ button: "ButtonA", label: "Open" }`) or a
+                        // multi-glyph cue rendered as N icons in a row before
+                        // the label (`{ buttons: ["DpadLeft", "DpadRight"],
+                        // label: "Change" }`). The Settings screen uses the
+                        // multi-glyph form to disambiguate "left/right cycles
+                        // the value" from "up/down moves between fields".
+                        delegate: Row {
+                            id: helpEntry
+                            required property var modelData
+                            spacing: Sizing.pctW(0.6)
 
-                        readonly property var buttonList: helpEntry.modelData.buttons !== undefined ? helpEntry.modelData.buttons : [helpEntry.modelData.button]
+                            readonly property var buttonList: helpEntry.modelData.buttons !== undefined ? helpEntry.modelData.buttons : [helpEntry.modelData.button]
 
-                        Repeater {
-                            model: helpEntry.buttonList
-                            delegate: Image {
-                                required property string modelData
-                                anchors.verticalCenter: parent.verticalCenter
-                                height: Sizing.pctH(4)
-                                width: height
-                                fillMode: Image.PreserveAspectFit
-                                sourceSize.height: Sizing.px(height)
-                                sourceSize.width: Sizing.px(width)
-                                source: Resources.iconUrl(modelData)
-                                smooth: true
+                            Repeater {
+                                model: helpEntry.buttonList
+                                delegate: Image {
+                                    required property string modelData
+                                    anchors.verticalCenter: parent.verticalCenter
+                                    height: Sizing.pctH(4)
+                                    width: height
+                                    fillMode: Image.PreserveAspectFit
+                                    sourceSize.height: Sizing.px(height)
+                                    sourceSize.width: Sizing.px(width)
+                                    source: Resources.iconUrl(modelData)
+                                    smooth: true
+                                }
+                            }
+
+                            Text {
+                                anchors.verticalCenter: helpEntry.verticalCenter
+                                text: helpEntry.modelData.label
+                                font.family: Theme.fontUi
+                                font.pixelSize: Sizing.fontSize(2.6)
+                                color: Theme.textPrimary
+                                renderType: Text.NativeRendering
                             }
                         }
-
-                        Text {
-                            anchors.verticalCenter: helpEntry.verticalCenter
-                            text: helpEntry.modelData.label
-                            font.family: Theme.fontUi
-                            font.pixelSize: Sizing.fontSize(2.6)
-                            color: Theme.textPrimary
-                            renderType: Text.NativeRendering
-                        }
                     }
                 }
             }
-        }
 
-        MouseArea {
-            anchors.fill: parent
-            z: 10000
-            visible: !Browse.Settings.current_mouse_enabled
-            enabled: visible
-            hoverEnabled: true
-            acceptedButtons: Qt.AllButtons
-            cursorShape: Qt.BlankCursor
-        }
+            MouseArea {
+                anchors.fill: parent
+                z: 10000
+                visible: !Browse.Settings.current_mouse_enabled
+                enabled: visible
+                hoverEnabled: true
+                acceptedButtons: Qt.AllButtons
+                cursorShape: Qt.BlankCursor
+            }
 
-        // Screen-burn protection. Sits inside `scene` so the bake-time
-        // grab captures the same logical dimensions Sizing reads from
-        // (CRT preview included). Z is above modals (300) and the help
-        // bar (400) so the screensaver covers every chrome layer; the
-        // mouse-blanking MouseArea above (z: 10000) still wins when
-        // mouse input is disabled, which keeps the cursor hidden.
-        ScreensaverOverlay {
-            id: screensaverOverlay
+            // Screen-burn protection. Sits inside `scene` so the bake-time
+            // grab captures the same logical dimensions Sizing reads from
+            // (CRT preview included). Z is above modals (300) and the help
+            // bar (400) so the screensaver covers every chrome layer; the
+            // mouse-blanking MouseArea above (z: 10000) still wins when
+            // mouse input is disabled, which keeps the cursor hidden.
+            ScreensaverOverlay {
+                id: screensaverOverlay
 
-            anchors.fill: parent
-            z: 500
-        }
+                anchors.fill: parent
+                z: 500
+            }
         }
     }
 }

--- a/src/ui/components/CoreStatusPill.qml
+++ b/src/ui/components/CoreStatusPill.qml
@@ -76,17 +76,17 @@ Item {
         }
         // Priority 3 — scraper.
         if (Browse.MediaStatus.scraping) {
-            const proc = Browse.MediaStatus.scrape_processed;
-            const total = Browse.MediaStatus.scrape_total;
-            const sys = Browse.MediaStatus.scrape_system_id;
+            const cur = Browse.MediaStatus.scrape_current_step;
+            const tot = Browse.MediaStatus.scrape_total_steps;
+            const display = Browse.MediaStatus.scrape_current_step_display;
             if (Browse.MediaStatus.scrape_paused)
                 return qsTr("Scrape paused");
 
-            if (total > 0 && sys !== "")
-                return qsTr("Scraping %1/%2 - %3").arg(proc).arg(total).arg(sys);
+            if (tot > 0 && display !== "")
+                return qsTr("Scraping %1/%2 - %3").arg(cur).arg(tot).arg(display);
 
-            if (total > 0)
-                return qsTr("Scraping %1/%2").arg(proc).arg(total);
+            if (tot > 0)
+                return qsTr("Scraping %1/%2").arg(cur).arg(tot);
 
             return qsTr("Scraping…");
         }

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -52,8 +52,7 @@ MediaListScreen {
     detailCanPreviousImage: Browse.GamesModel.current_detail_image_can_prev
     detailCanNextImage: Browse.GamesModel.current_detail_image_can_next
     detailIdentityForIndex: function (index) {
-        const entryType = Browse.GamesModel.entry_type_at(index);
-        if (entryType === "directory" || entryType === "root")
+        if (!Browse.GamesModel.is_media_capable_at(index))
             return "";
         const systemId = Browse.GamesModel.system_id_at(index);
         const path = Browse.GamesModel.path_at(index);
@@ -75,10 +74,7 @@ MediaListScreen {
     tateListViewId: games._tateListViewId
     listLeftAction: () => Browse.GamesModel.cycle_detail_image(-1)
     listRightAction: () => Browse.GamesModel.cycle_detail_image(1)
-    contextMenuEnabledAt: index => {
-        const entryType = Browse.GamesModel.entry_type_at(index);
-        return entryType !== "directory" && entryType !== "root";
-    }
+    contextMenuEnabledAt: index => Browse.GamesModel.is_media_capable_at(index)
     retryAction: () => {
         if (games._atFolderLevel()) {
             const stack = Browse.GamesState.path_stack;
@@ -92,7 +88,7 @@ MediaListScreen {
     }
     acceptAction: index => {
         const entryType = Browse.GamesModel.entry_type_at(index);
-        if (entryType === "directory" || entryType === "root") {
+        if ((entryType === "directory" || entryType === "root") && !Browse.GamesModel.is_media_capable_at(index)) {
             games.flushSelectedPersist();
             games.requestNavigateIntoFolder(Browse.GamesModel.path_at(index));
             return;

--- a/src/ui/screens/SettingsScreen.qml
+++ b/src/ui/screens/SettingsScreen.qml
@@ -212,6 +212,54 @@ Item {
         }
     }
 
+    function _fieldEnabled(id: string): bool {
+        if (id === "updateMediaDb")
+            return !settings._scrapeBusy;
+        if (id === "runScraper")
+            return !settings._indexBusy;
+        if (id === "rescrapeExisting")
+            return !settings._indexBusy && !settings._scrapeBusy;
+        return true;
+    }
+
+    function _fieldValue(id: string): string {
+        if (id === "resolution")
+            return settings._resolutionDisplay(Browse.Settings.current_resolution);
+        if (id === "language")
+            return settings._languageDisplay(Browse.Settings.current_language);
+        if (id === "orientation")
+            return settings._orientationDisplay(Browse.Settings.current_orientation);
+        if (id === "browseLayout")
+            return settings._browseLayoutDisplay(Browse.Settings.current_browse_layout);
+        if (id === "buttonLayout")
+            return settings._buttonLayoutDisplay(Browse.Settings.current_button_layout);
+        if (id === "screensaverTimeout")
+            return settings._screensaverTimeoutDisplay(Browse.Settings.current_screensaver_timeout);
+        if (id === "mediaImageType")
+            return settings._mediaImageTypeDisplay(Browse.Settings.current_media_image_type);
+        return "";
+    }
+
+    function _fieldControl(id: string): string {
+        if (id === "mouseEnabled" || id === "discoverArcadeAlternateVersions" || id === "debugLogging" || id === "rescrapeExisting")
+            return "toggle";
+        if (id === "aboutLicense")
+            return "navigate";
+        if (id === "updateMediaDb" || id === "runScraper" || id === "uploadLog")
+            return "action";
+        return "picker";
+    }
+
+    function _fieldChecked(id: string): bool {
+        if (id === "debugLogging")
+            return Browse.Settings.current_debug_logging;
+        if (id === "discoverArcadeAlternateVersions")
+            return Browse.Settings.current_discover_arcade_alternate_versions;
+        if (id === "rescrapeExisting")
+            return settings.rescrapeExisting;
+        return Browse.Settings.current_mouse_enabled;
+    }
+
     readonly property int fieldCount: settings.fields.length
 
     // True iff `idx` points at a focusable field row (not a header,
@@ -765,11 +813,11 @@ Item {
                         // dims and its MouseArea stops responding.
                         // Keyboard Accept is separately gated in
                         // `_triggerIndex`/`_triggerScrape`.
-                        enabled: row.modelData.id === "updateMediaDb" ? !settings._scrapeBusy : row.modelData.id === "runScraper" ? !settings._indexBusy : row.modelData.id === "rescrapeExisting" ? !settings._indexBusy && !settings._scrapeBusy : true
+                        enabled: settings._fieldEnabled(row.modelData.id)
                         label: row.modelData.label
-                        value: row.modelData.id === "resolution" ? settings._resolutionDisplay(Browse.Settings.current_resolution) : row.modelData.id === "language" ? settings._languageDisplay(Browse.Settings.current_language) : row.modelData.id === "orientation" ? settings._orientationDisplay(Browse.Settings.current_orientation) : row.modelData.id === "browseLayout" ? settings._browseLayoutDisplay(Browse.Settings.current_browse_layout) : row.modelData.id === "buttonLayout" ? settings._buttonLayoutDisplay(Browse.Settings.current_button_layout) : row.modelData.id === "screensaverTimeout" ? settings._screensaverTimeoutDisplay(Browse.Settings.current_screensaver_timeout) : row.modelData.id === "mediaImageType" ? settings._mediaImageTypeDisplay(Browse.Settings.current_media_image_type) : ""
-                        control: row.modelData.id === "mouseEnabled" || row.modelData.id === "discoverArcadeAlternateVersions" || row.modelData.id === "debugLogging" || row.modelData.id === "rescrapeExisting" ? "toggle" : row.modelData.id === "aboutLicense" ? "navigate" : (row.modelData.id === "updateMediaDb" || row.modelData.id === "runScraper" || row.modelData.id === "uploadLog") ? "action" : "picker"
-                        checked: row.modelData.id === "debugLogging" ? Browse.Settings.current_debug_logging : row.modelData.id === "discoverArcadeAlternateVersions" ? Browse.Settings.current_discover_arcade_alternate_versions : row.modelData.id === "rescrapeExisting" ? settings.rescrapeExisting : Browse.Settings.current_mouse_enabled
+                        value: settings._fieldValue(row.modelData.id)
+                        control: settings._fieldControl(row.modelData.id)
+                        checked: settings._fieldChecked(row.modelData.id)
                         actionStatus: row.modelData.id === "updateMediaDb" ? settings._indexActionStatus() : row.modelData.id === "runScraper" ? settings._scrapeActionStatus() : ""
                         onHovered: settings.currentIndex = row.index
                         onClicked: {

--- a/src/ui/screens/SettingsScreen.qml
+++ b/src/ui/screens/SettingsScreen.qml
@@ -103,6 +103,11 @@ Item {
         });
         out.push({
             kind: "field",
+            id: "mediaImageType",
+            label: qsTr("Preferred artwork")
+        });
+        out.push({
+            kind: "field",
             id: "updateMediaDb",
             label: qsTr("Update media database")
         });
@@ -110,6 +115,11 @@ Item {
             kind: "field",
             id: "runScraper",
             label: qsTr("Scrape metadata")
+        });
+        out.push({
+            kind: "field",
+            id: "rescrapeExisting",
+            label: qsTr("Re-scrape existing")
         });
         out.push({
             kind: "header",
@@ -172,6 +182,7 @@ Item {
     // don't queue a request that Core will reject.
     readonly property bool _indexBusy: Browse.MediaStatus.indexing || Browse.MediaStatus.optimizing
     readonly property bool _scrapeBusy: Browse.MediaStatus.scraping
+    property bool rescrapeExisting: false
 
     // Drive the top/bottom scroll chevrons. Mirrors PagedGrid's
     // `hasPagesAbove`/`hasPagesBelow` recipe, but for a continuous
@@ -195,8 +206,10 @@ Item {
             return;
         if (settings._scrapeBusy)
             Browse.MediaStatus.cancel_scrape();
-        else
-            Browse.MediaStatus.start_scrape();
+        else {
+            Browse.MediaStatus.start_scrape(settings.rescrapeExisting);
+            settings.rescrapeExisting = false;
+        }
     }
 
     readonly property int fieldCount: settings.fields.length
@@ -238,7 +251,7 @@ Item {
         if (!settings._isField(settings.currentIndex))
             return false;
         const id = settings.fields[settings.currentIndex].id;
-        return id === "mouseEnabled" || id === "discoverArcadeAlternateVersions" || id === "debugLogging";
+        return id === "mouseEnabled" || id === "discoverArcadeAlternateVersions" || id === "debugLogging" || id === "rescrapeExisting";
     }
     // True when the focused field is a list-picker row (Accept opens a
     // modal; left/right is a no-op — pickers don't cycle inline). Drives
@@ -247,7 +260,7 @@ Item {
         if (!settings._isField(settings.currentIndex))
             return false;
         const id = settings.fields[settings.currentIndex].id;
-        return id === "language" || id === "orientation" || id === "browseLayout" || id === "buttonLayout" || id === "resolution" || id === "screensaverTimeout";
+        return id === "language" || id === "orientation" || id === "browseLayout" || id === "buttonLayout" || id === "resolution" || id === "screensaverTimeout" || id === "mediaImageType";
     }
     // True when the focused field is an action button (updateMediaDb,
     // runScraper, uploadLog, aboutLicense). Drives the help-bar Accept
@@ -408,6 +421,11 @@ Item {
         return raw === undefined || raw === null ? [] : raw;
     }
 
+    function _mediaImageTypeList(): list<string> {
+        const raw = Browse.Settings.available_media_image_types;
+        return raw === undefined || raw === null ? [] : raw;
+    }
+
     function _screensaverTimeoutDisplay(value: string): string {
         if (value === "off")
             return qsTr("Off");
@@ -426,6 +444,36 @@ Item {
         if (value === "1800")
             return qsTr("30 minutes");
         return qsTr("%1 seconds").arg(value);
+    }
+
+    function _mediaImageTypeDisplay(value: string): string {
+        if (value === "auto")
+            return qsTr("Auto");
+        if (value === "image")
+            return qsTr("Image");
+        if (value === "thumbnail")
+            return qsTr("Thumbnail");
+        if (value === "boxart")
+            return qsTr("Box art");
+        if (value === "boxart3d")
+            return qsTr("3D box art");
+        if (value === "screenshot")
+            return qsTr("Screenshot");
+        if (value === "wheel")
+            return qsTr("Wheel");
+        if (value === "titleshot")
+            return qsTr("Title screen");
+        if (value === "map")
+            return qsTr("Map");
+        if (value === "marquee")
+            return qsTr("Marquee");
+        if (value === "fanart")
+            return qsTr("Fan art");
+        if (value === "boxartside")
+            return qsTr("Box side");
+        if (value === "boxartback")
+            return qsTr("Box back");
+        return value;
     }
 
     // Build the picker entry list for a field. Each entry is
@@ -491,6 +539,15 @@ Item {
                     label: settings._screensaverTimeoutDisplay(list[i])
                 });
             initialId = Browse.Settings.current_screensaver_timeout;
+        } else if (id === "mediaImageType") {
+            title = qsTr("Preferred artwork");
+            const list = settings._mediaImageTypeList();
+            for (let i = 0; i < list.length; i++)
+                entries.push({
+                    id: list[i],
+                    label: settings._mediaImageTypeDisplay(list[i])
+                });
+            initialId = Browse.Settings.current_media_image_type;
         } else {
             return;
         }
@@ -523,6 +580,18 @@ Item {
         Browse.Settings.set_discover_arcade_alternate_versions(!Browse.Settings.current_discover_arcade_alternate_versions);
     }
 
+    function _setRescrapeExisting(direction: int): void {
+        if (settings._indexBusy || settings._scrapeBusy)
+            return;
+        settings.rescrapeExisting = direction > 0;
+    }
+
+    function _toggleRescrapeExisting(): void {
+        if (settings._indexBusy || settings._scrapeBusy)
+            return;
+        settings.rescrapeExisting = !settings.rescrapeExisting;
+    }
+
     function _cycleFocused(direction: int): void {
         if (!settings._isField(settings.currentIndex))
             return;
@@ -536,6 +605,8 @@ Item {
             settings._setDiscoverArcadeAlternateVersions(direction);
         else if (id === "debugLogging")
             settings._setDebugLogging(direction);
+        else if (id === "rescrapeExisting")
+            settings._setRescrapeExisting(direction);
     }
 
     function handleAction(action: string): void {
@@ -557,6 +628,8 @@ Item {
                 settings._toggleDiscoverArcadeAlternateVersions();
             else if (id === "debugLogging")
                 settings._toggleDebugLogging();
+            else if (id === "rescrapeExisting")
+                settings._toggleRescrapeExisting();
             else if (id === "updateMediaDb")
                 settings._triggerIndex();
             else if (id === "runScraper")
@@ -692,11 +765,11 @@ Item {
                         // dims and its MouseArea stops responding.
                         // Keyboard Accept is separately gated in
                         // `_triggerIndex`/`_triggerScrape`.
-                        enabled: row.modelData.id === "updateMediaDb" ? !settings._scrapeBusy : row.modelData.id === "runScraper" ? !settings._indexBusy : true
+                        enabled: row.modelData.id === "updateMediaDb" ? !settings._scrapeBusy : row.modelData.id === "runScraper" ? !settings._indexBusy : row.modelData.id === "rescrapeExisting" ? !settings._indexBusy && !settings._scrapeBusy : true
                         label: row.modelData.label
-                        value: row.modelData.id === "resolution" ? settings._resolutionDisplay(Browse.Settings.current_resolution) : row.modelData.id === "language" ? settings._languageDisplay(Browse.Settings.current_language) : row.modelData.id === "orientation" ? settings._orientationDisplay(Browse.Settings.current_orientation) : row.modelData.id === "browseLayout" ? settings._browseLayoutDisplay(Browse.Settings.current_browse_layout) : row.modelData.id === "buttonLayout" ? settings._buttonLayoutDisplay(Browse.Settings.current_button_layout) : row.modelData.id === "screensaverTimeout" ? settings._screensaverTimeoutDisplay(Browse.Settings.current_screensaver_timeout) : ""
-                        control: row.modelData.id === "mouseEnabled" || row.modelData.id === "discoverArcadeAlternateVersions" || row.modelData.id === "debugLogging" ? "toggle" : row.modelData.id === "aboutLicense" ? "navigate" : (row.modelData.id === "updateMediaDb" || row.modelData.id === "runScraper" || row.modelData.id === "uploadLog") ? "action" : "picker"
-                        checked: row.modelData.id === "debugLogging" ? Browse.Settings.current_debug_logging : row.modelData.id === "discoverArcadeAlternateVersions" ? Browse.Settings.current_discover_arcade_alternate_versions : Browse.Settings.current_mouse_enabled
+                        value: row.modelData.id === "resolution" ? settings._resolutionDisplay(Browse.Settings.current_resolution) : row.modelData.id === "language" ? settings._languageDisplay(Browse.Settings.current_language) : row.modelData.id === "orientation" ? settings._orientationDisplay(Browse.Settings.current_orientation) : row.modelData.id === "browseLayout" ? settings._browseLayoutDisplay(Browse.Settings.current_browse_layout) : row.modelData.id === "buttonLayout" ? settings._buttonLayoutDisplay(Browse.Settings.current_button_layout) : row.modelData.id === "screensaverTimeout" ? settings._screensaverTimeoutDisplay(Browse.Settings.current_screensaver_timeout) : row.modelData.id === "mediaImageType" ? settings._mediaImageTypeDisplay(Browse.Settings.current_media_image_type) : ""
+                        control: row.modelData.id === "mouseEnabled" || row.modelData.id === "discoverArcadeAlternateVersions" || row.modelData.id === "debugLogging" || row.modelData.id === "rescrapeExisting" ? "toggle" : row.modelData.id === "aboutLicense" ? "navigate" : (row.modelData.id === "updateMediaDb" || row.modelData.id === "runScraper" || row.modelData.id === "uploadLog") ? "action" : "picker"
+                        checked: row.modelData.id === "debugLogging" ? Browse.Settings.current_debug_logging : row.modelData.id === "discoverArcadeAlternateVersions" ? Browse.Settings.current_discover_arcade_alternate_versions : row.modelData.id === "rescrapeExisting" ? settings.rescrapeExisting : Browse.Settings.current_mouse_enabled
                         actionStatus: row.modelData.id === "updateMediaDb" ? settings._indexActionStatus() : row.modelData.id === "runScraper" ? settings._scrapeActionStatus() : ""
                         onHovered: settings.currentIndex = row.index
                         onClicked: {
@@ -707,6 +780,8 @@ Item {
                                 settings._toggleDiscoverArcadeAlternateVersions();
                             else if (row.modelData.id === "debugLogging")
                                 settings._toggleDebugLogging();
+                            else if (row.modelData.id === "rescrapeExisting")
+                                settings._toggleRescrapeExisting();
                         }
                         onRightClicked: settings.requestHubScreen()
                         // Picker, action, and navigate rows route

--- a/src/ui/theme/BrowseLayouts.qml
+++ b/src/ui/theme/BrowseLayouts.qml
@@ -11,747 +11,747 @@ import Zaparoo.Theme
 QtObject {
     readonly property string currentThemeId: Theme.crtNativePath ? "crt" : "default"
     readonly property var _themes: ({
-        "default": {
-            "systemsGrid": {
-                "header": {
-                    "titleInHeader": false,
-                    "hudBottomAligned": false,
-                    "statusPillPinnedTop": false
+            "default": {
+                "systemsGrid": {
+                    "header": {
+                        "titleInHeader": false,
+                        "hudBottomAligned": false,
+                        "statusPillPinnedTop": false
+                    },
+                    "status": {
+                        "topStripVisible": true,
+                        "stripHeight": "pctH:7",
+                        "slotMargin": "pctW:5",
+                        "topMargin": "pctH:1"
+                    },
+                    "grid": {
+                        "leftInset": "pctW:5",
+                        "rightInset": "pctW:5",
+                        "gutterWidth": "pctW:3",
+                        "gutterGap": "pctW:1.5",
+                        "columnGap": "pctW:3",
+                        "topInset": "pctH:2",
+                        "bottomInset": "pctH:2",
+                        "rowGap": "pctH:4",
+                        "scrollThumbWidth": "pctW:1.2",
+                        "scrollThumbRightInset": 0,
+                        "scrollThumbRightAligned": false,
+                        "scrollArrowSize": "min(pctW:3,pctH:4)",
+                        "gutterFollowsContentWidth": false
+                    },
+                    "footer": {
+                        "activeLabelHeight": "pctH:7",
+                        "activeLabelBottomMargin": "pctH:8",
+                        "bottomStatusVisible": false,
+                        "bottomStatusLeftMargin": "pctW:5",
+                        "bottomStatusRightMargin": "pctW:5",
+                        "gridBottomMargin": "sum(pctH:6,pctH:8,pctH:7)",
+                        "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
+                    },
+                    "surface": {
+                        "cornerRadius": "cornerRadius"
+                    }
                 },
-                "status": {
-                    "topStripVisible": true,
-                    "stripHeight": "pctH:7",
-                    "slotMargin": "pctW:5",
-                    "topMargin": "pctH:1"
+                "systemsList": {
+                    "header": {
+                        "titleInHeader": false,
+                        "hudBottomAligned": false,
+                        "statusPillPinnedTop": false
+                    },
+                    "status": {
+                        "topStripVisible": true,
+                        "stripHeight": "pctH:7",
+                        "slotMargin": "pctW:5",
+                        "topMargin": "pctH:1"
+                    },
+                    "list": {
+                        "contentAxis": "horizontal",
+                        "listShare": 2,
+                        "detailShare": 1,
+                        "dividerWidth": 1,
+                        "dividerMargin": 0,
+                        "cardSideMargin": "pctW:5",
+                        "cardTopMargin": "pctH:2",
+                        "cardBottomMargin": "pctH:8",
+                        "cardPaddingLeft": "pctW:2",
+                        "cardPaddingRight": "pctW:2",
+                        "cardPaddingTop": "pctH:2",
+                        "cardPaddingBottom": "pctH:2",
+                        "rowHeight": 0,
+                        "rowSpacing": "pctH:0.7",
+                        "centerSlot": -1,
+                        "scrollbarGap": "pctW:1.5",
+                        "selectionAccentWidth": "pctW:0.45",
+                        "rowTextLeftPadding": "pctW:1.6",
+                        "rowTextRightPadding": "pctW:1.6",
+                        "favoriteRightPadding": "pctW:1.6",
+                        "overlayBottomMargin": "pctH:15"
+                    },
+                    "detail": {
+                        "contentAxis": "vertical",
+                        "sectionGap": "pctH:2",
+                        "imageShare": 2,
+                        "metadataShare": 1,
+                        "imageHeightRatioWithTitle": 48,
+                        "imageReservedWidth": 0,
+                        "imageReservedHeight": 0,
+                        "imageBottomMargin": 0,
+                        "panePaddingLeft": "pctW:2",
+                        "panePaddingRight": "pctW:2",
+                        "panePaddingTop": "pctH:2",
+                        "panePaddingBottom": "pctH:2",
+                        "imagePaddingLeft": 0,
+                        "imagePaddingRight": 0,
+                        "imagePaddingTop": 0,
+                        "imagePaddingBottom": 0,
+                        "metadataPaddingLeft": 0,
+                        "metadataPaddingRight": 0,
+                        "metadataPaddingTop": 0,
+                        "metadataPaddingBottom": 0,
+                        "metadataTopMargin": 0,
+                        "metadataLeftMargin": 0,
+                        "metadataRightMargin": 0,
+                        "metadataHeightAdjustment": 0,
+                        "metadataBottomAligned": false,
+                        "titleBottomMargin": "pctH:2",
+                        "tagRowHeight": "pctH:3",
+                        "tagRowSpacing": "pctH:0.55"
+                    },
+                    "footer": {
+                        "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
+                    },
+                    "surface": {
+                        "cornerRadius": "cornerRadius"
+                    }
                 },
-                "grid": {
-                    "leftInset": "pctW:5",
-                    "rightInset": "pctW:5",
-                    "gutterWidth": "pctW:3",
-                    "gutterGap": "pctW:1.5",
-                    "columnGap": "pctW:3",
-                    "topInset": "pctH:2",
-                    "bottomInset": "pctH:2",
-                    "rowGap": "pctH:4",
-                    "scrollThumbWidth": "pctW:1.2",
-                    "scrollThumbRightInset": 0,
-                    "scrollThumbRightAligned": false,
-                    "scrollArrowSize": "min(pctW:3,pctH:4)",
-                    "gutterFollowsContentWidth": false
+                "systemsListTate": {
+                    "header": {
+                        "titleInHeader": false,
+                        "hudBottomAligned": false,
+                        "statusPillPinnedTop": false
+                    },
+                    "status": {
+                        "topStripVisible": true,
+                        "stripHeight": "pctH:7",
+                        "slotMargin": "pctW:5",
+                        "topMargin": "pctH:1"
+                    },
+                    "list": {
+                        "contentAxis": "vertical",
+                        "listShare": 9,
+                        "detailShare": 7,
+                        "dividerWidth": 1,
+                        "dividerMargin": 0,
+                        "cardSideMargin": "pctW:5",
+                        "cardTopMargin": "pctH:2",
+                        "cardBottomMargin": "pctH:8",
+                        "cardPaddingLeft": "pctW:2",
+                        "cardPaddingRight": "pctW:2",
+                        "cardPaddingTop": "pctH:2",
+                        "cardPaddingBottom": "pctH:2",
+                        "rowHeight": 0,
+                        "rowSpacing": "pctH:0.3",
+                        "centerSlot": -1,
+                        "scrollbarGap": "pctW:1.5",
+                        "selectionAccentWidth": "pctW:0.45",
+                        "rowTextLeftPadding": "pctW:1.6",
+                        "rowTextRightPadding": "pctW:1.6",
+                        "favoriteRightPadding": "pctW:1.6",
+                        "overlayBottomMargin": "pctH:15"
+                    },
+                    "detail": {
+                        "contentAxis": "horizontal",
+                        "sectionGap": "pctW:2",
+                        "imageShare": 5,
+                        "metadataShare": 7,
+                        "imageHeightRatioWithTitle": 48,
+                        "imageReservedWidth": 0,
+                        "imageReservedHeight": 0,
+                        "imageBottomMargin": 0,
+                        "panePaddingLeft": "pctW:2",
+                        "panePaddingRight": "pctW:2",
+                        "panePaddingTop": "pctH:2",
+                        "panePaddingBottom": "pctH:2",
+                        "imagePaddingLeft": 0,
+                        "imagePaddingRight": 0,
+                        "imagePaddingTop": 0,
+                        "imagePaddingBottom": 0,
+                        "metadataPaddingLeft": 0,
+                        "metadataPaddingRight": 0,
+                        "metadataPaddingTop": 0,
+                        "metadataPaddingBottom": 0,
+                        "metadataTopMargin": 0,
+                        "metadataLeftMargin": 0,
+                        "metadataRightMargin": 0,
+                        "metadataHeightAdjustment": 0,
+                        "metadataBottomAligned": false,
+                        "titleBottomMargin": "pctH:2",
+                        "tagRowHeight": "pctH:3",
+                        "tagRowSpacing": "pctH:0.55"
+                    },
+                    "footer": {
+                        "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
+                    },
+                    "surface": {
+                        "cornerRadius": "cornerRadius"
+                    }
                 },
-                "footer": {
-                    "activeLabelHeight": "pctH:7",
-                    "activeLabelBottomMargin": "pctH:8",
-                    "bottomStatusVisible": false,
-                    "bottomStatusLeftMargin": "pctW:5",
-                    "bottomStatusRightMargin": "pctW:5",
-                    "gridBottomMargin": "sum(pctH:6,pctH:8,pctH:7)",
-                    "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
+                "gamesGrid": {
+                    "header": {
+                        "titleInHeader": false,
+                        "hudBottomAligned": false,
+                        "statusPillPinnedTop": false
+                    },
+                    "status": {
+                        "topStripVisible": true,
+                        "stripHeight": "pctH:7",
+                        "slotMargin": "pctW:5",
+                        "topMargin": "pctH:1"
+                    },
+                    "grid": {
+                        "leftInset": "pctW:5",
+                        "rightInset": "pctW:5",
+                        "gutterWidth": "pctW:3",
+                        "gutterGap": "pctW:1.5",
+                        "columnGap": "pctW:3",
+                        "topInset": "pctH:2",
+                        "bottomInset": "pctH:2",
+                        "rowGap": "pctH:4",
+                        "scrollThumbWidth": "pctW:1.2",
+                        "scrollThumbRightInset": 0,
+                        "scrollThumbRightAligned": false,
+                        "scrollArrowSize": "min(pctW:3,pctH:4)",
+                        "gutterFollowsContentWidth": false
+                    },
+                    "footer": {
+                        "activeLabelHeight": "pctH:7",
+                        "activeLabelBottomMargin": "pctH:8",
+                        "bottomStatusVisible": false,
+                        "bottomStatusLeftMargin": "pctW:5",
+                        "bottomStatusRightMargin": "pctW:5",
+                        "gridBottomMargin": "sum(pctH:6,pctH:8,pctH:7)",
+                        "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
+                    },
+                    "surface": {
+                        "cornerRadius": "cornerRadius"
+                    }
                 },
-                "surface": {
-                    "cornerRadius": "cornerRadius"
+                "gamesList": {
+                    "header": {
+                        "titleInHeader": false,
+                        "hudBottomAligned": false,
+                        "statusPillPinnedTop": false
+                    },
+                    "status": {
+                        "topStripVisible": true,
+                        "stripHeight": "pctH:7",
+                        "slotMargin": "pctW:5",
+                        "topMargin": "pctH:1"
+                    },
+                    "list": {
+                        "contentAxis": "horizontal",
+                        "listShare": 2,
+                        "detailShare": 1,
+                        "dividerWidth": 1,
+                        "dividerMargin": 0,
+                        "cardSideMargin": "pctW:5",
+                        "cardTopMargin": "pctH:2",
+                        "cardBottomMargin": "pctH:8",
+                        "cardPaddingLeft": "pctW:2",
+                        "cardPaddingRight": "pctW:2",
+                        "cardPaddingTop": "pctH:2",
+                        "cardPaddingBottom": "pctH:2",
+                        "rowHeight": 0,
+                        "rowSpacing": "pctH:0.7",
+                        "centerSlot": -1,
+                        "scrollbarGap": "pctW:1.5",
+                        "selectionAccentWidth": "pctW:0.45",
+                        "rowTextLeftPadding": "pctW:1.6",
+                        "rowTextRightPadding": "pctW:1.6",
+                        "favoriteRightPadding": "pctW:1.6",
+                        "overlayBottomMargin": "pctH:15"
+                    },
+                    "detail": {
+                        "contentAxis": "vertical",
+                        "sectionGap": "pctH:2",
+                        "imageShare": 2,
+                        "metadataShare": 1,
+                        "imageHeightRatioWithTitle": 48,
+                        "imageReservedWidth": 0,
+                        "imageReservedHeight": 0,
+                        "imageBottomMargin": 0,
+                        "panePaddingLeft": "pctW:2",
+                        "panePaddingRight": "pctW:2",
+                        "panePaddingTop": "pctH:2",
+                        "panePaddingBottom": "pctH:2",
+                        "imagePaddingLeft": 0,
+                        "imagePaddingRight": 0,
+                        "imagePaddingTop": 0,
+                        "imagePaddingBottom": 0,
+                        "metadataPaddingLeft": 0,
+                        "metadataPaddingRight": 0,
+                        "metadataPaddingTop": 0,
+                        "metadataPaddingBottom": 0,
+                        "metadataTopMargin": 0,
+                        "metadataLeftMargin": 0,
+                        "metadataRightMargin": 0,
+                        "metadataHeightAdjustment": 0,
+                        "metadataBottomAligned": true,
+                        "titleBottomMargin": "pctH:2",
+                        "tagRowHeight": "pctH:3",
+                        "tagRowSpacing": "pctH:0.55"
+                    },
+                    "footer": {
+                        "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
+                    },
+                    "surface": {
+                        "cornerRadius": "cornerRadius"
+                    }
+                },
+                "gamesListTate": {
+                    "header": {
+                        "titleInHeader": false,
+                        "hudBottomAligned": false,
+                        "statusPillPinnedTop": false
+                    },
+                    "status": {
+                        "topStripVisible": true,
+                        "stripHeight": "pctH:7",
+                        "slotMargin": "pctW:5",
+                        "topMargin": "pctH:1"
+                    },
+                    "list": {
+                        "contentAxis": "vertical",
+                        "listShare": 9,
+                        "detailShare": 7,
+                        "dividerWidth": 1,
+                        "dividerMargin": 0,
+                        "cardSideMargin": "pctW:5",
+                        "cardTopMargin": "pctH:2",
+                        "cardBottomMargin": "pctH:8",
+                        "cardPaddingLeft": "pctW:2",
+                        "cardPaddingRight": "pctW:2",
+                        "cardPaddingTop": "pctH:2",
+                        "cardPaddingBottom": "pctH:2",
+                        "rowHeight": 0,
+                        "rowSpacing": "pctH:0.3",
+                        "centerSlot": -1,
+                        "scrollbarGap": "pctW:1.5",
+                        "selectionAccentWidth": "pctW:0.45",
+                        "rowTextLeftPadding": "pctW:1.6",
+                        "rowTextRightPadding": "pctW:1.6",
+                        "favoriteRightPadding": "pctW:1.6",
+                        "overlayBottomMargin": "pctH:15"
+                    },
+                    "detail": {
+                        "contentAxis": "horizontal",
+                        "sectionGap": "pctW:2",
+                        "imageShare": 5,
+                        "metadataShare": 7,
+                        "imageHeightRatioWithTitle": 48,
+                        "imageReservedWidth": 0,
+                        "imageReservedHeight": 0,
+                        "imageBottomMargin": 0,
+                        "panePaddingLeft": "pctW:2",
+                        "panePaddingRight": "pctW:2",
+                        "panePaddingTop": "pctH:2",
+                        "panePaddingBottom": "pctH:2",
+                        "imagePaddingLeft": 0,
+                        "imagePaddingRight": 0,
+                        "imagePaddingTop": 0,
+                        "imagePaddingBottom": 0,
+                        "metadataPaddingLeft": 0,
+                        "metadataPaddingRight": 0,
+                        "metadataPaddingTop": 0,
+                        "metadataPaddingBottom": 0,
+                        "metadataTopMargin": 0,
+                        "metadataLeftMargin": 0,
+                        "metadataRightMargin": 0,
+                        "metadataHeightAdjustment": 0,
+                        "metadataBottomAligned": false,
+                        "titleBottomMargin": "pctH:2",
+                        "tagRowHeight": "pctH:3",
+                        "tagRowSpacing": "pctH:0.55"
+                    },
+                    "footer": {
+                        "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
+                    },
+                    "surface": {
+                        "cornerRadius": "cornerRadius"
+                    }
                 }
             },
-            "systemsList": {
-                "header": {
-                    "titleInHeader": false,
-                    "hudBottomAligned": false,
-                    "statusPillPinnedTop": false
+            "crt": {
+                "systemsGrid": {
+                    "header": {
+                        "titleInHeader": true,
+                        "hudBottomAligned": true,
+                        "statusPillPinnedTop": true
+                    },
+                    "status": {
+                        "topStripVisible": false,
+                        "stripHeight": 0,
+                        "slotMargin": "headerSideMargin",
+                        "topMargin": "pctH:1"
+                    },
+                    "grid": {
+                        "leftInset": 4,
+                        "rightInset": 0,
+                        "gutterWidth": 8,
+                        "gutterGap": 4,
+                        "columnGap": 4,
+                        "topInset": 2,
+                        "bottomInset": 4,
+                        "rowGap": 4,
+                        "scrollThumbWidth": 4,
+                        "scrollThumbRightInset": 2,
+                        "scrollThumbRightAligned": false,
+                        "scrollArrowSize": 8,
+                        "gutterFollowsContentWidth": true
+                    },
+                    "footer": {
+                        "activeLabelHeight": 8,
+                        "activeLabelBottomMargin": "pctH:6",
+                        "bottomStatusVisible": true,
+                        "bottomStatusLeftMargin": 4,
+                        "bottomStatusRightMargin": "pctW:5",
+                        "gridBottomMargin": "sum(pctH:6,8)",
+                        "bottomUnsafeHeight": 16
+                    },
+                    "surface": {
+                        "cornerRadius": 4
+                    }
                 },
-                "status": {
-                    "topStripVisible": true,
-                    "stripHeight": "pctH:7",
-                    "slotMargin": "pctW:5",
-                    "topMargin": "pctH:1"
+                "systemsList": {
+                    "header": {
+                        "titleInHeader": true,
+                        "hudBottomAligned": true,
+                        "statusPillPinnedTop": true
+                    },
+                    "status": {
+                        "topStripVisible": true,
+                        "stripHeight": 8,
+                        "slotMargin": "headerSideMargin",
+                        "topMargin": "pctH:1"
+                    },
+                    "list": {
+                        "contentAxis": "horizontal",
+                        "listShare": 2,
+                        "detailShare": 1,
+                        "dividerWidth": 1,
+                        "dividerMargin": -16,
+                        "cardSideMargin": 4,
+                        "cardTopMargin": "pctH:2",
+                        "cardBottomMargin": "pctH:8",
+                        "cardPaddingLeft": 3,
+                        "cardPaddingRight": 2,
+                        "cardPaddingTop": 3,
+                        "cardPaddingBottom": 2,
+                        "rowHeight": 12,
+                        "rowSpacing": 0,
+                        "centerSlot": 7,
+                        "scrollbarGap": 2,
+                        "selectionAccentWidth": 2,
+                        "rowTextLeftPadding": 4,
+                        "rowTextRightPadding": 2,
+                        "favoriteRightPadding": 2,
+                        "overlayBottomMargin": "pctH:14"
+                    },
+                    "detail": {
+                        "contentAxis": "vertical",
+                        "sectionGap": 2,
+                        "imageShare": 2,
+                        "metadataShare": 1,
+                        "imageHeightRatioWithTitle": 48,
+                        "imageReservedWidth": 16,
+                        "imageReservedHeight": 0,
+                        "imageBottomMargin": 2,
+                        "panePaddingLeft": 1,
+                        "panePaddingRight": 1,
+                        "panePaddingTop": 3,
+                        "panePaddingBottom": 2,
+                        "imagePaddingLeft": 2,
+                        "imagePaddingRight": 2,
+                        "imagePaddingTop": 0,
+                        "imagePaddingBottom": 2,
+                        "metadataPaddingLeft": 2,
+                        "metadataPaddingRight": 1,
+                        "metadataPaddingTop": 0,
+                        "metadataPaddingBottom": 0,
+                        "metadataTopMargin": -14,
+                        "metadataLeftMargin": 2,
+                        "metadataRightMargin": 1,
+                        "metadataHeightAdjustment": 2,
+                        "metadataBottomAligned": false,
+                        "titleBottomMargin": 2,
+                        "tagRowHeight": 9,
+                        "tagRowSpacing": 0
+                    },
+                    "footer": {
+                        "bottomUnsafeHeight": 16
+                    },
+                    "surface": {
+                        "cornerRadius": 4
+                    }
                 },
-                "list": {
-                    "contentAxis": "horizontal",
-                    "listShare": 2,
-                    "detailShare": 1,
-                    "dividerWidth": 1,
-                    "dividerMargin": 0,
-                    "cardSideMargin": "pctW:5",
-                    "cardTopMargin": "pctH:2",
-                    "cardBottomMargin": "pctH:8",
-                    "cardPaddingLeft": "pctW:2",
-                    "cardPaddingRight": "pctW:2",
-                    "cardPaddingTop": "pctH:2",
-                    "cardPaddingBottom": "pctH:2",
-                    "rowHeight": 0,
-                    "rowSpacing": "pctH:0.7",
-                    "centerSlot": -1,
-                    "scrollbarGap": "pctW:1.5",
-                    "selectionAccentWidth": "pctW:0.45",
-                    "rowTextLeftPadding": "pctW:1.6",
-                    "rowTextRightPadding": "pctW:1.6",
-                    "favoriteRightPadding": "pctW:1.6",
-                    "overlayBottomMargin": "pctH:15"
+                "systemsListTate": {
+                    "header": {
+                        "titleInHeader": true,
+                        "hudBottomAligned": true,
+                        "statusPillPinnedTop": true
+                    },
+                    "status": {
+                        "topStripVisible": true,
+                        "stripHeight": 8,
+                        "slotMargin": "headerSideMargin",
+                        "topMargin": "pctH:1"
+                    },
+                    "list": {
+                        "contentAxis": "vertical",
+                        "listShare": 9,
+                        "detailShare": 7,
+                        "dividerWidth": 1,
+                        "dividerMargin": 0,
+                        "cardSideMargin": 4,
+                        "cardTopMargin": "pctH:2",
+                        "cardBottomMargin": "pctH:8",
+                        "cardPaddingLeft": 3,
+                        "cardPaddingRight": 2,
+                        "cardPaddingTop": 3,
+                        "cardPaddingBottom": 2,
+                        "rowHeight": 12,
+                        "rowSpacing": 0,
+                        "centerSlot": 7,
+                        "scrollbarGap": 2,
+                        "selectionAccentWidth": 2,
+                        "rowTextLeftPadding": 4,
+                        "rowTextRightPadding": 2,
+                        "favoriteRightPadding": 2,
+                        "overlayBottomMargin": "pctH:14"
+                    },
+                    "detail": {
+                        "contentAxis": "horizontal",
+                        "sectionGap": 2,
+                        "imageShare": 5,
+                        "metadataShare": 7,
+                        "imageHeightRatioWithTitle": 48,
+                        "imageReservedWidth": 16,
+                        "imageReservedHeight": 0,
+                        "imageBottomMargin": 2,
+                        "panePaddingLeft": 1,
+                        "panePaddingRight": 1,
+                        "panePaddingTop": 3,
+                        "panePaddingBottom": 2,
+                        "imagePaddingLeft": 2,
+                        "imagePaddingRight": 2,
+                        "imagePaddingTop": 0,
+                        "imagePaddingBottom": 2,
+                        "metadataPaddingLeft": 2,
+                        "metadataPaddingRight": 1,
+                        "metadataPaddingTop": 0,
+                        "metadataPaddingBottom": 0,
+                        "metadataTopMargin": 0,
+                        "metadataLeftMargin": 0,
+                        "metadataRightMargin": 0,
+                        "metadataHeightAdjustment": 0,
+                        "metadataBottomAligned": false,
+                        "titleBottomMargin": 2,
+                        "tagRowHeight": 9,
+                        "tagRowSpacing": 0
+                    },
+                    "footer": {
+                        "bottomUnsafeHeight": 16
+                    },
+                    "surface": {
+                        "cornerRadius": 4
+                    }
                 },
-                "detail": {
-                    "contentAxis": "vertical",
-                    "sectionGap": "pctH:2",
-                    "imageShare": 2,
-                    "metadataShare": 1,
-                    "imageHeightRatioWithTitle": 48,
-                    "imageReservedWidth": 0,
-                    "imageReservedHeight": 0,
-                    "imageBottomMargin": 0,
-                    "panePaddingLeft": "pctW:2",
-                    "panePaddingRight": "pctW:2",
-                    "panePaddingTop": "pctH:2",
-                    "panePaddingBottom": "pctH:2",
-                    "imagePaddingLeft": 0,
-                    "imagePaddingRight": 0,
-                    "imagePaddingTop": 0,
-                    "imagePaddingBottom": 0,
-                    "metadataPaddingLeft": 0,
-                    "metadataPaddingRight": 0,
-                    "metadataPaddingTop": 0,
-                    "metadataPaddingBottom": 0,
-                    "metadataTopMargin": 0,
-                    "metadataLeftMargin": 0,
-                    "metadataRightMargin": 0,
-                    "metadataHeightAdjustment": 0,
-                    "metadataBottomAligned": false,
-                    "titleBottomMargin": "pctH:2",
-                    "tagRowHeight": "pctH:3",
-                    "tagRowSpacing": "pctH:0.55"
+                "gamesGrid": {
+                    "header": {
+                        "titleInHeader": true,
+                        "hudBottomAligned": true,
+                        "statusPillPinnedTop": true
+                    },
+                    "status": {
+                        "topStripVisible": false,
+                        "stripHeight": 0,
+                        "slotMargin": "headerSideMargin",
+                        "topMargin": "pctH:1"
+                    },
+                    "grid": {
+                        "leftInset": 4,
+                        "rightInset": 0,
+                        "gutterWidth": 8,
+                        "gutterGap": 4,
+                        "columnGap": 4,
+                        "topInset": 2,
+                        "bottomInset": 4,
+                        "rowGap": 4,
+                        "scrollThumbWidth": 4,
+                        "scrollThumbRightInset": 2,
+                        "scrollThumbRightAligned": false,
+                        "scrollArrowSize": 8,
+                        "gutterFollowsContentWidth": true
+                    },
+                    "footer": {
+                        "activeLabelHeight": 8,
+                        "activeLabelBottomMargin": "pctH:6",
+                        "bottomStatusVisible": true,
+                        "bottomStatusLeftMargin": 4,
+                        "bottomStatusRightMargin": "pctW:5",
+                        "gridBottomMargin": "sum(pctH:6,8)",
+                        "bottomUnsafeHeight": 16
+                    },
+                    "surface": {
+                        "cornerRadius": 4
+                    }
                 },
-                "footer": {
-                    "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
+                "gamesList": {
+                    "header": {
+                        "titleInHeader": true,
+                        "hudBottomAligned": true,
+                        "statusPillPinnedTop": true
+                    },
+                    "status": {
+                        "topStripVisible": true,
+                        "stripHeight": 8,
+                        "slotMargin": "headerSideMargin",
+                        "topMargin": "pctH:1"
+                    },
+                    "list": {
+                        "contentAxis": "horizontal",
+                        "listShare": 2,
+                        "detailShare": 1,
+                        "dividerWidth": 1,
+                        "dividerMargin": -16,
+                        "cardSideMargin": 4,
+                        "cardTopMargin": "pctH:2",
+                        "cardBottomMargin": "pctH:8",
+                        "cardPaddingLeft": 3,
+                        "cardPaddingRight": 2,
+                        "cardPaddingTop": 3,
+                        "cardPaddingBottom": 2,
+                        "rowHeight": 12,
+                        "rowSpacing": 0,
+                        "centerSlot": 7,
+                        "scrollbarGap": 2,
+                        "selectionAccentWidth": 2,
+                        "rowTextLeftPadding": 4,
+                        "rowTextRightPadding": 2,
+                        "favoriteRightPadding": 2,
+                        "overlayBottomMargin": "pctH:14"
+                    },
+                    "detail": {
+                        "contentAxis": "vertical",
+                        "sectionGap": 2,
+                        "imageShare": 2,
+                        "metadataShare": 1,
+                        "imageHeightRatioWithTitle": 48,
+                        "imageReservedWidth": 16,
+                        "imageReservedHeight": 0,
+                        "imageBottomMargin": 2,
+                        "panePaddingLeft": 1,
+                        "panePaddingRight": 1,
+                        "panePaddingTop": 3,
+                        "panePaddingBottom": 2,
+                        "imagePaddingLeft": 2,
+                        "imagePaddingRight": 2,
+                        "imagePaddingTop": 0,
+                        "imagePaddingBottom": 2,
+                        "metadataPaddingLeft": 2,
+                        "metadataPaddingRight": 1,
+                        "metadataPaddingTop": 0,
+                        "metadataPaddingBottom": 0,
+                        "metadataTopMargin": -14,
+                        "metadataLeftMargin": 2,
+                        "metadataRightMargin": 1,
+                        "metadataHeightAdjustment": 2,
+                        "metadataBottomAligned": true,
+                        "titleBottomMargin": 2,
+                        "tagRowHeight": 9,
+                        "tagRowSpacing": 0
+                    },
+                    "footer": {
+                        "bottomUnsafeHeight": 16
+                    },
+                    "surface": {
+                        "cornerRadius": 4
+                    }
                 },
-                "surface": {
-                    "cornerRadius": "cornerRadius"
-                }
-            },
-            "systemsListTate": {
-                "header": {
-                    "titleInHeader": false,
-                    "hudBottomAligned": false,
-                    "statusPillPinnedTop": false
-                },
-                "status": {
-                    "topStripVisible": true,
-                    "stripHeight": "pctH:7",
-                    "slotMargin": "pctW:5",
-                    "topMargin": "pctH:1"
-                },
-                "list": {
-                    "contentAxis": "vertical",
-                    "listShare": 9,
-                    "detailShare": 7,
-                    "dividerWidth": 1,
-                    "dividerMargin": 0,
-                    "cardSideMargin": "pctW:5",
-                    "cardTopMargin": "pctH:2",
-                    "cardBottomMargin": "pctH:8",
-                    "cardPaddingLeft": "pctW:2",
-                    "cardPaddingRight": "pctW:2",
-                    "cardPaddingTop": "pctH:2",
-                    "cardPaddingBottom": "pctH:2",
-                    "rowHeight": 0,
-                    "rowSpacing": "pctH:0.3",
-                    "centerSlot": -1,
-                    "scrollbarGap": "pctW:1.5",
-                    "selectionAccentWidth": "pctW:0.45",
-                    "rowTextLeftPadding": "pctW:1.6",
-                    "rowTextRightPadding": "pctW:1.6",
-                    "favoriteRightPadding": "pctW:1.6",
-                    "overlayBottomMargin": "pctH:15"
-                },
-                "detail": {
-                    "contentAxis": "horizontal",
-                    "sectionGap": "pctW:2",
-                    "imageShare": 5,
-                    "metadataShare": 7,
-                    "imageHeightRatioWithTitle": 48,
-                    "imageReservedWidth": 0,
-                    "imageReservedHeight": 0,
-                    "imageBottomMargin": 0,
-                    "panePaddingLeft": "pctW:2",
-                    "panePaddingRight": "pctW:2",
-                    "panePaddingTop": "pctH:2",
-                    "panePaddingBottom": "pctH:2",
-                    "imagePaddingLeft": 0,
-                    "imagePaddingRight": 0,
-                    "imagePaddingTop": 0,
-                    "imagePaddingBottom": 0,
-                    "metadataPaddingLeft": 0,
-                    "metadataPaddingRight": 0,
-                    "metadataPaddingTop": 0,
-                    "metadataPaddingBottom": 0,
-                    "metadataTopMargin": 0,
-                    "metadataLeftMargin": 0,
-                    "metadataRightMargin": 0,
-                    "metadataHeightAdjustment": 0,
-                    "metadataBottomAligned": false,
-                    "titleBottomMargin": "pctH:2",
-                    "tagRowHeight": "pctH:3",
-                    "tagRowSpacing": "pctH:0.55"
-                },
-                "footer": {
-                    "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
-                },
-                "surface": {
-                    "cornerRadius": "cornerRadius"
-                }
-            },
-            "gamesGrid": {
-                "header": {
-                    "titleInHeader": false,
-                    "hudBottomAligned": false,
-                    "statusPillPinnedTop": false
-                },
-                "status": {
-                    "topStripVisible": true,
-                    "stripHeight": "pctH:7",
-                    "slotMargin": "pctW:5",
-                    "topMargin": "pctH:1"
-                },
-                "grid": {
-                    "leftInset": "pctW:5",
-                    "rightInset": "pctW:5",
-                    "gutterWidth": "pctW:3",
-                    "gutterGap": "pctW:1.5",
-                    "columnGap": "pctW:3",
-                    "topInset": "pctH:2",
-                    "bottomInset": "pctH:2",
-                    "rowGap": "pctH:4",
-                    "scrollThumbWidth": "pctW:1.2",
-                    "scrollThumbRightInset": 0,
-                    "scrollThumbRightAligned": false,
-                    "scrollArrowSize": "min(pctW:3,pctH:4)",
-                    "gutterFollowsContentWidth": false
-                },
-                "footer": {
-                    "activeLabelHeight": "pctH:7",
-                    "activeLabelBottomMargin": "pctH:8",
-                    "bottomStatusVisible": false,
-                    "bottomStatusLeftMargin": "pctW:5",
-                    "bottomStatusRightMargin": "pctW:5",
-                    "gridBottomMargin": "sum(pctH:6,pctH:8,pctH:7)",
-                    "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
-                },
-                "surface": {
-                    "cornerRadius": "cornerRadius"
-                }
-            },
-            "gamesList": {
-                "header": {
-                    "titleInHeader": false,
-                    "hudBottomAligned": false,
-                    "statusPillPinnedTop": false
-                },
-                "status": {
-                    "topStripVisible": true,
-                    "stripHeight": "pctH:7",
-                    "slotMargin": "pctW:5",
-                    "topMargin": "pctH:1"
-                },
-                "list": {
-                    "contentAxis": "horizontal",
-                    "listShare": 2,
-                    "detailShare": 1,
-                    "dividerWidth": 1,
-                    "dividerMargin": 0,
-                    "cardSideMargin": "pctW:5",
-                    "cardTopMargin": "pctH:2",
-                    "cardBottomMargin": "pctH:8",
-                    "cardPaddingLeft": "pctW:2",
-                    "cardPaddingRight": "pctW:2",
-                    "cardPaddingTop": "pctH:2",
-                    "cardPaddingBottom": "pctH:2",
-                    "rowHeight": 0,
-                    "rowSpacing": "pctH:0.7",
-                    "centerSlot": -1,
-                    "scrollbarGap": "pctW:1.5",
-                    "selectionAccentWidth": "pctW:0.45",
-                    "rowTextLeftPadding": "pctW:1.6",
-                    "rowTextRightPadding": "pctW:1.6",
-                    "favoriteRightPadding": "pctW:1.6",
-                    "overlayBottomMargin": "pctH:15"
-                },
-                "detail": {
-                    "contentAxis": "vertical",
-                    "sectionGap": "pctH:2",
-                    "imageShare": 2,
-                    "metadataShare": 1,
-                    "imageHeightRatioWithTitle": 48,
-                    "imageReservedWidth": 0,
-                    "imageReservedHeight": 0,
-                    "imageBottomMargin": 0,
-                    "panePaddingLeft": "pctW:2",
-                    "panePaddingRight": "pctW:2",
-                    "panePaddingTop": "pctH:2",
-                    "panePaddingBottom": "pctH:2",
-                    "imagePaddingLeft": 0,
-                    "imagePaddingRight": 0,
-                    "imagePaddingTop": 0,
-                    "imagePaddingBottom": 0,
-                    "metadataPaddingLeft": 0,
-                    "metadataPaddingRight": 0,
-                    "metadataPaddingTop": 0,
-                    "metadataPaddingBottom": 0,
-                    "metadataTopMargin": 0,
-                    "metadataLeftMargin": 0,
-                    "metadataRightMargin": 0,
-                    "metadataHeightAdjustment": 0,
-                    "metadataBottomAligned": true,
-                    "titleBottomMargin": "pctH:2",
-                    "tagRowHeight": "pctH:3",
-                    "tagRowSpacing": "pctH:0.55"
-                },
-                "footer": {
-                    "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
-                },
-                "surface": {
-                    "cornerRadius": "cornerRadius"
-                }
-            },
-            "gamesListTate": {
-                "header": {
-                    "titleInHeader": false,
-                    "hudBottomAligned": false,
-                    "statusPillPinnedTop": false
-                },
-                "status": {
-                    "topStripVisible": true,
-                    "stripHeight": "pctH:7",
-                    "slotMargin": "pctW:5",
-                    "topMargin": "pctH:1"
-                },
-                "list": {
-                    "contentAxis": "vertical",
-                    "listShare": 9,
-                    "detailShare": 7,
-                    "dividerWidth": 1,
-                    "dividerMargin": 0,
-                    "cardSideMargin": "pctW:5",
-                    "cardTopMargin": "pctH:2",
-                    "cardBottomMargin": "pctH:8",
-                    "cardPaddingLeft": "pctW:2",
-                    "cardPaddingRight": "pctW:2",
-                    "cardPaddingTop": "pctH:2",
-                    "cardPaddingBottom": "pctH:2",
-                    "rowHeight": 0,
-                    "rowSpacing": "pctH:0.3",
-                    "centerSlot": -1,
-                    "scrollbarGap": "pctW:1.5",
-                    "selectionAccentWidth": "pctW:0.45",
-                    "rowTextLeftPadding": "pctW:1.6",
-                    "rowTextRightPadding": "pctW:1.6",
-                    "favoriteRightPadding": "pctW:1.6",
-                    "overlayBottomMargin": "pctH:15"
-                },
-                "detail": {
-                    "contentAxis": "horizontal",
-                    "sectionGap": "pctW:2",
-                    "imageShare": 5,
-                    "metadataShare": 7,
-                    "imageHeightRatioWithTitle": 48,
-                    "imageReservedWidth": 0,
-                    "imageReservedHeight": 0,
-                    "imageBottomMargin": 0,
-                    "panePaddingLeft": "pctW:2",
-                    "panePaddingRight": "pctW:2",
-                    "panePaddingTop": "pctH:2",
-                    "panePaddingBottom": "pctH:2",
-                    "imagePaddingLeft": 0,
-                    "imagePaddingRight": 0,
-                    "imagePaddingTop": 0,
-                    "imagePaddingBottom": 0,
-                    "metadataPaddingLeft": 0,
-                    "metadataPaddingRight": 0,
-                    "metadataPaddingTop": 0,
-                    "metadataPaddingBottom": 0,
-                    "metadataTopMargin": 0,
-                    "metadataLeftMargin": 0,
-                    "metadataRightMargin": 0,
-                    "metadataHeightAdjustment": 0,
-                    "metadataBottomAligned": false,
-                    "titleBottomMargin": "pctH:2",
-                    "tagRowHeight": "pctH:3",
-                    "tagRowSpacing": "pctH:0.55"
-                },
-                "footer": {
-                    "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
-                },
-                "surface": {
-                    "cornerRadius": "cornerRadius"
+                "gamesListTate": {
+                    "header": {
+                        "titleInHeader": true,
+                        "hudBottomAligned": true,
+                        "statusPillPinnedTop": true
+                    },
+                    "status": {
+                        "topStripVisible": true,
+                        "stripHeight": 8,
+                        "slotMargin": "headerSideMargin",
+                        "topMargin": "pctH:1"
+                    },
+                    "list": {
+                        "contentAxis": "vertical",
+                        "listShare": 9,
+                        "detailShare": 7,
+                        "dividerWidth": 1,
+                        "dividerMargin": 0,
+                        "cardSideMargin": 4,
+                        "cardTopMargin": "pctH:2",
+                        "cardBottomMargin": "pctH:8",
+                        "cardPaddingLeft": 3,
+                        "cardPaddingRight": 2,
+                        "cardPaddingTop": 3,
+                        "cardPaddingBottom": 2,
+                        "rowHeight": 12,
+                        "rowSpacing": 0,
+                        "centerSlot": 7,
+                        "scrollbarGap": 2,
+                        "selectionAccentWidth": 2,
+                        "rowTextLeftPadding": 4,
+                        "rowTextRightPadding": 2,
+                        "favoriteRightPadding": 2,
+                        "overlayBottomMargin": "pctH:14"
+                    },
+                    "detail": {
+                        "contentAxis": "horizontal",
+                        "sectionGap": 2,
+                        "imageShare": 5,
+                        "metadataShare": 7,
+                        "imageHeightRatioWithTitle": 48,
+                        "imageReservedWidth": 16,
+                        "imageReservedHeight": 0,
+                        "imageBottomMargin": 2,
+                        "panePaddingLeft": 1,
+                        "panePaddingRight": 1,
+                        "panePaddingTop": 3,
+                        "panePaddingBottom": 2,
+                        "imagePaddingLeft": 2,
+                        "imagePaddingRight": 2,
+                        "imagePaddingTop": 0,
+                        "imagePaddingBottom": 2,
+                        "metadataPaddingLeft": 2,
+                        "metadataPaddingRight": 1,
+                        "metadataPaddingTop": 0,
+                        "metadataPaddingBottom": 0,
+                        "metadataTopMargin": 0,
+                        "metadataLeftMargin": 0,
+                        "metadataRightMargin": 0,
+                        "metadataHeightAdjustment": 0,
+                        "metadataBottomAligned": false,
+                        "titleBottomMargin": 2,
+                        "tagRowHeight": 9,
+                        "tagRowSpacing": 0
+                    },
+                    "footer": {
+                        "bottomUnsafeHeight": 16
+                    },
+                    "surface": {
+                        "cornerRadius": 4
+                    }
                 }
             }
-        },
-        "crt": {
-            "systemsGrid": {
-                "header": {
-                    "titleInHeader": true,
-                    "hudBottomAligned": true,
-                    "statusPillPinnedTop": true
-                },
-                "status": {
-                    "topStripVisible": false,
-                    "stripHeight": 0,
-                    "slotMargin": "headerSideMargin",
-                    "topMargin": "pctH:1"
-                },
-                "grid": {
-                    "leftInset": 4,
-                    "rightInset": 0,
-                    "gutterWidth": 8,
-                    "gutterGap": 4,
-                    "columnGap": 4,
-                    "topInset": 2,
-                    "bottomInset": 4,
-                    "rowGap": 4,
-                    "scrollThumbWidth": 4,
-                    "scrollThumbRightInset": 2,
-                    "scrollThumbRightAligned": false,
-                    "scrollArrowSize": 8,
-                    "gutterFollowsContentWidth": true
-                },
-                "footer": {
-                    "activeLabelHeight": 8,
-                    "activeLabelBottomMargin": "pctH:6",
-                    "bottomStatusVisible": true,
-                    "bottomStatusLeftMargin": 4,
-                    "bottomStatusRightMargin": "pctW:5",
-                    "gridBottomMargin": "sum(pctH:6,8)",
-                    "bottomUnsafeHeight": 16
-                },
-                "surface": {
-                    "cornerRadius": 4
-                }
-            },
-            "systemsList": {
-                "header": {
-                    "titleInHeader": true,
-                    "hudBottomAligned": true,
-                    "statusPillPinnedTop": true
-                },
-                "status": {
-                    "topStripVisible": true,
-                    "stripHeight": 8,
-                    "slotMargin": "headerSideMargin",
-                    "topMargin": "pctH:1"
-                },
-                "list": {
-                    "contentAxis": "horizontal",
-                    "listShare": 2,
-                    "detailShare": 1,
-                    "dividerWidth": 1,
-                    "dividerMargin": -16,
-                    "cardSideMargin": 4,
-                    "cardTopMargin": "pctH:2",
-                    "cardBottomMargin": "pctH:8",
-                    "cardPaddingLeft": 3,
-                    "cardPaddingRight": 2,
-                    "cardPaddingTop": 3,
-                    "cardPaddingBottom": 2,
-                    "rowHeight": 12,
-                    "rowSpacing": 0,
-                    "centerSlot": 7,
-                    "scrollbarGap": 2,
-                    "selectionAccentWidth": 2,
-                    "rowTextLeftPadding": 4,
-                    "rowTextRightPadding": 2,
-                    "favoriteRightPadding": 2,
-                    "overlayBottomMargin": "pctH:14"
-                },
-                "detail": {
-                    "contentAxis": "vertical",
-                    "sectionGap": 2,
-                    "imageShare": 2,
-                    "metadataShare": 1,
-                    "imageHeightRatioWithTitle": 48,
-                    "imageReservedWidth": 16,
-                    "imageReservedHeight": 0,
-                    "imageBottomMargin": 2,
-                    "panePaddingLeft": 1,
-                    "panePaddingRight": 1,
-                    "panePaddingTop": 3,
-                    "panePaddingBottom": 2,
-                    "imagePaddingLeft": 2,
-                    "imagePaddingRight": 2,
-                    "imagePaddingTop": 0,
-                    "imagePaddingBottom": 2,
-                    "metadataPaddingLeft": 2,
-                    "metadataPaddingRight": 1,
-                    "metadataPaddingTop": 0,
-                    "metadataPaddingBottom": 0,
-                    "metadataTopMargin": -14,
-                    "metadataLeftMargin": 2,
-                    "metadataRightMargin": 1,
-                    "metadataHeightAdjustment": 2,
-                    "metadataBottomAligned": false,
-                    "titleBottomMargin": 2,
-                    "tagRowHeight": 9,
-                    "tagRowSpacing": 0
-                },
-                "footer": {
-                    "bottomUnsafeHeight": 16
-                },
-                "surface": {
-                    "cornerRadius": 4
-                }
-            },
-            "systemsListTate": {
-                "header": {
-                    "titleInHeader": true,
-                    "hudBottomAligned": true,
-                    "statusPillPinnedTop": true
-                },
-                "status": {
-                    "topStripVisible": true,
-                    "stripHeight": 8,
-                    "slotMargin": "headerSideMargin",
-                    "topMargin": "pctH:1"
-                },
-                "list": {
-                    "contentAxis": "vertical",
-                    "listShare": 9,
-                    "detailShare": 7,
-                    "dividerWidth": 1,
-                    "dividerMargin": 0,
-                    "cardSideMargin": 4,
-                    "cardTopMargin": "pctH:2",
-                    "cardBottomMargin": "pctH:8",
-                    "cardPaddingLeft": 3,
-                    "cardPaddingRight": 2,
-                    "cardPaddingTop": 3,
-                    "cardPaddingBottom": 2,
-                    "rowHeight": 12,
-                    "rowSpacing": 0,
-                    "centerSlot": 7,
-                    "scrollbarGap": 2,
-                    "selectionAccentWidth": 2,
-                    "rowTextLeftPadding": 4,
-                    "rowTextRightPadding": 2,
-                    "favoriteRightPadding": 2,
-                    "overlayBottomMargin": "pctH:14"
-                },
-                "detail": {
-                    "contentAxis": "horizontal",
-                    "sectionGap": 2,
-                    "imageShare": 5,
-                    "metadataShare": 7,
-                    "imageHeightRatioWithTitle": 48,
-                    "imageReservedWidth": 16,
-                    "imageReservedHeight": 0,
-                    "imageBottomMargin": 2,
-                    "panePaddingLeft": 1,
-                    "panePaddingRight": 1,
-                    "panePaddingTop": 3,
-                    "panePaddingBottom": 2,
-                    "imagePaddingLeft": 2,
-                    "imagePaddingRight": 2,
-                    "imagePaddingTop": 0,
-                    "imagePaddingBottom": 2,
-                    "metadataPaddingLeft": 2,
-                    "metadataPaddingRight": 1,
-                    "metadataPaddingTop": 0,
-                    "metadataPaddingBottom": 0,
-                    "metadataTopMargin": 0,
-                    "metadataLeftMargin": 0,
-                    "metadataRightMargin": 0,
-                    "metadataHeightAdjustment": 0,
-                    "metadataBottomAligned": false,
-                    "titleBottomMargin": 2,
-                    "tagRowHeight": 9,
-                    "tagRowSpacing": 0
-                },
-                "footer": {
-                    "bottomUnsafeHeight": 16
-                },
-                "surface": {
-                    "cornerRadius": 4
-                }
-            },
-            "gamesGrid": {
-                "header": {
-                    "titleInHeader": true,
-                    "hudBottomAligned": true,
-                    "statusPillPinnedTop": true
-                },
-                "status": {
-                    "topStripVisible": false,
-                    "stripHeight": 0,
-                    "slotMargin": "headerSideMargin",
-                    "topMargin": "pctH:1"
-                },
-                "grid": {
-                    "leftInset": 4,
-                    "rightInset": 0,
-                    "gutterWidth": 8,
-                    "gutterGap": 4,
-                    "columnGap": 4,
-                    "topInset": 2,
-                    "bottomInset": 4,
-                    "rowGap": 4,
-                    "scrollThumbWidth": 4,
-                    "scrollThumbRightInset": 2,
-                    "scrollThumbRightAligned": false,
-                    "scrollArrowSize": 8,
-                    "gutterFollowsContentWidth": true
-                },
-                "footer": {
-                    "activeLabelHeight": 8,
-                    "activeLabelBottomMargin": "pctH:6",
-                    "bottomStatusVisible": true,
-                    "bottomStatusLeftMargin": 4,
-                    "bottomStatusRightMargin": "pctW:5",
-                    "gridBottomMargin": "sum(pctH:6,8)",
-                    "bottomUnsafeHeight": 16
-                },
-                "surface": {
-                    "cornerRadius": 4
-                }
-            },
-            "gamesList": {
-                "header": {
-                    "titleInHeader": true,
-                    "hudBottomAligned": true,
-                    "statusPillPinnedTop": true
-                },
-                "status": {
-                    "topStripVisible": true,
-                    "stripHeight": 8,
-                    "slotMargin": "headerSideMargin",
-                    "topMargin": "pctH:1"
-                },
-                "list": {
-                    "contentAxis": "horizontal",
-                    "listShare": 2,
-                    "detailShare": 1,
-                    "dividerWidth": 1,
-                    "dividerMargin": -16,
-                    "cardSideMargin": 4,
-                    "cardTopMargin": "pctH:2",
-                    "cardBottomMargin": "pctH:8",
-                    "cardPaddingLeft": 3,
-                    "cardPaddingRight": 2,
-                    "cardPaddingTop": 3,
-                    "cardPaddingBottom": 2,
-                    "rowHeight": 12,
-                    "rowSpacing": 0,
-                    "centerSlot": 7,
-                    "scrollbarGap": 2,
-                    "selectionAccentWidth": 2,
-                    "rowTextLeftPadding": 4,
-                    "rowTextRightPadding": 2,
-                    "favoriteRightPadding": 2,
-                    "overlayBottomMargin": "pctH:14"
-                },
-                "detail": {
-                    "contentAxis": "vertical",
-                    "sectionGap": 2,
-                    "imageShare": 2,
-                    "metadataShare": 1,
-                    "imageHeightRatioWithTitle": 48,
-                    "imageReservedWidth": 16,
-                    "imageReservedHeight": 0,
-                    "imageBottomMargin": 2,
-                    "panePaddingLeft": 1,
-                    "panePaddingRight": 1,
-                    "panePaddingTop": 3,
-                    "panePaddingBottom": 2,
-                    "imagePaddingLeft": 2,
-                    "imagePaddingRight": 2,
-                    "imagePaddingTop": 0,
-                    "imagePaddingBottom": 2,
-                    "metadataPaddingLeft": 2,
-                    "metadataPaddingRight": 1,
-                    "metadataPaddingTop": 0,
-                    "metadataPaddingBottom": 0,
-                    "metadataTopMargin": -14,
-                    "metadataLeftMargin": 2,
-                    "metadataRightMargin": 1,
-                    "metadataHeightAdjustment": 2,
-                    "metadataBottomAligned": true,
-                    "titleBottomMargin": 2,
-                    "tagRowHeight": 9,
-                    "tagRowSpacing": 0
-                },
-                "footer": {
-                    "bottomUnsafeHeight": 16
-                },
-                "surface": {
-                    "cornerRadius": 4
-                }
-            },
-            "gamesListTate": {
-                "header": {
-                    "titleInHeader": true,
-                    "hudBottomAligned": true,
-                    "statusPillPinnedTop": true
-                },
-                "status": {
-                    "topStripVisible": true,
-                    "stripHeight": 8,
-                    "slotMargin": "headerSideMargin",
-                    "topMargin": "pctH:1"
-                },
-                "list": {
-                    "contentAxis": "vertical",
-                    "listShare": 9,
-                    "detailShare": 7,
-                    "dividerWidth": 1,
-                    "dividerMargin": 0,
-                    "cardSideMargin": 4,
-                    "cardTopMargin": "pctH:2",
-                    "cardBottomMargin": "pctH:8",
-                    "cardPaddingLeft": 3,
-                    "cardPaddingRight": 2,
-                    "cardPaddingTop": 3,
-                    "cardPaddingBottom": 2,
-                    "rowHeight": 12,
-                    "rowSpacing": 0,
-                    "centerSlot": 7,
-                    "scrollbarGap": 2,
-                    "selectionAccentWidth": 2,
-                    "rowTextLeftPadding": 4,
-                    "rowTextRightPadding": 2,
-                    "favoriteRightPadding": 2,
-                    "overlayBottomMargin": "pctH:14"
-                },
-                "detail": {
-                    "contentAxis": "horizontal",
-                    "sectionGap": 2,
-                    "imageShare": 5,
-                    "metadataShare": 7,
-                    "imageHeightRatioWithTitle": 48,
-                    "imageReservedWidth": 16,
-                    "imageReservedHeight": 0,
-                    "imageBottomMargin": 2,
-                    "panePaddingLeft": 1,
-                    "panePaddingRight": 1,
-                    "panePaddingTop": 3,
-                    "panePaddingBottom": 2,
-                    "imagePaddingLeft": 2,
-                    "imagePaddingRight": 2,
-                    "imagePaddingTop": 0,
-                    "imagePaddingBottom": 2,
-                    "metadataPaddingLeft": 2,
-                    "metadataPaddingRight": 1,
-                    "metadataPaddingTop": 0,
-                    "metadataPaddingBottom": 0,
-                    "metadataTopMargin": 0,
-                    "metadataLeftMargin": 0,
-                    "metadataRightMargin": 0,
-                    "metadataHeightAdjustment": 0,
-                    "metadataBottomAligned": false,
-                    "titleBottomMargin": 2,
-                    "tagRowHeight": 9,
-                    "tagRowSpacing": 0
-                },
-                "footer": {
-                    "bottomUnsafeHeight": 16
-                },
-                "surface": {
-                    "cornerRadius": 4
-                }
-            }
-        }
-    })
+        })
 
     function currentProfile(viewId: string): var {
         return BrowseLayouts.themeProfile(BrowseLayouts.currentThemeId, viewId);

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -90,47 +90,47 @@
         <translation type="unfinished">جارٍ التحميل…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <location filename="../components/BrowseDetailPane.qml" line="77"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <location filename="../components/BrowseDetailPane.qml" line="79"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <location filename="../components/BrowseDetailPane.qml" line="81"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <location filename="../components/BrowseDetailPane.qml" line="83"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="55"/>
+        <location filename="../components/BrowseDetailPane.qml" line="85"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="57"/>
+        <location filename="../components/BrowseDetailPane.qml" line="87"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="59"/>
+        <location filename="../components/BrowseDetailPane.qml" line="89"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="61"/>
+        <location filename="../components/BrowseDetailPane.qml" line="91"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="63"/>
+        <location filename="../components/BrowseDetailPane.qml" line="93"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
@@ -329,34 +329,34 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="109"/>
-        <location filename="../screens/GamesScreen.qml" line="138"/>
+        <location filename="../screens/GamesScreen.qml" line="117"/>
+        <location filename="../screens/GamesScreen.qml" line="145"/>
         <source>%1 files</source>
         <translation>%1 ملفات</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="40"/>
+        <location filename="../screens/GamesScreen.qml" line="51"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="118"/>
-        <location filename="../screens/GamesScreen.qml" line="139"/>
+        <location filename="../screens/GamesScreen.qml" line="126"/>
+        <location filename="../screens/GamesScreen.qml" line="146"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="33"/>
+        <location filename="../screens/GamesScreen.qml" line="44"/>
         <source>No games in this system</source>
         <translation>لا توجد ألعاب في هذا النظام</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="34"/>
+        <location filename="../screens/GamesScreen.qml" line="45"/>
         <source>Loading games…</source>
         <translation>جارٍ تحميل الألعاب…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="114"/>
+        <location filename="../screens/GamesScreen.qml" line="122"/>
         <source>Loading more…</source>
         <translation>جارٍ تحميل المزيد…</translation>
     </message>
@@ -434,7 +434,7 @@
     </message>
     <message>
         <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="955"/>
+        <location filename="../app/Main.qml" line="958"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
@@ -465,67 +465,67 @@
         <translation>رمز QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="951"/>
+        <location filename="../app/Main.qml" line="954"/>
         <source>Default</source>
         <translation type="unfinished">افتراضي</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="951"/>
+        <location filename="../app/Main.qml" line="954"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1227"/>
+        <location filename="../app/Main.qml" line="1230"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1231"/>
+        <location filename="../app/Main.qml" line="1234"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1245"/>
+        <location filename="../app/Main.qml" line="1248"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1249"/>
+        <location filename="../app/Main.qml" line="1252"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1253"/>
+        <location filename="../app/Main.qml" line="1256"/>
         <source>Retry</source>
         <translation type="unfinished">إعادة المحاولة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1257"/>
+        <location filename="../app/Main.qml" line="1260"/>
         <source>Cancel</source>
         <translation type="unfinished">إلغاء</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1769"/>
+        <location filename="../app/Main.qml" line="1776"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1771"/>
+        <location filename="../app/Main.qml" line="1778"/>
         <source>Loading games…</source>
         <translation>جارٍ تحميل الألعاب…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1773"/>
+        <location filename="../app/Main.qml" line="1780"/>
         <source>Loading favorites…</source>
         <translation>جارٍ تحميل المفضلة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
+        <location filename="../app/Main.qml" line="1782"/>
         <source>Loading recently played…</source>
         <translation>جارٍ تحميل آخر ما تم لعبه…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1777"/>
+        <location filename="../app/Main.qml" line="1784"/>
         <source>Loading…</source>
         <translation>جارٍ التحميل…</translation>
     </message>
@@ -533,12 +533,12 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="545"/>
+        <location filename="../app/MainLayout.qml" line="581"/>
         <source>Writing failed</source>
         <translation>فشلت الكتابة</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="545"/>
+        <location filename="../app/MainLayout.qml" line="581"/>
         <source>Put a writable card near the reader</source>
         <translation>ضع بطاقة قابلة للكتابة بالقرب من القارئ</translation>
     </message>
@@ -548,136 +548,146 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="556"/>
+        <location filename="../app/MainLayout.qml" line="323"/>
+        <source>Favorites</source>
+        <translation type="unfinished">المفضلة</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="325"/>
+        <source>Recently Played</source>
+        <translation type="unfinished">تم لعبها مؤخرًا</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="592"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="557"/>
+        <location filename="../app/MainLayout.qml" line="593"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="632"/>
+        <location filename="../app/MainLayout.qml" line="668"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="633"/>
+        <location filename="../app/MainLayout.qml" line="669"/>
         <source>Are you sure you want to exit?</source>
         <translation>هل أنت متأكد أنك تريد الخروج؟</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="705"/>
-        <location filename="../app/MainLayout.qml" line="777"/>
-        <location filename="../app/MainLayout.qml" line="820"/>
-        <location filename="../app/MainLayout.qml" line="849"/>
-        <location filename="../app/MainLayout.qml" line="896"/>
-        <location filename="../app/MainLayout.qml" line="937"/>
-        <location filename="../app/MainLayout.qml" line="1001"/>
+        <location filename="../app/MainLayout.qml" line="741"/>
+        <location filename="../app/MainLayout.qml" line="813"/>
+        <location filename="../app/MainLayout.qml" line="856"/>
+        <location filename="../app/MainLayout.qml" line="885"/>
+        <location filename="../app/MainLayout.qml" line="932"/>
+        <location filename="../app/MainLayout.qml" line="973"/>
+        <location filename="../app/MainLayout.qml" line="1037"/>
         <source>Move</source>
         <translation>تحريك</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="709"/>
-        <location filename="../app/MainLayout.qml" line="781"/>
+        <location filename="../app/MainLayout.qml" line="745"/>
+        <location filename="../app/MainLayout.qml" line="817"/>
         <source>Select</source>
         <translation>تحديد</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="713"/>
-        <location filename="../app/MainLayout.qml" line="717"/>
-        <location filename="../app/MainLayout.qml" line="731"/>
-        <location filename="../app/MainLayout.qml" line="744"/>
-        <location filename="../app/MainLayout.qml" line="755"/>
+        <location filename="../app/MainLayout.qml" line="749"/>
+        <location filename="../app/MainLayout.qml" line="753"/>
+        <location filename="../app/MainLayout.qml" line="767"/>
+        <location filename="../app/MainLayout.qml" line="780"/>
+        <location filename="../app/MainLayout.qml" line="791"/>
         <source>Close</source>
         <translation>إغلاق</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="724"/>
-        <location filename="../app/MainLayout.qml" line="762"/>
-        <location filename="../app/MainLayout.qml" line="785"/>
-        <location filename="../app/MainLayout.qml" line="796"/>
+        <location filename="../app/MainLayout.qml" line="760"/>
+        <location filename="../app/MainLayout.qml" line="798"/>
+        <location filename="../app/MainLayout.qml" line="821"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Cancel</source>
         <translation>إلغاء</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="740"/>
+        <location filename="../app/MainLayout.qml" line="776"/>
         <source>Done</source>
         <translation>تم</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="751"/>
-        <location filename="../app/MainLayout.qml" line="872"/>
-        <location filename="../app/MainLayout.qml" line="922"/>
-        <location filename="../app/MainLayout.qml" line="1027"/>
+        <location filename="../app/MainLayout.qml" line="787"/>
+        <location filename="../app/MainLayout.qml" line="908"/>
+        <location filename="../app/MainLayout.qml" line="958"/>
+        <location filename="../app/MainLayout.qml" line="1063"/>
         <source>Retry</source>
         <translation>إعادة المحاولة</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="770"/>
+        <location filename="../app/MainLayout.qml" line="806"/>
         <source>I understand</source>
         <translation>أفهم</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="804"/>
+        <location filename="../app/MainLayout.qml" line="840"/>
         <source>Start</source>
         <translation>ابدأ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
-        <location filename="../app/MainLayout.qml" line="859"/>
-        <location filename="../app/MainLayout.qml" line="906"/>
-        <location filename="../app/MainLayout.qml" line="1011"/>
+        <location filename="../app/MainLayout.qml" line="860"/>
+        <location filename="../app/MainLayout.qml" line="895"/>
+        <location filename="../app/MainLayout.qml" line="942"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
         <source>Open</source>
         <translation>فتح</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="828"/>
+        <location filename="../app/MainLayout.qml" line="864"/>
         <source>Quit</source>
         <translation>إنهاء</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="837"/>
-        <location filename="../app/MainLayout.qml" line="865"/>
-        <location filename="../app/MainLayout.qml" line="876"/>
-        <location filename="../app/MainLayout.qml" line="888"/>
-        <location filename="../app/MainLayout.qml" line="915"/>
-        <location filename="../app/MainLayout.qml" line="926"/>
-        <location filename="../app/MainLayout.qml" line="961"/>
-        <location filename="../app/MainLayout.qml" line="977"/>
-        <location filename="../app/MainLayout.qml" line="986"/>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1031"/>
+        <location filename="../app/MainLayout.qml" line="873"/>
+        <location filename="../app/MainLayout.qml" line="901"/>
+        <location filename="../app/MainLayout.qml" line="912"/>
+        <location filename="../app/MainLayout.qml" line="924"/>
+        <location filename="../app/MainLayout.qml" line="951"/>
+        <location filename="../app/MainLayout.qml" line="962"/>
+        <location filename="../app/MainLayout.qml" line="997"/>
+        <location filename="../app/MainLayout.qml" line="1013"/>
+        <location filename="../app/MainLayout.qml" line="1022"/>
+        <location filename="../app/MainLayout.qml" line="1056"/>
+        <location filename="../app/MainLayout.qml" line="1067"/>
         <source>Back</source>
         <translation>رجوع</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="855"/>
-        <location filename="../app/MainLayout.qml" line="902"/>
-        <location filename="../app/MainLayout.qml" line="1007"/>
+        <location filename="../app/MainLayout.qml" line="891"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="1043"/>
         <source>Page</source>
         <translation>صفحة</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="862"/>
-        <location filename="../app/MainLayout.qml" line="911"/>
-        <location filename="../app/MainLayout.qml" line="1016"/>
+        <location filename="../app/MainLayout.qml" line="898"/>
+        <location filename="../app/MainLayout.qml" line="947"/>
+        <location filename="../app/MainLayout.qml" line="1052"/>
         <source>Options</source>
         <translation>الخيارات</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="946"/>
+        <location filename="../app/MainLayout.qml" line="982"/>
         <source>Change</source>
         <translation>تغيير</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="952"/>
+        <location filename="../app/MainLayout.qml" line="988"/>
         <source>Toggle</source>
         <translation>تبديل</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="973"/>
+        <location filename="../app/MainLayout.qml" line="1009"/>
         <source>Scroll</source>
         <translation>تمرير</translation>
     </message>
@@ -690,12 +700,12 @@
         <translation type="unfinished">جارٍ التحميل…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="295"/>
+        <location filename="../screens/MediaListScreen.qml" line="306"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 عناصر</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="296"/>
+        <location filename="../screens/MediaListScreen.qml" line="307"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -768,288 +778,381 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="73"/>
-        <location filename="../screens/SettingsScreen.qml" line="432"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Language</source>
         <translation>اللغة</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="78"/>
-        <location filename="../screens/SettingsScreen.qml" line="441"/>
+        <location filename="../screens/SettingsScreen.qml" line="507"/>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="516"/>
         <source>Browsing layout</source>
         <translation>تخطيط التصفح</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="450"/>
+        <location filename="../screens/SettingsScreen.qml" line="88"/>
+        <location filename="../screens/SettingsScreen.qml" line="525"/>
         <source>Button style</source>
         <translation>نمط الأزرار</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88"/>
-        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <location filename="../screens/SettingsScreen.qml" line="93"/>
+        <location filename="../screens/SettingsScreen.qml" line="534"/>
         <source>Screensaver</source>
         <translation>شاشة التوقف</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="92"/>
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
         <source>Library</source>
         <translation>المكتبة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="107"/>
+        <location filename="../screens/SettingsScreen.qml" line="543"/>
+        <source>Preferred artwork</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="112"/>
         <source>Update media database</source>
         <translation>تحديث قاعدة بيانات الوسائط</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="107"/>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
         <source>Scrape metadata</source>
         <translation>استخراج البيانات الوصفية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <source>Re-scrape existing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Advanced</source>
         <translation>متقدم</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116"/>
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
         <source>Mouse support</source>
         <translation>دعم الفأرة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121"/>
+        <location filename="../screens/SettingsScreen.qml" line="136"/>
         <source>Debug logging</source>
         <translation>تسجيل التصحيح</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
+        <location filename="../screens/SettingsScreen.qml" line="141"/>
         <source>Upload log file</source>
         <translation>رفع ملف السجل</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="146"/>
         <source>About / License</source>
         <translation>حول / الترخيص</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147"/>
+        <location filename="../screens/SettingsScreen.qml" line="162"/>
         <source>Optimizing</source>
         <translation>جارٍ التحسين</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149"/>
-        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="173"/>
         <source>Paused</source>
         <translation>متوقف مؤقتًا</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149"/>
-        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="173"/>
         <source>In progress</source>
         <translation>قيد التنفيذ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152"/>
+        <location filename="../screens/SettingsScreen.qml" line="167"/>
         <source>%1 indexed</source>
         <translation>تمت فهرسة %1</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="161"/>
+        <location filename="../screens/SettingsScreen.qml" line="176"/>
         <source>%1 scraped</source>
         <translation>تم استخراج %1</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="266"/>
+        <location filename="../screens/SettingsScreen.qml" line="284"/>
         <source>Cancel</source>
         <translation>إلغاء</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="266"/>
+        <location filename="../screens/SettingsScreen.qml" line="284"/>
         <source>Start</source>
         <translation>ابدأ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="268"/>
+        <location filename="../screens/SettingsScreen.qml" line="286"/>
         <source>Upload</source>
         <translation>رفع</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <location filename="../screens/SettingsScreen.qml" line="288"/>
         <source>Open</source>
         <translation>فتح</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="322"/>
+        <location filename="../screens/SettingsScreen.qml" line="340"/>
         <source>Default</source>
         <translation>افتراضي</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="342"/>
+        <location filename="../screens/SettingsScreen.qml" line="365"/>
         <source>English</source>
         <translation>الإنجليزية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="344"/>
+        <location filename="../screens/SettingsScreen.qml" line="367"/>
         <source>Italian</source>
         <translation>الإيطالية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="346"/>
+        <location filename="../screens/SettingsScreen.qml" line="369"/>
         <source>German</source>
         <translation>الألمانية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="348"/>
+        <location filename="../screens/SettingsScreen.qml" line="371"/>
         <source>Greek</source>
         <translation>اليونانية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="350"/>
+        <location filename="../screens/SettingsScreen.qml" line="373"/>
         <source>Japanese</source>
         <translation>اليابانية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="352"/>
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Korean</source>
         <translation>الكورية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
         <source>Dutch</source>
         <translation>الهولندية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="356"/>
+        <location filename="../screens/SettingsScreen.qml" line="379"/>
         <source>Romanian</source>
         <translation>الرومانية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="358"/>
+        <location filename="../screens/SettingsScreen.qml" line="381"/>
         <source>Slovak</source>
         <translation>السلوفاكية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="360"/>
+        <location filename="../screens/SettingsScreen.qml" line="383"/>
         <source>Ukrainian</source>
         <translation>الأوكرانية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="362"/>
+        <location filename="../screens/SettingsScreen.qml" line="385"/>
         <source>Chinese (Simplified)</source>
         <translation>الصينية المبسطة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="364"/>
+        <location filename="../screens/SettingsScreen.qml" line="387"/>
         <source>Hebrew</source>
         <translation>العبرية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="366"/>
+        <location filename="../screens/SettingsScreen.qml" line="389"/>
         <source>Arabic</source>
         <translation>العربية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="368"/>
+        <location filename="../screens/SettingsScreen.qml" line="391"/>
         <source>Hindi</source>
         <translation>الهندية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="392"/>
+        <location filename="../screens/SettingsScreen.qml" line="451"/>
         <source>Auto</source>
         <translation>تلقائي</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="374"/>
+        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <source>Rotated CW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <source>Rotated CCW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="400"/>
+        <source>Horizontal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="405"/>
         <source>Detailed list view</source>
         <translation>عرض قائمة مفصلة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="375"/>
+        <location filename="../screens/SettingsScreen.qml" line="406"/>
         <source>Grid view</source>
         <translation>عرض الشبكة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="411"/>
         <source>Style B</source>
         <translation>النمط B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="382"/>
+        <location filename="../screens/SettingsScreen.qml" line="413"/>
         <source>Style C</source>
         <translation>النمط C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="384"/>
+        <location filename="../screens/SettingsScreen.qml" line="415"/>
         <source>Style D</source>
         <translation>النمط D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="385"/>
+        <location filename="../screens/SettingsScreen.qml" line="416"/>
         <source>Style A</source>
         <translation>النمط A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="395"/>
+        <location filename="../screens/SettingsScreen.qml" line="431"/>
         <source>Off</source>
         <translation>إيقاف</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <location filename="../screens/SettingsScreen.qml" line="433"/>
         <source>1 second (testing)</source>
         <translation>ثانية واحدة (اختبار)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <location filename="../screens/SettingsScreen.qml" line="435"/>
         <source>1 minute</source>
         <translation>دقيقة واحدة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="401"/>
+        <location filename="../screens/SettingsScreen.qml" line="437"/>
         <source>2 minutes</source>
         <translation>دقيقتان</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="403"/>
+        <location filename="../screens/SettingsScreen.qml" line="439"/>
         <source>5 minutes</source>
         <translation>5 دقائق</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405"/>
+        <location filename="../screens/SettingsScreen.qml" line="441"/>
         <source>10 minutes</source>
         <translation>10 دقائق</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="407"/>
+        <location filename="../screens/SettingsScreen.qml" line="443"/>
         <source>15 minutes</source>
         <translation>15 دقيقة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="409"/>
+        <location filename="../screens/SettingsScreen.qml" line="445"/>
         <source>30 minutes</source>
         <translation>30 دقيقة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="410"/>
+        <location filename="../screens/SettingsScreen.qml" line="446"/>
         <source>%1 seconds</source>
         <translation>%1 ثوانٍ</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="423"/>
+        <location filename="../screens/SettingsScreen.qml" line="489"/>
         <source>Resolution</source>
         <translation>الدقة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="563"/>
+        <location filename="../screens/SettingsScreen.qml" line="453"/>
+        <source>Image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="455"/>
+        <source>Thumbnail</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="457"/>
+        <source>Box art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <source>3D box art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="461"/>
+        <source>Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="463"/>
+        <source>Wheel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="465"/>
+        <source>Title screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="467"/>
+        <source>Map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="469"/>
+        <source>Marquee</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="471"/>
+        <source>Fan art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="473"/>
+        <source>Box side</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <source>Box back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="663"/>
         <source>Settings</source>
         <translation>الإعدادات</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="755"/>
+        <location filename="../screens/SettingsScreen.qml" line="857"/>
         <source>No settings available on this platform</source>
         <translation>لا توجد إعدادات متاحة على هذه المنصة</translation>
     </message>
@@ -1057,24 +1160,24 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="185"/>
-        <location filename="../screens/SystemsScreen.qml" line="285"/>
+        <location filename="../screens/SystemsScreen.qml" line="195"/>
+        <location filename="../screens/SystemsScreen.qml" line="292"/>
         <source>%1 systems</source>
         <translation>%1 أنظمة</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="189"/>
-        <location filename="../screens/SystemsScreen.qml" line="302"/>
+        <location filename="../screens/SystemsScreen.qml" line="196"/>
+        <location filename="../screens/SystemsScreen.qml" line="309"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="317"/>
+        <location filename="../screens/SystemsScreen.qml" line="324"/>
         <source>No systems in this category</source>
         <translation>لا توجد أنظمة في هذه الفئة</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="318"/>
+        <location filename="../screens/SystemsScreen.qml" line="325"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -90,47 +90,47 @@
         <translation type="unfinished">Wird geladen…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <location filename="../components/BrowseDetailPane.qml" line="77"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <location filename="../components/BrowseDetailPane.qml" line="79"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <location filename="../components/BrowseDetailPane.qml" line="81"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <location filename="../components/BrowseDetailPane.qml" line="83"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="55"/>
+        <location filename="../components/BrowseDetailPane.qml" line="85"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="57"/>
+        <location filename="../components/BrowseDetailPane.qml" line="87"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="59"/>
+        <location filename="../components/BrowseDetailPane.qml" line="89"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="61"/>
+        <location filename="../components/BrowseDetailPane.qml" line="91"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="63"/>
+        <location filename="../components/BrowseDetailPane.qml" line="93"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
@@ -329,34 +329,34 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="109"/>
-        <location filename="../screens/GamesScreen.qml" line="138"/>
+        <location filename="../screens/GamesScreen.qml" line="117"/>
+        <location filename="../screens/GamesScreen.qml" line="145"/>
         <source>%1 files</source>
         <translation>%1 Dateien</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="40"/>
+        <location filename="../screens/GamesScreen.qml" line="51"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="118"/>
-        <location filename="../screens/GamesScreen.qml" line="139"/>
+        <location filename="../screens/GamesScreen.qml" line="126"/>
+        <location filename="../screens/GamesScreen.qml" line="146"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="34"/>
+        <location filename="../screens/GamesScreen.qml" line="45"/>
         <source>Loading games…</source>
         <translation>Spiele werden geladen…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="114"/>
+        <location filename="../screens/GamesScreen.qml" line="122"/>
         <source>Loading more…</source>
         <translation>Mehr laden…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="33"/>
+        <location filename="../screens/GamesScreen.qml" line="44"/>
         <source>No games in this system</source>
         <translation>Keine Spiele in diesem System</translation>
     </message>
@@ -434,7 +434,7 @@
     </message>
     <message>
         <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="955"/>
+        <location filename="../app/Main.qml" line="958"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
@@ -465,67 +465,67 @@
         <translation>Spiel starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1769"/>
+        <location filename="../app/Main.qml" line="1776"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1773"/>
+        <location filename="../app/Main.qml" line="1780"/>
         <source>Loading favorites…</source>
         <translation>Favoriten werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1771"/>
+        <location filename="../app/Main.qml" line="1778"/>
         <source>Loading games…</source>
         <translation>Spiele werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="951"/>
+        <location filename="../app/Main.qml" line="954"/>
         <source>Default</source>
         <translation type="unfinished">Standard</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="951"/>
+        <location filename="../app/Main.qml" line="954"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1227"/>
+        <location filename="../app/Main.qml" line="1230"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1231"/>
+        <location filename="../app/Main.qml" line="1234"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1245"/>
+        <location filename="../app/Main.qml" line="1248"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1249"/>
+        <location filename="../app/Main.qml" line="1252"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1253"/>
+        <location filename="../app/Main.qml" line="1256"/>
         <source>Retry</source>
         <translation type="unfinished">Wiederholen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1257"/>
+        <location filename="../app/Main.qml" line="1260"/>
         <source>Cancel</source>
         <translation type="unfinished">Abbrechen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
+        <location filename="../app/Main.qml" line="1782"/>
         <source>Loading recently played…</source>
         <translation>Zuletzt gespielte werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1777"/>
+        <location filename="../app/Main.qml" line="1784"/>
         <source>Loading…</source>
         <translation>Wird geladen…</translation>
     </message>
@@ -533,71 +533,71 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="545"/>
+        <location filename="../app/MainLayout.qml" line="581"/>
         <source>Writing failed</source>
         <translation>Schreiben fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="545"/>
+        <location filename="../app/MainLayout.qml" line="581"/>
         <source>Put a writable card near the reader</source>
         <translation>Beschreibbare Karte an den Leser halten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="633"/>
+        <location filename="../app/MainLayout.qml" line="669"/>
         <source>Are you sure you want to exit?</source>
         <translation>Wirklich beenden?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="709"/>
-        <location filename="../app/MainLayout.qml" line="781"/>
+        <location filename="../app/MainLayout.qml" line="745"/>
+        <location filename="../app/MainLayout.qml" line="817"/>
         <source>Select</source>
         <translation>Auswählen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="713"/>
-        <location filename="../app/MainLayout.qml" line="717"/>
-        <location filename="../app/MainLayout.qml" line="731"/>
-        <location filename="../app/MainLayout.qml" line="744"/>
-        <location filename="../app/MainLayout.qml" line="755"/>
+        <location filename="../app/MainLayout.qml" line="749"/>
+        <location filename="../app/MainLayout.qml" line="753"/>
+        <location filename="../app/MainLayout.qml" line="767"/>
+        <location filename="../app/MainLayout.qml" line="780"/>
+        <location filename="../app/MainLayout.qml" line="791"/>
         <source>Close</source>
         <translation>Schließen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="724"/>
-        <location filename="../app/MainLayout.qml" line="762"/>
-        <location filename="../app/MainLayout.qml" line="785"/>
-        <location filename="../app/MainLayout.qml" line="796"/>
+        <location filename="../app/MainLayout.qml" line="760"/>
+        <location filename="../app/MainLayout.qml" line="798"/>
+        <location filename="../app/MainLayout.qml" line="821"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="740"/>
+        <location filename="../app/MainLayout.qml" line="776"/>
         <source>Done</source>
         <translation>Fertig</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="770"/>
+        <location filename="../app/MainLayout.qml" line="806"/>
         <source>I understand</source>
         <translation>Ich verstehe</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="804"/>
+        <location filename="../app/MainLayout.qml" line="840"/>
         <source>Start</source>
         <translation>Starten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="973"/>
+        <location filename="../app/MainLayout.qml" line="1009"/>
         <source>Scroll</source>
         <translation>Scrollen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="705"/>
-        <location filename="../app/MainLayout.qml" line="777"/>
-        <location filename="../app/MainLayout.qml" line="820"/>
-        <location filename="../app/MainLayout.qml" line="849"/>
-        <location filename="../app/MainLayout.qml" line="896"/>
-        <location filename="../app/MainLayout.qml" line="937"/>
-        <location filename="../app/MainLayout.qml" line="1001"/>
+        <location filename="../app/MainLayout.qml" line="741"/>
+        <location filename="../app/MainLayout.qml" line="813"/>
+        <location filename="../app/MainLayout.qml" line="856"/>
+        <location filename="../app/MainLayout.qml" line="885"/>
+        <location filename="../app/MainLayout.qml" line="932"/>
+        <location filename="../app/MainLayout.qml" line="973"/>
+        <location filename="../app/MainLayout.qml" line="1037"/>
         <source>Move</source>
         <translation>Bewegen</translation>
     </message>
@@ -607,77 +607,87 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="556"/>
+        <location filename="../app/MainLayout.qml" line="323"/>
+        <source>Favorites</source>
+        <translation type="unfinished">Favoriten</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="325"/>
+        <source>Recently Played</source>
+        <translation type="unfinished">Zuletzt gespielt</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="592"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="557"/>
+        <location filename="../app/MainLayout.qml" line="593"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="632"/>
+        <location filename="../app/MainLayout.qml" line="668"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
-        <location filename="../app/MainLayout.qml" line="859"/>
-        <location filename="../app/MainLayout.qml" line="906"/>
-        <location filename="../app/MainLayout.qml" line="1011"/>
+        <location filename="../app/MainLayout.qml" line="860"/>
+        <location filename="../app/MainLayout.qml" line="895"/>
+        <location filename="../app/MainLayout.qml" line="942"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
         <source>Open</source>
         <translation>Öffnen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="828"/>
+        <location filename="../app/MainLayout.qml" line="864"/>
         <source>Quit</source>
         <translation>Beenden</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="837"/>
-        <location filename="../app/MainLayout.qml" line="865"/>
-        <location filename="../app/MainLayout.qml" line="876"/>
-        <location filename="../app/MainLayout.qml" line="888"/>
-        <location filename="../app/MainLayout.qml" line="915"/>
-        <location filename="../app/MainLayout.qml" line="926"/>
-        <location filename="../app/MainLayout.qml" line="961"/>
-        <location filename="../app/MainLayout.qml" line="977"/>
-        <location filename="../app/MainLayout.qml" line="986"/>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1031"/>
+        <location filename="../app/MainLayout.qml" line="873"/>
+        <location filename="../app/MainLayout.qml" line="901"/>
+        <location filename="../app/MainLayout.qml" line="912"/>
+        <location filename="../app/MainLayout.qml" line="924"/>
+        <location filename="../app/MainLayout.qml" line="951"/>
+        <location filename="../app/MainLayout.qml" line="962"/>
+        <location filename="../app/MainLayout.qml" line="997"/>
+        <location filename="../app/MainLayout.qml" line="1013"/>
+        <location filename="../app/MainLayout.qml" line="1022"/>
+        <location filename="../app/MainLayout.qml" line="1056"/>
+        <location filename="../app/MainLayout.qml" line="1067"/>
         <source>Back</source>
         <translation>Zurück</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="855"/>
-        <location filename="../app/MainLayout.qml" line="902"/>
-        <location filename="../app/MainLayout.qml" line="1007"/>
+        <location filename="../app/MainLayout.qml" line="891"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="1043"/>
         <source>Page</source>
         <translation>Seite</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="862"/>
-        <location filename="../app/MainLayout.qml" line="911"/>
-        <location filename="../app/MainLayout.qml" line="1016"/>
+        <location filename="../app/MainLayout.qml" line="898"/>
+        <location filename="../app/MainLayout.qml" line="947"/>
+        <location filename="../app/MainLayout.qml" line="1052"/>
         <source>Options</source>
         <translation>Optionen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="751"/>
-        <location filename="../app/MainLayout.qml" line="872"/>
-        <location filename="../app/MainLayout.qml" line="922"/>
-        <location filename="../app/MainLayout.qml" line="1027"/>
+        <location filename="../app/MainLayout.qml" line="787"/>
+        <location filename="../app/MainLayout.qml" line="908"/>
+        <location filename="../app/MainLayout.qml" line="958"/>
+        <location filename="../app/MainLayout.qml" line="1063"/>
         <source>Retry</source>
         <translation>Wiederholen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="946"/>
+        <location filename="../app/MainLayout.qml" line="982"/>
         <source>Change</source>
         <translation>Ändern</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="952"/>
+        <location filename="../app/MainLayout.qml" line="988"/>
         <source>Toggle</source>
         <translation>Umschalten</translation>
     </message>
@@ -690,12 +700,12 @@
         <translation type="unfinished">Wird geladen…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="295"/>
+        <location filename="../screens/MediaListScreen.qml" line="306"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 Einträge</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="296"/>
+        <location filename="../screens/MediaListScreen.qml" line="307"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -763,23 +773,23 @@
     <name>SettingsScreen</name>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="73"/>
-        <location filename="../screens/SettingsScreen.qml" line="432"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Language</source>
         <translation>Sprache</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78"/>
-        <location filename="../screens/SettingsScreen.qml" line="441"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="516"/>
         <source>Browsing layout</source>
         <translation>Darstellungsmodus</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116"/>
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
         <source>Mouse support</source>
         <translation>Mausunterstützung</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="112"/>
         <source>Update media database</source>
         <translation>Mediendatenbank aktualisieren</translation>
     </message>
@@ -789,267 +799,360 @@
         <translation>Allgemein</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="450"/>
+        <location filename="../screens/SettingsScreen.qml" line="78"/>
+        <location filename="../screens/SettingsScreen.qml" line="507"/>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="88"/>
+        <location filename="../screens/SettingsScreen.qml" line="525"/>
         <source>Button style</source>
         <translation>Schaltflächenstil</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88"/>
-        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <location filename="../screens/SettingsScreen.qml" line="93"/>
+        <location filename="../screens/SettingsScreen.qml" line="534"/>
         <source>Screensaver</source>
         <translation>Bildschirmschoner</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="92"/>
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
         <source>Library</source>
         <translation>Bibliothek</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
+        <location filename="../screens/SettingsScreen.qml" line="543"/>
+        <source>Preferred artwork</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
         <source>Scrape metadata</source>
         <translation>Metadaten abrufen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <source>Re-scrape existing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Advanced</source>
         <translation>Erweitert</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121"/>
+        <location filename="../screens/SettingsScreen.qml" line="136"/>
         <source>Debug logging</source>
         <translation>Debug-Protokollierung</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
+        <location filename="../screens/SettingsScreen.qml" line="141"/>
         <source>Upload log file</source>
         <translation>Protokolldatei hochladen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="146"/>
         <source>About / License</source>
         <translation>Über / Lizenz</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147"/>
+        <location filename="../screens/SettingsScreen.qml" line="162"/>
         <source>Optimizing</source>
         <translation>Wird optimiert</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149"/>
-        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="173"/>
         <source>Paused</source>
         <translation>Pausiert</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149"/>
-        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="173"/>
         <source>In progress</source>
         <translation>In Bearbeitung</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152"/>
+        <location filename="../screens/SettingsScreen.qml" line="167"/>
         <source>%1 indexed</source>
         <translation>%1 indiziert</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="161"/>
+        <location filename="../screens/SettingsScreen.qml" line="176"/>
         <source>%1 scraped</source>
         <translation>%1 erfasst</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="266"/>
+        <location filename="../screens/SettingsScreen.qml" line="284"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="266"/>
+        <location filename="../screens/SettingsScreen.qml" line="284"/>
         <source>Start</source>
         <translation>Starten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="268"/>
+        <location filename="../screens/SettingsScreen.qml" line="286"/>
         <source>Upload</source>
         <translation>Hochladen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <location filename="../screens/SettingsScreen.qml" line="288"/>
         <source>Open</source>
         <translation>Öffnen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="342"/>
+        <location filename="../screens/SettingsScreen.qml" line="365"/>
         <source>English</source>
         <translation>Englisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="344"/>
+        <location filename="../screens/SettingsScreen.qml" line="367"/>
         <source>Italian</source>
         <translation>Italienisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="346"/>
+        <location filename="../screens/SettingsScreen.qml" line="369"/>
         <source>German</source>
         <translation>Deutsch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="348"/>
+        <location filename="../screens/SettingsScreen.qml" line="371"/>
         <source>Greek</source>
         <translation>Griechisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="350"/>
+        <location filename="../screens/SettingsScreen.qml" line="373"/>
         <source>Japanese</source>
         <translation>Japanisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="352"/>
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Korean</source>
         <translation>Koreanisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
         <source>Dutch</source>
         <translation>Niederländisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="356"/>
+        <location filename="../screens/SettingsScreen.qml" line="379"/>
         <source>Romanian</source>
         <translation>Rumänisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="358"/>
+        <location filename="../screens/SettingsScreen.qml" line="381"/>
         <source>Slovak</source>
         <translation>Slowakisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="360"/>
+        <location filename="../screens/SettingsScreen.qml" line="383"/>
         <source>Ukrainian</source>
         <translation>Ukrainisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="362"/>
+        <location filename="../screens/SettingsScreen.qml" line="385"/>
         <source>Chinese (Simplified)</source>
         <translation>Chinesisch (vereinfacht)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="364"/>
+        <location filename="../screens/SettingsScreen.qml" line="387"/>
         <source>Hebrew</source>
         <translation>Hebräisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="366"/>
+        <location filename="../screens/SettingsScreen.qml" line="389"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="368"/>
+        <location filename="../screens/SettingsScreen.qml" line="391"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="392"/>
+        <location filename="../screens/SettingsScreen.qml" line="451"/>
         <source>Auto</source>
         <translation>Automatisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="374"/>
+        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <source>Rotated CW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <source>Rotated CCW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="400"/>
+        <source>Horizontal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="405"/>
         <source>Detailed list view</source>
         <translation>Detaillierte Listenansicht</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="375"/>
+        <location filename="../screens/SettingsScreen.qml" line="406"/>
         <source>Grid view</source>
         <translation>Rasteransicht</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="411"/>
         <source>Style B</source>
         <translation>Stil B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="382"/>
+        <location filename="../screens/SettingsScreen.qml" line="413"/>
         <source>Style C</source>
         <translation>Stil C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="384"/>
+        <location filename="../screens/SettingsScreen.qml" line="415"/>
         <source>Style D</source>
         <translation>Stil D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="385"/>
+        <location filename="../screens/SettingsScreen.qml" line="416"/>
         <source>Style A</source>
         <translation>Stil A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="322"/>
+        <location filename="../screens/SettingsScreen.qml" line="340"/>
         <source>Default</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="395"/>
+        <location filename="../screens/SettingsScreen.qml" line="431"/>
         <source>Off</source>
         <translation>Aus</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <location filename="../screens/SettingsScreen.qml" line="433"/>
         <source>1 second (testing)</source>
         <translation>1 Sekunde (Test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <location filename="../screens/SettingsScreen.qml" line="435"/>
         <source>1 minute</source>
         <translation>1 Minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="401"/>
+        <location filename="../screens/SettingsScreen.qml" line="437"/>
         <source>2 minutes</source>
         <translation>2 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="403"/>
+        <location filename="../screens/SettingsScreen.qml" line="439"/>
         <source>5 minutes</source>
         <translation>5 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405"/>
+        <location filename="../screens/SettingsScreen.qml" line="441"/>
         <source>10 minutes</source>
         <translation>10 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="407"/>
+        <location filename="../screens/SettingsScreen.qml" line="443"/>
         <source>15 minutes</source>
         <translation>15 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="409"/>
+        <location filename="../screens/SettingsScreen.qml" line="445"/>
         <source>30 minutes</source>
         <translation>30 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="410"/>
+        <location filename="../screens/SettingsScreen.qml" line="446"/>
         <source>%1 seconds</source>
         <translation>%1 Sekunden</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="423"/>
+        <location filename="../screens/SettingsScreen.qml" line="489"/>
         <source>Resolution</source>
         <translation>Auflösung</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="563"/>
+        <location filename="../screens/SettingsScreen.qml" line="453"/>
+        <source>Image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="455"/>
+        <source>Thumbnail</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="457"/>
+        <source>Box art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <source>3D box art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="461"/>
+        <source>Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="463"/>
+        <source>Wheel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="465"/>
+        <source>Title screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="467"/>
+        <source>Map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="469"/>
+        <source>Marquee</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="471"/>
+        <source>Fan art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="473"/>
+        <source>Box side</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <source>Box back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="663"/>
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="755"/>
+        <location filename="../screens/SettingsScreen.qml" line="857"/>
         <source>No settings available on this platform</source>
         <translation>Keine Einstellungen für diese Plattform verfügbar</translation>
     </message>
@@ -1057,24 +1160,24 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="185"/>
-        <location filename="../screens/SystemsScreen.qml" line="285"/>
+        <location filename="../screens/SystemsScreen.qml" line="195"/>
+        <location filename="../screens/SystemsScreen.qml" line="292"/>
         <source>%1 systems</source>
         <translation>%1 Systeme</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="189"/>
-        <location filename="../screens/SystemsScreen.qml" line="302"/>
+        <location filename="../screens/SystemsScreen.qml" line="196"/>
+        <location filename="../screens/SystemsScreen.qml" line="309"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="317"/>
+        <location filename="../screens/SystemsScreen.qml" line="324"/>
         <source>No systems in this category</source>
         <translation>Keine Systeme in dieser Kategorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="318"/>
+        <location filename="../screens/SystemsScreen.qml" line="325"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -90,47 +90,47 @@
         <translation type="unfinished">Φόρτωση…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <location filename="../components/BrowseDetailPane.qml" line="77"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <location filename="../components/BrowseDetailPane.qml" line="79"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <location filename="../components/BrowseDetailPane.qml" line="81"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <location filename="../components/BrowseDetailPane.qml" line="83"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="55"/>
+        <location filename="../components/BrowseDetailPane.qml" line="85"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="57"/>
+        <location filename="../components/BrowseDetailPane.qml" line="87"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="59"/>
+        <location filename="../components/BrowseDetailPane.qml" line="89"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="61"/>
+        <location filename="../components/BrowseDetailPane.qml" line="91"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="63"/>
+        <location filename="../components/BrowseDetailPane.qml" line="93"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
@@ -329,34 +329,34 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="109"/>
-        <location filename="../screens/GamesScreen.qml" line="138"/>
+        <location filename="../screens/GamesScreen.qml" line="117"/>
+        <location filename="../screens/GamesScreen.qml" line="145"/>
         <source>%1 files</source>
         <translation>%1 αρχεία</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="40"/>
+        <location filename="../screens/GamesScreen.qml" line="51"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="118"/>
-        <location filename="../screens/GamesScreen.qml" line="139"/>
+        <location filename="../screens/GamesScreen.qml" line="126"/>
+        <location filename="../screens/GamesScreen.qml" line="146"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="34"/>
+        <location filename="../screens/GamesScreen.qml" line="45"/>
         <source>Loading games…</source>
         <translation>Φόρτωση παιχνιδιών…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="114"/>
+        <location filename="../screens/GamesScreen.qml" line="122"/>
         <source>Loading more…</source>
         <translation>Φόρτωση περισσότερων…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="33"/>
+        <location filename="../screens/GamesScreen.qml" line="44"/>
         <source>No games in this system</source>
         <translation>Δεν υπάρχουν παιχνίδια σε αυτό το σύστημα</translation>
     </message>
@@ -434,7 +434,7 @@
     </message>
     <message>
         <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="955"/>
+        <location filename="../app/Main.qml" line="958"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
@@ -465,67 +465,67 @@
         <translation>Εκκίνηση παιχνιδιού</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1769"/>
+        <location filename="../app/Main.qml" line="1776"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1773"/>
+        <location filename="../app/Main.qml" line="1780"/>
         <source>Loading favorites…</source>
         <translation>Φόρτωση αγαπημένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1771"/>
+        <location filename="../app/Main.qml" line="1778"/>
         <source>Loading games…</source>
         <translation>Φόρτωση παιχνιδιών…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="951"/>
+        <location filename="../app/Main.qml" line="954"/>
         <source>Default</source>
         <translation type="unfinished">Προεπιλογή</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="951"/>
+        <location filename="../app/Main.qml" line="954"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1227"/>
+        <location filename="../app/Main.qml" line="1230"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1231"/>
+        <location filename="../app/Main.qml" line="1234"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1245"/>
+        <location filename="../app/Main.qml" line="1248"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1249"/>
+        <location filename="../app/Main.qml" line="1252"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1253"/>
+        <location filename="../app/Main.qml" line="1256"/>
         <source>Retry</source>
         <translation type="unfinished">Επανάληψη</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1257"/>
+        <location filename="../app/Main.qml" line="1260"/>
         <source>Cancel</source>
         <translation type="unfinished">Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
+        <location filename="../app/Main.qml" line="1782"/>
         <source>Loading recently played…</source>
         <translation>Φόρτωση πρόσφατα παιγμένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1777"/>
+        <location filename="../app/Main.qml" line="1784"/>
         <source>Loading…</source>
         <translation>Φόρτωση…</translation>
     </message>
@@ -533,71 +533,71 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="545"/>
+        <location filename="../app/MainLayout.qml" line="581"/>
         <source>Writing failed</source>
         <translation>Αποτυχία εγγραφής</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="545"/>
+        <location filename="../app/MainLayout.qml" line="581"/>
         <source>Put a writable card near the reader</source>
         <translation>Τοποθετήστε μια εγγράψιμη κάρτα κοντά στον αναγνώστη</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="633"/>
+        <location filename="../app/MainLayout.qml" line="669"/>
         <source>Are you sure you want to exit?</source>
         <translation>Είστε σίγουροι ότι θέλετε να βγείτε;</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="709"/>
-        <location filename="../app/MainLayout.qml" line="781"/>
+        <location filename="../app/MainLayout.qml" line="745"/>
+        <location filename="../app/MainLayout.qml" line="817"/>
         <source>Select</source>
         <translation>Επιλογή</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="713"/>
-        <location filename="../app/MainLayout.qml" line="717"/>
-        <location filename="../app/MainLayout.qml" line="731"/>
-        <location filename="../app/MainLayout.qml" line="744"/>
-        <location filename="../app/MainLayout.qml" line="755"/>
+        <location filename="../app/MainLayout.qml" line="749"/>
+        <location filename="../app/MainLayout.qml" line="753"/>
+        <location filename="../app/MainLayout.qml" line="767"/>
+        <location filename="../app/MainLayout.qml" line="780"/>
+        <location filename="../app/MainLayout.qml" line="791"/>
         <source>Close</source>
         <translation>Κλείσιμο</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="724"/>
-        <location filename="../app/MainLayout.qml" line="762"/>
-        <location filename="../app/MainLayout.qml" line="785"/>
-        <location filename="../app/MainLayout.qml" line="796"/>
+        <location filename="../app/MainLayout.qml" line="760"/>
+        <location filename="../app/MainLayout.qml" line="798"/>
+        <location filename="../app/MainLayout.qml" line="821"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Cancel</source>
         <translation>Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="740"/>
+        <location filename="../app/MainLayout.qml" line="776"/>
         <source>Done</source>
         <translation>Ολοκληρώθηκε</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="770"/>
+        <location filename="../app/MainLayout.qml" line="806"/>
         <source>I understand</source>
         <translation>Κατανοώ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="804"/>
+        <location filename="../app/MainLayout.qml" line="840"/>
         <source>Start</source>
         <translation>Έναρξη</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="973"/>
+        <location filename="../app/MainLayout.qml" line="1009"/>
         <source>Scroll</source>
         <translation>Κύλιση</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="705"/>
-        <location filename="../app/MainLayout.qml" line="777"/>
-        <location filename="../app/MainLayout.qml" line="820"/>
-        <location filename="../app/MainLayout.qml" line="849"/>
-        <location filename="../app/MainLayout.qml" line="896"/>
-        <location filename="../app/MainLayout.qml" line="937"/>
-        <location filename="../app/MainLayout.qml" line="1001"/>
+        <location filename="../app/MainLayout.qml" line="741"/>
+        <location filename="../app/MainLayout.qml" line="813"/>
+        <location filename="../app/MainLayout.qml" line="856"/>
+        <location filename="../app/MainLayout.qml" line="885"/>
+        <location filename="../app/MainLayout.qml" line="932"/>
+        <location filename="../app/MainLayout.qml" line="973"/>
+        <location filename="../app/MainLayout.qml" line="1037"/>
         <source>Move</source>
         <translation>Μετακίνηση</translation>
     </message>
@@ -607,77 +607,87 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="556"/>
+        <location filename="../app/MainLayout.qml" line="323"/>
+        <source>Favorites</source>
+        <translation type="unfinished">Αγαπημένα</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="325"/>
+        <source>Recently Played</source>
+        <translation type="unfinished">Πρόσφατα Παιγμένα</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="592"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="557"/>
+        <location filename="../app/MainLayout.qml" line="593"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="632"/>
+        <location filename="../app/MainLayout.qml" line="668"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
-        <location filename="../app/MainLayout.qml" line="859"/>
-        <location filename="../app/MainLayout.qml" line="906"/>
-        <location filename="../app/MainLayout.qml" line="1011"/>
+        <location filename="../app/MainLayout.qml" line="860"/>
+        <location filename="../app/MainLayout.qml" line="895"/>
+        <location filename="../app/MainLayout.qml" line="942"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
         <source>Open</source>
         <translation>Άνοιγμα</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="828"/>
+        <location filename="../app/MainLayout.qml" line="864"/>
         <source>Quit</source>
         <translation>Έξοδος</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="837"/>
-        <location filename="../app/MainLayout.qml" line="865"/>
-        <location filename="../app/MainLayout.qml" line="876"/>
-        <location filename="../app/MainLayout.qml" line="888"/>
-        <location filename="../app/MainLayout.qml" line="915"/>
-        <location filename="../app/MainLayout.qml" line="926"/>
-        <location filename="../app/MainLayout.qml" line="961"/>
-        <location filename="../app/MainLayout.qml" line="977"/>
-        <location filename="../app/MainLayout.qml" line="986"/>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1031"/>
+        <location filename="../app/MainLayout.qml" line="873"/>
+        <location filename="../app/MainLayout.qml" line="901"/>
+        <location filename="../app/MainLayout.qml" line="912"/>
+        <location filename="../app/MainLayout.qml" line="924"/>
+        <location filename="../app/MainLayout.qml" line="951"/>
+        <location filename="../app/MainLayout.qml" line="962"/>
+        <location filename="../app/MainLayout.qml" line="997"/>
+        <location filename="../app/MainLayout.qml" line="1013"/>
+        <location filename="../app/MainLayout.qml" line="1022"/>
+        <location filename="../app/MainLayout.qml" line="1056"/>
+        <location filename="../app/MainLayout.qml" line="1067"/>
         <source>Back</source>
         <translation>Πίσω</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="855"/>
-        <location filename="../app/MainLayout.qml" line="902"/>
-        <location filename="../app/MainLayout.qml" line="1007"/>
+        <location filename="../app/MainLayout.qml" line="891"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="1043"/>
         <source>Page</source>
         <translation>Σελίδα</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="862"/>
-        <location filename="../app/MainLayout.qml" line="911"/>
-        <location filename="../app/MainLayout.qml" line="1016"/>
+        <location filename="../app/MainLayout.qml" line="898"/>
+        <location filename="../app/MainLayout.qml" line="947"/>
+        <location filename="../app/MainLayout.qml" line="1052"/>
         <source>Options</source>
         <translation>Επιλογές</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="751"/>
-        <location filename="../app/MainLayout.qml" line="872"/>
-        <location filename="../app/MainLayout.qml" line="922"/>
-        <location filename="../app/MainLayout.qml" line="1027"/>
+        <location filename="../app/MainLayout.qml" line="787"/>
+        <location filename="../app/MainLayout.qml" line="908"/>
+        <location filename="../app/MainLayout.qml" line="958"/>
+        <location filename="../app/MainLayout.qml" line="1063"/>
         <source>Retry</source>
         <translation>Επανάληψη</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="946"/>
+        <location filename="../app/MainLayout.qml" line="982"/>
         <source>Change</source>
         <translation>Αλλαγή</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="952"/>
+        <location filename="../app/MainLayout.qml" line="988"/>
         <source>Toggle</source>
         <translation>Εναλλαγή</translation>
     </message>
@@ -690,12 +700,12 @@
         <translation type="unfinished">Φόρτωση…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="295"/>
+        <location filename="../screens/MediaListScreen.qml" line="306"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 εγγραφές</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="296"/>
+        <location filename="../screens/MediaListScreen.qml" line="307"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -763,23 +773,23 @@
     <name>SettingsScreen</name>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="73"/>
-        <location filename="../screens/SettingsScreen.qml" line="432"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Language</source>
         <translation>Γλώσσα</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78"/>
-        <location filename="../screens/SettingsScreen.qml" line="441"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="516"/>
         <source>Browsing layout</source>
         <translation>Διάταξη περιήγησης</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116"/>
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
         <source>Mouse support</source>
         <translation>Υποστήριξη ποντικιού</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="112"/>
         <source>Update media database</source>
         <translation>Ενημέρωση βάσης δεδομένων</translation>
     </message>
@@ -789,267 +799,360 @@
         <translation>Γενικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="450"/>
+        <location filename="../screens/SettingsScreen.qml" line="78"/>
+        <location filename="../screens/SettingsScreen.qml" line="507"/>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="88"/>
+        <location filename="../screens/SettingsScreen.qml" line="525"/>
         <source>Button style</source>
         <translation>Στυλ κουμπιών</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88"/>
-        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <location filename="../screens/SettingsScreen.qml" line="93"/>
+        <location filename="../screens/SettingsScreen.qml" line="534"/>
         <source>Screensaver</source>
         <translation>Προφύλαξη οθόνης</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="92"/>
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
         <source>Library</source>
         <translation>Βιβλιοθήκη</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
+        <location filename="../screens/SettingsScreen.qml" line="543"/>
+        <source>Preferred artwork</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
         <source>Scrape metadata</source>
         <translation>Ανάκτηση μεταδεδομένων</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <source>Re-scrape existing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Advanced</source>
         <translation>Για προχωρημένους</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121"/>
+        <location filename="../screens/SettingsScreen.qml" line="136"/>
         <source>Debug logging</source>
         <translation>Καταγραφή εντοπισμού σφαλμάτων</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
+        <location filename="../screens/SettingsScreen.qml" line="141"/>
         <source>Upload log file</source>
         <translation>Αποστολή αρχείου καταγραφής</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="146"/>
         <source>About / License</source>
         <translation>Σχετικά / Άδεια</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147"/>
+        <location filename="../screens/SettingsScreen.qml" line="162"/>
         <source>Optimizing</source>
         <translation>Βελτιστοποίηση</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149"/>
-        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="173"/>
         <source>Paused</source>
         <translation>Σε παύση</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149"/>
-        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="173"/>
         <source>In progress</source>
         <translation>Σε εξέλιξη</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152"/>
+        <location filename="../screens/SettingsScreen.qml" line="167"/>
         <source>%1 indexed</source>
         <translation>%1 ευρετηριάστηκαν</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="161"/>
+        <location filename="../screens/SettingsScreen.qml" line="176"/>
         <source>%1 scraped</source>
         <translation>%1 συλλέχθηκαν</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="266"/>
+        <location filename="../screens/SettingsScreen.qml" line="284"/>
         <source>Cancel</source>
         <translation>Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="266"/>
+        <location filename="../screens/SettingsScreen.qml" line="284"/>
         <source>Start</source>
         <translation>Έναρξη</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="268"/>
+        <location filename="../screens/SettingsScreen.qml" line="286"/>
         <source>Upload</source>
         <translation>Μεταφόρτωση</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <location filename="../screens/SettingsScreen.qml" line="288"/>
         <source>Open</source>
         <translation>Άνοιγμα</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="342"/>
+        <location filename="../screens/SettingsScreen.qml" line="365"/>
         <source>English</source>
         <translation>Αγγλικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="344"/>
+        <location filename="../screens/SettingsScreen.qml" line="367"/>
         <source>Italian</source>
         <translation>Ιταλικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="346"/>
+        <location filename="../screens/SettingsScreen.qml" line="369"/>
         <source>German</source>
         <translation>Γερμανικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="348"/>
+        <location filename="../screens/SettingsScreen.qml" line="371"/>
         <source>Greek</source>
         <translation>Ελληνικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="350"/>
+        <location filename="../screens/SettingsScreen.qml" line="373"/>
         <source>Japanese</source>
         <translation>Ιαπωνικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="352"/>
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Korean</source>
         <translation>Κορεατικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
         <source>Dutch</source>
         <translation>Ολλανδικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="356"/>
+        <location filename="../screens/SettingsScreen.qml" line="379"/>
         <source>Romanian</source>
         <translation>Ρουμανικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="358"/>
+        <location filename="../screens/SettingsScreen.qml" line="381"/>
         <source>Slovak</source>
         <translation>Σλοβακικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="360"/>
+        <location filename="../screens/SettingsScreen.qml" line="383"/>
         <source>Ukrainian</source>
         <translation>Ουκρανικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="362"/>
+        <location filename="../screens/SettingsScreen.qml" line="385"/>
         <source>Chinese (Simplified)</source>
         <translation>Κινεζικά (Απλοποιημένα)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="364"/>
+        <location filename="../screens/SettingsScreen.qml" line="387"/>
         <source>Hebrew</source>
         <translation>Εβραϊκά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="366"/>
+        <location filename="../screens/SettingsScreen.qml" line="389"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="368"/>
+        <location filename="../screens/SettingsScreen.qml" line="391"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="392"/>
+        <location filename="../screens/SettingsScreen.qml" line="451"/>
         <source>Auto</source>
         <translation>Αυτόματο</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="374"/>
+        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <source>Rotated CW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <source>Rotated CCW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="400"/>
+        <source>Horizontal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="405"/>
         <source>Detailed list view</source>
         <translation>Λεπτομερής προβολή λίστας</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="375"/>
+        <location filename="../screens/SettingsScreen.qml" line="406"/>
         <source>Grid view</source>
         <translation>Προβολή πλέγματος</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="411"/>
         <source>Style B</source>
         <translation>Στυλ B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="382"/>
+        <location filename="../screens/SettingsScreen.qml" line="413"/>
         <source>Style C</source>
         <translation>Στυλ C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="384"/>
+        <location filename="../screens/SettingsScreen.qml" line="415"/>
         <source>Style D</source>
         <translation>Στυλ D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="385"/>
+        <location filename="../screens/SettingsScreen.qml" line="416"/>
         <source>Style A</source>
         <translation>Στυλ A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="322"/>
+        <location filename="../screens/SettingsScreen.qml" line="340"/>
         <source>Default</source>
         <translation>Προεπιλογή</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="395"/>
+        <location filename="../screens/SettingsScreen.qml" line="431"/>
         <source>Off</source>
         <translation>Απενεργοποιημένο</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <location filename="../screens/SettingsScreen.qml" line="433"/>
         <source>1 second (testing)</source>
         <translation>1 δευτερόλεπτο (δοκιμή)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <location filename="../screens/SettingsScreen.qml" line="435"/>
         <source>1 minute</source>
         <translation>1 λεπτό</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="401"/>
+        <location filename="../screens/SettingsScreen.qml" line="437"/>
         <source>2 minutes</source>
         <translation>2 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="403"/>
+        <location filename="../screens/SettingsScreen.qml" line="439"/>
         <source>5 minutes</source>
         <translation>5 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405"/>
+        <location filename="../screens/SettingsScreen.qml" line="441"/>
         <source>10 minutes</source>
         <translation>10 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="407"/>
+        <location filename="../screens/SettingsScreen.qml" line="443"/>
         <source>15 minutes</source>
         <translation>15 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="409"/>
+        <location filename="../screens/SettingsScreen.qml" line="445"/>
         <source>30 minutes</source>
         <translation>30 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="410"/>
+        <location filename="../screens/SettingsScreen.qml" line="446"/>
         <source>%1 seconds</source>
         <translation>%1 δευτερόλεπτα</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="423"/>
+        <location filename="../screens/SettingsScreen.qml" line="489"/>
         <source>Resolution</source>
         <translation>Ανάλυση</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="563"/>
+        <location filename="../screens/SettingsScreen.qml" line="453"/>
+        <source>Image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="455"/>
+        <source>Thumbnail</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="457"/>
+        <source>Box art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <source>3D box art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="461"/>
+        <source>Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="463"/>
+        <source>Wheel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="465"/>
+        <source>Title screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="467"/>
+        <source>Map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="469"/>
+        <source>Marquee</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="471"/>
+        <source>Fan art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="473"/>
+        <source>Box side</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <source>Box back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="663"/>
         <source>Settings</source>
         <translation>Ρυθμίσεις</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="755"/>
+        <location filename="../screens/SettingsScreen.qml" line="857"/>
         <source>No settings available on this platform</source>
         <translation>Δεν υπάρχουν διαθέσιμες ρυθμίσεις για αυτή την πλατφόρμα</translation>
     </message>
@@ -1057,24 +1160,24 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="185"/>
-        <location filename="../screens/SystemsScreen.qml" line="285"/>
+        <location filename="../screens/SystemsScreen.qml" line="195"/>
+        <location filename="../screens/SystemsScreen.qml" line="292"/>
         <source>%1 systems</source>
         <translation>%1 συστήματα</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="189"/>
-        <location filename="../screens/SystemsScreen.qml" line="302"/>
+        <location filename="../screens/SystemsScreen.qml" line="196"/>
+        <location filename="../screens/SystemsScreen.qml" line="309"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="317"/>
+        <location filename="../screens/SystemsScreen.qml" line="324"/>
         <source>No systems in this category</source>
         <translation>Δεν υπάρχουν συστήματα σε αυτή την κατηγορία</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="318"/>
+        <location filename="../screens/SystemsScreen.qml" line="325"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -90,47 +90,47 @@
         <translation type="unfinished">Loading…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <location filename="../components/BrowseDetailPane.qml" line="77"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <location filename="../components/BrowseDetailPane.qml" line="79"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <location filename="../components/BrowseDetailPane.qml" line="81"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <location filename="../components/BrowseDetailPane.qml" line="83"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="55"/>
+        <location filename="../components/BrowseDetailPane.qml" line="85"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="57"/>
+        <location filename="../components/BrowseDetailPane.qml" line="87"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="59"/>
+        <location filename="../components/BrowseDetailPane.qml" line="89"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="61"/>
+        <location filename="../components/BrowseDetailPane.qml" line="91"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="63"/>
+        <location filename="../components/BrowseDetailPane.qml" line="93"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
@@ -329,34 +329,34 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="109"/>
-        <location filename="../screens/GamesScreen.qml" line="138"/>
+        <location filename="../screens/GamesScreen.qml" line="117"/>
+        <location filename="../screens/GamesScreen.qml" line="145"/>
         <source>%1 files</source>
         <translation>%1 files</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="40"/>
+        <location filename="../screens/GamesScreen.qml" line="51"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="118"/>
-        <location filename="../screens/GamesScreen.qml" line="139"/>
+        <location filename="../screens/GamesScreen.qml" line="126"/>
+        <location filename="../screens/GamesScreen.qml" line="146"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="34"/>
+        <location filename="../screens/GamesScreen.qml" line="45"/>
         <source>Loading games…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="114"/>
+        <location filename="../screens/GamesScreen.qml" line="122"/>
         <source>Loading more…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="33"/>
+        <location filename="../screens/GamesScreen.qml" line="44"/>
         <source>No games in this system</source>
         <translation>No games in this system</translation>
     </message>
@@ -434,7 +434,7 @@
     </message>
     <message>
         <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="955"/>
+        <location filename="../app/Main.qml" line="958"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
@@ -465,67 +465,67 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1769"/>
+        <location filename="../app/Main.qml" line="1776"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1773"/>
+        <location filename="../app/Main.qml" line="1780"/>
         <source>Loading favorites…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1771"/>
+        <location filename="../app/Main.qml" line="1778"/>
         <source>Loading games…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="951"/>
+        <location filename="../app/Main.qml" line="954"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="951"/>
+        <location filename="../app/Main.qml" line="954"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1227"/>
+        <location filename="../app/Main.qml" line="1230"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1231"/>
+        <location filename="../app/Main.qml" line="1234"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1245"/>
+        <location filename="../app/Main.qml" line="1248"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1249"/>
+        <location filename="../app/Main.qml" line="1252"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1253"/>
+        <location filename="../app/Main.qml" line="1256"/>
         <source>Retry</source>
         <translation type="unfinished">Retry</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1257"/>
+        <location filename="../app/Main.qml" line="1260"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
+        <location filename="../app/Main.qml" line="1782"/>
         <source>Loading recently played…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1777"/>
+        <location filename="../app/Main.qml" line="1784"/>
         <source>Loading…</source>
         <translation type="unfinished">Loading…</translation>
     </message>
@@ -533,71 +533,71 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="545"/>
+        <location filename="../app/MainLayout.qml" line="581"/>
         <source>Writing failed</source>
         <translation>Writing failed</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="545"/>
+        <location filename="../app/MainLayout.qml" line="581"/>
         <source>Put a writable card near the reader</source>
         <translation>Put a writable card near the reader</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="633"/>
+        <location filename="../app/MainLayout.qml" line="669"/>
         <source>Are you sure you want to exit?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="709"/>
-        <location filename="../app/MainLayout.qml" line="781"/>
+        <location filename="../app/MainLayout.qml" line="745"/>
+        <location filename="../app/MainLayout.qml" line="817"/>
         <source>Select</source>
         <translation>Select</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="713"/>
-        <location filename="../app/MainLayout.qml" line="717"/>
-        <location filename="../app/MainLayout.qml" line="731"/>
-        <location filename="../app/MainLayout.qml" line="744"/>
-        <location filename="../app/MainLayout.qml" line="755"/>
+        <location filename="../app/MainLayout.qml" line="749"/>
+        <location filename="../app/MainLayout.qml" line="753"/>
+        <location filename="../app/MainLayout.qml" line="767"/>
+        <location filename="../app/MainLayout.qml" line="780"/>
+        <location filename="../app/MainLayout.qml" line="791"/>
         <source>Close</source>
         <translation>Close</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="724"/>
-        <location filename="../app/MainLayout.qml" line="762"/>
-        <location filename="../app/MainLayout.qml" line="785"/>
-        <location filename="../app/MainLayout.qml" line="796"/>
+        <location filename="../app/MainLayout.qml" line="760"/>
+        <location filename="../app/MainLayout.qml" line="798"/>
+        <location filename="../app/MainLayout.qml" line="821"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="740"/>
+        <location filename="../app/MainLayout.qml" line="776"/>
         <source>Done</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="770"/>
+        <location filename="../app/MainLayout.qml" line="806"/>
         <source>I understand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="804"/>
+        <location filename="../app/MainLayout.qml" line="840"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="973"/>
+        <location filename="../app/MainLayout.qml" line="1009"/>
         <source>Scroll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="705"/>
-        <location filename="../app/MainLayout.qml" line="777"/>
-        <location filename="../app/MainLayout.qml" line="820"/>
-        <location filename="../app/MainLayout.qml" line="849"/>
-        <location filename="../app/MainLayout.qml" line="896"/>
-        <location filename="../app/MainLayout.qml" line="937"/>
-        <location filename="../app/MainLayout.qml" line="1001"/>
+        <location filename="../app/MainLayout.qml" line="741"/>
+        <location filename="../app/MainLayout.qml" line="813"/>
+        <location filename="../app/MainLayout.qml" line="856"/>
+        <location filename="../app/MainLayout.qml" line="885"/>
+        <location filename="../app/MainLayout.qml" line="932"/>
+        <location filename="../app/MainLayout.qml" line="973"/>
+        <location filename="../app/MainLayout.qml" line="1037"/>
         <source>Move</source>
         <translation>Move</translation>
     </message>
@@ -607,77 +607,87 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="556"/>
+        <location filename="../app/MainLayout.qml" line="323"/>
+        <source>Favorites</source>
+        <translation type="unfinished">Favorites</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="325"/>
+        <source>Recently Played</source>
+        <translation type="unfinished">Recently Played</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="592"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="557"/>
+        <location filename="../app/MainLayout.qml" line="593"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="632"/>
+        <location filename="../app/MainLayout.qml" line="668"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
-        <location filename="../app/MainLayout.qml" line="859"/>
-        <location filename="../app/MainLayout.qml" line="906"/>
-        <location filename="../app/MainLayout.qml" line="1011"/>
+        <location filename="../app/MainLayout.qml" line="860"/>
+        <location filename="../app/MainLayout.qml" line="895"/>
+        <location filename="../app/MainLayout.qml" line="942"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
         <source>Open</source>
         <translation>Open</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="828"/>
+        <location filename="../app/MainLayout.qml" line="864"/>
         <source>Quit</source>
         <translation>Quit</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="837"/>
-        <location filename="../app/MainLayout.qml" line="865"/>
-        <location filename="../app/MainLayout.qml" line="876"/>
-        <location filename="../app/MainLayout.qml" line="888"/>
-        <location filename="../app/MainLayout.qml" line="915"/>
-        <location filename="../app/MainLayout.qml" line="926"/>
-        <location filename="../app/MainLayout.qml" line="961"/>
-        <location filename="../app/MainLayout.qml" line="977"/>
-        <location filename="../app/MainLayout.qml" line="986"/>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1031"/>
+        <location filename="../app/MainLayout.qml" line="873"/>
+        <location filename="../app/MainLayout.qml" line="901"/>
+        <location filename="../app/MainLayout.qml" line="912"/>
+        <location filename="../app/MainLayout.qml" line="924"/>
+        <location filename="../app/MainLayout.qml" line="951"/>
+        <location filename="../app/MainLayout.qml" line="962"/>
+        <location filename="../app/MainLayout.qml" line="997"/>
+        <location filename="../app/MainLayout.qml" line="1013"/>
+        <location filename="../app/MainLayout.qml" line="1022"/>
+        <location filename="../app/MainLayout.qml" line="1056"/>
+        <location filename="../app/MainLayout.qml" line="1067"/>
         <source>Back</source>
         <translation>Back</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="855"/>
-        <location filename="../app/MainLayout.qml" line="902"/>
-        <location filename="../app/MainLayout.qml" line="1007"/>
+        <location filename="../app/MainLayout.qml" line="891"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="1043"/>
         <source>Page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="862"/>
-        <location filename="../app/MainLayout.qml" line="911"/>
-        <location filename="../app/MainLayout.qml" line="1016"/>
+        <location filename="../app/MainLayout.qml" line="898"/>
+        <location filename="../app/MainLayout.qml" line="947"/>
+        <location filename="../app/MainLayout.qml" line="1052"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="751"/>
-        <location filename="../app/MainLayout.qml" line="872"/>
-        <location filename="../app/MainLayout.qml" line="922"/>
-        <location filename="../app/MainLayout.qml" line="1027"/>
+        <location filename="../app/MainLayout.qml" line="787"/>
+        <location filename="../app/MainLayout.qml" line="908"/>
+        <location filename="../app/MainLayout.qml" line="958"/>
+        <location filename="../app/MainLayout.qml" line="1063"/>
         <source>Retry</source>
         <translation>Retry</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="946"/>
+        <location filename="../app/MainLayout.qml" line="982"/>
         <source>Change</source>
         <translation>Change</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="952"/>
+        <location filename="../app/MainLayout.qml" line="988"/>
         <source>Toggle</source>
         <translation>Toggle</translation>
     </message>
@@ -690,12 +700,12 @@
         <translation type="unfinished">Loading…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="295"/>
+        <location filename="../screens/MediaListScreen.qml" line="306"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 entries</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="296"/>
+        <location filename="../screens/MediaListScreen.qml" line="307"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -763,23 +773,23 @@
     <name>SettingsScreen</name>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="73"/>
-        <location filename="../screens/SettingsScreen.qml" line="432"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Language</source>
         <translation>Language</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78"/>
-        <location filename="../screens/SettingsScreen.qml" line="441"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="516"/>
         <source>Browsing layout</source>
         <translation>Browsing layout</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116"/>
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
         <source>Mouse support</source>
         <translation>Mouse support</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="112"/>
         <source>Update media database</source>
         <translation type="unfinished"></translation>
     </message>
@@ -789,267 +799,360 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="450"/>
-        <source>Button style</source>
+        <location filename="../screens/SettingsScreen.qml" line="78"/>
+        <location filename="../screens/SettingsScreen.qml" line="507"/>
+        <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="88"/>
-        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <location filename="../screens/SettingsScreen.qml" line="525"/>
+        <source>Button style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="93"/>
+        <location filename="../screens/SettingsScreen.qml" line="534"/>
         <source>Screensaver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="92"/>
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
         <source>Library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
+        <location filename="../screens/SettingsScreen.qml" line="543"/>
+        <source>Preferred artwork</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
         <source>Scrape metadata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
-        <source>Advanced</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="121"/>
-        <source>Debug logging</source>
+        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="126"/>
+        <source>Advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="136"/>
+        <source>Debug logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="141"/>
         <source>Upload log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="146"/>
         <source>About / License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147"/>
+        <location filename="../screens/SettingsScreen.qml" line="162"/>
         <source>Optimizing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149"/>
-        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="173"/>
         <source>Paused</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149"/>
-        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="173"/>
         <source>In progress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152"/>
+        <location filename="../screens/SettingsScreen.qml" line="167"/>
         <source>%1 indexed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="161"/>
+        <location filename="../screens/SettingsScreen.qml" line="176"/>
         <source>%1 scraped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="266"/>
+        <location filename="../screens/SettingsScreen.qml" line="284"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="266"/>
+        <location filename="../screens/SettingsScreen.qml" line="284"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="268"/>
+        <location filename="../screens/SettingsScreen.qml" line="286"/>
         <source>Upload</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <location filename="../screens/SettingsScreen.qml" line="288"/>
         <source>Open</source>
         <translation type="unfinished">Open</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="342"/>
+        <location filename="../screens/SettingsScreen.qml" line="365"/>
         <source>English</source>
         <translation>English</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="344"/>
+        <location filename="../screens/SettingsScreen.qml" line="367"/>
         <source>Italian</source>
         <translation>Italian</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="346"/>
+        <location filename="../screens/SettingsScreen.qml" line="369"/>
         <source>German</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="348"/>
+        <location filename="../screens/SettingsScreen.qml" line="371"/>
         <source>Greek</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="350"/>
+        <location filename="../screens/SettingsScreen.qml" line="373"/>
         <source>Japanese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="352"/>
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Korean</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
         <source>Dutch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="356"/>
+        <location filename="../screens/SettingsScreen.qml" line="379"/>
         <source>Romanian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="358"/>
+        <location filename="../screens/SettingsScreen.qml" line="381"/>
         <source>Slovak</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="360"/>
+        <location filename="../screens/SettingsScreen.qml" line="383"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="362"/>
+        <location filename="../screens/SettingsScreen.qml" line="385"/>
         <source>Chinese (Simplified)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="364"/>
+        <location filename="../screens/SettingsScreen.qml" line="387"/>
         <source>Hebrew</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="366"/>
+        <location filename="../screens/SettingsScreen.qml" line="389"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="368"/>
+        <location filename="../screens/SettingsScreen.qml" line="391"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="392"/>
+        <location filename="../screens/SettingsScreen.qml" line="451"/>
         <source>Auto</source>
         <translation>Auto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="374"/>
-        <source>Detailed list view</source>
-        <translation>Detailed list view</translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="375"/>
-        <source>Grid view</source>
-        <translation>Grid view</translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
-        <source>Style B</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="382"/>
-        <source>Style C</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="384"/>
-        <source>Style D</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="385"/>
-        <source>Style A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="322"/>
-        <source>Default</source>
-        <translation>Default</translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="395"/>
-        <source>Off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../screens/SettingsScreen.qml" line="397"/>
-        <source>1 second (testing)</source>
+        <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="399"/>
-        <source>1 minute</source>
+        <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="401"/>
-        <source>2 minutes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="403"/>
-        <source>5 minutes</source>
+        <location filename="../screens/SettingsScreen.qml" line="400"/>
+        <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="405"/>
+        <source>Detailed list view</source>
+        <translation>Detailed list view</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="406"/>
+        <source>Grid view</source>
+        <translation>Grid view</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="411"/>
+        <source>Style B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="413"/>
+        <source>Style C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="415"/>
+        <source>Style D</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="416"/>
+        <source>Style A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="340"/>
+        <source>Default</source>
+        <translation>Default</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="431"/>
+        <source>Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="433"/>
+        <source>1 second (testing)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="435"/>
+        <source>1 minute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="437"/>
+        <source>2 minutes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="439"/>
+        <source>5 minutes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="441"/>
         <source>10 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="407"/>
+        <location filename="../screens/SettingsScreen.qml" line="443"/>
         <source>15 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="409"/>
+        <location filename="../screens/SettingsScreen.qml" line="445"/>
         <source>30 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="410"/>
+        <location filename="../screens/SettingsScreen.qml" line="446"/>
         <source>%1 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="423"/>
+        <location filename="../screens/SettingsScreen.qml" line="489"/>
         <source>Resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="563"/>
+        <location filename="../screens/SettingsScreen.qml" line="453"/>
+        <source>Image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="455"/>
+        <source>Thumbnail</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="457"/>
+        <source>Box art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <source>3D box art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="461"/>
+        <source>Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="463"/>
+        <source>Wheel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="465"/>
+        <source>Title screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="467"/>
+        <source>Map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="469"/>
+        <source>Marquee</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="471"/>
+        <source>Fan art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="473"/>
+        <source>Box side</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <source>Box back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="663"/>
         <source>Settings</source>
         <translation>Settings</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="755"/>
+        <location filename="../screens/SettingsScreen.qml" line="857"/>
         <source>No settings available on this platform</source>
         <translation>No settings available on this platform</translation>
     </message>
@@ -1057,24 +1160,24 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="185"/>
-        <location filename="../screens/SystemsScreen.qml" line="285"/>
+        <location filename="../screens/SystemsScreen.qml" line="195"/>
+        <location filename="../screens/SystemsScreen.qml" line="292"/>
         <source>%1 systems</source>
         <translation>%1 systems</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="189"/>
-        <location filename="../screens/SystemsScreen.qml" line="302"/>
+        <location filename="../screens/SystemsScreen.qml" line="196"/>
+        <location filename="../screens/SystemsScreen.qml" line="309"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="317"/>
+        <location filename="../screens/SystemsScreen.qml" line="324"/>
         <source>No systems in this category</source>
         <translation>No systems in this category</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="318"/>
+        <location filename="../screens/SystemsScreen.qml" line="325"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -90,47 +90,47 @@
         <translation type="unfinished">Cargando…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <location filename="../components/BrowseDetailPane.qml" line="77"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <location filename="../components/BrowseDetailPane.qml" line="79"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <location filename="../components/BrowseDetailPane.qml" line="81"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <location filename="../components/BrowseDetailPane.qml" line="83"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="55"/>
+        <location filename="../components/BrowseDetailPane.qml" line="85"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="57"/>
+        <location filename="../components/BrowseDetailPane.qml" line="87"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="59"/>
+        <location filename="../components/BrowseDetailPane.qml" line="89"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="61"/>
+        <location filename="../components/BrowseDetailPane.qml" line="91"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="63"/>
+        <location filename="../components/BrowseDetailPane.qml" line="93"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
@@ -329,34 +329,34 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="109"/>
-        <location filename="../screens/GamesScreen.qml" line="138"/>
+        <location filename="../screens/GamesScreen.qml" line="117"/>
+        <location filename="../screens/GamesScreen.qml" line="145"/>
         <source>%1 files</source>
         <translation>%1 archivos</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="40"/>
+        <location filename="../screens/GamesScreen.qml" line="51"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="118"/>
-        <location filename="../screens/GamesScreen.qml" line="139"/>
+        <location filename="../screens/GamesScreen.qml" line="126"/>
+        <location filename="../screens/GamesScreen.qml" line="146"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="34"/>
+        <location filename="../screens/GamesScreen.qml" line="45"/>
         <source>Loading games…</source>
         <translation>Cargando juegos…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="114"/>
+        <location filename="../screens/GamesScreen.qml" line="122"/>
         <source>Loading more…</source>
         <translation>Cargando más…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="33"/>
+        <location filename="../screens/GamesScreen.qml" line="44"/>
         <source>No games in this system</source>
         <translation>No hay juegos en este sistema</translation>
     </message>
@@ -434,7 +434,7 @@
     </message>
     <message>
         <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="955"/>
+        <location filename="../app/Main.qml" line="958"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
@@ -465,67 +465,67 @@
         <translation>Iniciar juego</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1769"/>
+        <location filename="../app/Main.qml" line="1776"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1773"/>
+        <location filename="../app/Main.qml" line="1780"/>
         <source>Loading favorites…</source>
         <translation>Cargando favoritos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1771"/>
+        <location filename="../app/Main.qml" line="1778"/>
         <source>Loading games…</source>
         <translation>Cargando juegos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="951"/>
+        <location filename="../app/Main.qml" line="954"/>
         <source>Default</source>
         <translation type="unfinished">Por defecto</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="951"/>
+        <location filename="../app/Main.qml" line="954"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1227"/>
+        <location filename="../app/Main.qml" line="1230"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1231"/>
+        <location filename="../app/Main.qml" line="1234"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1245"/>
+        <location filename="../app/Main.qml" line="1248"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1249"/>
+        <location filename="../app/Main.qml" line="1252"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1253"/>
+        <location filename="../app/Main.qml" line="1256"/>
         <source>Retry</source>
         <translation type="unfinished">Reintentar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1257"/>
+        <location filename="../app/Main.qml" line="1260"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
+        <location filename="../app/Main.qml" line="1782"/>
         <source>Loading recently played…</source>
         <translation>Cargando jugados recientemente…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1777"/>
+        <location filename="../app/Main.qml" line="1784"/>
         <source>Loading…</source>
         <translation>Cargando…</translation>
     </message>
@@ -533,71 +533,71 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="545"/>
+        <location filename="../app/MainLayout.qml" line="581"/>
         <source>Writing failed</source>
         <translation>Error de escritura</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="545"/>
+        <location filename="../app/MainLayout.qml" line="581"/>
         <source>Put a writable card near the reader</source>
         <translation>Pon una tarjeta escribible junto al lector</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="633"/>
+        <location filename="../app/MainLayout.qml" line="669"/>
         <source>Are you sure you want to exit?</source>
         <translation>¿Seguro que quieres salir?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="709"/>
-        <location filename="../app/MainLayout.qml" line="781"/>
+        <location filename="../app/MainLayout.qml" line="745"/>
+        <location filename="../app/MainLayout.qml" line="817"/>
         <source>Select</source>
         <translation>Seleccionar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="713"/>
-        <location filename="../app/MainLayout.qml" line="717"/>
-        <location filename="../app/MainLayout.qml" line="731"/>
-        <location filename="../app/MainLayout.qml" line="744"/>
-        <location filename="../app/MainLayout.qml" line="755"/>
+        <location filename="../app/MainLayout.qml" line="749"/>
+        <location filename="../app/MainLayout.qml" line="753"/>
+        <location filename="../app/MainLayout.qml" line="767"/>
+        <location filename="../app/MainLayout.qml" line="780"/>
+        <location filename="../app/MainLayout.qml" line="791"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="724"/>
-        <location filename="../app/MainLayout.qml" line="762"/>
-        <location filename="../app/MainLayout.qml" line="785"/>
-        <location filename="../app/MainLayout.qml" line="796"/>
+        <location filename="../app/MainLayout.qml" line="760"/>
+        <location filename="../app/MainLayout.qml" line="798"/>
+        <location filename="../app/MainLayout.qml" line="821"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="740"/>
+        <location filename="../app/MainLayout.qml" line="776"/>
         <source>Done</source>
         <translation>Hecho</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="770"/>
+        <location filename="../app/MainLayout.qml" line="806"/>
         <source>I understand</source>
         <translation>Entendido</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="804"/>
+        <location filename="../app/MainLayout.qml" line="840"/>
         <source>Start</source>
         <translation>Iniciar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="973"/>
+        <location filename="../app/MainLayout.qml" line="1009"/>
         <source>Scroll</source>
         <translation>Desplazar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="705"/>
-        <location filename="../app/MainLayout.qml" line="777"/>
-        <location filename="../app/MainLayout.qml" line="820"/>
-        <location filename="../app/MainLayout.qml" line="849"/>
-        <location filename="../app/MainLayout.qml" line="896"/>
-        <location filename="../app/MainLayout.qml" line="937"/>
-        <location filename="../app/MainLayout.qml" line="1001"/>
+        <location filename="../app/MainLayout.qml" line="741"/>
+        <location filename="../app/MainLayout.qml" line="813"/>
+        <location filename="../app/MainLayout.qml" line="856"/>
+        <location filename="../app/MainLayout.qml" line="885"/>
+        <location filename="../app/MainLayout.qml" line="932"/>
+        <location filename="../app/MainLayout.qml" line="973"/>
+        <location filename="../app/MainLayout.qml" line="1037"/>
         <source>Move</source>
         <translation>Mover</translation>
     </message>
@@ -607,77 +607,87 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="556"/>
+        <location filename="../app/MainLayout.qml" line="323"/>
+        <source>Favorites</source>
+        <translation type="unfinished">Favoritos</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="325"/>
+        <source>Recently Played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="592"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="557"/>
+        <location filename="../app/MainLayout.qml" line="593"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="632"/>
+        <location filename="../app/MainLayout.qml" line="668"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
-        <location filename="../app/MainLayout.qml" line="859"/>
-        <location filename="../app/MainLayout.qml" line="906"/>
-        <location filename="../app/MainLayout.qml" line="1011"/>
+        <location filename="../app/MainLayout.qml" line="860"/>
+        <location filename="../app/MainLayout.qml" line="895"/>
+        <location filename="../app/MainLayout.qml" line="942"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="828"/>
+        <location filename="../app/MainLayout.qml" line="864"/>
         <source>Quit</source>
         <translation>Salir</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="837"/>
-        <location filename="../app/MainLayout.qml" line="865"/>
-        <location filename="../app/MainLayout.qml" line="876"/>
-        <location filename="../app/MainLayout.qml" line="888"/>
-        <location filename="../app/MainLayout.qml" line="915"/>
-        <location filename="../app/MainLayout.qml" line="926"/>
-        <location filename="../app/MainLayout.qml" line="961"/>
-        <location filename="../app/MainLayout.qml" line="977"/>
-        <location filename="../app/MainLayout.qml" line="986"/>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1031"/>
+        <location filename="../app/MainLayout.qml" line="873"/>
+        <location filename="../app/MainLayout.qml" line="901"/>
+        <location filename="../app/MainLayout.qml" line="912"/>
+        <location filename="../app/MainLayout.qml" line="924"/>
+        <location filename="../app/MainLayout.qml" line="951"/>
+        <location filename="../app/MainLayout.qml" line="962"/>
+        <location filename="../app/MainLayout.qml" line="997"/>
+        <location filename="../app/MainLayout.qml" line="1013"/>
+        <location filename="../app/MainLayout.qml" line="1022"/>
+        <location filename="../app/MainLayout.qml" line="1056"/>
+        <location filename="../app/MainLayout.qml" line="1067"/>
         <source>Back</source>
         <translation>Atrás</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="855"/>
-        <location filename="../app/MainLayout.qml" line="902"/>
-        <location filename="../app/MainLayout.qml" line="1007"/>
+        <location filename="../app/MainLayout.qml" line="891"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="1043"/>
         <source>Page</source>
         <translation>Página</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="862"/>
-        <location filename="../app/MainLayout.qml" line="911"/>
-        <location filename="../app/MainLayout.qml" line="1016"/>
+        <location filename="../app/MainLayout.qml" line="898"/>
+        <location filename="../app/MainLayout.qml" line="947"/>
+        <location filename="../app/MainLayout.qml" line="1052"/>
         <source>Options</source>
         <translation>Opciones</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="751"/>
-        <location filename="../app/MainLayout.qml" line="872"/>
-        <location filename="../app/MainLayout.qml" line="922"/>
-        <location filename="../app/MainLayout.qml" line="1027"/>
+        <location filename="../app/MainLayout.qml" line="787"/>
+        <location filename="../app/MainLayout.qml" line="908"/>
+        <location filename="../app/MainLayout.qml" line="958"/>
+        <location filename="../app/MainLayout.qml" line="1063"/>
         <source>Retry</source>
         <translation>Reintentar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="946"/>
+        <location filename="../app/MainLayout.qml" line="982"/>
         <source>Change</source>
         <translation>Cambiar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="952"/>
+        <location filename="../app/MainLayout.qml" line="988"/>
         <source>Toggle</source>
         <translation>Alternar</translation>
     </message>
@@ -690,12 +700,12 @@
         <translation type="unfinished">Cargando…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="295"/>
+        <location filename="../screens/MediaListScreen.qml" line="306"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 entradas</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="296"/>
+        <location filename="../screens/MediaListScreen.qml" line="307"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -763,17 +773,17 @@
     <name>SettingsScreen</name>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="73"/>
-        <location filename="../screens/SettingsScreen.qml" line="432"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Language</source>
         <translation>Idioma</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116"/>
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
         <source>Mouse support</source>
         <translation>Soporte a ratón</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="112"/>
         <source>Update media database</source>
         <translation>Actualizar base de datos de medios</translation>
     </message>
@@ -784,272 +794,365 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="78"/>
-        <location filename="../screens/SettingsScreen.qml" line="441"/>
+        <location filename="../screens/SettingsScreen.qml" line="507"/>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="516"/>
         <source>Browsing layout</source>
         <translation>Diseño de exploración</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="450"/>
+        <location filename="../screens/SettingsScreen.qml" line="88"/>
+        <location filename="../screens/SettingsScreen.qml" line="525"/>
         <source>Button style</source>
         <translation>Estilo de botón</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88"/>
-        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <location filename="../screens/SettingsScreen.qml" line="93"/>
+        <location filename="../screens/SettingsScreen.qml" line="534"/>
         <source>Screensaver</source>
         <translation>Salvapantallas</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="92"/>
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
         <source>Library</source>
         <translation>Biblioteca</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
+        <location filename="../screens/SettingsScreen.qml" line="543"/>
+        <source>Preferred artwork</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
         <source>Scrape metadata</source>
         <translation>Extraer metadatos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <source>Re-scrape existing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Advanced</source>
         <translation>Avanzado</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121"/>
+        <location filename="../screens/SettingsScreen.qml" line="136"/>
         <source>Debug logging</source>
         <translation>Registro de depuración</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
+        <location filename="../screens/SettingsScreen.qml" line="141"/>
         <source>Upload log file</source>
         <translation>Subir archivo de registro</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="146"/>
         <source>About / License</source>
         <translation>Acerca de / Licencia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147"/>
+        <location filename="../screens/SettingsScreen.qml" line="162"/>
         <source>Optimizing</source>
         <translation>Optimizando</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149"/>
-        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="173"/>
         <source>Paused</source>
         <translation>Pausado</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149"/>
-        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="173"/>
         <source>In progress</source>
         <translation>En progreso</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152"/>
+        <location filename="../screens/SettingsScreen.qml" line="167"/>
         <source>%1 indexed</source>
         <translation>%1 indexados</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="161"/>
+        <location filename="../screens/SettingsScreen.qml" line="176"/>
         <source>%1 scraped</source>
         <translation>%1 extraídos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="266"/>
+        <location filename="../screens/SettingsScreen.qml" line="284"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="266"/>
+        <location filename="../screens/SettingsScreen.qml" line="284"/>
         <source>Start</source>
         <translation>Iniciar</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="268"/>
+        <location filename="../screens/SettingsScreen.qml" line="286"/>
         <source>Upload</source>
         <translation>Subir</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <location filename="../screens/SettingsScreen.qml" line="288"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="342"/>
+        <location filename="../screens/SettingsScreen.qml" line="365"/>
         <source>English</source>
         <translation>Inglés</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="344"/>
+        <location filename="../screens/SettingsScreen.qml" line="367"/>
         <source>Italian</source>
         <translation>Italiano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="346"/>
+        <location filename="../screens/SettingsScreen.qml" line="369"/>
         <source>German</source>
         <translation>Alemán</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="348"/>
+        <location filename="../screens/SettingsScreen.qml" line="371"/>
         <source>Greek</source>
         <translation>Griego</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="350"/>
+        <location filename="../screens/SettingsScreen.qml" line="373"/>
         <source>Japanese</source>
         <translation>Japonés</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="352"/>
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Korean</source>
         <translation>Coreano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
         <source>Dutch</source>
         <translation>Neerlandés</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="356"/>
+        <location filename="../screens/SettingsScreen.qml" line="379"/>
         <source>Romanian</source>
         <translation>Rumano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="358"/>
+        <location filename="../screens/SettingsScreen.qml" line="381"/>
         <source>Slovak</source>
         <translation>Eslovaco</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="360"/>
+        <location filename="../screens/SettingsScreen.qml" line="383"/>
         <source>Ukrainian</source>
         <translation>Ucraniano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="362"/>
+        <location filename="../screens/SettingsScreen.qml" line="385"/>
         <source>Chinese (Simplified)</source>
         <translation>Chino (simplificado)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="364"/>
+        <location filename="../screens/SettingsScreen.qml" line="387"/>
         <source>Hebrew</source>
         <translation>Hebreo</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="366"/>
+        <location filename="../screens/SettingsScreen.qml" line="389"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="368"/>
+        <location filename="../screens/SettingsScreen.qml" line="391"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="392"/>
+        <location filename="../screens/SettingsScreen.qml" line="451"/>
         <source>Auto</source>
         <translation>Automático</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="374"/>
+        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <source>Rotated CW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <source>Rotated CCW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="400"/>
+        <source>Horizontal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="405"/>
         <source>Detailed list view</source>
         <translation>Vista de lista detallada</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="375"/>
+        <location filename="../screens/SettingsScreen.qml" line="406"/>
         <source>Grid view</source>
         <translation>Vista de cuadrícula</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="411"/>
         <source>Style B</source>
         <translation>Estilo B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="382"/>
+        <location filename="../screens/SettingsScreen.qml" line="413"/>
         <source>Style C</source>
         <translation>Estilo C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="384"/>
+        <location filename="../screens/SettingsScreen.qml" line="415"/>
         <source>Style D</source>
         <translation>Estilo D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="385"/>
+        <location filename="../screens/SettingsScreen.qml" line="416"/>
         <source>Style A</source>
         <translation>Estilo A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="322"/>
+        <location filename="../screens/SettingsScreen.qml" line="340"/>
         <source>Default</source>
         <translation>Por defecto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="395"/>
+        <location filename="../screens/SettingsScreen.qml" line="431"/>
         <source>Off</source>
         <translation>Desactivado</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <location filename="../screens/SettingsScreen.qml" line="433"/>
         <source>1 second (testing)</source>
         <translation>1 segundo (prueba)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <location filename="../screens/SettingsScreen.qml" line="435"/>
         <source>1 minute</source>
         <translation>1 minuto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="401"/>
+        <location filename="../screens/SettingsScreen.qml" line="437"/>
         <source>2 minutes</source>
         <translation>2 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="403"/>
+        <location filename="../screens/SettingsScreen.qml" line="439"/>
         <source>5 minutes</source>
         <translation>5 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405"/>
+        <location filename="../screens/SettingsScreen.qml" line="441"/>
         <source>10 minutes</source>
         <translation>10 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="407"/>
+        <location filename="../screens/SettingsScreen.qml" line="443"/>
         <source>15 minutes</source>
         <translation>15 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="409"/>
+        <location filename="../screens/SettingsScreen.qml" line="445"/>
         <source>30 minutes</source>
         <translation>30 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="410"/>
+        <location filename="../screens/SettingsScreen.qml" line="446"/>
         <source>%1 seconds</source>
         <translation>%1 segundos</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="423"/>
+        <location filename="../screens/SettingsScreen.qml" line="489"/>
         <source>Resolution</source>
         <translation>Resolución</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="563"/>
+        <location filename="../screens/SettingsScreen.qml" line="453"/>
+        <source>Image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="455"/>
+        <source>Thumbnail</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="457"/>
+        <source>Box art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <source>3D box art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="461"/>
+        <source>Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="463"/>
+        <source>Wheel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="465"/>
+        <source>Title screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="467"/>
+        <source>Map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="469"/>
+        <source>Marquee</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="471"/>
+        <source>Fan art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="473"/>
+        <source>Box side</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <source>Box back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="663"/>
         <source>Settings</source>
         <translation>Ajustes</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="755"/>
+        <location filename="../screens/SettingsScreen.qml" line="857"/>
         <source>No settings available on this platform</source>
         <translation>No hay ajustes en esta plataforma</translation>
     </message>
@@ -1057,24 +1160,24 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="185"/>
-        <location filename="../screens/SystemsScreen.qml" line="285"/>
+        <location filename="../screens/SystemsScreen.qml" line="195"/>
+        <location filename="../screens/SystemsScreen.qml" line="292"/>
         <source>%1 systems</source>
         <translation>%1 sistemas</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="189"/>
-        <location filename="../screens/SystemsScreen.qml" line="302"/>
+        <location filename="../screens/SystemsScreen.qml" line="196"/>
+        <location filename="../screens/SystemsScreen.qml" line="309"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="317"/>
+        <location filename="../screens/SystemsScreen.qml" line="324"/>
         <source>No systems in this category</source>
         <translation>No hay sistemas en esta categoría</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="318"/>
+        <location filename="../screens/SystemsScreen.qml" line="325"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -90,47 +90,47 @@
         <translation type="unfinished">טוען…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <location filename="../components/BrowseDetailPane.qml" line="77"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <location filename="../components/BrowseDetailPane.qml" line="79"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <location filename="../components/BrowseDetailPane.qml" line="81"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <location filename="../components/BrowseDetailPane.qml" line="83"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="55"/>
+        <location filename="../components/BrowseDetailPane.qml" line="85"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="57"/>
+        <location filename="../components/BrowseDetailPane.qml" line="87"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="59"/>
+        <location filename="../components/BrowseDetailPane.qml" line="89"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="61"/>
+        <location filename="../components/BrowseDetailPane.qml" line="91"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="63"/>
+        <location filename="../components/BrowseDetailPane.qml" line="93"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
@@ -329,34 +329,34 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="109"/>
-        <location filename="../screens/GamesScreen.qml" line="138"/>
+        <location filename="../screens/GamesScreen.qml" line="117"/>
+        <location filename="../screens/GamesScreen.qml" line="145"/>
         <source>%1 files</source>
         <translation>%1 קבצים</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="40"/>
+        <location filename="../screens/GamesScreen.qml" line="51"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="118"/>
-        <location filename="../screens/GamesScreen.qml" line="139"/>
+        <location filename="../screens/GamesScreen.qml" line="126"/>
+        <location filename="../screens/GamesScreen.qml" line="146"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="33"/>
+        <location filename="../screens/GamesScreen.qml" line="44"/>
         <source>No games in this system</source>
         <translation>אין משחקים במערכת זו</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="34"/>
+        <location filename="../screens/GamesScreen.qml" line="45"/>
         <source>Loading games…</source>
         <translation>טוען משחקים…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="114"/>
+        <location filename="../screens/GamesScreen.qml" line="122"/>
         <source>Loading more…</source>
         <translation>טוען עוד…</translation>
     </message>
@@ -434,7 +434,7 @@
     </message>
     <message>
         <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="955"/>
+        <location filename="../app/Main.qml" line="958"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
@@ -465,67 +465,67 @@
         <translation>קוד QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="951"/>
+        <location filename="../app/Main.qml" line="954"/>
         <source>Default</source>
         <translation type="unfinished">ברירת מחדל</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="951"/>
+        <location filename="../app/Main.qml" line="954"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1227"/>
+        <location filename="../app/Main.qml" line="1230"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1231"/>
+        <location filename="../app/Main.qml" line="1234"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1245"/>
+        <location filename="../app/Main.qml" line="1248"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1249"/>
+        <location filename="../app/Main.qml" line="1252"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1253"/>
+        <location filename="../app/Main.qml" line="1256"/>
         <source>Retry</source>
         <translation type="unfinished">נסה שוב</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1257"/>
+        <location filename="../app/Main.qml" line="1260"/>
         <source>Cancel</source>
         <translation type="unfinished">ביטול</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1769"/>
+        <location filename="../app/Main.qml" line="1776"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1771"/>
+        <location filename="../app/Main.qml" line="1778"/>
         <source>Loading games…</source>
         <translation>טוען משחקים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1773"/>
+        <location filename="../app/Main.qml" line="1780"/>
         <source>Loading favorites…</source>
         <translation>טוען מועדפים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
+        <location filename="../app/Main.qml" line="1782"/>
         <source>Loading recently played…</source>
         <translation>טוען את הפריטים ששוחקו לאחרונה…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1777"/>
+        <location filename="../app/Main.qml" line="1784"/>
         <source>Loading…</source>
         <translation>טוען…</translation>
     </message>
@@ -533,12 +533,12 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="545"/>
+        <location filename="../app/MainLayout.qml" line="581"/>
         <source>Writing failed</source>
         <translation>הכתיבה נכשלה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="545"/>
+        <location filename="../app/MainLayout.qml" line="581"/>
         <source>Put a writable card near the reader</source>
         <translation>הניחו כרטיס הניתן לכתיבה ליד הקורא</translation>
     </message>
@@ -548,136 +548,146 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="556"/>
+        <location filename="../app/MainLayout.qml" line="323"/>
+        <source>Favorites</source>
+        <translation type="unfinished">מועדפים</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="325"/>
+        <source>Recently Played</source>
+        <translation type="unfinished">שוחקו לאחרונה</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="592"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="557"/>
+        <location filename="../app/MainLayout.qml" line="593"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="632"/>
+        <location filename="../app/MainLayout.qml" line="668"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="633"/>
+        <location filename="../app/MainLayout.qml" line="669"/>
         <source>Are you sure you want to exit?</source>
         <translation>האם אתה בטוח שברצונך לצאת?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="705"/>
-        <location filename="../app/MainLayout.qml" line="777"/>
-        <location filename="../app/MainLayout.qml" line="820"/>
-        <location filename="../app/MainLayout.qml" line="849"/>
-        <location filename="../app/MainLayout.qml" line="896"/>
-        <location filename="../app/MainLayout.qml" line="937"/>
-        <location filename="../app/MainLayout.qml" line="1001"/>
+        <location filename="../app/MainLayout.qml" line="741"/>
+        <location filename="../app/MainLayout.qml" line="813"/>
+        <location filename="../app/MainLayout.qml" line="856"/>
+        <location filename="../app/MainLayout.qml" line="885"/>
+        <location filename="../app/MainLayout.qml" line="932"/>
+        <location filename="../app/MainLayout.qml" line="973"/>
+        <location filename="../app/MainLayout.qml" line="1037"/>
         <source>Move</source>
         <translation>הזזה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="709"/>
-        <location filename="../app/MainLayout.qml" line="781"/>
+        <location filename="../app/MainLayout.qml" line="745"/>
+        <location filename="../app/MainLayout.qml" line="817"/>
         <source>Select</source>
         <translation>בחירה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="713"/>
-        <location filename="../app/MainLayout.qml" line="717"/>
-        <location filename="../app/MainLayout.qml" line="731"/>
-        <location filename="../app/MainLayout.qml" line="744"/>
-        <location filename="../app/MainLayout.qml" line="755"/>
+        <location filename="../app/MainLayout.qml" line="749"/>
+        <location filename="../app/MainLayout.qml" line="753"/>
+        <location filename="../app/MainLayout.qml" line="767"/>
+        <location filename="../app/MainLayout.qml" line="780"/>
+        <location filename="../app/MainLayout.qml" line="791"/>
         <source>Close</source>
         <translation>סגור</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="724"/>
-        <location filename="../app/MainLayout.qml" line="762"/>
-        <location filename="../app/MainLayout.qml" line="785"/>
-        <location filename="../app/MainLayout.qml" line="796"/>
+        <location filename="../app/MainLayout.qml" line="760"/>
+        <location filename="../app/MainLayout.qml" line="798"/>
+        <location filename="../app/MainLayout.qml" line="821"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Cancel</source>
         <translation>ביטול</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="740"/>
+        <location filename="../app/MainLayout.qml" line="776"/>
         <source>Done</source>
         <translation>הושלם</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="751"/>
-        <location filename="../app/MainLayout.qml" line="872"/>
-        <location filename="../app/MainLayout.qml" line="922"/>
-        <location filename="../app/MainLayout.qml" line="1027"/>
+        <location filename="../app/MainLayout.qml" line="787"/>
+        <location filename="../app/MainLayout.qml" line="908"/>
+        <location filename="../app/MainLayout.qml" line="958"/>
+        <location filename="../app/MainLayout.qml" line="1063"/>
         <source>Retry</source>
         <translation>נסה שוב</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="770"/>
+        <location filename="../app/MainLayout.qml" line="806"/>
         <source>I understand</source>
         <translation>הבנתי</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="804"/>
+        <location filename="../app/MainLayout.qml" line="840"/>
         <source>Start</source>
         <translation>התחל</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
-        <location filename="../app/MainLayout.qml" line="859"/>
-        <location filename="../app/MainLayout.qml" line="906"/>
-        <location filename="../app/MainLayout.qml" line="1011"/>
+        <location filename="../app/MainLayout.qml" line="860"/>
+        <location filename="../app/MainLayout.qml" line="895"/>
+        <location filename="../app/MainLayout.qml" line="942"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
         <source>Open</source>
         <translation>פתח</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="828"/>
+        <location filename="../app/MainLayout.qml" line="864"/>
         <source>Quit</source>
         <translation>יציאה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="837"/>
-        <location filename="../app/MainLayout.qml" line="865"/>
-        <location filename="../app/MainLayout.qml" line="876"/>
-        <location filename="../app/MainLayout.qml" line="888"/>
-        <location filename="../app/MainLayout.qml" line="915"/>
-        <location filename="../app/MainLayout.qml" line="926"/>
-        <location filename="../app/MainLayout.qml" line="961"/>
-        <location filename="../app/MainLayout.qml" line="977"/>
-        <location filename="../app/MainLayout.qml" line="986"/>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1031"/>
+        <location filename="../app/MainLayout.qml" line="873"/>
+        <location filename="../app/MainLayout.qml" line="901"/>
+        <location filename="../app/MainLayout.qml" line="912"/>
+        <location filename="../app/MainLayout.qml" line="924"/>
+        <location filename="../app/MainLayout.qml" line="951"/>
+        <location filename="../app/MainLayout.qml" line="962"/>
+        <location filename="../app/MainLayout.qml" line="997"/>
+        <location filename="../app/MainLayout.qml" line="1013"/>
+        <location filename="../app/MainLayout.qml" line="1022"/>
+        <location filename="../app/MainLayout.qml" line="1056"/>
+        <location filename="../app/MainLayout.qml" line="1067"/>
         <source>Back</source>
         <translation>חזרה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="855"/>
-        <location filename="../app/MainLayout.qml" line="902"/>
-        <location filename="../app/MainLayout.qml" line="1007"/>
+        <location filename="../app/MainLayout.qml" line="891"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="1043"/>
         <source>Page</source>
         <translation>עמוד</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="862"/>
-        <location filename="../app/MainLayout.qml" line="911"/>
-        <location filename="../app/MainLayout.qml" line="1016"/>
+        <location filename="../app/MainLayout.qml" line="898"/>
+        <location filename="../app/MainLayout.qml" line="947"/>
+        <location filename="../app/MainLayout.qml" line="1052"/>
         <source>Options</source>
         <translation>אפשרויות</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="946"/>
+        <location filename="../app/MainLayout.qml" line="982"/>
         <source>Change</source>
         <translation>שינוי</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="952"/>
+        <location filename="../app/MainLayout.qml" line="988"/>
         <source>Toggle</source>
         <translation>החלף</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="973"/>
+        <location filename="../app/MainLayout.qml" line="1009"/>
         <source>Scroll</source>
         <translation>גלילה</translation>
     </message>
@@ -690,12 +700,12 @@
         <translation type="unfinished">טוען…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="295"/>
+        <location filename="../screens/MediaListScreen.qml" line="306"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 פריטים</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="296"/>
+        <location filename="../screens/MediaListScreen.qml" line="307"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -768,288 +778,381 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="73"/>
-        <location filename="../screens/SettingsScreen.qml" line="432"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Language</source>
         <translation>שפה</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="78"/>
-        <location filename="../screens/SettingsScreen.qml" line="441"/>
+        <location filename="../screens/SettingsScreen.qml" line="507"/>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="516"/>
         <source>Browsing layout</source>
         <translation>פריסת עיון</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="450"/>
+        <location filename="../screens/SettingsScreen.qml" line="88"/>
+        <location filename="../screens/SettingsScreen.qml" line="525"/>
         <source>Button style</source>
         <translation>סגנון כפתורים</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88"/>
-        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <location filename="../screens/SettingsScreen.qml" line="93"/>
+        <location filename="../screens/SettingsScreen.qml" line="534"/>
         <source>Screensaver</source>
         <translation>שומר מסך</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="92"/>
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
         <source>Library</source>
         <translation>ספרייה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="107"/>
+        <location filename="../screens/SettingsScreen.qml" line="543"/>
+        <source>Preferred artwork</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="112"/>
         <source>Update media database</source>
         <translation>עדכון מסד נתוני המדיה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="107"/>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
         <source>Scrape metadata</source>
         <translation>איסוף מטא-נתונים</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <source>Re-scrape existing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Advanced</source>
         <translation>מתקדם</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116"/>
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
         <source>Mouse support</source>
         <translation>תמיכת עכבר</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121"/>
+        <location filename="../screens/SettingsScreen.qml" line="136"/>
         <source>Debug logging</source>
         <translation>רישום ניפוי שגיאות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
+        <location filename="../screens/SettingsScreen.qml" line="141"/>
         <source>Upload log file</source>
         <translation>העלאת קובץ יומן</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="146"/>
         <source>About / License</source>
         <translation>אודות / רישיון</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147"/>
+        <location filename="../screens/SettingsScreen.qml" line="162"/>
         <source>Optimizing</source>
         <translation>מבצע אופטימיזציה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149"/>
-        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="173"/>
         <source>Paused</source>
         <translation>מושהה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149"/>
-        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="173"/>
         <source>In progress</source>
         <translation>בתהליך</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152"/>
+        <location filename="../screens/SettingsScreen.qml" line="167"/>
         <source>%1 indexed</source>
         <translation>%1 אונדקסו</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="161"/>
+        <location filename="../screens/SettingsScreen.qml" line="176"/>
         <source>%1 scraped</source>
         <translation>%1 נאספו</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="266"/>
+        <location filename="../screens/SettingsScreen.qml" line="284"/>
         <source>Cancel</source>
         <translation>ביטול</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="266"/>
+        <location filename="../screens/SettingsScreen.qml" line="284"/>
         <source>Start</source>
         <translation>התחל</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="268"/>
+        <location filename="../screens/SettingsScreen.qml" line="286"/>
         <source>Upload</source>
         <translation>העלאה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <location filename="../screens/SettingsScreen.qml" line="288"/>
         <source>Open</source>
         <translation>פתח</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="322"/>
+        <location filename="../screens/SettingsScreen.qml" line="340"/>
         <source>Default</source>
         <translation>ברירת מחדל</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="342"/>
+        <location filename="../screens/SettingsScreen.qml" line="365"/>
         <source>English</source>
         <translation>אנגלית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="344"/>
+        <location filename="../screens/SettingsScreen.qml" line="367"/>
         <source>Italian</source>
         <translation>איטלקית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="346"/>
+        <location filename="../screens/SettingsScreen.qml" line="369"/>
         <source>German</source>
         <translation>גרמנית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="348"/>
+        <location filename="../screens/SettingsScreen.qml" line="371"/>
         <source>Greek</source>
         <translation>יוונית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="350"/>
+        <location filename="../screens/SettingsScreen.qml" line="373"/>
         <source>Japanese</source>
         <translation>יפנית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="352"/>
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Korean</source>
         <translation>קוריאנית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
         <source>Dutch</source>
         <translation>הולנדית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="356"/>
+        <location filename="../screens/SettingsScreen.qml" line="379"/>
         <source>Romanian</source>
         <translation>רומנית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="358"/>
+        <location filename="../screens/SettingsScreen.qml" line="381"/>
         <source>Slovak</source>
         <translation>סלובקית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="360"/>
+        <location filename="../screens/SettingsScreen.qml" line="383"/>
         <source>Ukrainian</source>
         <translation>אוקראינית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="362"/>
+        <location filename="../screens/SettingsScreen.qml" line="385"/>
         <source>Chinese (Simplified)</source>
         <translation>סינית (מפושטת)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="364"/>
+        <location filename="../screens/SettingsScreen.qml" line="387"/>
         <source>Hebrew</source>
         <translation>עברית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="366"/>
+        <location filename="../screens/SettingsScreen.qml" line="389"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="368"/>
+        <location filename="../screens/SettingsScreen.qml" line="391"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="392"/>
+        <location filename="../screens/SettingsScreen.qml" line="451"/>
         <source>Auto</source>
         <translation>אוטומטי</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="374"/>
+        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <source>Rotated CW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <source>Rotated CCW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="400"/>
+        <source>Horizontal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="405"/>
         <source>Detailed list view</source>
         <translation>תצוגת רשימה מפורטת</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="375"/>
+        <location filename="../screens/SettingsScreen.qml" line="406"/>
         <source>Grid view</source>
         <translation>תצוגת רשת</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="411"/>
         <source>Style B</source>
         <translation>סגנון B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="382"/>
+        <location filename="../screens/SettingsScreen.qml" line="413"/>
         <source>Style C</source>
         <translation>סגנון C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="384"/>
+        <location filename="../screens/SettingsScreen.qml" line="415"/>
         <source>Style D</source>
         <translation>סגנון D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="385"/>
+        <location filename="../screens/SettingsScreen.qml" line="416"/>
         <source>Style A</source>
         <translation>סגנון A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="395"/>
+        <location filename="../screens/SettingsScreen.qml" line="431"/>
         <source>Off</source>
         <translation>כבוי</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <location filename="../screens/SettingsScreen.qml" line="433"/>
         <source>1 second (testing)</source>
         <translation>שנייה אחת (לבדיקה)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <location filename="../screens/SettingsScreen.qml" line="435"/>
         <source>1 minute</source>
         <translation>דקה אחת</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="401"/>
+        <location filename="../screens/SettingsScreen.qml" line="437"/>
         <source>2 minutes</source>
         <translation>2 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="403"/>
+        <location filename="../screens/SettingsScreen.qml" line="439"/>
         <source>5 minutes</source>
         <translation>5 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405"/>
+        <location filename="../screens/SettingsScreen.qml" line="441"/>
         <source>10 minutes</source>
         <translation>10 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="407"/>
+        <location filename="../screens/SettingsScreen.qml" line="443"/>
         <source>15 minutes</source>
         <translation>15 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="409"/>
+        <location filename="../screens/SettingsScreen.qml" line="445"/>
         <source>30 minutes</source>
         <translation>30 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="410"/>
+        <location filename="../screens/SettingsScreen.qml" line="446"/>
         <source>%1 seconds</source>
         <translation>%1 שניות</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="423"/>
+        <location filename="../screens/SettingsScreen.qml" line="489"/>
         <source>Resolution</source>
         <translation>רזולוציה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="563"/>
+        <location filename="../screens/SettingsScreen.qml" line="453"/>
+        <source>Image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="455"/>
+        <source>Thumbnail</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="457"/>
+        <source>Box art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <source>3D box art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="461"/>
+        <source>Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="463"/>
+        <source>Wheel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="465"/>
+        <source>Title screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="467"/>
+        <source>Map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="469"/>
+        <source>Marquee</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="471"/>
+        <source>Fan art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="473"/>
+        <source>Box side</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <source>Box back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="663"/>
         <source>Settings</source>
         <translation>הגדרות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="755"/>
+        <location filename="../screens/SettingsScreen.qml" line="857"/>
         <source>No settings available on this platform</source>
         <translation>אין הגדרות זמינות בפלטפורמה זו</translation>
     </message>
@@ -1057,24 +1160,24 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="185"/>
-        <location filename="../screens/SystemsScreen.qml" line="285"/>
+        <location filename="../screens/SystemsScreen.qml" line="195"/>
+        <location filename="../screens/SystemsScreen.qml" line="292"/>
         <source>%1 systems</source>
         <translation>%1 מערכות</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="189"/>
-        <location filename="../screens/SystemsScreen.qml" line="302"/>
+        <location filename="../screens/SystemsScreen.qml" line="196"/>
+        <location filename="../screens/SystemsScreen.qml" line="309"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="317"/>
+        <location filename="../screens/SystemsScreen.qml" line="324"/>
         <source>No systems in this category</source>
         <translation>אין מערכות בקטגוריה זו</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="318"/>
+        <location filename="../screens/SystemsScreen.qml" line="325"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -90,47 +90,47 @@
         <translation type="unfinished">लोड हो रहा है…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <location filename="../components/BrowseDetailPane.qml" line="77"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <location filename="../components/BrowseDetailPane.qml" line="79"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <location filename="../components/BrowseDetailPane.qml" line="81"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <location filename="../components/BrowseDetailPane.qml" line="83"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="55"/>
+        <location filename="../components/BrowseDetailPane.qml" line="85"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="57"/>
+        <location filename="../components/BrowseDetailPane.qml" line="87"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="59"/>
+        <location filename="../components/BrowseDetailPane.qml" line="89"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="61"/>
+        <location filename="../components/BrowseDetailPane.qml" line="91"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="63"/>
+        <location filename="../components/BrowseDetailPane.qml" line="93"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
@@ -329,34 +329,34 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="109"/>
-        <location filename="../screens/GamesScreen.qml" line="138"/>
+        <location filename="../screens/GamesScreen.qml" line="117"/>
+        <location filename="../screens/GamesScreen.qml" line="145"/>
         <source>%1 files</source>
         <translation>%1 फ़ाइलें</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="40"/>
+        <location filename="../screens/GamesScreen.qml" line="51"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="118"/>
-        <location filename="../screens/GamesScreen.qml" line="139"/>
+        <location filename="../screens/GamesScreen.qml" line="126"/>
+        <location filename="../screens/GamesScreen.qml" line="146"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="33"/>
+        <location filename="../screens/GamesScreen.qml" line="44"/>
         <source>No games in this system</source>
         <translation>इस सिस्टम में कोई गेम नहीं है</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="34"/>
+        <location filename="../screens/GamesScreen.qml" line="45"/>
         <source>Loading games…</source>
         <translation>गेम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="114"/>
+        <location filename="../screens/GamesScreen.qml" line="122"/>
         <source>Loading more…</source>
         <translation>और लोड हो रहा है…</translation>
     </message>
@@ -434,7 +434,7 @@
     </message>
     <message>
         <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="955"/>
+        <location filename="../app/Main.qml" line="958"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
@@ -465,67 +465,67 @@
         <translation>QR कोड</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="951"/>
+        <location filename="../app/Main.qml" line="954"/>
         <source>Default</source>
         <translation type="unfinished">डिफ़ॉल्ट</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="951"/>
+        <location filename="../app/Main.qml" line="954"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1227"/>
+        <location filename="../app/Main.qml" line="1230"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1231"/>
+        <location filename="../app/Main.qml" line="1234"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1245"/>
+        <location filename="../app/Main.qml" line="1248"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1249"/>
+        <location filename="../app/Main.qml" line="1252"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1253"/>
+        <location filename="../app/Main.qml" line="1256"/>
         <source>Retry</source>
         <translation type="unfinished">फिर से प्रयास करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1257"/>
+        <location filename="../app/Main.qml" line="1260"/>
         <source>Cancel</source>
         <translation type="unfinished">रद्द करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1769"/>
+        <location filename="../app/Main.qml" line="1776"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1771"/>
+        <location filename="../app/Main.qml" line="1778"/>
         <source>Loading games…</source>
         <translation>गेम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1773"/>
+        <location filename="../app/Main.qml" line="1780"/>
         <source>Loading favorites…</source>
         <translation>पसंदीदा लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
+        <location filename="../app/Main.qml" line="1782"/>
         <source>Loading recently played…</source>
         <translation>हाल ही में खेले गए लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1777"/>
+        <location filename="../app/Main.qml" line="1784"/>
         <source>Loading…</source>
         <translation>लोड हो रहा है…</translation>
     </message>
@@ -533,12 +533,12 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="545"/>
+        <location filename="../app/MainLayout.qml" line="581"/>
         <source>Writing failed</source>
         <translation>लिखना विफल हुआ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="545"/>
+        <location filename="../app/MainLayout.qml" line="581"/>
         <source>Put a writable card near the reader</source>
         <translation>रीडर के पास लिखने योग्य कार्ड रखें</translation>
     </message>
@@ -548,136 +548,146 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="556"/>
+        <location filename="../app/MainLayout.qml" line="323"/>
+        <source>Favorites</source>
+        <translation type="unfinished">पसंदीदा</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="325"/>
+        <source>Recently Played</source>
+        <translation type="unfinished">हाल ही में खेले गए</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="592"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="557"/>
+        <location filename="../app/MainLayout.qml" line="593"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="632"/>
+        <location filename="../app/MainLayout.qml" line="668"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="633"/>
+        <location filename="../app/MainLayout.qml" line="669"/>
         <source>Are you sure you want to exit?</source>
         <translation>क्या आप वाकई बाहर निकलना चाहते हैं?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="705"/>
-        <location filename="../app/MainLayout.qml" line="777"/>
-        <location filename="../app/MainLayout.qml" line="820"/>
-        <location filename="../app/MainLayout.qml" line="849"/>
-        <location filename="../app/MainLayout.qml" line="896"/>
-        <location filename="../app/MainLayout.qml" line="937"/>
-        <location filename="../app/MainLayout.qml" line="1001"/>
+        <location filename="../app/MainLayout.qml" line="741"/>
+        <location filename="../app/MainLayout.qml" line="813"/>
+        <location filename="../app/MainLayout.qml" line="856"/>
+        <location filename="../app/MainLayout.qml" line="885"/>
+        <location filename="../app/MainLayout.qml" line="932"/>
+        <location filename="../app/MainLayout.qml" line="973"/>
+        <location filename="../app/MainLayout.qml" line="1037"/>
         <source>Move</source>
         <translation>स्थानांतरित करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="709"/>
-        <location filename="../app/MainLayout.qml" line="781"/>
+        <location filename="../app/MainLayout.qml" line="745"/>
+        <location filename="../app/MainLayout.qml" line="817"/>
         <source>Select</source>
         <translation>चुनें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="713"/>
-        <location filename="../app/MainLayout.qml" line="717"/>
-        <location filename="../app/MainLayout.qml" line="731"/>
-        <location filename="../app/MainLayout.qml" line="744"/>
-        <location filename="../app/MainLayout.qml" line="755"/>
+        <location filename="../app/MainLayout.qml" line="749"/>
+        <location filename="../app/MainLayout.qml" line="753"/>
+        <location filename="../app/MainLayout.qml" line="767"/>
+        <location filename="../app/MainLayout.qml" line="780"/>
+        <location filename="../app/MainLayout.qml" line="791"/>
         <source>Close</source>
         <translation>बंद करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="724"/>
-        <location filename="../app/MainLayout.qml" line="762"/>
-        <location filename="../app/MainLayout.qml" line="785"/>
-        <location filename="../app/MainLayout.qml" line="796"/>
+        <location filename="../app/MainLayout.qml" line="760"/>
+        <location filename="../app/MainLayout.qml" line="798"/>
+        <location filename="../app/MainLayout.qml" line="821"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Cancel</source>
         <translation>रद्द करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="740"/>
+        <location filename="../app/MainLayout.qml" line="776"/>
         <source>Done</source>
         <translation>पूरा</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="751"/>
-        <location filename="../app/MainLayout.qml" line="872"/>
-        <location filename="../app/MainLayout.qml" line="922"/>
-        <location filename="../app/MainLayout.qml" line="1027"/>
+        <location filename="../app/MainLayout.qml" line="787"/>
+        <location filename="../app/MainLayout.qml" line="908"/>
+        <location filename="../app/MainLayout.qml" line="958"/>
+        <location filename="../app/MainLayout.qml" line="1063"/>
         <source>Retry</source>
         <translation>फिर से प्रयास करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="770"/>
+        <location filename="../app/MainLayout.qml" line="806"/>
         <source>I understand</source>
         <translation>मैं समझ गया</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="804"/>
+        <location filename="../app/MainLayout.qml" line="840"/>
         <source>Start</source>
         <translation>शुरू करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
-        <location filename="../app/MainLayout.qml" line="859"/>
-        <location filename="../app/MainLayout.qml" line="906"/>
-        <location filename="../app/MainLayout.qml" line="1011"/>
+        <location filename="../app/MainLayout.qml" line="860"/>
+        <location filename="../app/MainLayout.qml" line="895"/>
+        <location filename="../app/MainLayout.qml" line="942"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
         <source>Open</source>
         <translation>खोलें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="828"/>
+        <location filename="../app/MainLayout.qml" line="864"/>
         <source>Quit</source>
         <translation>बंद करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="837"/>
-        <location filename="../app/MainLayout.qml" line="865"/>
-        <location filename="../app/MainLayout.qml" line="876"/>
-        <location filename="../app/MainLayout.qml" line="888"/>
-        <location filename="../app/MainLayout.qml" line="915"/>
-        <location filename="../app/MainLayout.qml" line="926"/>
-        <location filename="../app/MainLayout.qml" line="961"/>
-        <location filename="../app/MainLayout.qml" line="977"/>
-        <location filename="../app/MainLayout.qml" line="986"/>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1031"/>
+        <location filename="../app/MainLayout.qml" line="873"/>
+        <location filename="../app/MainLayout.qml" line="901"/>
+        <location filename="../app/MainLayout.qml" line="912"/>
+        <location filename="../app/MainLayout.qml" line="924"/>
+        <location filename="../app/MainLayout.qml" line="951"/>
+        <location filename="../app/MainLayout.qml" line="962"/>
+        <location filename="../app/MainLayout.qml" line="997"/>
+        <location filename="../app/MainLayout.qml" line="1013"/>
+        <location filename="../app/MainLayout.qml" line="1022"/>
+        <location filename="../app/MainLayout.qml" line="1056"/>
+        <location filename="../app/MainLayout.qml" line="1067"/>
         <source>Back</source>
         <translation>वापस</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="855"/>
-        <location filename="../app/MainLayout.qml" line="902"/>
-        <location filename="../app/MainLayout.qml" line="1007"/>
+        <location filename="../app/MainLayout.qml" line="891"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="1043"/>
         <source>Page</source>
         <translation>पृष्ठ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="862"/>
-        <location filename="../app/MainLayout.qml" line="911"/>
-        <location filename="../app/MainLayout.qml" line="1016"/>
+        <location filename="../app/MainLayout.qml" line="898"/>
+        <location filename="../app/MainLayout.qml" line="947"/>
+        <location filename="../app/MainLayout.qml" line="1052"/>
         <source>Options</source>
         <translation>विकल्प</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="946"/>
+        <location filename="../app/MainLayout.qml" line="982"/>
         <source>Change</source>
         <translation>बदलें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="952"/>
+        <location filename="../app/MainLayout.qml" line="988"/>
         <source>Toggle</source>
         <translation>टॉगल</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="973"/>
+        <location filename="../app/MainLayout.qml" line="1009"/>
         <source>Scroll</source>
         <translation>स्क्रॉल</translation>
     </message>
@@ -690,12 +700,12 @@
         <translation type="unfinished">लोड हो रहा है…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="295"/>
+        <location filename="../screens/MediaListScreen.qml" line="306"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 प्रविष्टियाँ</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="296"/>
+        <location filename="../screens/MediaListScreen.qml" line="307"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -768,288 +778,381 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="73"/>
-        <location filename="../screens/SettingsScreen.qml" line="432"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Language</source>
         <translation>भाषा</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="78"/>
-        <location filename="../screens/SettingsScreen.qml" line="441"/>
+        <location filename="../screens/SettingsScreen.qml" line="507"/>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="516"/>
         <source>Browsing layout</source>
         <translation>ब्राउज़िंग लेआउट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="450"/>
+        <location filename="../screens/SettingsScreen.qml" line="88"/>
+        <location filename="../screens/SettingsScreen.qml" line="525"/>
         <source>Button style</source>
         <translation>बटन शैली</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88"/>
-        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <location filename="../screens/SettingsScreen.qml" line="93"/>
+        <location filename="../screens/SettingsScreen.qml" line="534"/>
         <source>Screensaver</source>
         <translation>स्क्रीनसेवर</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="92"/>
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
         <source>Library</source>
         <translation>लाइब्रेरी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="107"/>
+        <location filename="../screens/SettingsScreen.qml" line="543"/>
+        <source>Preferred artwork</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="112"/>
         <source>Update media database</source>
         <translation>मीडिया डेटाबेस अपडेट करें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="107"/>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
         <source>Scrape metadata</source>
         <translation>मेटाडेटा स्क्रैप करें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <source>Re-scrape existing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Advanced</source>
         <translation>उन्नत</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116"/>
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
         <source>Mouse support</source>
         <translation>माउस समर्थन</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121"/>
+        <location filename="../screens/SettingsScreen.qml" line="136"/>
         <source>Debug logging</source>
         <translation>डीबग लॉगिंग</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
+        <location filename="../screens/SettingsScreen.qml" line="141"/>
         <source>Upload log file</source>
         <translation>लॉग फ़ाइल अपलोड करें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="146"/>
         <source>About / License</source>
         <translation>परिचय / लाइसेंस</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147"/>
+        <location filename="../screens/SettingsScreen.qml" line="162"/>
         <source>Optimizing</source>
         <translation>अनुकूलित किया जा रहा है</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149"/>
-        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="173"/>
         <source>Paused</source>
         <translation>रोक दिया गया</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149"/>
-        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="173"/>
         <source>In progress</source>
         <translation>प्रगति पर</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152"/>
+        <location filename="../screens/SettingsScreen.qml" line="167"/>
         <source>%1 indexed</source>
         <translation>%1 इंडेक्स किए गए</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="161"/>
+        <location filename="../screens/SettingsScreen.qml" line="176"/>
         <source>%1 scraped</source>
         <translation>%1 स्क्रैप किए गए</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="266"/>
+        <location filename="../screens/SettingsScreen.qml" line="284"/>
         <source>Cancel</source>
         <translation>रद्द करें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="266"/>
+        <location filename="../screens/SettingsScreen.qml" line="284"/>
         <source>Start</source>
         <translation>शुरू करें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="268"/>
+        <location filename="../screens/SettingsScreen.qml" line="286"/>
         <source>Upload</source>
         <translation>अपलोड</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <location filename="../screens/SettingsScreen.qml" line="288"/>
         <source>Open</source>
         <translation>खोलें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="322"/>
+        <location filename="../screens/SettingsScreen.qml" line="340"/>
         <source>Default</source>
         <translation>डिफ़ॉल्ट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="342"/>
+        <location filename="../screens/SettingsScreen.qml" line="365"/>
         <source>English</source>
         <translation>अंग्रेज़ी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="344"/>
+        <location filename="../screens/SettingsScreen.qml" line="367"/>
         <source>Italian</source>
         <translation>इतालवी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="346"/>
+        <location filename="../screens/SettingsScreen.qml" line="369"/>
         <source>German</source>
         <translation>जर्मन</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="348"/>
+        <location filename="../screens/SettingsScreen.qml" line="371"/>
         <source>Greek</source>
         <translation>ग्रीक</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="350"/>
+        <location filename="../screens/SettingsScreen.qml" line="373"/>
         <source>Japanese</source>
         <translation>जापानी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="352"/>
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Korean</source>
         <translation>कोरियाई</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
         <source>Dutch</source>
         <translation>डच</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="356"/>
+        <location filename="../screens/SettingsScreen.qml" line="379"/>
         <source>Romanian</source>
         <translation>रोमानियाई</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="358"/>
+        <location filename="../screens/SettingsScreen.qml" line="381"/>
         <source>Slovak</source>
         <translation>स्लोवाक</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="360"/>
+        <location filename="../screens/SettingsScreen.qml" line="383"/>
         <source>Ukrainian</source>
         <translation>यूक्रेनी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="362"/>
+        <location filename="../screens/SettingsScreen.qml" line="385"/>
         <source>Chinese (Simplified)</source>
         <translation>चीनी (सरलीकृत)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="364"/>
+        <location filename="../screens/SettingsScreen.qml" line="387"/>
         <source>Hebrew</source>
         <translation>हिब्रू</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="366"/>
+        <location filename="../screens/SettingsScreen.qml" line="389"/>
         <source>Arabic</source>
         <translation>अरबी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="368"/>
+        <location filename="../screens/SettingsScreen.qml" line="391"/>
         <source>Hindi</source>
         <translation>हिंदी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="392"/>
+        <location filename="../screens/SettingsScreen.qml" line="451"/>
         <source>Auto</source>
         <translation>स्वचालित</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="374"/>
+        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <source>Rotated CW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <source>Rotated CCW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="400"/>
+        <source>Horizontal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="405"/>
         <source>Detailed list view</source>
         <translation>विस्तृत सूची दृश्य</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="375"/>
+        <location filename="../screens/SettingsScreen.qml" line="406"/>
         <source>Grid view</source>
         <translation>ग्रिड दृश्य</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="411"/>
         <source>Style B</source>
         <translation>शैली B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="382"/>
+        <location filename="../screens/SettingsScreen.qml" line="413"/>
         <source>Style C</source>
         <translation>शैली C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="384"/>
+        <location filename="../screens/SettingsScreen.qml" line="415"/>
         <source>Style D</source>
         <translation>शैली D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="385"/>
+        <location filename="../screens/SettingsScreen.qml" line="416"/>
         <source>Style A</source>
         <translation>शैली A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="395"/>
+        <location filename="../screens/SettingsScreen.qml" line="431"/>
         <source>Off</source>
         <translation>बंद</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <location filename="../screens/SettingsScreen.qml" line="433"/>
         <source>1 second (testing)</source>
         <translation>1 सेकंड (परीक्षण)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <location filename="../screens/SettingsScreen.qml" line="435"/>
         <source>1 minute</source>
         <translation>1 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="401"/>
+        <location filename="../screens/SettingsScreen.qml" line="437"/>
         <source>2 minutes</source>
         <translation>2 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="403"/>
+        <location filename="../screens/SettingsScreen.qml" line="439"/>
         <source>5 minutes</source>
         <translation>5 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405"/>
+        <location filename="../screens/SettingsScreen.qml" line="441"/>
         <source>10 minutes</source>
         <translation>10 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="407"/>
+        <location filename="../screens/SettingsScreen.qml" line="443"/>
         <source>15 minutes</source>
         <translation>15 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="409"/>
+        <location filename="../screens/SettingsScreen.qml" line="445"/>
         <source>30 minutes</source>
         <translation>30 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="410"/>
+        <location filename="../screens/SettingsScreen.qml" line="446"/>
         <source>%1 seconds</source>
         <translation>%1 सेकंड</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="423"/>
+        <location filename="../screens/SettingsScreen.qml" line="489"/>
         <source>Resolution</source>
         <translation>रिज़ॉल्यूशन</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="563"/>
+        <location filename="../screens/SettingsScreen.qml" line="453"/>
+        <source>Image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="455"/>
+        <source>Thumbnail</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="457"/>
+        <source>Box art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <source>3D box art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="461"/>
+        <source>Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="463"/>
+        <source>Wheel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="465"/>
+        <source>Title screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="467"/>
+        <source>Map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="469"/>
+        <source>Marquee</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="471"/>
+        <source>Fan art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="473"/>
+        <source>Box side</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <source>Box back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="663"/>
         <source>Settings</source>
         <translation>सेटिंग्स</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="755"/>
+        <location filename="../screens/SettingsScreen.qml" line="857"/>
         <source>No settings available on this platform</source>
         <translation>इस प्लेटफ़ॉर्म पर कोई सेटिंग उपलब्ध नहीं है</translation>
     </message>
@@ -1057,24 +1160,24 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="185"/>
-        <location filename="../screens/SystemsScreen.qml" line="285"/>
+        <location filename="../screens/SystemsScreen.qml" line="195"/>
+        <location filename="../screens/SystemsScreen.qml" line="292"/>
         <source>%1 systems</source>
         <translation>%1 सिस्टम</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="189"/>
-        <location filename="../screens/SystemsScreen.qml" line="302"/>
+        <location filename="../screens/SystemsScreen.qml" line="196"/>
+        <location filename="../screens/SystemsScreen.qml" line="309"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="317"/>
+        <location filename="../screens/SystemsScreen.qml" line="324"/>
         <source>No systems in this category</source>
         <translation>इस श्रेणी में कोई सिस्टम नहीं है</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="318"/>
+        <location filename="../screens/SystemsScreen.qml" line="325"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -90,47 +90,47 @@
         <translation type="unfinished">Caricamento…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <location filename="../components/BrowseDetailPane.qml" line="77"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <location filename="../components/BrowseDetailPane.qml" line="79"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <location filename="../components/BrowseDetailPane.qml" line="81"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <location filename="../components/BrowseDetailPane.qml" line="83"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="55"/>
+        <location filename="../components/BrowseDetailPane.qml" line="85"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="57"/>
+        <location filename="../components/BrowseDetailPane.qml" line="87"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="59"/>
+        <location filename="../components/BrowseDetailPane.qml" line="89"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="61"/>
+        <location filename="../components/BrowseDetailPane.qml" line="91"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="63"/>
+        <location filename="../components/BrowseDetailPane.qml" line="93"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
@@ -329,34 +329,34 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="109"/>
-        <location filename="../screens/GamesScreen.qml" line="138"/>
+        <location filename="../screens/GamesScreen.qml" line="117"/>
+        <location filename="../screens/GamesScreen.qml" line="145"/>
         <source>%1 files</source>
         <translation>%1 file</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="40"/>
+        <location filename="../screens/GamesScreen.qml" line="51"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="118"/>
-        <location filename="../screens/GamesScreen.qml" line="139"/>
+        <location filename="../screens/GamesScreen.qml" line="126"/>
+        <location filename="../screens/GamesScreen.qml" line="146"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="34"/>
+        <location filename="../screens/GamesScreen.qml" line="45"/>
         <source>Loading games…</source>
         <translation>Caricamento giochi…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="114"/>
+        <location filename="../screens/GamesScreen.qml" line="122"/>
         <source>Loading more…</source>
         <translation>Caricamento altro…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="33"/>
+        <location filename="../screens/GamesScreen.qml" line="44"/>
         <source>No games in this system</source>
         <translation>Nessun gioco in questo sistema</translation>
     </message>
@@ -434,7 +434,7 @@
     </message>
     <message>
         <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="955"/>
+        <location filename="../app/Main.qml" line="958"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
@@ -465,67 +465,67 @@
         <translation>Avvia gioco</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1769"/>
+        <location filename="../app/Main.qml" line="1776"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1773"/>
+        <location filename="../app/Main.qml" line="1780"/>
         <source>Loading favorites…</source>
         <translation>Caricamento preferiti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1771"/>
+        <location filename="../app/Main.qml" line="1778"/>
         <source>Loading games…</source>
         <translation>Caricamento giochi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="951"/>
+        <location filename="../app/Main.qml" line="954"/>
         <source>Default</source>
         <translation type="unfinished">Predefinito</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="951"/>
+        <location filename="../app/Main.qml" line="954"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1227"/>
+        <location filename="../app/Main.qml" line="1230"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1231"/>
+        <location filename="../app/Main.qml" line="1234"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1245"/>
+        <location filename="../app/Main.qml" line="1248"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1249"/>
+        <location filename="../app/Main.qml" line="1252"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1253"/>
+        <location filename="../app/Main.qml" line="1256"/>
         <source>Retry</source>
         <translation type="unfinished">Riprova</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1257"/>
+        <location filename="../app/Main.qml" line="1260"/>
         <source>Cancel</source>
         <translation type="unfinished">Annulla</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
+        <location filename="../app/Main.qml" line="1782"/>
         <source>Loading recently played…</source>
         <translation>Caricamento recenti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1777"/>
+        <location filename="../app/Main.qml" line="1784"/>
         <source>Loading…</source>
         <translation>Caricamento…</translation>
     </message>
@@ -533,71 +533,71 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="545"/>
+        <location filename="../app/MainLayout.qml" line="581"/>
         <source>Writing failed</source>
         <translation>Scrittura non riuscita</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="545"/>
+        <location filename="../app/MainLayout.qml" line="581"/>
         <source>Put a writable card near the reader</source>
         <translation>Avvicina una scheda scrivibile al lettore</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="633"/>
+        <location filename="../app/MainLayout.qml" line="669"/>
         <source>Are you sure you want to exit?</source>
         <translation>Sei sicuro di voler uscire?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="709"/>
-        <location filename="../app/MainLayout.qml" line="781"/>
+        <location filename="../app/MainLayout.qml" line="745"/>
+        <location filename="../app/MainLayout.qml" line="817"/>
         <source>Select</source>
         <translation>Seleziona</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="713"/>
-        <location filename="../app/MainLayout.qml" line="717"/>
-        <location filename="../app/MainLayout.qml" line="731"/>
-        <location filename="../app/MainLayout.qml" line="744"/>
-        <location filename="../app/MainLayout.qml" line="755"/>
+        <location filename="../app/MainLayout.qml" line="749"/>
+        <location filename="../app/MainLayout.qml" line="753"/>
+        <location filename="../app/MainLayout.qml" line="767"/>
+        <location filename="../app/MainLayout.qml" line="780"/>
+        <location filename="../app/MainLayout.qml" line="791"/>
         <source>Close</source>
         <translation>Chiudi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="724"/>
-        <location filename="../app/MainLayout.qml" line="762"/>
-        <location filename="../app/MainLayout.qml" line="785"/>
-        <location filename="../app/MainLayout.qml" line="796"/>
+        <location filename="../app/MainLayout.qml" line="760"/>
+        <location filename="../app/MainLayout.qml" line="798"/>
+        <location filename="../app/MainLayout.qml" line="821"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="740"/>
+        <location filename="../app/MainLayout.qml" line="776"/>
         <source>Done</source>
         <translation>Fatto</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="770"/>
+        <location filename="../app/MainLayout.qml" line="806"/>
         <source>I understand</source>
         <translation>Ho capito</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="804"/>
+        <location filename="../app/MainLayout.qml" line="840"/>
         <source>Start</source>
         <translation>Avvia</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="973"/>
+        <location filename="../app/MainLayout.qml" line="1009"/>
         <source>Scroll</source>
         <translation>Scorri</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="705"/>
-        <location filename="../app/MainLayout.qml" line="777"/>
-        <location filename="../app/MainLayout.qml" line="820"/>
-        <location filename="../app/MainLayout.qml" line="849"/>
-        <location filename="../app/MainLayout.qml" line="896"/>
-        <location filename="../app/MainLayout.qml" line="937"/>
-        <location filename="../app/MainLayout.qml" line="1001"/>
+        <location filename="../app/MainLayout.qml" line="741"/>
+        <location filename="../app/MainLayout.qml" line="813"/>
+        <location filename="../app/MainLayout.qml" line="856"/>
+        <location filename="../app/MainLayout.qml" line="885"/>
+        <location filename="../app/MainLayout.qml" line="932"/>
+        <location filename="../app/MainLayout.qml" line="973"/>
+        <location filename="../app/MainLayout.qml" line="1037"/>
         <source>Move</source>
         <translation>Muovi</translation>
     </message>
@@ -607,77 +607,87 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="556"/>
+        <location filename="../app/MainLayout.qml" line="323"/>
+        <source>Favorites</source>
+        <translation type="unfinished">Preferiti</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="325"/>
+        <source>Recently Played</source>
+        <translation type="unfinished">Giocati di recente</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="592"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="557"/>
+        <location filename="../app/MainLayout.qml" line="593"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="632"/>
+        <location filename="../app/MainLayout.qml" line="668"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
-        <location filename="../app/MainLayout.qml" line="859"/>
-        <location filename="../app/MainLayout.qml" line="906"/>
-        <location filename="../app/MainLayout.qml" line="1011"/>
+        <location filename="../app/MainLayout.qml" line="860"/>
+        <location filename="../app/MainLayout.qml" line="895"/>
+        <location filename="../app/MainLayout.qml" line="942"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
         <source>Open</source>
         <translation>Apri</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="828"/>
+        <location filename="../app/MainLayout.qml" line="864"/>
         <source>Quit</source>
         <translation>Esci</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="837"/>
-        <location filename="../app/MainLayout.qml" line="865"/>
-        <location filename="../app/MainLayout.qml" line="876"/>
-        <location filename="../app/MainLayout.qml" line="888"/>
-        <location filename="../app/MainLayout.qml" line="915"/>
-        <location filename="../app/MainLayout.qml" line="926"/>
-        <location filename="../app/MainLayout.qml" line="961"/>
-        <location filename="../app/MainLayout.qml" line="977"/>
-        <location filename="../app/MainLayout.qml" line="986"/>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1031"/>
+        <location filename="../app/MainLayout.qml" line="873"/>
+        <location filename="../app/MainLayout.qml" line="901"/>
+        <location filename="../app/MainLayout.qml" line="912"/>
+        <location filename="../app/MainLayout.qml" line="924"/>
+        <location filename="../app/MainLayout.qml" line="951"/>
+        <location filename="../app/MainLayout.qml" line="962"/>
+        <location filename="../app/MainLayout.qml" line="997"/>
+        <location filename="../app/MainLayout.qml" line="1013"/>
+        <location filename="../app/MainLayout.qml" line="1022"/>
+        <location filename="../app/MainLayout.qml" line="1056"/>
+        <location filename="../app/MainLayout.qml" line="1067"/>
         <source>Back</source>
         <translation>Indietro</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="855"/>
-        <location filename="../app/MainLayout.qml" line="902"/>
-        <location filename="../app/MainLayout.qml" line="1007"/>
+        <location filename="../app/MainLayout.qml" line="891"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="1043"/>
         <source>Page</source>
         <translation>Pagina</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="862"/>
-        <location filename="../app/MainLayout.qml" line="911"/>
-        <location filename="../app/MainLayout.qml" line="1016"/>
+        <location filename="../app/MainLayout.qml" line="898"/>
+        <location filename="../app/MainLayout.qml" line="947"/>
+        <location filename="../app/MainLayout.qml" line="1052"/>
         <source>Options</source>
         <translation>Opzioni</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="751"/>
-        <location filename="../app/MainLayout.qml" line="872"/>
-        <location filename="../app/MainLayout.qml" line="922"/>
-        <location filename="../app/MainLayout.qml" line="1027"/>
+        <location filename="../app/MainLayout.qml" line="787"/>
+        <location filename="../app/MainLayout.qml" line="908"/>
+        <location filename="../app/MainLayout.qml" line="958"/>
+        <location filename="../app/MainLayout.qml" line="1063"/>
         <source>Retry</source>
         <translation>Riprova</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="946"/>
+        <location filename="../app/MainLayout.qml" line="982"/>
         <source>Change</source>
         <translation>Cambia</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="952"/>
+        <location filename="../app/MainLayout.qml" line="988"/>
         <source>Toggle</source>
         <translation>Alterna</translation>
     </message>
@@ -690,12 +700,12 @@
         <translation type="unfinished">Caricamento…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="295"/>
+        <location filename="../screens/MediaListScreen.qml" line="306"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 elementi</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="296"/>
+        <location filename="../screens/MediaListScreen.qml" line="307"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -763,23 +773,23 @@
     <name>SettingsScreen</name>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="73"/>
-        <location filename="../screens/SettingsScreen.qml" line="432"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Language</source>
         <translation>Lingua</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78"/>
-        <location filename="../screens/SettingsScreen.qml" line="441"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="516"/>
         <source>Browsing layout</source>
         <translation>Layout navigazione</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116"/>
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
         <source>Mouse support</source>
         <translation>Supporto mouse</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="112"/>
         <source>Update media database</source>
         <translation>Aggiorna database multimediale</translation>
     </message>
@@ -789,267 +799,360 @@
         <translation>Generale</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="450"/>
+        <location filename="../screens/SettingsScreen.qml" line="78"/>
+        <location filename="../screens/SettingsScreen.qml" line="507"/>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="88"/>
+        <location filename="../screens/SettingsScreen.qml" line="525"/>
         <source>Button style</source>
         <translation>Stile pulsanti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88"/>
-        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <location filename="../screens/SettingsScreen.qml" line="93"/>
+        <location filename="../screens/SettingsScreen.qml" line="534"/>
         <source>Screensaver</source>
         <translation>Salvaschermo</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="92"/>
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
         <source>Library</source>
         <translation>Libreria</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
+        <location filename="../screens/SettingsScreen.qml" line="543"/>
+        <source>Preferred artwork</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
         <source>Scrape metadata</source>
         <translation>Recupera metadati</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <source>Re-scrape existing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Advanced</source>
         <translation>Avanzate</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121"/>
+        <location filename="../screens/SettingsScreen.qml" line="136"/>
         <source>Debug logging</source>
         <translation>Log di debug</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
+        <location filename="../screens/SettingsScreen.qml" line="141"/>
         <source>Upload log file</source>
         <translation>Carica file di log</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="146"/>
         <source>About / License</source>
         <translation>Informazioni / Licenza</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147"/>
+        <location filename="../screens/SettingsScreen.qml" line="162"/>
         <source>Optimizing</source>
         <translation>Ottimizzazione</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149"/>
-        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="173"/>
         <source>Paused</source>
         <translation>In pausa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149"/>
-        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="173"/>
         <source>In progress</source>
         <translation>In corso</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152"/>
+        <location filename="../screens/SettingsScreen.qml" line="167"/>
         <source>%1 indexed</source>
         <translation>%1 indicizzati</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="161"/>
+        <location filename="../screens/SettingsScreen.qml" line="176"/>
         <source>%1 scraped</source>
         <translation>%1 recuperati</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="266"/>
+        <location filename="../screens/SettingsScreen.qml" line="284"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="266"/>
+        <location filename="../screens/SettingsScreen.qml" line="284"/>
         <source>Start</source>
         <translation>Avvia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="268"/>
+        <location filename="../screens/SettingsScreen.qml" line="286"/>
         <source>Upload</source>
         <translation>Carica</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <location filename="../screens/SettingsScreen.qml" line="288"/>
         <source>Open</source>
         <translation>Apri</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="342"/>
+        <location filename="../screens/SettingsScreen.qml" line="365"/>
         <source>English</source>
         <translation>Inglese</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="344"/>
+        <location filename="../screens/SettingsScreen.qml" line="367"/>
         <source>Italian</source>
         <translation>Italiano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="346"/>
+        <location filename="../screens/SettingsScreen.qml" line="369"/>
         <source>German</source>
         <translation>Tedesco</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="348"/>
+        <location filename="../screens/SettingsScreen.qml" line="371"/>
         <source>Greek</source>
         <translation>Greco</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="350"/>
+        <location filename="../screens/SettingsScreen.qml" line="373"/>
         <source>Japanese</source>
         <translation>Giapponese</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="352"/>
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Korean</source>
         <translation>Coreano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
         <source>Dutch</source>
         <translation>Olandese</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="356"/>
+        <location filename="../screens/SettingsScreen.qml" line="379"/>
         <source>Romanian</source>
         <translation>Rumeno</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="358"/>
+        <location filename="../screens/SettingsScreen.qml" line="381"/>
         <source>Slovak</source>
         <translation>Slovacco</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="360"/>
+        <location filename="../screens/SettingsScreen.qml" line="383"/>
         <source>Ukrainian</source>
         <translation>Ucraino</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="362"/>
+        <location filename="../screens/SettingsScreen.qml" line="385"/>
         <source>Chinese (Simplified)</source>
         <translation>Cinese (semplificato)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="364"/>
+        <location filename="../screens/SettingsScreen.qml" line="387"/>
         <source>Hebrew</source>
         <translation>Ebraico</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="366"/>
+        <location filename="../screens/SettingsScreen.qml" line="389"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="368"/>
+        <location filename="../screens/SettingsScreen.qml" line="391"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="392"/>
+        <location filename="../screens/SettingsScreen.qml" line="451"/>
         <source>Auto</source>
         <translation>Automatico</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="374"/>
+        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <source>Rotated CW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <source>Rotated CCW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="400"/>
+        <source>Horizontal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="405"/>
         <source>Detailed list view</source>
         <translation>Vista elenco dettagliata</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="375"/>
+        <location filename="../screens/SettingsScreen.qml" line="406"/>
         <source>Grid view</source>
         <translation>Vista griglia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="411"/>
         <source>Style B</source>
         <translation>Stile B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="382"/>
+        <location filename="../screens/SettingsScreen.qml" line="413"/>
         <source>Style C</source>
         <translation>Stile C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="384"/>
+        <location filename="../screens/SettingsScreen.qml" line="415"/>
         <source>Style D</source>
         <translation>Stile D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="385"/>
+        <location filename="../screens/SettingsScreen.qml" line="416"/>
         <source>Style A</source>
         <translation>Stile A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="322"/>
+        <location filename="../screens/SettingsScreen.qml" line="340"/>
         <source>Default</source>
         <translation>Predefinito</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="395"/>
+        <location filename="../screens/SettingsScreen.qml" line="431"/>
         <source>Off</source>
         <translation>Disattivato</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <location filename="../screens/SettingsScreen.qml" line="433"/>
         <source>1 second (testing)</source>
         <translation>1 secondo (test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <location filename="../screens/SettingsScreen.qml" line="435"/>
         <source>1 minute</source>
         <translation>1 minuto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="401"/>
+        <location filename="../screens/SettingsScreen.qml" line="437"/>
         <source>2 minutes</source>
         <translation>2 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="403"/>
+        <location filename="../screens/SettingsScreen.qml" line="439"/>
         <source>5 minutes</source>
         <translation>5 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405"/>
+        <location filename="../screens/SettingsScreen.qml" line="441"/>
         <source>10 minutes</source>
         <translation>10 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="407"/>
+        <location filename="../screens/SettingsScreen.qml" line="443"/>
         <source>15 minutes</source>
         <translation>15 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="409"/>
+        <location filename="../screens/SettingsScreen.qml" line="445"/>
         <source>30 minutes</source>
         <translation>30 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="410"/>
+        <location filename="../screens/SettingsScreen.qml" line="446"/>
         <source>%1 seconds</source>
         <translation>%1 secondi</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="423"/>
+        <location filename="../screens/SettingsScreen.qml" line="489"/>
         <source>Resolution</source>
         <translation>Risoluzione</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="563"/>
+        <location filename="../screens/SettingsScreen.qml" line="453"/>
+        <source>Image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="455"/>
+        <source>Thumbnail</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="457"/>
+        <source>Box art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <source>3D box art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="461"/>
+        <source>Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="463"/>
+        <source>Wheel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="465"/>
+        <source>Title screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="467"/>
+        <source>Map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="469"/>
+        <source>Marquee</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="471"/>
+        <source>Fan art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="473"/>
+        <source>Box side</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <source>Box back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="663"/>
         <source>Settings</source>
         <translation>Impostazioni</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="755"/>
+        <location filename="../screens/SettingsScreen.qml" line="857"/>
         <source>No settings available on this platform</source>
         <translation>Nessuna impostazione disponibile su questa piattaforma</translation>
     </message>
@@ -1057,24 +1160,24 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="185"/>
-        <location filename="../screens/SystemsScreen.qml" line="285"/>
+        <location filename="../screens/SystemsScreen.qml" line="195"/>
+        <location filename="../screens/SystemsScreen.qml" line="292"/>
         <source>%1 systems</source>
         <translation>%1 sistemi</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="189"/>
-        <location filename="../screens/SystemsScreen.qml" line="302"/>
+        <location filename="../screens/SystemsScreen.qml" line="196"/>
+        <location filename="../screens/SystemsScreen.qml" line="309"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="317"/>
+        <location filename="../screens/SystemsScreen.qml" line="324"/>
         <source>No systems in this category</source>
         <translation>Nessun sistema in questa categoria</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="318"/>
+        <location filename="../screens/SystemsScreen.qml" line="325"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -90,47 +90,47 @@
         <translation type="unfinished">読み込み中…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <location filename="../components/BrowseDetailPane.qml" line="77"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <location filename="../components/BrowseDetailPane.qml" line="79"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <location filename="../components/BrowseDetailPane.qml" line="81"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <location filename="../components/BrowseDetailPane.qml" line="83"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="55"/>
+        <location filename="../components/BrowseDetailPane.qml" line="85"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="57"/>
+        <location filename="../components/BrowseDetailPane.qml" line="87"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="59"/>
+        <location filename="../components/BrowseDetailPane.qml" line="89"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="61"/>
+        <location filename="../components/BrowseDetailPane.qml" line="91"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="63"/>
+        <location filename="../components/BrowseDetailPane.qml" line="93"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
@@ -329,34 +329,34 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="109"/>
-        <location filename="../screens/GamesScreen.qml" line="138"/>
+        <location filename="../screens/GamesScreen.qml" line="117"/>
+        <location filename="../screens/GamesScreen.qml" line="145"/>
         <source>%1 files</source>
         <translation>%1 ファイル</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="40"/>
+        <location filename="../screens/GamesScreen.qml" line="51"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="118"/>
-        <location filename="../screens/GamesScreen.qml" line="139"/>
+        <location filename="../screens/GamesScreen.qml" line="126"/>
+        <location filename="../screens/GamesScreen.qml" line="146"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="34"/>
+        <location filename="../screens/GamesScreen.qml" line="45"/>
         <source>Loading games…</source>
         <translation>ゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="114"/>
+        <location filename="../screens/GamesScreen.qml" line="122"/>
         <source>Loading more…</source>
         <translation>さらに読み込み中…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="33"/>
+        <location filename="../screens/GamesScreen.qml" line="44"/>
         <source>No games in this system</source>
         <translation>このシステムにゲームはありません</translation>
     </message>
@@ -434,7 +434,7 @@
     </message>
     <message>
         <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="955"/>
+        <location filename="../app/Main.qml" line="958"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
@@ -465,67 +465,67 @@
         <translation>ゲームを起動</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1769"/>
+        <location filename="../app/Main.qml" line="1776"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1773"/>
+        <location filename="../app/Main.qml" line="1780"/>
         <source>Loading favorites…</source>
         <translation>お気に入りを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1771"/>
+        <location filename="../app/Main.qml" line="1778"/>
         <source>Loading games…</source>
         <translation>ゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="951"/>
+        <location filename="../app/Main.qml" line="954"/>
         <source>Default</source>
         <translation type="unfinished">デフォルト</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="951"/>
+        <location filename="../app/Main.qml" line="954"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1227"/>
+        <location filename="../app/Main.qml" line="1230"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1231"/>
+        <location filename="../app/Main.qml" line="1234"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1245"/>
+        <location filename="../app/Main.qml" line="1248"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1249"/>
+        <location filename="../app/Main.qml" line="1252"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1253"/>
+        <location filename="../app/Main.qml" line="1256"/>
         <source>Retry</source>
         <translation type="unfinished">再試行</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1257"/>
+        <location filename="../app/Main.qml" line="1260"/>
         <source>Cancel</source>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
+        <location filename="../app/Main.qml" line="1782"/>
         <source>Loading recently played…</source>
         <translation>最近プレイしたゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1777"/>
+        <location filename="../app/Main.qml" line="1784"/>
         <source>Loading…</source>
         <translation>読み込み中…</translation>
     </message>
@@ -533,71 +533,71 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="545"/>
+        <location filename="../app/MainLayout.qml" line="581"/>
         <source>Writing failed</source>
         <translation>書き込み失敗</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="545"/>
+        <location filename="../app/MainLayout.qml" line="581"/>
         <source>Put a writable card near the reader</source>
         <translation>書き込み可能なカードをリーダーに近づけてください</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="633"/>
+        <location filename="../app/MainLayout.qml" line="669"/>
         <source>Are you sure you want to exit?</source>
         <translation>本当に終了しますか？</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="709"/>
-        <location filename="../app/MainLayout.qml" line="781"/>
+        <location filename="../app/MainLayout.qml" line="745"/>
+        <location filename="../app/MainLayout.qml" line="817"/>
         <source>Select</source>
         <translation>選択</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="713"/>
-        <location filename="../app/MainLayout.qml" line="717"/>
-        <location filename="../app/MainLayout.qml" line="731"/>
-        <location filename="../app/MainLayout.qml" line="744"/>
-        <location filename="../app/MainLayout.qml" line="755"/>
+        <location filename="../app/MainLayout.qml" line="749"/>
+        <location filename="../app/MainLayout.qml" line="753"/>
+        <location filename="../app/MainLayout.qml" line="767"/>
+        <location filename="../app/MainLayout.qml" line="780"/>
+        <location filename="../app/MainLayout.qml" line="791"/>
         <source>Close</source>
         <translation>閉じる</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="724"/>
-        <location filename="../app/MainLayout.qml" line="762"/>
-        <location filename="../app/MainLayout.qml" line="785"/>
-        <location filename="../app/MainLayout.qml" line="796"/>
+        <location filename="../app/MainLayout.qml" line="760"/>
+        <location filename="../app/MainLayout.qml" line="798"/>
+        <location filename="../app/MainLayout.qml" line="821"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="740"/>
+        <location filename="../app/MainLayout.qml" line="776"/>
         <source>Done</source>
         <translation>完了</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="770"/>
+        <location filename="../app/MainLayout.qml" line="806"/>
         <source>I understand</source>
         <translation>了解しました</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="804"/>
+        <location filename="../app/MainLayout.qml" line="840"/>
         <source>Start</source>
         <translation>開始</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="973"/>
+        <location filename="../app/MainLayout.qml" line="1009"/>
         <source>Scroll</source>
         <translation>スクロール</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="705"/>
-        <location filename="../app/MainLayout.qml" line="777"/>
-        <location filename="../app/MainLayout.qml" line="820"/>
-        <location filename="../app/MainLayout.qml" line="849"/>
-        <location filename="../app/MainLayout.qml" line="896"/>
-        <location filename="../app/MainLayout.qml" line="937"/>
-        <location filename="../app/MainLayout.qml" line="1001"/>
+        <location filename="../app/MainLayout.qml" line="741"/>
+        <location filename="../app/MainLayout.qml" line="813"/>
+        <location filename="../app/MainLayout.qml" line="856"/>
+        <location filename="../app/MainLayout.qml" line="885"/>
+        <location filename="../app/MainLayout.qml" line="932"/>
+        <location filename="../app/MainLayout.qml" line="973"/>
+        <location filename="../app/MainLayout.qml" line="1037"/>
         <source>Move</source>
         <translation>移動</translation>
     </message>
@@ -607,77 +607,87 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="556"/>
+        <location filename="../app/MainLayout.qml" line="323"/>
+        <source>Favorites</source>
+        <translation type="unfinished">お気に入り</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="325"/>
+        <source>Recently Played</source>
+        <translation type="unfinished">最近プレイしたゲーム</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="592"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="557"/>
+        <location filename="../app/MainLayout.qml" line="593"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="632"/>
+        <location filename="../app/MainLayout.qml" line="668"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
-        <location filename="../app/MainLayout.qml" line="859"/>
-        <location filename="../app/MainLayout.qml" line="906"/>
-        <location filename="../app/MainLayout.qml" line="1011"/>
+        <location filename="../app/MainLayout.qml" line="860"/>
+        <location filename="../app/MainLayout.qml" line="895"/>
+        <location filename="../app/MainLayout.qml" line="942"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
         <source>Open</source>
         <translation>開く</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="828"/>
+        <location filename="../app/MainLayout.qml" line="864"/>
         <source>Quit</source>
         <translation>終了</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="837"/>
-        <location filename="../app/MainLayout.qml" line="865"/>
-        <location filename="../app/MainLayout.qml" line="876"/>
-        <location filename="../app/MainLayout.qml" line="888"/>
-        <location filename="../app/MainLayout.qml" line="915"/>
-        <location filename="../app/MainLayout.qml" line="926"/>
-        <location filename="../app/MainLayout.qml" line="961"/>
-        <location filename="../app/MainLayout.qml" line="977"/>
-        <location filename="../app/MainLayout.qml" line="986"/>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1031"/>
+        <location filename="../app/MainLayout.qml" line="873"/>
+        <location filename="../app/MainLayout.qml" line="901"/>
+        <location filename="../app/MainLayout.qml" line="912"/>
+        <location filename="../app/MainLayout.qml" line="924"/>
+        <location filename="../app/MainLayout.qml" line="951"/>
+        <location filename="../app/MainLayout.qml" line="962"/>
+        <location filename="../app/MainLayout.qml" line="997"/>
+        <location filename="../app/MainLayout.qml" line="1013"/>
+        <location filename="../app/MainLayout.qml" line="1022"/>
+        <location filename="../app/MainLayout.qml" line="1056"/>
+        <location filename="../app/MainLayout.qml" line="1067"/>
         <source>Back</source>
         <translation>戻る</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="855"/>
-        <location filename="../app/MainLayout.qml" line="902"/>
-        <location filename="../app/MainLayout.qml" line="1007"/>
+        <location filename="../app/MainLayout.qml" line="891"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="1043"/>
         <source>Page</source>
         <translation>ページ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="862"/>
-        <location filename="../app/MainLayout.qml" line="911"/>
-        <location filename="../app/MainLayout.qml" line="1016"/>
+        <location filename="../app/MainLayout.qml" line="898"/>
+        <location filename="../app/MainLayout.qml" line="947"/>
+        <location filename="../app/MainLayout.qml" line="1052"/>
         <source>Options</source>
         <translation>オプション</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="751"/>
-        <location filename="../app/MainLayout.qml" line="872"/>
-        <location filename="../app/MainLayout.qml" line="922"/>
-        <location filename="../app/MainLayout.qml" line="1027"/>
+        <location filename="../app/MainLayout.qml" line="787"/>
+        <location filename="../app/MainLayout.qml" line="908"/>
+        <location filename="../app/MainLayout.qml" line="958"/>
+        <location filename="../app/MainLayout.qml" line="1063"/>
         <source>Retry</source>
         <translation>再試行</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="946"/>
+        <location filename="../app/MainLayout.qml" line="982"/>
         <source>Change</source>
         <translation>変更</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="952"/>
+        <location filename="../app/MainLayout.qml" line="988"/>
         <source>Toggle</source>
         <translation>切り替え</translation>
     </message>
@@ -690,12 +700,12 @@
         <translation type="unfinished">読み込み中…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="295"/>
+        <location filename="../screens/MediaListScreen.qml" line="306"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 件</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="296"/>
+        <location filename="../screens/MediaListScreen.qml" line="307"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -763,23 +773,23 @@
     <name>SettingsScreen</name>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="73"/>
-        <location filename="../screens/SettingsScreen.qml" line="432"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Language</source>
         <translation>言語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78"/>
-        <location filename="../screens/SettingsScreen.qml" line="441"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="516"/>
         <source>Browsing layout</source>
         <translation>ブラウジングレイアウト</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116"/>
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
         <source>Mouse support</source>
         <translation>マウスサポート</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="112"/>
         <source>Update media database</source>
         <translation>メディアデータベースを更新</translation>
     </message>
@@ -789,267 +799,360 @@
         <translation>一般</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="450"/>
+        <location filename="../screens/SettingsScreen.qml" line="78"/>
+        <location filename="../screens/SettingsScreen.qml" line="507"/>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="88"/>
+        <location filename="../screens/SettingsScreen.qml" line="525"/>
         <source>Button style</source>
         <translation>ボタンスタイル</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88"/>
-        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <location filename="../screens/SettingsScreen.qml" line="93"/>
+        <location filename="../screens/SettingsScreen.qml" line="534"/>
         <source>Screensaver</source>
         <translation>スクリーンセーバー</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="92"/>
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
         <source>Library</source>
         <translation>ライブラリ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
+        <location filename="../screens/SettingsScreen.qml" line="543"/>
+        <source>Preferred artwork</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
         <source>Scrape metadata</source>
         <translation>メタデータをスクレイピング</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <source>Re-scrape existing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Advanced</source>
         <translation>詳細設定</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121"/>
+        <location filename="../screens/SettingsScreen.qml" line="136"/>
         <source>Debug logging</source>
         <translation>デバッグログ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
+        <location filename="../screens/SettingsScreen.qml" line="141"/>
         <source>Upload log file</source>
         <translation>ログファイルをアップロード</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="146"/>
         <source>About / License</source>
         <translation>情報 / ライセンス</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147"/>
+        <location filename="../screens/SettingsScreen.qml" line="162"/>
         <source>Optimizing</source>
         <translation>最適化中</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149"/>
-        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="173"/>
         <source>Paused</source>
         <translation>一時停止中</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149"/>
-        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="173"/>
         <source>In progress</source>
         <translation>実行中</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152"/>
+        <location filename="../screens/SettingsScreen.qml" line="167"/>
         <source>%1 indexed</source>
         <translation>%1 件を索引化</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="161"/>
+        <location filename="../screens/SettingsScreen.qml" line="176"/>
         <source>%1 scraped</source>
         <translation>%1 件取得済み</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="266"/>
+        <location filename="../screens/SettingsScreen.qml" line="284"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="266"/>
+        <location filename="../screens/SettingsScreen.qml" line="284"/>
         <source>Start</source>
         <translation>開始</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="268"/>
+        <location filename="../screens/SettingsScreen.qml" line="286"/>
         <source>Upload</source>
         <translation>アップロード</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <location filename="../screens/SettingsScreen.qml" line="288"/>
         <source>Open</source>
         <translation>開く</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="342"/>
+        <location filename="../screens/SettingsScreen.qml" line="365"/>
         <source>English</source>
         <translation>英語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="344"/>
+        <location filename="../screens/SettingsScreen.qml" line="367"/>
         <source>Italian</source>
         <translation>イタリア語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="346"/>
+        <location filename="../screens/SettingsScreen.qml" line="369"/>
         <source>German</source>
         <translation>ドイツ語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="348"/>
+        <location filename="../screens/SettingsScreen.qml" line="371"/>
         <source>Greek</source>
         <translation>ギリシャ語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="350"/>
+        <location filename="../screens/SettingsScreen.qml" line="373"/>
         <source>Japanese</source>
         <translation>日本語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="352"/>
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Korean</source>
         <translation>韓国語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
         <source>Dutch</source>
         <translation>オランダ語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="356"/>
+        <location filename="../screens/SettingsScreen.qml" line="379"/>
         <source>Romanian</source>
         <translation>ルーマニア語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="358"/>
+        <location filename="../screens/SettingsScreen.qml" line="381"/>
         <source>Slovak</source>
         <translation>スロバキア語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="360"/>
+        <location filename="../screens/SettingsScreen.qml" line="383"/>
         <source>Ukrainian</source>
         <translation>ウクライナ語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="362"/>
+        <location filename="../screens/SettingsScreen.qml" line="385"/>
         <source>Chinese (Simplified)</source>
         <translation>中国語（簡体字）</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="364"/>
+        <location filename="../screens/SettingsScreen.qml" line="387"/>
         <source>Hebrew</source>
         <translation>ヘブライ語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="366"/>
+        <location filename="../screens/SettingsScreen.qml" line="389"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="368"/>
+        <location filename="../screens/SettingsScreen.qml" line="391"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="392"/>
+        <location filename="../screens/SettingsScreen.qml" line="451"/>
         <source>Auto</source>
         <translation>自動</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="374"/>
+        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <source>Rotated CW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <source>Rotated CCW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="400"/>
+        <source>Horizontal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="405"/>
         <source>Detailed list view</source>
         <translation>詳細リスト表示</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="375"/>
+        <location filename="../screens/SettingsScreen.qml" line="406"/>
         <source>Grid view</source>
         <translation>グリッド表示</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="411"/>
         <source>Style B</source>
         <translation>スタイル B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="382"/>
+        <location filename="../screens/SettingsScreen.qml" line="413"/>
         <source>Style C</source>
         <translation>スタイル C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="384"/>
+        <location filename="../screens/SettingsScreen.qml" line="415"/>
         <source>Style D</source>
         <translation>スタイル D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="385"/>
+        <location filename="../screens/SettingsScreen.qml" line="416"/>
         <source>Style A</source>
         <translation>スタイル A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="322"/>
+        <location filename="../screens/SettingsScreen.qml" line="340"/>
         <source>Default</source>
         <translation>デフォルト</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="395"/>
+        <location filename="../screens/SettingsScreen.qml" line="431"/>
         <source>Off</source>
         <translation>オフ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <location filename="../screens/SettingsScreen.qml" line="433"/>
         <source>1 second (testing)</source>
         <translation>1秒（テスト）</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <location filename="../screens/SettingsScreen.qml" line="435"/>
         <source>1 minute</source>
         <translation>1分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="401"/>
+        <location filename="../screens/SettingsScreen.qml" line="437"/>
         <source>2 minutes</source>
         <translation>2分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="403"/>
+        <location filename="../screens/SettingsScreen.qml" line="439"/>
         <source>5 minutes</source>
         <translation>5分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405"/>
+        <location filename="../screens/SettingsScreen.qml" line="441"/>
         <source>10 minutes</source>
         <translation>10分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="407"/>
+        <location filename="../screens/SettingsScreen.qml" line="443"/>
         <source>15 minutes</source>
         <translation>15分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="409"/>
+        <location filename="../screens/SettingsScreen.qml" line="445"/>
         <source>30 minutes</source>
         <translation>30分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="410"/>
+        <location filename="../screens/SettingsScreen.qml" line="446"/>
         <source>%1 seconds</source>
         <translation>%1秒</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="423"/>
+        <location filename="../screens/SettingsScreen.qml" line="489"/>
         <source>Resolution</source>
         <translation>解像度</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="563"/>
+        <location filename="../screens/SettingsScreen.qml" line="453"/>
+        <source>Image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="455"/>
+        <source>Thumbnail</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="457"/>
+        <source>Box art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <source>3D box art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="461"/>
+        <source>Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="463"/>
+        <source>Wheel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="465"/>
+        <source>Title screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="467"/>
+        <source>Map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="469"/>
+        <source>Marquee</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="471"/>
+        <source>Fan art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="473"/>
+        <source>Box side</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <source>Box back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="663"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="755"/>
+        <location filename="../screens/SettingsScreen.qml" line="857"/>
         <source>No settings available on this platform</source>
         <translation>このプラットフォームでは設定項目がありません</translation>
     </message>
@@ -1057,24 +1160,24 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="185"/>
-        <location filename="../screens/SystemsScreen.qml" line="285"/>
+        <location filename="../screens/SystemsScreen.qml" line="195"/>
+        <location filename="../screens/SystemsScreen.qml" line="292"/>
         <source>%1 systems</source>
         <translation>%1 システム</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="189"/>
-        <location filename="../screens/SystemsScreen.qml" line="302"/>
+        <location filename="../screens/SystemsScreen.qml" line="196"/>
+        <location filename="../screens/SystemsScreen.qml" line="309"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="317"/>
+        <location filename="../screens/SystemsScreen.qml" line="324"/>
         <source>No systems in this category</source>
         <translation>このカテゴリにシステムはありません</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="318"/>
+        <location filename="../screens/SystemsScreen.qml" line="325"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -90,47 +90,47 @@
         <translation type="unfinished">불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <location filename="../components/BrowseDetailPane.qml" line="77"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <location filename="../components/BrowseDetailPane.qml" line="79"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <location filename="../components/BrowseDetailPane.qml" line="81"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <location filename="../components/BrowseDetailPane.qml" line="83"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="55"/>
+        <location filename="../components/BrowseDetailPane.qml" line="85"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="57"/>
+        <location filename="../components/BrowseDetailPane.qml" line="87"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="59"/>
+        <location filename="../components/BrowseDetailPane.qml" line="89"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="61"/>
+        <location filename="../components/BrowseDetailPane.qml" line="91"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="63"/>
+        <location filename="../components/BrowseDetailPane.qml" line="93"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
@@ -329,34 +329,34 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="109"/>
-        <location filename="../screens/GamesScreen.qml" line="138"/>
+        <location filename="../screens/GamesScreen.qml" line="117"/>
+        <location filename="../screens/GamesScreen.qml" line="145"/>
         <source>%1 files</source>
         <translation>파일 %1개</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="40"/>
+        <location filename="../screens/GamesScreen.qml" line="51"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="118"/>
-        <location filename="../screens/GamesScreen.qml" line="139"/>
+        <location filename="../screens/GamesScreen.qml" line="126"/>
+        <location filename="../screens/GamesScreen.qml" line="146"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="33"/>
+        <location filename="../screens/GamesScreen.qml" line="44"/>
         <source>No games in this system</source>
         <translation>이 시스템에는 게임이 없습니다</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="34"/>
+        <location filename="../screens/GamesScreen.qml" line="45"/>
         <source>Loading games…</source>
         <translation>게임 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="114"/>
+        <location filename="../screens/GamesScreen.qml" line="122"/>
         <source>Loading more…</source>
         <translation>더 불러오는 중…</translation>
     </message>
@@ -434,7 +434,7 @@
     </message>
     <message>
         <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="955"/>
+        <location filename="../app/Main.qml" line="958"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
@@ -465,67 +465,67 @@
         <translation>QR 코드</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="951"/>
+        <location filename="../app/Main.qml" line="954"/>
         <source>Default</source>
         <translation type="unfinished">기본값</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="951"/>
+        <location filename="../app/Main.qml" line="954"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1227"/>
+        <location filename="../app/Main.qml" line="1230"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1231"/>
+        <location filename="../app/Main.qml" line="1234"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1245"/>
+        <location filename="../app/Main.qml" line="1248"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1249"/>
+        <location filename="../app/Main.qml" line="1252"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1253"/>
+        <location filename="../app/Main.qml" line="1256"/>
         <source>Retry</source>
         <translation type="unfinished">다시 시도</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1257"/>
+        <location filename="../app/Main.qml" line="1260"/>
         <source>Cancel</source>
         <translation type="unfinished">취소</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1769"/>
+        <location filename="../app/Main.qml" line="1776"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1771"/>
+        <location filename="../app/Main.qml" line="1778"/>
         <source>Loading games…</source>
         <translation>게임 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1773"/>
+        <location filename="../app/Main.qml" line="1780"/>
         <source>Loading favorites…</source>
         <translation>즐겨찾기 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
+        <location filename="../app/Main.qml" line="1782"/>
         <source>Loading recently played…</source>
         <translation>최근 플레이 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1777"/>
+        <location filename="../app/Main.qml" line="1784"/>
         <source>Loading…</source>
         <translation>불러오는 중…</translation>
     </message>
@@ -533,12 +533,12 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="545"/>
+        <location filename="../app/MainLayout.qml" line="581"/>
         <source>Writing failed</source>
         <translation>쓰기 실패</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="545"/>
+        <location filename="../app/MainLayout.qml" line="581"/>
         <source>Put a writable card near the reader</source>
         <translation>기록 가능한 카드를 리더 근처에 놓으세요</translation>
     </message>
@@ -548,136 +548,146 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="556"/>
+        <location filename="../app/MainLayout.qml" line="323"/>
+        <source>Favorites</source>
+        <translation type="unfinished">즐겨찾기</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="325"/>
+        <source>Recently Played</source>
+        <translation type="unfinished">최근 플레이</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="592"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="557"/>
+        <location filename="../app/MainLayout.qml" line="593"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="632"/>
+        <location filename="../app/MainLayout.qml" line="668"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="633"/>
+        <location filename="../app/MainLayout.qml" line="669"/>
         <source>Are you sure you want to exit?</source>
         <translation>정말 종료하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="705"/>
-        <location filename="../app/MainLayout.qml" line="777"/>
-        <location filename="../app/MainLayout.qml" line="820"/>
-        <location filename="../app/MainLayout.qml" line="849"/>
-        <location filename="../app/MainLayout.qml" line="896"/>
-        <location filename="../app/MainLayout.qml" line="937"/>
-        <location filename="../app/MainLayout.qml" line="1001"/>
+        <location filename="../app/MainLayout.qml" line="741"/>
+        <location filename="../app/MainLayout.qml" line="813"/>
+        <location filename="../app/MainLayout.qml" line="856"/>
+        <location filename="../app/MainLayout.qml" line="885"/>
+        <location filename="../app/MainLayout.qml" line="932"/>
+        <location filename="../app/MainLayout.qml" line="973"/>
+        <location filename="../app/MainLayout.qml" line="1037"/>
         <source>Move</source>
         <translation>이동</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="709"/>
-        <location filename="../app/MainLayout.qml" line="781"/>
+        <location filename="../app/MainLayout.qml" line="745"/>
+        <location filename="../app/MainLayout.qml" line="817"/>
         <source>Select</source>
         <translation>선택</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="713"/>
-        <location filename="../app/MainLayout.qml" line="717"/>
-        <location filename="../app/MainLayout.qml" line="731"/>
-        <location filename="../app/MainLayout.qml" line="744"/>
-        <location filename="../app/MainLayout.qml" line="755"/>
+        <location filename="../app/MainLayout.qml" line="749"/>
+        <location filename="../app/MainLayout.qml" line="753"/>
+        <location filename="../app/MainLayout.qml" line="767"/>
+        <location filename="../app/MainLayout.qml" line="780"/>
+        <location filename="../app/MainLayout.qml" line="791"/>
         <source>Close</source>
         <translation>닫기</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="724"/>
-        <location filename="../app/MainLayout.qml" line="762"/>
-        <location filename="../app/MainLayout.qml" line="785"/>
-        <location filename="../app/MainLayout.qml" line="796"/>
+        <location filename="../app/MainLayout.qml" line="760"/>
+        <location filename="../app/MainLayout.qml" line="798"/>
+        <location filename="../app/MainLayout.qml" line="821"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Cancel</source>
         <translation>취소</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="740"/>
+        <location filename="../app/MainLayout.qml" line="776"/>
         <source>Done</source>
         <translation>완료</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="751"/>
-        <location filename="../app/MainLayout.qml" line="872"/>
-        <location filename="../app/MainLayout.qml" line="922"/>
-        <location filename="../app/MainLayout.qml" line="1027"/>
+        <location filename="../app/MainLayout.qml" line="787"/>
+        <location filename="../app/MainLayout.qml" line="908"/>
+        <location filename="../app/MainLayout.qml" line="958"/>
+        <location filename="../app/MainLayout.qml" line="1063"/>
         <source>Retry</source>
         <translation>다시 시도</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="770"/>
+        <location filename="../app/MainLayout.qml" line="806"/>
         <source>I understand</source>
         <translation>이해했습니다</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="804"/>
+        <location filename="../app/MainLayout.qml" line="840"/>
         <source>Start</source>
         <translation>시작</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
-        <location filename="../app/MainLayout.qml" line="859"/>
-        <location filename="../app/MainLayout.qml" line="906"/>
-        <location filename="../app/MainLayout.qml" line="1011"/>
+        <location filename="../app/MainLayout.qml" line="860"/>
+        <location filename="../app/MainLayout.qml" line="895"/>
+        <location filename="../app/MainLayout.qml" line="942"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
         <source>Open</source>
         <translation>열기</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="828"/>
+        <location filename="../app/MainLayout.qml" line="864"/>
         <source>Quit</source>
         <translation>종료</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="837"/>
-        <location filename="../app/MainLayout.qml" line="865"/>
-        <location filename="../app/MainLayout.qml" line="876"/>
-        <location filename="../app/MainLayout.qml" line="888"/>
-        <location filename="../app/MainLayout.qml" line="915"/>
-        <location filename="../app/MainLayout.qml" line="926"/>
-        <location filename="../app/MainLayout.qml" line="961"/>
-        <location filename="../app/MainLayout.qml" line="977"/>
-        <location filename="../app/MainLayout.qml" line="986"/>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1031"/>
+        <location filename="../app/MainLayout.qml" line="873"/>
+        <location filename="../app/MainLayout.qml" line="901"/>
+        <location filename="../app/MainLayout.qml" line="912"/>
+        <location filename="../app/MainLayout.qml" line="924"/>
+        <location filename="../app/MainLayout.qml" line="951"/>
+        <location filename="../app/MainLayout.qml" line="962"/>
+        <location filename="../app/MainLayout.qml" line="997"/>
+        <location filename="../app/MainLayout.qml" line="1013"/>
+        <location filename="../app/MainLayout.qml" line="1022"/>
+        <location filename="../app/MainLayout.qml" line="1056"/>
+        <location filename="../app/MainLayout.qml" line="1067"/>
         <source>Back</source>
         <translation>뒤로</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="855"/>
-        <location filename="../app/MainLayout.qml" line="902"/>
-        <location filename="../app/MainLayout.qml" line="1007"/>
+        <location filename="../app/MainLayout.qml" line="891"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="1043"/>
         <source>Page</source>
         <translation>페이지</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="862"/>
-        <location filename="../app/MainLayout.qml" line="911"/>
-        <location filename="../app/MainLayout.qml" line="1016"/>
+        <location filename="../app/MainLayout.qml" line="898"/>
+        <location filename="../app/MainLayout.qml" line="947"/>
+        <location filename="../app/MainLayout.qml" line="1052"/>
         <source>Options</source>
         <translation>옵션</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="946"/>
+        <location filename="../app/MainLayout.qml" line="982"/>
         <source>Change</source>
         <translation>변경</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="952"/>
+        <location filename="../app/MainLayout.qml" line="988"/>
         <source>Toggle</source>
         <translation>전환</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="973"/>
+        <location filename="../app/MainLayout.qml" line="1009"/>
         <source>Scroll</source>
         <translation>스크롤</translation>
     </message>
@@ -690,12 +700,12 @@
         <translation type="unfinished">불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="295"/>
+        <location filename="../screens/MediaListScreen.qml" line="306"/>
         <source>%1 entries</source>
         <translation type="unfinished">항목 %1개</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="296"/>
+        <location filename="../screens/MediaListScreen.qml" line="307"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -768,288 +778,381 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="73"/>
-        <location filename="../screens/SettingsScreen.qml" line="432"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Language</source>
         <translation>언어</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="78"/>
-        <location filename="../screens/SettingsScreen.qml" line="441"/>
+        <location filename="../screens/SettingsScreen.qml" line="507"/>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="516"/>
         <source>Browsing layout</source>
         <translation>탐색 레이아웃</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="450"/>
+        <location filename="../screens/SettingsScreen.qml" line="88"/>
+        <location filename="../screens/SettingsScreen.qml" line="525"/>
         <source>Button style</source>
         <translation>버튼 스타일</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88"/>
-        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <location filename="../screens/SettingsScreen.qml" line="93"/>
+        <location filename="../screens/SettingsScreen.qml" line="534"/>
         <source>Screensaver</source>
         <translation>화면 보호기</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="92"/>
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
         <source>Library</source>
         <translation>라이브러리</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="107"/>
+        <location filename="../screens/SettingsScreen.qml" line="543"/>
+        <source>Preferred artwork</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="112"/>
         <source>Update media database</source>
         <translation>미디어 데이터베이스 업데이트</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="107"/>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
         <source>Scrape metadata</source>
         <translation>메타데이터 수집</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <source>Re-scrape existing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Advanced</source>
         <translation>고급</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116"/>
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
         <source>Mouse support</source>
         <translation>마우스 지원</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121"/>
+        <location filename="../screens/SettingsScreen.qml" line="136"/>
         <source>Debug logging</source>
         <translation>디버그 로깅</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
+        <location filename="../screens/SettingsScreen.qml" line="141"/>
         <source>Upload log file</source>
         <translation>로그 파일 업로드</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="146"/>
         <source>About / License</source>
         <translation>정보 / 라이선스</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147"/>
+        <location filename="../screens/SettingsScreen.qml" line="162"/>
         <source>Optimizing</source>
         <translation>최적화 중</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149"/>
-        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="173"/>
         <source>Paused</source>
         <translation>일시중지됨</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149"/>
-        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="173"/>
         <source>In progress</source>
         <translation>진행 중</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152"/>
+        <location filename="../screens/SettingsScreen.qml" line="167"/>
         <source>%1 indexed</source>
         <translation>%1개 인덱싱됨</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="161"/>
+        <location filename="../screens/SettingsScreen.qml" line="176"/>
         <source>%1 scraped</source>
         <translation>%1개 수집됨</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="266"/>
+        <location filename="../screens/SettingsScreen.qml" line="284"/>
         <source>Cancel</source>
         <translation>취소</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="266"/>
+        <location filename="../screens/SettingsScreen.qml" line="284"/>
         <source>Start</source>
         <translation>시작</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="268"/>
+        <location filename="../screens/SettingsScreen.qml" line="286"/>
         <source>Upload</source>
         <translation>업로드</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <location filename="../screens/SettingsScreen.qml" line="288"/>
         <source>Open</source>
         <translation>열기</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="322"/>
+        <location filename="../screens/SettingsScreen.qml" line="340"/>
         <source>Default</source>
         <translation>기본값</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="342"/>
+        <location filename="../screens/SettingsScreen.qml" line="365"/>
         <source>English</source>
         <translation>영어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="344"/>
+        <location filename="../screens/SettingsScreen.qml" line="367"/>
         <source>Italian</source>
         <translation>이탈리아어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="346"/>
+        <location filename="../screens/SettingsScreen.qml" line="369"/>
         <source>German</source>
         <translation>독일어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="348"/>
+        <location filename="../screens/SettingsScreen.qml" line="371"/>
         <source>Greek</source>
         <translation>그리스어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="350"/>
+        <location filename="../screens/SettingsScreen.qml" line="373"/>
         <source>Japanese</source>
         <translation>일본어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="352"/>
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Korean</source>
         <translation>한국어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
         <source>Dutch</source>
         <translation>네덜란드어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="356"/>
+        <location filename="../screens/SettingsScreen.qml" line="379"/>
         <source>Romanian</source>
         <translation>루마니아어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="358"/>
+        <location filename="../screens/SettingsScreen.qml" line="381"/>
         <source>Slovak</source>
         <translation>슬로바키아어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="360"/>
+        <location filename="../screens/SettingsScreen.qml" line="383"/>
         <source>Ukrainian</source>
         <translation>우크라이나어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="362"/>
+        <location filename="../screens/SettingsScreen.qml" line="385"/>
         <source>Chinese (Simplified)</source>
         <translation>중국어(간체)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="364"/>
+        <location filename="../screens/SettingsScreen.qml" line="387"/>
         <source>Hebrew</source>
         <translation>히브리어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="366"/>
+        <location filename="../screens/SettingsScreen.qml" line="389"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="368"/>
+        <location filename="../screens/SettingsScreen.qml" line="391"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="392"/>
+        <location filename="../screens/SettingsScreen.qml" line="451"/>
         <source>Auto</source>
         <translation>자동</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="374"/>
+        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <source>Rotated CW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <source>Rotated CCW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="400"/>
+        <source>Horizontal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="405"/>
         <source>Detailed list view</source>
         <translation>자세한 목록 보기</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="375"/>
+        <location filename="../screens/SettingsScreen.qml" line="406"/>
         <source>Grid view</source>
         <translation>그리드 보기</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="411"/>
         <source>Style B</source>
         <translation>스타일 B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="382"/>
+        <location filename="../screens/SettingsScreen.qml" line="413"/>
         <source>Style C</source>
         <translation>스타일 C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="384"/>
+        <location filename="../screens/SettingsScreen.qml" line="415"/>
         <source>Style D</source>
         <translation>스타일 D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="385"/>
+        <location filename="../screens/SettingsScreen.qml" line="416"/>
         <source>Style A</source>
         <translation>스타일 A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="395"/>
+        <location filename="../screens/SettingsScreen.qml" line="431"/>
         <source>Off</source>
         <translation>끔</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <location filename="../screens/SettingsScreen.qml" line="433"/>
         <source>1 second (testing)</source>
         <translation>1초 (테스트용)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <location filename="../screens/SettingsScreen.qml" line="435"/>
         <source>1 minute</source>
         <translation>1분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="401"/>
+        <location filename="../screens/SettingsScreen.qml" line="437"/>
         <source>2 minutes</source>
         <translation>2분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="403"/>
+        <location filename="../screens/SettingsScreen.qml" line="439"/>
         <source>5 minutes</source>
         <translation>5분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405"/>
+        <location filename="../screens/SettingsScreen.qml" line="441"/>
         <source>10 minutes</source>
         <translation>10분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="407"/>
+        <location filename="../screens/SettingsScreen.qml" line="443"/>
         <source>15 minutes</source>
         <translation>15분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="409"/>
+        <location filename="../screens/SettingsScreen.qml" line="445"/>
         <source>30 minutes</source>
         <translation>30분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="410"/>
+        <location filename="../screens/SettingsScreen.qml" line="446"/>
         <source>%1 seconds</source>
         <translation>%1초</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="423"/>
+        <location filename="../screens/SettingsScreen.qml" line="489"/>
         <source>Resolution</source>
         <translation>해상도</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="563"/>
+        <location filename="../screens/SettingsScreen.qml" line="453"/>
+        <source>Image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="455"/>
+        <source>Thumbnail</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="457"/>
+        <source>Box art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <source>3D box art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="461"/>
+        <source>Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="463"/>
+        <source>Wheel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="465"/>
+        <source>Title screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="467"/>
+        <source>Map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="469"/>
+        <source>Marquee</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="471"/>
+        <source>Fan art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="473"/>
+        <source>Box side</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <source>Box back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="663"/>
         <source>Settings</source>
         <translation>설정</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="755"/>
+        <location filename="../screens/SettingsScreen.qml" line="857"/>
         <source>No settings available on this platform</source>
         <translation>이 플랫폼에서는 설정을 사용할 수 없습니다</translation>
     </message>
@@ -1057,24 +1160,24 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="185"/>
-        <location filename="../screens/SystemsScreen.qml" line="285"/>
+        <location filename="../screens/SystemsScreen.qml" line="195"/>
+        <location filename="../screens/SystemsScreen.qml" line="292"/>
         <source>%1 systems</source>
         <translation>시스템 %1개</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="189"/>
-        <location filename="../screens/SystemsScreen.qml" line="302"/>
+        <location filename="../screens/SystemsScreen.qml" line="196"/>
+        <location filename="../screens/SystemsScreen.qml" line="309"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="317"/>
+        <location filename="../screens/SystemsScreen.qml" line="324"/>
         <source>No systems in this category</source>
         <translation>이 카테고리에는 시스템이 없습니다</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="318"/>
+        <location filename="../screens/SystemsScreen.qml" line="325"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -90,47 +90,47 @@
         <translation type="unfinished">Laden…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <location filename="../components/BrowseDetailPane.qml" line="77"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <location filename="../components/BrowseDetailPane.qml" line="79"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <location filename="../components/BrowseDetailPane.qml" line="81"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <location filename="../components/BrowseDetailPane.qml" line="83"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="55"/>
+        <location filename="../components/BrowseDetailPane.qml" line="85"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="57"/>
+        <location filename="../components/BrowseDetailPane.qml" line="87"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="59"/>
+        <location filename="../components/BrowseDetailPane.qml" line="89"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="61"/>
+        <location filename="../components/BrowseDetailPane.qml" line="91"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="63"/>
+        <location filename="../components/BrowseDetailPane.qml" line="93"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
@@ -329,34 +329,34 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="109"/>
-        <location filename="../screens/GamesScreen.qml" line="138"/>
+        <location filename="../screens/GamesScreen.qml" line="117"/>
+        <location filename="../screens/GamesScreen.qml" line="145"/>
         <source>%1 files</source>
         <translation>%1 bestanden</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="40"/>
+        <location filename="../screens/GamesScreen.qml" line="51"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="118"/>
-        <location filename="../screens/GamesScreen.qml" line="139"/>
+        <location filename="../screens/GamesScreen.qml" line="126"/>
+        <location filename="../screens/GamesScreen.qml" line="146"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="34"/>
+        <location filename="../screens/GamesScreen.qml" line="45"/>
         <source>Loading games…</source>
         <translation>Games laden…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="114"/>
+        <location filename="../screens/GamesScreen.qml" line="122"/>
         <source>Loading more…</source>
         <translation>Meer laden…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="33"/>
+        <location filename="../screens/GamesScreen.qml" line="44"/>
         <source>No games in this system</source>
         <translation>Geen games in dit systeem</translation>
     </message>
@@ -434,7 +434,7 @@
     </message>
     <message>
         <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="955"/>
+        <location filename="../app/Main.qml" line="958"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
@@ -465,67 +465,67 @@
         <translation>Game starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1769"/>
+        <location filename="../app/Main.qml" line="1776"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1773"/>
+        <location filename="../app/Main.qml" line="1780"/>
         <source>Loading favorites…</source>
         <translation>Favorieten laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1771"/>
+        <location filename="../app/Main.qml" line="1778"/>
         <source>Loading games…</source>
         <translation>Games laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="951"/>
+        <location filename="../app/Main.qml" line="954"/>
         <source>Default</source>
         <translation type="unfinished">Standaard</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="951"/>
+        <location filename="../app/Main.qml" line="954"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1227"/>
+        <location filename="../app/Main.qml" line="1230"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1231"/>
+        <location filename="../app/Main.qml" line="1234"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1245"/>
+        <location filename="../app/Main.qml" line="1248"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1249"/>
+        <location filename="../app/Main.qml" line="1252"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1253"/>
+        <location filename="../app/Main.qml" line="1256"/>
         <source>Retry</source>
         <translation type="unfinished">Opnieuw proberen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1257"/>
+        <location filename="../app/Main.qml" line="1260"/>
         <source>Cancel</source>
         <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
+        <location filename="../app/Main.qml" line="1782"/>
         <source>Loading recently played…</source>
         <translation>Recent gespeeld laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1777"/>
+        <location filename="../app/Main.qml" line="1784"/>
         <source>Loading…</source>
         <translation>Laden…</translation>
     </message>
@@ -533,71 +533,71 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="545"/>
+        <location filename="../app/MainLayout.qml" line="581"/>
         <source>Writing failed</source>
         <translation>Schrijven mislukt</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="545"/>
+        <location filename="../app/MainLayout.qml" line="581"/>
         <source>Put a writable card near the reader</source>
         <translation>Houd een beschrijfbare kaart bij de lezer</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="633"/>
+        <location filename="../app/MainLayout.qml" line="669"/>
         <source>Are you sure you want to exit?</source>
         <translation>Weet u zeker dat u wilt afsluiten?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="709"/>
-        <location filename="../app/MainLayout.qml" line="781"/>
+        <location filename="../app/MainLayout.qml" line="745"/>
+        <location filename="../app/MainLayout.qml" line="817"/>
         <source>Select</source>
         <translation>Selecteren</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="713"/>
-        <location filename="../app/MainLayout.qml" line="717"/>
-        <location filename="../app/MainLayout.qml" line="731"/>
-        <location filename="../app/MainLayout.qml" line="744"/>
-        <location filename="../app/MainLayout.qml" line="755"/>
+        <location filename="../app/MainLayout.qml" line="749"/>
+        <location filename="../app/MainLayout.qml" line="753"/>
+        <location filename="../app/MainLayout.qml" line="767"/>
+        <location filename="../app/MainLayout.qml" line="780"/>
+        <location filename="../app/MainLayout.qml" line="791"/>
         <source>Close</source>
         <translation>Sluiten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="724"/>
-        <location filename="../app/MainLayout.qml" line="762"/>
-        <location filename="../app/MainLayout.qml" line="785"/>
-        <location filename="../app/MainLayout.qml" line="796"/>
+        <location filename="../app/MainLayout.qml" line="760"/>
+        <location filename="../app/MainLayout.qml" line="798"/>
+        <location filename="../app/MainLayout.qml" line="821"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="740"/>
+        <location filename="../app/MainLayout.qml" line="776"/>
         <source>Done</source>
         <translation>Klaar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="770"/>
+        <location filename="../app/MainLayout.qml" line="806"/>
         <source>I understand</source>
         <translation>Ik begrijp het</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="804"/>
+        <location filename="../app/MainLayout.qml" line="840"/>
         <source>Start</source>
         <translation>Starten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="973"/>
+        <location filename="../app/MainLayout.qml" line="1009"/>
         <source>Scroll</source>
         <translation>Scrollen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="705"/>
-        <location filename="../app/MainLayout.qml" line="777"/>
-        <location filename="../app/MainLayout.qml" line="820"/>
-        <location filename="../app/MainLayout.qml" line="849"/>
-        <location filename="../app/MainLayout.qml" line="896"/>
-        <location filename="../app/MainLayout.qml" line="937"/>
-        <location filename="../app/MainLayout.qml" line="1001"/>
+        <location filename="../app/MainLayout.qml" line="741"/>
+        <location filename="../app/MainLayout.qml" line="813"/>
+        <location filename="../app/MainLayout.qml" line="856"/>
+        <location filename="../app/MainLayout.qml" line="885"/>
+        <location filename="../app/MainLayout.qml" line="932"/>
+        <location filename="../app/MainLayout.qml" line="973"/>
+        <location filename="../app/MainLayout.qml" line="1037"/>
         <source>Move</source>
         <translation>Bewegen</translation>
     </message>
@@ -607,77 +607,87 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="556"/>
+        <location filename="../app/MainLayout.qml" line="323"/>
+        <source>Favorites</source>
+        <translation type="unfinished">Favorieten</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="325"/>
+        <source>Recently Played</source>
+        <translation type="unfinished">Recent gespeeld</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="592"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="557"/>
+        <location filename="../app/MainLayout.qml" line="593"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="632"/>
+        <location filename="../app/MainLayout.qml" line="668"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
-        <location filename="../app/MainLayout.qml" line="859"/>
-        <location filename="../app/MainLayout.qml" line="906"/>
-        <location filename="../app/MainLayout.qml" line="1011"/>
+        <location filename="../app/MainLayout.qml" line="860"/>
+        <location filename="../app/MainLayout.qml" line="895"/>
+        <location filename="../app/MainLayout.qml" line="942"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
         <source>Open</source>
         <translation>Openen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="828"/>
+        <location filename="../app/MainLayout.qml" line="864"/>
         <source>Quit</source>
         <translation>Afsluiten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="837"/>
-        <location filename="../app/MainLayout.qml" line="865"/>
-        <location filename="../app/MainLayout.qml" line="876"/>
-        <location filename="../app/MainLayout.qml" line="888"/>
-        <location filename="../app/MainLayout.qml" line="915"/>
-        <location filename="../app/MainLayout.qml" line="926"/>
-        <location filename="../app/MainLayout.qml" line="961"/>
-        <location filename="../app/MainLayout.qml" line="977"/>
-        <location filename="../app/MainLayout.qml" line="986"/>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1031"/>
+        <location filename="../app/MainLayout.qml" line="873"/>
+        <location filename="../app/MainLayout.qml" line="901"/>
+        <location filename="../app/MainLayout.qml" line="912"/>
+        <location filename="../app/MainLayout.qml" line="924"/>
+        <location filename="../app/MainLayout.qml" line="951"/>
+        <location filename="../app/MainLayout.qml" line="962"/>
+        <location filename="../app/MainLayout.qml" line="997"/>
+        <location filename="../app/MainLayout.qml" line="1013"/>
+        <location filename="../app/MainLayout.qml" line="1022"/>
+        <location filename="../app/MainLayout.qml" line="1056"/>
+        <location filename="../app/MainLayout.qml" line="1067"/>
         <source>Back</source>
         <translation>Terug</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="855"/>
-        <location filename="../app/MainLayout.qml" line="902"/>
-        <location filename="../app/MainLayout.qml" line="1007"/>
+        <location filename="../app/MainLayout.qml" line="891"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="1043"/>
         <source>Page</source>
         <translation>Pagina</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="862"/>
-        <location filename="../app/MainLayout.qml" line="911"/>
-        <location filename="../app/MainLayout.qml" line="1016"/>
+        <location filename="../app/MainLayout.qml" line="898"/>
+        <location filename="../app/MainLayout.qml" line="947"/>
+        <location filename="../app/MainLayout.qml" line="1052"/>
         <source>Options</source>
         <translation>Opties</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="751"/>
-        <location filename="../app/MainLayout.qml" line="872"/>
-        <location filename="../app/MainLayout.qml" line="922"/>
-        <location filename="../app/MainLayout.qml" line="1027"/>
+        <location filename="../app/MainLayout.qml" line="787"/>
+        <location filename="../app/MainLayout.qml" line="908"/>
+        <location filename="../app/MainLayout.qml" line="958"/>
+        <location filename="../app/MainLayout.qml" line="1063"/>
         <source>Retry</source>
         <translation>Opnieuw proberen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="946"/>
+        <location filename="../app/MainLayout.qml" line="982"/>
         <source>Change</source>
         <translation>Wijzigen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="952"/>
+        <location filename="../app/MainLayout.qml" line="988"/>
         <source>Toggle</source>
         <translation>Schakelen</translation>
     </message>
@@ -690,12 +700,12 @@
         <translation type="unfinished">Laden…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="295"/>
+        <location filename="../screens/MediaListScreen.qml" line="306"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 items</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="296"/>
+        <location filename="../screens/MediaListScreen.qml" line="307"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -763,23 +773,23 @@
     <name>SettingsScreen</name>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="73"/>
-        <location filename="../screens/SettingsScreen.qml" line="432"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Language</source>
         <translation>Taal</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78"/>
-        <location filename="../screens/SettingsScreen.qml" line="441"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="516"/>
         <source>Browsing layout</source>
         <translation>Bladerlayout</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116"/>
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
         <source>Mouse support</source>
         <translation>Muisondersteuning</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="112"/>
         <source>Update media database</source>
         <translation>Mediadatabase bijwerken</translation>
     </message>
@@ -789,267 +799,360 @@
         <translation>Algemeen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="450"/>
+        <location filename="../screens/SettingsScreen.qml" line="78"/>
+        <location filename="../screens/SettingsScreen.qml" line="507"/>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="88"/>
+        <location filename="../screens/SettingsScreen.qml" line="525"/>
         <source>Button style</source>
         <translation>Knopstijl</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88"/>
-        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <location filename="../screens/SettingsScreen.qml" line="93"/>
+        <location filename="../screens/SettingsScreen.qml" line="534"/>
         <source>Screensaver</source>
         <translation>Schermbeveiliging</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="92"/>
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
         <source>Library</source>
         <translation>Bibliotheek</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
+        <location filename="../screens/SettingsScreen.qml" line="543"/>
+        <source>Preferred artwork</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
         <source>Scrape metadata</source>
         <translation>Metadata ophalen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <source>Re-scrape existing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Advanced</source>
         <translation>Geavanceerd</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121"/>
+        <location filename="../screens/SettingsScreen.qml" line="136"/>
         <source>Debug logging</source>
         <translation>Debug-logging</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
+        <location filename="../screens/SettingsScreen.qml" line="141"/>
         <source>Upload log file</source>
         <translation>Logbestand uploaden</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="146"/>
         <source>About / License</source>
         <translation>Over / Licentie</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147"/>
+        <location filename="../screens/SettingsScreen.qml" line="162"/>
         <source>Optimizing</source>
         <translation>Optimaliseren</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149"/>
-        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="173"/>
         <source>Paused</source>
         <translation>Gepauzeerd</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149"/>
-        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="173"/>
         <source>In progress</source>
         <translation>Bezig</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152"/>
+        <location filename="../screens/SettingsScreen.qml" line="167"/>
         <source>%1 indexed</source>
         <translation>%1 geïndexeerd</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="161"/>
+        <location filename="../screens/SettingsScreen.qml" line="176"/>
         <source>%1 scraped</source>
         <translation>%1 opgehaald</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="266"/>
+        <location filename="../screens/SettingsScreen.qml" line="284"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="266"/>
+        <location filename="../screens/SettingsScreen.qml" line="284"/>
         <source>Start</source>
         <translation>Starten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="268"/>
+        <location filename="../screens/SettingsScreen.qml" line="286"/>
         <source>Upload</source>
         <translation>Uploaden</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <location filename="../screens/SettingsScreen.qml" line="288"/>
         <source>Open</source>
         <translation>Openen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="342"/>
+        <location filename="../screens/SettingsScreen.qml" line="365"/>
         <source>English</source>
         <translation>Engels</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="344"/>
+        <location filename="../screens/SettingsScreen.qml" line="367"/>
         <source>Italian</source>
         <translation>Italiaans</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="346"/>
+        <location filename="../screens/SettingsScreen.qml" line="369"/>
         <source>German</source>
         <translation>Duits</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="348"/>
+        <location filename="../screens/SettingsScreen.qml" line="371"/>
         <source>Greek</source>
         <translation>Grieks</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="350"/>
+        <location filename="../screens/SettingsScreen.qml" line="373"/>
         <source>Japanese</source>
         <translation>Japans</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="352"/>
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Korean</source>
         <translation>Koreaans</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
         <source>Dutch</source>
         <translation>Nederlands</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="356"/>
+        <location filename="../screens/SettingsScreen.qml" line="379"/>
         <source>Romanian</source>
         <translation>Roemeens</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="358"/>
+        <location filename="../screens/SettingsScreen.qml" line="381"/>
         <source>Slovak</source>
         <translation>Slowaaks</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="360"/>
+        <location filename="../screens/SettingsScreen.qml" line="383"/>
         <source>Ukrainian</source>
         <translation>Oekraïens</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="362"/>
+        <location filename="../screens/SettingsScreen.qml" line="385"/>
         <source>Chinese (Simplified)</source>
         <translation>Chinees (vereenvoudigd)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="364"/>
+        <location filename="../screens/SettingsScreen.qml" line="387"/>
         <source>Hebrew</source>
         <translation>Hebreeuws</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="366"/>
+        <location filename="../screens/SettingsScreen.qml" line="389"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="368"/>
+        <location filename="../screens/SettingsScreen.qml" line="391"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="392"/>
+        <location filename="../screens/SettingsScreen.qml" line="451"/>
         <source>Auto</source>
         <translation>Automatisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="374"/>
+        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <source>Rotated CW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <source>Rotated CCW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="400"/>
+        <source>Horizontal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="405"/>
         <source>Detailed list view</source>
         <translation>Gedetailleerde lijstweergave</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="375"/>
+        <location filename="../screens/SettingsScreen.qml" line="406"/>
         <source>Grid view</source>
         <translation>Rasterweergave</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="411"/>
         <source>Style B</source>
         <translation>Stijl B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="382"/>
+        <location filename="../screens/SettingsScreen.qml" line="413"/>
         <source>Style C</source>
         <translation>Stijl C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="384"/>
+        <location filename="../screens/SettingsScreen.qml" line="415"/>
         <source>Style D</source>
         <translation>Stijl D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="385"/>
+        <location filename="../screens/SettingsScreen.qml" line="416"/>
         <source>Style A</source>
         <translation>Stijl A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="322"/>
+        <location filename="../screens/SettingsScreen.qml" line="340"/>
         <source>Default</source>
         <translation>Standaard</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="395"/>
+        <location filename="../screens/SettingsScreen.qml" line="431"/>
         <source>Off</source>
         <translation>Uit</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <location filename="../screens/SettingsScreen.qml" line="433"/>
         <source>1 second (testing)</source>
         <translation>1 seconde (test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <location filename="../screens/SettingsScreen.qml" line="435"/>
         <source>1 minute</source>
         <translation>1 minuut</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="401"/>
+        <location filename="../screens/SettingsScreen.qml" line="437"/>
         <source>2 minutes</source>
         <translation>2 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="403"/>
+        <location filename="../screens/SettingsScreen.qml" line="439"/>
         <source>5 minutes</source>
         <translation>5 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405"/>
+        <location filename="../screens/SettingsScreen.qml" line="441"/>
         <source>10 minutes</source>
         <translation>10 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="407"/>
+        <location filename="../screens/SettingsScreen.qml" line="443"/>
         <source>15 minutes</source>
         <translation>15 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="409"/>
+        <location filename="../screens/SettingsScreen.qml" line="445"/>
         <source>30 minutes</source>
         <translation>30 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="410"/>
+        <location filename="../screens/SettingsScreen.qml" line="446"/>
         <source>%1 seconds</source>
         <translation>%1 seconden</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="423"/>
+        <location filename="../screens/SettingsScreen.qml" line="489"/>
         <source>Resolution</source>
         <translation>Resolutie</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="563"/>
+        <location filename="../screens/SettingsScreen.qml" line="453"/>
+        <source>Image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="455"/>
+        <source>Thumbnail</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="457"/>
+        <source>Box art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <source>3D box art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="461"/>
+        <source>Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="463"/>
+        <source>Wheel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="465"/>
+        <source>Title screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="467"/>
+        <source>Map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="469"/>
+        <source>Marquee</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="471"/>
+        <source>Fan art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="473"/>
+        <source>Box side</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <source>Box back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="663"/>
         <source>Settings</source>
         <translation>Instellingen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="755"/>
+        <location filename="../screens/SettingsScreen.qml" line="857"/>
         <source>No settings available on this platform</source>
         <translation>Geen instellingen beschikbaar op dit platform</translation>
     </message>
@@ -1057,24 +1160,24 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="185"/>
-        <location filename="../screens/SystemsScreen.qml" line="285"/>
+        <location filename="../screens/SystemsScreen.qml" line="195"/>
+        <location filename="../screens/SystemsScreen.qml" line="292"/>
         <source>%1 systems</source>
         <translation>%1 systemen</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="189"/>
-        <location filename="../screens/SystemsScreen.qml" line="302"/>
+        <location filename="../screens/SystemsScreen.qml" line="196"/>
+        <location filename="../screens/SystemsScreen.qml" line="309"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="317"/>
+        <location filename="../screens/SystemsScreen.qml" line="324"/>
         <source>No systems in this category</source>
         <translation>Geen systemen in deze categorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="318"/>
+        <location filename="../screens/SystemsScreen.qml" line="325"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -90,47 +90,47 @@
         <translation type="unfinished">Se încarcă…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <location filename="../components/BrowseDetailPane.qml" line="77"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <location filename="../components/BrowseDetailPane.qml" line="79"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <location filename="../components/BrowseDetailPane.qml" line="81"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <location filename="../components/BrowseDetailPane.qml" line="83"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="55"/>
+        <location filename="../components/BrowseDetailPane.qml" line="85"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="57"/>
+        <location filename="../components/BrowseDetailPane.qml" line="87"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="59"/>
+        <location filename="../components/BrowseDetailPane.qml" line="89"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="61"/>
+        <location filename="../components/BrowseDetailPane.qml" line="91"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="63"/>
+        <location filename="../components/BrowseDetailPane.qml" line="93"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
@@ -329,34 +329,34 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="109"/>
-        <location filename="../screens/GamesScreen.qml" line="138"/>
+        <location filename="../screens/GamesScreen.qml" line="117"/>
+        <location filename="../screens/GamesScreen.qml" line="145"/>
         <source>%1 files</source>
         <translation>%1 fișiere</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="40"/>
+        <location filename="../screens/GamesScreen.qml" line="51"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="118"/>
-        <location filename="../screens/GamesScreen.qml" line="139"/>
+        <location filename="../screens/GamesScreen.qml" line="126"/>
+        <location filename="../screens/GamesScreen.qml" line="146"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="34"/>
+        <location filename="../screens/GamesScreen.qml" line="45"/>
         <source>Loading games…</source>
         <translation>Se încarcă jocurile…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="114"/>
+        <location filename="../screens/GamesScreen.qml" line="122"/>
         <source>Loading more…</source>
         <translation>Se încarcă mai multe…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="33"/>
+        <location filename="../screens/GamesScreen.qml" line="44"/>
         <source>No games in this system</source>
         <translation>Niciun joc în acest sistem</translation>
     </message>
@@ -434,7 +434,7 @@
     </message>
     <message>
         <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="955"/>
+        <location filename="../app/Main.qml" line="958"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
@@ -465,67 +465,67 @@
         <translation>Lansare joc</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1769"/>
+        <location filename="../app/Main.qml" line="1776"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1773"/>
+        <location filename="../app/Main.qml" line="1780"/>
         <source>Loading favorites…</source>
         <translation>Se încarcă favoritele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1771"/>
+        <location filename="../app/Main.qml" line="1778"/>
         <source>Loading games…</source>
         <translation>Se încarcă jocurile…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="951"/>
+        <location filename="../app/Main.qml" line="954"/>
         <source>Default</source>
         <translation type="unfinished">Implicit</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="951"/>
+        <location filename="../app/Main.qml" line="954"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1227"/>
+        <location filename="../app/Main.qml" line="1230"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1231"/>
+        <location filename="../app/Main.qml" line="1234"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1245"/>
+        <location filename="../app/Main.qml" line="1248"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1249"/>
+        <location filename="../app/Main.qml" line="1252"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1253"/>
+        <location filename="../app/Main.qml" line="1256"/>
         <source>Retry</source>
         <translation type="unfinished">Reîncercare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1257"/>
+        <location filename="../app/Main.qml" line="1260"/>
         <source>Cancel</source>
         <translation type="unfinished">Anulare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
+        <location filename="../app/Main.qml" line="1782"/>
         <source>Loading recently played…</source>
         <translation>Se încarcă recent jucatele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1777"/>
+        <location filename="../app/Main.qml" line="1784"/>
         <source>Loading…</source>
         <translation>Se încarcă…</translation>
     </message>
@@ -533,71 +533,71 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="545"/>
+        <location filename="../app/MainLayout.qml" line="581"/>
         <source>Writing failed</source>
         <translation>Scriere eșuată</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="545"/>
+        <location filename="../app/MainLayout.qml" line="581"/>
         <source>Put a writable card near the reader</source>
         <translation>Apropiați un card inscriptibil de cititor</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="633"/>
+        <location filename="../app/MainLayout.qml" line="669"/>
         <source>Are you sure you want to exit?</source>
         <translation>Sigur doriți să ieșiți?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="709"/>
-        <location filename="../app/MainLayout.qml" line="781"/>
+        <location filename="../app/MainLayout.qml" line="745"/>
+        <location filename="../app/MainLayout.qml" line="817"/>
         <source>Select</source>
         <translation>Selectare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="713"/>
-        <location filename="../app/MainLayout.qml" line="717"/>
-        <location filename="../app/MainLayout.qml" line="731"/>
-        <location filename="../app/MainLayout.qml" line="744"/>
-        <location filename="../app/MainLayout.qml" line="755"/>
+        <location filename="../app/MainLayout.qml" line="749"/>
+        <location filename="../app/MainLayout.qml" line="753"/>
+        <location filename="../app/MainLayout.qml" line="767"/>
+        <location filename="../app/MainLayout.qml" line="780"/>
+        <location filename="../app/MainLayout.qml" line="791"/>
         <source>Close</source>
         <translation>Închidere</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="724"/>
-        <location filename="../app/MainLayout.qml" line="762"/>
-        <location filename="../app/MainLayout.qml" line="785"/>
-        <location filename="../app/MainLayout.qml" line="796"/>
+        <location filename="../app/MainLayout.qml" line="760"/>
+        <location filename="../app/MainLayout.qml" line="798"/>
+        <location filename="../app/MainLayout.qml" line="821"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Cancel</source>
         <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="740"/>
+        <location filename="../app/MainLayout.qml" line="776"/>
         <source>Done</source>
         <translation>Gata</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="770"/>
+        <location filename="../app/MainLayout.qml" line="806"/>
         <source>I understand</source>
         <translation>Am înțeles</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="804"/>
+        <location filename="../app/MainLayout.qml" line="840"/>
         <source>Start</source>
         <translation>Pornire</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="973"/>
+        <location filename="../app/MainLayout.qml" line="1009"/>
         <source>Scroll</source>
         <translation>Derulare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="705"/>
-        <location filename="../app/MainLayout.qml" line="777"/>
-        <location filename="../app/MainLayout.qml" line="820"/>
-        <location filename="../app/MainLayout.qml" line="849"/>
-        <location filename="../app/MainLayout.qml" line="896"/>
-        <location filename="../app/MainLayout.qml" line="937"/>
-        <location filename="../app/MainLayout.qml" line="1001"/>
+        <location filename="../app/MainLayout.qml" line="741"/>
+        <location filename="../app/MainLayout.qml" line="813"/>
+        <location filename="../app/MainLayout.qml" line="856"/>
+        <location filename="../app/MainLayout.qml" line="885"/>
+        <location filename="../app/MainLayout.qml" line="932"/>
+        <location filename="../app/MainLayout.qml" line="973"/>
+        <location filename="../app/MainLayout.qml" line="1037"/>
         <source>Move</source>
         <translation>Mutare</translation>
     </message>
@@ -607,77 +607,87 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="556"/>
+        <location filename="../app/MainLayout.qml" line="323"/>
+        <source>Favorites</source>
+        <translation type="unfinished">Favorite</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="325"/>
+        <source>Recently Played</source>
+        <translation type="unfinished">Recent Jucate</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="592"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="557"/>
+        <location filename="../app/MainLayout.qml" line="593"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="632"/>
+        <location filename="../app/MainLayout.qml" line="668"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
-        <location filename="../app/MainLayout.qml" line="859"/>
-        <location filename="../app/MainLayout.qml" line="906"/>
-        <location filename="../app/MainLayout.qml" line="1011"/>
+        <location filename="../app/MainLayout.qml" line="860"/>
+        <location filename="../app/MainLayout.qml" line="895"/>
+        <location filename="../app/MainLayout.qml" line="942"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
         <source>Open</source>
         <translation>Deschidere</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="828"/>
+        <location filename="../app/MainLayout.qml" line="864"/>
         <source>Quit</source>
         <translation>Ieșire</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="837"/>
-        <location filename="../app/MainLayout.qml" line="865"/>
-        <location filename="../app/MainLayout.qml" line="876"/>
-        <location filename="../app/MainLayout.qml" line="888"/>
-        <location filename="../app/MainLayout.qml" line="915"/>
-        <location filename="../app/MainLayout.qml" line="926"/>
-        <location filename="../app/MainLayout.qml" line="961"/>
-        <location filename="../app/MainLayout.qml" line="977"/>
-        <location filename="../app/MainLayout.qml" line="986"/>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1031"/>
+        <location filename="../app/MainLayout.qml" line="873"/>
+        <location filename="../app/MainLayout.qml" line="901"/>
+        <location filename="../app/MainLayout.qml" line="912"/>
+        <location filename="../app/MainLayout.qml" line="924"/>
+        <location filename="../app/MainLayout.qml" line="951"/>
+        <location filename="../app/MainLayout.qml" line="962"/>
+        <location filename="../app/MainLayout.qml" line="997"/>
+        <location filename="../app/MainLayout.qml" line="1013"/>
+        <location filename="../app/MainLayout.qml" line="1022"/>
+        <location filename="../app/MainLayout.qml" line="1056"/>
+        <location filename="../app/MainLayout.qml" line="1067"/>
         <source>Back</source>
         <translation>Înapoi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="855"/>
-        <location filename="../app/MainLayout.qml" line="902"/>
-        <location filename="../app/MainLayout.qml" line="1007"/>
+        <location filename="../app/MainLayout.qml" line="891"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="1043"/>
         <source>Page</source>
         <translation>Pagină</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="862"/>
-        <location filename="../app/MainLayout.qml" line="911"/>
-        <location filename="../app/MainLayout.qml" line="1016"/>
+        <location filename="../app/MainLayout.qml" line="898"/>
+        <location filename="../app/MainLayout.qml" line="947"/>
+        <location filename="../app/MainLayout.qml" line="1052"/>
         <source>Options</source>
         <translation>Opțiuni</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="751"/>
-        <location filename="../app/MainLayout.qml" line="872"/>
-        <location filename="../app/MainLayout.qml" line="922"/>
-        <location filename="../app/MainLayout.qml" line="1027"/>
+        <location filename="../app/MainLayout.qml" line="787"/>
+        <location filename="../app/MainLayout.qml" line="908"/>
+        <location filename="../app/MainLayout.qml" line="958"/>
+        <location filename="../app/MainLayout.qml" line="1063"/>
         <source>Retry</source>
         <translation>Reîncercare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="946"/>
+        <location filename="../app/MainLayout.qml" line="982"/>
         <source>Change</source>
         <translation>Schimbare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="952"/>
+        <location filename="../app/MainLayout.qml" line="988"/>
         <source>Toggle</source>
         <translation>Comutare</translation>
     </message>
@@ -690,12 +700,12 @@
         <translation type="unfinished">Se încarcă…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="295"/>
+        <location filename="../screens/MediaListScreen.qml" line="306"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 intrări</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="296"/>
+        <location filename="../screens/MediaListScreen.qml" line="307"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -763,23 +773,23 @@
     <name>SettingsScreen</name>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="73"/>
-        <location filename="../screens/SettingsScreen.qml" line="432"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Language</source>
         <translation>Limbă</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78"/>
-        <location filename="../screens/SettingsScreen.qml" line="441"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="516"/>
         <source>Browsing layout</source>
         <translation>Aspect navigare</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116"/>
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
         <source>Mouse support</source>
         <translation>Suport mouse</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="112"/>
         <source>Update media database</source>
         <translation>Actualizare bază de date media</translation>
     </message>
@@ -789,267 +799,360 @@
         <translation>Generale</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="450"/>
+        <location filename="../screens/SettingsScreen.qml" line="78"/>
+        <location filename="../screens/SettingsScreen.qml" line="507"/>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="88"/>
+        <location filename="../screens/SettingsScreen.qml" line="525"/>
         <source>Button style</source>
         <translation>Stil butoane</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88"/>
-        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <location filename="../screens/SettingsScreen.qml" line="93"/>
+        <location filename="../screens/SettingsScreen.qml" line="534"/>
         <source>Screensaver</source>
         <translation>Economizor de ecran</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="92"/>
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
         <source>Library</source>
         <translation>Bibliotecă</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
+        <location filename="../screens/SettingsScreen.qml" line="543"/>
+        <source>Preferred artwork</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
         <source>Scrape metadata</source>
         <translation>Extragere metadate</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <source>Re-scrape existing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Advanced</source>
         <translation>Avansat</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121"/>
+        <location filename="../screens/SettingsScreen.qml" line="136"/>
         <source>Debug logging</source>
         <translation>Jurnal depanare</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
+        <location filename="../screens/SettingsScreen.qml" line="141"/>
         <source>Upload log file</source>
         <translation>Încărcare fișier jurnal</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="146"/>
         <source>About / License</source>
         <translation>Despre / Licență</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147"/>
+        <location filename="../screens/SettingsScreen.qml" line="162"/>
         <source>Optimizing</source>
         <translation>Optimizare</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149"/>
-        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="173"/>
         <source>Paused</source>
         <translation>În pauză</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149"/>
-        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="173"/>
         <source>In progress</source>
         <translation>În curs</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152"/>
+        <location filename="../screens/SettingsScreen.qml" line="167"/>
         <source>%1 indexed</source>
         <translation>%1 indexate</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="161"/>
+        <location filename="../screens/SettingsScreen.qml" line="176"/>
         <source>%1 scraped</source>
         <translation>%1 extrase</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="266"/>
+        <location filename="../screens/SettingsScreen.qml" line="284"/>
         <source>Cancel</source>
         <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="266"/>
+        <location filename="../screens/SettingsScreen.qml" line="284"/>
         <source>Start</source>
         <translation>Pornire</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="268"/>
+        <location filename="../screens/SettingsScreen.qml" line="286"/>
         <source>Upload</source>
         <translation>Încărcare</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <location filename="../screens/SettingsScreen.qml" line="288"/>
         <source>Open</source>
         <translation>Deschidere</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="342"/>
+        <location filename="../screens/SettingsScreen.qml" line="365"/>
         <source>English</source>
         <translation>Engleză</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="344"/>
+        <location filename="../screens/SettingsScreen.qml" line="367"/>
         <source>Italian</source>
         <translation>Italiană</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="346"/>
+        <location filename="../screens/SettingsScreen.qml" line="369"/>
         <source>German</source>
         <translation>Germană</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="348"/>
+        <location filename="../screens/SettingsScreen.qml" line="371"/>
         <source>Greek</source>
         <translation>Greacă</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="350"/>
+        <location filename="../screens/SettingsScreen.qml" line="373"/>
         <source>Japanese</source>
         <translation>Japoneză</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="352"/>
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Korean</source>
         <translation>Coreeană</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
         <source>Dutch</source>
         <translation>Olandeză</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="356"/>
+        <location filename="../screens/SettingsScreen.qml" line="379"/>
         <source>Romanian</source>
         <translation>Română</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="358"/>
+        <location filename="../screens/SettingsScreen.qml" line="381"/>
         <source>Slovak</source>
         <translation>Slovacă</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="360"/>
+        <location filename="../screens/SettingsScreen.qml" line="383"/>
         <source>Ukrainian</source>
         <translation>Ucraineană</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="362"/>
+        <location filename="../screens/SettingsScreen.qml" line="385"/>
         <source>Chinese (Simplified)</source>
         <translation>Chineză (simplificată)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="364"/>
+        <location filename="../screens/SettingsScreen.qml" line="387"/>
         <source>Hebrew</source>
         <translation>Ebraică</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="366"/>
+        <location filename="../screens/SettingsScreen.qml" line="389"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="368"/>
+        <location filename="../screens/SettingsScreen.qml" line="391"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="392"/>
+        <location filename="../screens/SettingsScreen.qml" line="451"/>
         <source>Auto</source>
         <translation>Automat</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="374"/>
+        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <source>Rotated CW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <source>Rotated CCW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="400"/>
+        <source>Horizontal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="405"/>
         <source>Detailed list view</source>
         <translation>Vizualizare listă detaliată</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="375"/>
+        <location filename="../screens/SettingsScreen.qml" line="406"/>
         <source>Grid view</source>
         <translation>Vizualizare grilă</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="411"/>
         <source>Style B</source>
         <translation>Stil B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="382"/>
+        <location filename="../screens/SettingsScreen.qml" line="413"/>
         <source>Style C</source>
         <translation>Stil C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="384"/>
+        <location filename="../screens/SettingsScreen.qml" line="415"/>
         <source>Style D</source>
         <translation>Stil D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="385"/>
+        <location filename="../screens/SettingsScreen.qml" line="416"/>
         <source>Style A</source>
         <translation>Stil A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="322"/>
+        <location filename="../screens/SettingsScreen.qml" line="340"/>
         <source>Default</source>
         <translation>Implicit</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="395"/>
+        <location filename="../screens/SettingsScreen.qml" line="431"/>
         <source>Off</source>
         <translation>Dezactivat</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <location filename="../screens/SettingsScreen.qml" line="433"/>
         <source>1 second (testing)</source>
         <translation>1 secundă (test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <location filename="../screens/SettingsScreen.qml" line="435"/>
         <source>1 minute</source>
         <translation>1 minut</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="401"/>
+        <location filename="../screens/SettingsScreen.qml" line="437"/>
         <source>2 minutes</source>
         <translation>2 minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="403"/>
+        <location filename="../screens/SettingsScreen.qml" line="439"/>
         <source>5 minutes</source>
         <translation>5 minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405"/>
+        <location filename="../screens/SettingsScreen.qml" line="441"/>
         <source>10 minutes</source>
         <translation>10 minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="407"/>
+        <location filename="../screens/SettingsScreen.qml" line="443"/>
         <source>15 minutes</source>
         <translation>15 minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="409"/>
+        <location filename="../screens/SettingsScreen.qml" line="445"/>
         <source>30 minutes</source>
         <translation>30 de minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="410"/>
+        <location filename="../screens/SettingsScreen.qml" line="446"/>
         <source>%1 seconds</source>
         <translation>%1 secunde</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="423"/>
+        <location filename="../screens/SettingsScreen.qml" line="489"/>
         <source>Resolution</source>
         <translation>Rezoluție</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="563"/>
+        <location filename="../screens/SettingsScreen.qml" line="453"/>
+        <source>Image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="455"/>
+        <source>Thumbnail</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="457"/>
+        <source>Box art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <source>3D box art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="461"/>
+        <source>Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="463"/>
+        <source>Wheel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="465"/>
+        <source>Title screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="467"/>
+        <source>Map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="469"/>
+        <source>Marquee</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="471"/>
+        <source>Fan art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="473"/>
+        <source>Box side</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <source>Box back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="663"/>
         <source>Settings</source>
         <translation>Setări</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="755"/>
+        <location filename="../screens/SettingsScreen.qml" line="857"/>
         <source>No settings available on this platform</source>
         <translation>Nicio setare disponibilă pe această platformă</translation>
     </message>
@@ -1057,24 +1160,24 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="185"/>
-        <location filename="../screens/SystemsScreen.qml" line="285"/>
+        <location filename="../screens/SystemsScreen.qml" line="195"/>
+        <location filename="../screens/SystemsScreen.qml" line="292"/>
         <source>%1 systems</source>
         <translation>%1 sisteme</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="189"/>
-        <location filename="../screens/SystemsScreen.qml" line="302"/>
+        <location filename="../screens/SystemsScreen.qml" line="196"/>
+        <location filename="../screens/SystemsScreen.qml" line="309"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="317"/>
+        <location filename="../screens/SystemsScreen.qml" line="324"/>
         <source>No systems in this category</source>
         <translation>Niciun sistem în această categorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="318"/>
+        <location filename="../screens/SystemsScreen.qml" line="325"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -90,47 +90,47 @@
         <translation type="unfinished">Načítanie…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <location filename="../components/BrowseDetailPane.qml" line="77"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <location filename="../components/BrowseDetailPane.qml" line="79"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <location filename="../components/BrowseDetailPane.qml" line="81"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <location filename="../components/BrowseDetailPane.qml" line="83"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="55"/>
+        <location filename="../components/BrowseDetailPane.qml" line="85"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="57"/>
+        <location filename="../components/BrowseDetailPane.qml" line="87"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="59"/>
+        <location filename="../components/BrowseDetailPane.qml" line="89"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="61"/>
+        <location filename="../components/BrowseDetailPane.qml" line="91"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="63"/>
+        <location filename="../components/BrowseDetailPane.qml" line="93"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
@@ -329,34 +329,34 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="109"/>
-        <location filename="../screens/GamesScreen.qml" line="138"/>
+        <location filename="../screens/GamesScreen.qml" line="117"/>
+        <location filename="../screens/GamesScreen.qml" line="145"/>
         <source>%1 files</source>
         <translation>%1 súborov</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="40"/>
+        <location filename="../screens/GamesScreen.qml" line="51"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="118"/>
-        <location filename="../screens/GamesScreen.qml" line="139"/>
+        <location filename="../screens/GamesScreen.qml" line="126"/>
+        <location filename="../screens/GamesScreen.qml" line="146"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="34"/>
+        <location filename="../screens/GamesScreen.qml" line="45"/>
         <source>Loading games…</source>
         <translation>Načítanie hier…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="114"/>
+        <location filename="../screens/GamesScreen.qml" line="122"/>
         <source>Loading more…</source>
         <translation>Načítava sa viac…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="33"/>
+        <location filename="../screens/GamesScreen.qml" line="44"/>
         <source>No games in this system</source>
         <translation>V tomto systéme nie sú žiadne hry</translation>
     </message>
@@ -434,7 +434,7 @@
     </message>
     <message>
         <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="955"/>
+        <location filename="../app/Main.qml" line="958"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
@@ -465,67 +465,67 @@
         <translation>Spustiť hru</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1769"/>
+        <location filename="../app/Main.qml" line="1776"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1773"/>
+        <location filename="../app/Main.qml" line="1780"/>
         <source>Loading favorites…</source>
         <translation>Načítanie obľúbených…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1771"/>
+        <location filename="../app/Main.qml" line="1778"/>
         <source>Loading games…</source>
         <translation>Načítanie hier…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="951"/>
+        <location filename="../app/Main.qml" line="954"/>
         <source>Default</source>
         <translation type="unfinished">Predvolené</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="951"/>
+        <location filename="../app/Main.qml" line="954"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1227"/>
+        <location filename="../app/Main.qml" line="1230"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1231"/>
+        <location filename="../app/Main.qml" line="1234"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1245"/>
+        <location filename="../app/Main.qml" line="1248"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1249"/>
+        <location filename="../app/Main.qml" line="1252"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1253"/>
+        <location filename="../app/Main.qml" line="1256"/>
         <source>Retry</source>
         <translation type="unfinished">Skúsiť znova</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1257"/>
+        <location filename="../app/Main.qml" line="1260"/>
         <source>Cancel</source>
         <translation type="unfinished">Zrušiť</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
+        <location filename="../app/Main.qml" line="1782"/>
         <source>Loading recently played…</source>
         <translation>Načítanie nedávno hraných…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1777"/>
+        <location filename="../app/Main.qml" line="1784"/>
         <source>Loading…</source>
         <translation>Načítanie…</translation>
     </message>
@@ -533,71 +533,71 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="545"/>
+        <location filename="../app/MainLayout.qml" line="581"/>
         <source>Writing failed</source>
         <translation>Zápis zlyhal</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="545"/>
+        <location filename="../app/MainLayout.qml" line="581"/>
         <source>Put a writable card near the reader</source>
         <translation>Priložte zapisovateľnú kartu k čítačke</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="633"/>
+        <location filename="../app/MainLayout.qml" line="669"/>
         <source>Are you sure you want to exit?</source>
         <translation>Naozaj chcete ukončiť?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="709"/>
-        <location filename="../app/MainLayout.qml" line="781"/>
+        <location filename="../app/MainLayout.qml" line="745"/>
+        <location filename="../app/MainLayout.qml" line="817"/>
         <source>Select</source>
         <translation>Vybrať</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="713"/>
-        <location filename="../app/MainLayout.qml" line="717"/>
-        <location filename="../app/MainLayout.qml" line="731"/>
-        <location filename="../app/MainLayout.qml" line="744"/>
-        <location filename="../app/MainLayout.qml" line="755"/>
+        <location filename="../app/MainLayout.qml" line="749"/>
+        <location filename="../app/MainLayout.qml" line="753"/>
+        <location filename="../app/MainLayout.qml" line="767"/>
+        <location filename="../app/MainLayout.qml" line="780"/>
+        <location filename="../app/MainLayout.qml" line="791"/>
         <source>Close</source>
         <translation>Zavrieť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="724"/>
-        <location filename="../app/MainLayout.qml" line="762"/>
-        <location filename="../app/MainLayout.qml" line="785"/>
-        <location filename="../app/MainLayout.qml" line="796"/>
+        <location filename="../app/MainLayout.qml" line="760"/>
+        <location filename="../app/MainLayout.qml" line="798"/>
+        <location filename="../app/MainLayout.qml" line="821"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Cancel</source>
         <translation>Zrušiť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="740"/>
+        <location filename="../app/MainLayout.qml" line="776"/>
         <source>Done</source>
         <translation>Hotovo</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="770"/>
+        <location filename="../app/MainLayout.qml" line="806"/>
         <source>I understand</source>
         <translation>Rozumiem</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="804"/>
+        <location filename="../app/MainLayout.qml" line="840"/>
         <source>Start</source>
         <translation>Spustiť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="973"/>
+        <location filename="../app/MainLayout.qml" line="1009"/>
         <source>Scroll</source>
         <translation>Posúvať</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="705"/>
-        <location filename="../app/MainLayout.qml" line="777"/>
-        <location filename="../app/MainLayout.qml" line="820"/>
-        <location filename="../app/MainLayout.qml" line="849"/>
-        <location filename="../app/MainLayout.qml" line="896"/>
-        <location filename="../app/MainLayout.qml" line="937"/>
-        <location filename="../app/MainLayout.qml" line="1001"/>
+        <location filename="../app/MainLayout.qml" line="741"/>
+        <location filename="../app/MainLayout.qml" line="813"/>
+        <location filename="../app/MainLayout.qml" line="856"/>
+        <location filename="../app/MainLayout.qml" line="885"/>
+        <location filename="../app/MainLayout.qml" line="932"/>
+        <location filename="../app/MainLayout.qml" line="973"/>
+        <location filename="../app/MainLayout.qml" line="1037"/>
         <source>Move</source>
         <translation>Presunúť</translation>
     </message>
@@ -607,77 +607,87 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="556"/>
+        <location filename="../app/MainLayout.qml" line="323"/>
+        <source>Favorites</source>
+        <translation type="unfinished">Obľúbené</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="325"/>
+        <source>Recently Played</source>
+        <translation type="unfinished">Nedávno hrané</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="592"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="557"/>
+        <location filename="../app/MainLayout.qml" line="593"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="632"/>
+        <location filename="../app/MainLayout.qml" line="668"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
-        <location filename="../app/MainLayout.qml" line="859"/>
-        <location filename="../app/MainLayout.qml" line="906"/>
-        <location filename="../app/MainLayout.qml" line="1011"/>
+        <location filename="../app/MainLayout.qml" line="860"/>
+        <location filename="../app/MainLayout.qml" line="895"/>
+        <location filename="../app/MainLayout.qml" line="942"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
         <source>Open</source>
         <translation>Otvoriť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="828"/>
+        <location filename="../app/MainLayout.qml" line="864"/>
         <source>Quit</source>
         <translation>Ukončiť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="837"/>
-        <location filename="../app/MainLayout.qml" line="865"/>
-        <location filename="../app/MainLayout.qml" line="876"/>
-        <location filename="../app/MainLayout.qml" line="888"/>
-        <location filename="../app/MainLayout.qml" line="915"/>
-        <location filename="../app/MainLayout.qml" line="926"/>
-        <location filename="../app/MainLayout.qml" line="961"/>
-        <location filename="../app/MainLayout.qml" line="977"/>
-        <location filename="../app/MainLayout.qml" line="986"/>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1031"/>
+        <location filename="../app/MainLayout.qml" line="873"/>
+        <location filename="../app/MainLayout.qml" line="901"/>
+        <location filename="../app/MainLayout.qml" line="912"/>
+        <location filename="../app/MainLayout.qml" line="924"/>
+        <location filename="../app/MainLayout.qml" line="951"/>
+        <location filename="../app/MainLayout.qml" line="962"/>
+        <location filename="../app/MainLayout.qml" line="997"/>
+        <location filename="../app/MainLayout.qml" line="1013"/>
+        <location filename="../app/MainLayout.qml" line="1022"/>
+        <location filename="../app/MainLayout.qml" line="1056"/>
+        <location filename="../app/MainLayout.qml" line="1067"/>
         <source>Back</source>
         <translation>Späť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="855"/>
-        <location filename="../app/MainLayout.qml" line="902"/>
-        <location filename="../app/MainLayout.qml" line="1007"/>
+        <location filename="../app/MainLayout.qml" line="891"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="1043"/>
         <source>Page</source>
         <translation>Stránka</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="862"/>
-        <location filename="../app/MainLayout.qml" line="911"/>
-        <location filename="../app/MainLayout.qml" line="1016"/>
+        <location filename="../app/MainLayout.qml" line="898"/>
+        <location filename="../app/MainLayout.qml" line="947"/>
+        <location filename="../app/MainLayout.qml" line="1052"/>
         <source>Options</source>
         <translation>Možnosti</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="751"/>
-        <location filename="../app/MainLayout.qml" line="872"/>
-        <location filename="../app/MainLayout.qml" line="922"/>
-        <location filename="../app/MainLayout.qml" line="1027"/>
+        <location filename="../app/MainLayout.qml" line="787"/>
+        <location filename="../app/MainLayout.qml" line="908"/>
+        <location filename="../app/MainLayout.qml" line="958"/>
+        <location filename="../app/MainLayout.qml" line="1063"/>
         <source>Retry</source>
         <translation>Skúsiť znova</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="946"/>
+        <location filename="../app/MainLayout.qml" line="982"/>
         <source>Change</source>
         <translation>Zmeniť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="952"/>
+        <location filename="../app/MainLayout.qml" line="988"/>
         <source>Toggle</source>
         <translation>Prepínať</translation>
     </message>
@@ -690,12 +700,12 @@
         <translation type="unfinished">Načítanie…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="295"/>
+        <location filename="../screens/MediaListScreen.qml" line="306"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 položiek</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="296"/>
+        <location filename="../screens/MediaListScreen.qml" line="307"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -763,23 +773,23 @@
     <name>SettingsScreen</name>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="73"/>
-        <location filename="../screens/SettingsScreen.qml" line="432"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Language</source>
         <translation>Jazyk</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78"/>
-        <location filename="../screens/SettingsScreen.qml" line="441"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="516"/>
         <source>Browsing layout</source>
         <translation>Rozloženie prehliadania</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116"/>
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
         <source>Mouse support</source>
         <translation>Podpora myši</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="112"/>
         <source>Update media database</source>
         <translation>Aktualizovať databázu médií</translation>
     </message>
@@ -789,267 +799,360 @@
         <translation>Všeobecné</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="450"/>
+        <location filename="../screens/SettingsScreen.qml" line="78"/>
+        <location filename="../screens/SettingsScreen.qml" line="507"/>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="88"/>
+        <location filename="../screens/SettingsScreen.qml" line="525"/>
         <source>Button style</source>
         <translation>Štýl tlačidiel</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88"/>
-        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <location filename="../screens/SettingsScreen.qml" line="93"/>
+        <location filename="../screens/SettingsScreen.qml" line="534"/>
         <source>Screensaver</source>
         <translation>Šetrič obrazovky</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="92"/>
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
         <source>Library</source>
         <translation>Knižnica</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
+        <location filename="../screens/SettingsScreen.qml" line="543"/>
+        <source>Preferred artwork</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
         <source>Scrape metadata</source>
         <translation>Získať metadáta</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <source>Re-scrape existing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Advanced</source>
         <translation>Rozšírené</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121"/>
+        <location filename="../screens/SettingsScreen.qml" line="136"/>
         <source>Debug logging</source>
         <translation>Ladiace záznamy</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
+        <location filename="../screens/SettingsScreen.qml" line="141"/>
         <source>Upload log file</source>
         <translation>Nahrať súbor protokolu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="146"/>
         <source>About / License</source>
         <translation>O aplikácii / Licencia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147"/>
+        <location filename="../screens/SettingsScreen.qml" line="162"/>
         <source>Optimizing</source>
         <translation>Optimalizácia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149"/>
-        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="173"/>
         <source>Paused</source>
         <translation>Pozastavené</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149"/>
-        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="173"/>
         <source>In progress</source>
         <translation>Prebieha</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152"/>
+        <location filename="../screens/SettingsScreen.qml" line="167"/>
         <source>%1 indexed</source>
         <translation>%1 indexovaných</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="161"/>
+        <location filename="../screens/SettingsScreen.qml" line="176"/>
         <source>%1 scraped</source>
         <translation>%1 zozbieraných</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="266"/>
+        <location filename="../screens/SettingsScreen.qml" line="284"/>
         <source>Cancel</source>
         <translation>Zrušiť</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="266"/>
+        <location filename="../screens/SettingsScreen.qml" line="284"/>
         <source>Start</source>
         <translation>Spustiť</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="268"/>
+        <location filename="../screens/SettingsScreen.qml" line="286"/>
         <source>Upload</source>
         <translation>Nahrať</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <location filename="../screens/SettingsScreen.qml" line="288"/>
         <source>Open</source>
         <translation>Otvoriť</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="342"/>
+        <location filename="../screens/SettingsScreen.qml" line="365"/>
         <source>English</source>
         <translation>Angličtina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="344"/>
+        <location filename="../screens/SettingsScreen.qml" line="367"/>
         <source>Italian</source>
         <translation>Taliančina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="346"/>
+        <location filename="../screens/SettingsScreen.qml" line="369"/>
         <source>German</source>
         <translation>Nemčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="348"/>
+        <location filename="../screens/SettingsScreen.qml" line="371"/>
         <source>Greek</source>
         <translation>Gréčtina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="350"/>
+        <location filename="../screens/SettingsScreen.qml" line="373"/>
         <source>Japanese</source>
         <translation>Japončina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="352"/>
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Korean</source>
         <translation>Kórejčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
         <source>Dutch</source>
         <translation>Holandčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="356"/>
+        <location filename="../screens/SettingsScreen.qml" line="379"/>
         <source>Romanian</source>
         <translation>Rumunčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="358"/>
+        <location filename="../screens/SettingsScreen.qml" line="381"/>
         <source>Slovak</source>
         <translation>Slovenčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="360"/>
+        <location filename="../screens/SettingsScreen.qml" line="383"/>
         <source>Ukrainian</source>
         <translation>Ukrajinčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="362"/>
+        <location filename="../screens/SettingsScreen.qml" line="385"/>
         <source>Chinese (Simplified)</source>
         <translation>Čínština (zjednodušená)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="364"/>
+        <location filename="../screens/SettingsScreen.qml" line="387"/>
         <source>Hebrew</source>
         <translation>Hebrejčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="366"/>
+        <location filename="../screens/SettingsScreen.qml" line="389"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="368"/>
+        <location filename="../screens/SettingsScreen.qml" line="391"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="392"/>
+        <location filename="../screens/SettingsScreen.qml" line="451"/>
         <source>Auto</source>
         <translation>Automaticky</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="374"/>
+        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <source>Rotated CW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <source>Rotated CCW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="400"/>
+        <source>Horizontal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="405"/>
         <source>Detailed list view</source>
         <translation>Podrobné zobrazenie zoznamu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="375"/>
+        <location filename="../screens/SettingsScreen.qml" line="406"/>
         <source>Grid view</source>
         <translation>Zobrazenie mriežky</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="411"/>
         <source>Style B</source>
         <translation>Štýl B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="382"/>
+        <location filename="../screens/SettingsScreen.qml" line="413"/>
         <source>Style C</source>
         <translation>Štýl C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="384"/>
+        <location filename="../screens/SettingsScreen.qml" line="415"/>
         <source>Style D</source>
         <translation>Štýl D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="385"/>
+        <location filename="../screens/SettingsScreen.qml" line="416"/>
         <source>Style A</source>
         <translation>Štýl A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="322"/>
+        <location filename="../screens/SettingsScreen.qml" line="340"/>
         <source>Default</source>
         <translation>Predvolené</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="395"/>
+        <location filename="../screens/SettingsScreen.qml" line="431"/>
         <source>Off</source>
         <translation>Vypnuté</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <location filename="../screens/SettingsScreen.qml" line="433"/>
         <source>1 second (testing)</source>
         <translation>1 sekunda (test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <location filename="../screens/SettingsScreen.qml" line="435"/>
         <source>1 minute</source>
         <translation>1 minúta</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="401"/>
+        <location filename="../screens/SettingsScreen.qml" line="437"/>
         <source>2 minutes</source>
         <translation>2 minúty</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="403"/>
+        <location filename="../screens/SettingsScreen.qml" line="439"/>
         <source>5 minutes</source>
         <translation>5 minút</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405"/>
+        <location filename="../screens/SettingsScreen.qml" line="441"/>
         <source>10 minutes</source>
         <translation>10 minút</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="407"/>
+        <location filename="../screens/SettingsScreen.qml" line="443"/>
         <source>15 minutes</source>
         <translation>15 minút</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="409"/>
+        <location filename="../screens/SettingsScreen.qml" line="445"/>
         <source>30 minutes</source>
         <translation>30 minút</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="410"/>
+        <location filename="../screens/SettingsScreen.qml" line="446"/>
         <source>%1 seconds</source>
         <translation>%1 sekúnd</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="423"/>
+        <location filename="../screens/SettingsScreen.qml" line="489"/>
         <source>Resolution</source>
         <translation>Rozlíšenie</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="563"/>
+        <location filename="../screens/SettingsScreen.qml" line="453"/>
+        <source>Image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="455"/>
+        <source>Thumbnail</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="457"/>
+        <source>Box art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <source>3D box art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="461"/>
+        <source>Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="463"/>
+        <source>Wheel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="465"/>
+        <source>Title screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="467"/>
+        <source>Map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="469"/>
+        <source>Marquee</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="471"/>
+        <source>Fan art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="473"/>
+        <source>Box side</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <source>Box back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="663"/>
         <source>Settings</source>
         <translation>Nastavenia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="755"/>
+        <location filename="../screens/SettingsScreen.qml" line="857"/>
         <source>No settings available on this platform</source>
         <translation>Na tejto platforme nie sú dostupné žiadne nastavenia</translation>
     </message>
@@ -1057,24 +1160,24 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="185"/>
-        <location filename="../screens/SystemsScreen.qml" line="285"/>
+        <location filename="../screens/SystemsScreen.qml" line="195"/>
+        <location filename="../screens/SystemsScreen.qml" line="292"/>
         <source>%1 systems</source>
         <translation>%1 systémov</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="189"/>
-        <location filename="../screens/SystemsScreen.qml" line="302"/>
+        <location filename="../screens/SystemsScreen.qml" line="196"/>
+        <location filename="../screens/SystemsScreen.qml" line="309"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="317"/>
+        <location filename="../screens/SystemsScreen.qml" line="324"/>
         <source>No systems in this category</source>
         <translation>V tejto kategórii nie sú žiadne systémy</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="318"/>
+        <location filename="../screens/SystemsScreen.qml" line="325"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -90,47 +90,47 @@
         <translation type="unfinished">Завантаження…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <location filename="../components/BrowseDetailPane.qml" line="77"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <location filename="../components/BrowseDetailPane.qml" line="79"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <location filename="../components/BrowseDetailPane.qml" line="81"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <location filename="../components/BrowseDetailPane.qml" line="83"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="55"/>
+        <location filename="../components/BrowseDetailPane.qml" line="85"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="57"/>
+        <location filename="../components/BrowseDetailPane.qml" line="87"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="59"/>
+        <location filename="../components/BrowseDetailPane.qml" line="89"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="61"/>
+        <location filename="../components/BrowseDetailPane.qml" line="91"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="63"/>
+        <location filename="../components/BrowseDetailPane.qml" line="93"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
@@ -329,34 +329,34 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="109"/>
-        <location filename="../screens/GamesScreen.qml" line="138"/>
+        <location filename="../screens/GamesScreen.qml" line="117"/>
+        <location filename="../screens/GamesScreen.qml" line="145"/>
         <source>%1 files</source>
         <translation>%1 файлів</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="40"/>
+        <location filename="../screens/GamesScreen.qml" line="51"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="118"/>
-        <location filename="../screens/GamesScreen.qml" line="139"/>
+        <location filename="../screens/GamesScreen.qml" line="126"/>
+        <location filename="../screens/GamesScreen.qml" line="146"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="34"/>
+        <location filename="../screens/GamesScreen.qml" line="45"/>
         <source>Loading games…</source>
         <translation>Завантаження ігор…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="114"/>
+        <location filename="../screens/GamesScreen.qml" line="122"/>
         <source>Loading more…</source>
         <translation>Завантаження ще…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="33"/>
+        <location filename="../screens/GamesScreen.qml" line="44"/>
         <source>No games in this system</source>
         <translation>У цій системі немає ігор</translation>
     </message>
@@ -434,7 +434,7 @@
     </message>
     <message>
         <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="955"/>
+        <location filename="../app/Main.qml" line="958"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
@@ -465,67 +465,67 @@
         <translation>Запустити гру</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1769"/>
+        <location filename="../app/Main.qml" line="1776"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1773"/>
+        <location filename="../app/Main.qml" line="1780"/>
         <source>Loading favorites…</source>
         <translation>Завантаження вибраного…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1771"/>
+        <location filename="../app/Main.qml" line="1778"/>
         <source>Loading games…</source>
         <translation>Завантаження ігор…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="951"/>
+        <location filename="../app/Main.qml" line="954"/>
         <source>Default</source>
         <translation type="unfinished">Типовий</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="951"/>
+        <location filename="../app/Main.qml" line="954"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1227"/>
+        <location filename="../app/Main.qml" line="1230"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1231"/>
+        <location filename="../app/Main.qml" line="1234"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1245"/>
+        <location filename="../app/Main.qml" line="1248"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1249"/>
+        <location filename="../app/Main.qml" line="1252"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1253"/>
+        <location filename="../app/Main.qml" line="1256"/>
         <source>Retry</source>
         <translation type="unfinished">Повторити</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1257"/>
+        <location filename="../app/Main.qml" line="1260"/>
         <source>Cancel</source>
         <translation type="unfinished">Скасувати</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
+        <location filename="../app/Main.qml" line="1782"/>
         <source>Loading recently played…</source>
         <translation>Завантаження нещодавніх…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1777"/>
+        <location filename="../app/Main.qml" line="1784"/>
         <source>Loading…</source>
         <translation>Завантаження…</translation>
     </message>
@@ -533,71 +533,71 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="545"/>
+        <location filename="../app/MainLayout.qml" line="581"/>
         <source>Writing failed</source>
         <translation>Помилка запису</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="545"/>
+        <location filename="../app/MainLayout.qml" line="581"/>
         <source>Put a writable card near the reader</source>
         <translation>Прикладіть картку для запису до зчитувача</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="633"/>
+        <location filename="../app/MainLayout.qml" line="669"/>
         <source>Are you sure you want to exit?</source>
         <translation>Ви впевнені, що хочете вийти?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="709"/>
-        <location filename="../app/MainLayout.qml" line="781"/>
+        <location filename="../app/MainLayout.qml" line="745"/>
+        <location filename="../app/MainLayout.qml" line="817"/>
         <source>Select</source>
         <translation>Вибрати</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="713"/>
-        <location filename="../app/MainLayout.qml" line="717"/>
-        <location filename="../app/MainLayout.qml" line="731"/>
-        <location filename="../app/MainLayout.qml" line="744"/>
-        <location filename="../app/MainLayout.qml" line="755"/>
+        <location filename="../app/MainLayout.qml" line="749"/>
+        <location filename="../app/MainLayout.qml" line="753"/>
+        <location filename="../app/MainLayout.qml" line="767"/>
+        <location filename="../app/MainLayout.qml" line="780"/>
+        <location filename="../app/MainLayout.qml" line="791"/>
         <source>Close</source>
         <translation>Закрити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="724"/>
-        <location filename="../app/MainLayout.qml" line="762"/>
-        <location filename="../app/MainLayout.qml" line="785"/>
-        <location filename="../app/MainLayout.qml" line="796"/>
+        <location filename="../app/MainLayout.qml" line="760"/>
+        <location filename="../app/MainLayout.qml" line="798"/>
+        <location filename="../app/MainLayout.qml" line="821"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="740"/>
+        <location filename="../app/MainLayout.qml" line="776"/>
         <source>Done</source>
         <translation>Готово</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="770"/>
+        <location filename="../app/MainLayout.qml" line="806"/>
         <source>I understand</source>
         <translation>Я розумію</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="804"/>
+        <location filename="../app/MainLayout.qml" line="840"/>
         <source>Start</source>
         <translation>Почати</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="973"/>
+        <location filename="../app/MainLayout.qml" line="1009"/>
         <source>Scroll</source>
         <translation>Прокрутка</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="705"/>
-        <location filename="../app/MainLayout.qml" line="777"/>
-        <location filename="../app/MainLayout.qml" line="820"/>
-        <location filename="../app/MainLayout.qml" line="849"/>
-        <location filename="../app/MainLayout.qml" line="896"/>
-        <location filename="../app/MainLayout.qml" line="937"/>
-        <location filename="../app/MainLayout.qml" line="1001"/>
+        <location filename="../app/MainLayout.qml" line="741"/>
+        <location filename="../app/MainLayout.qml" line="813"/>
+        <location filename="../app/MainLayout.qml" line="856"/>
+        <location filename="../app/MainLayout.qml" line="885"/>
+        <location filename="../app/MainLayout.qml" line="932"/>
+        <location filename="../app/MainLayout.qml" line="973"/>
+        <location filename="../app/MainLayout.qml" line="1037"/>
         <source>Move</source>
         <translation>Переміщення</translation>
     </message>
@@ -607,77 +607,87 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="556"/>
+        <location filename="../app/MainLayout.qml" line="323"/>
+        <source>Favorites</source>
+        <translation type="unfinished">Вибране</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="325"/>
+        <source>Recently Played</source>
+        <translation type="unfinished">Нещодавно зіграні</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="592"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="557"/>
+        <location filename="../app/MainLayout.qml" line="593"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="632"/>
+        <location filename="../app/MainLayout.qml" line="668"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
-        <location filename="../app/MainLayout.qml" line="859"/>
-        <location filename="../app/MainLayout.qml" line="906"/>
-        <location filename="../app/MainLayout.qml" line="1011"/>
+        <location filename="../app/MainLayout.qml" line="860"/>
+        <location filename="../app/MainLayout.qml" line="895"/>
+        <location filename="../app/MainLayout.qml" line="942"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
         <source>Open</source>
         <translation>Відкрити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="828"/>
+        <location filename="../app/MainLayout.qml" line="864"/>
         <source>Quit</source>
         <translation>Вийти</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="837"/>
-        <location filename="../app/MainLayout.qml" line="865"/>
-        <location filename="../app/MainLayout.qml" line="876"/>
-        <location filename="../app/MainLayout.qml" line="888"/>
-        <location filename="../app/MainLayout.qml" line="915"/>
-        <location filename="../app/MainLayout.qml" line="926"/>
-        <location filename="../app/MainLayout.qml" line="961"/>
-        <location filename="../app/MainLayout.qml" line="977"/>
-        <location filename="../app/MainLayout.qml" line="986"/>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1031"/>
+        <location filename="../app/MainLayout.qml" line="873"/>
+        <location filename="../app/MainLayout.qml" line="901"/>
+        <location filename="../app/MainLayout.qml" line="912"/>
+        <location filename="../app/MainLayout.qml" line="924"/>
+        <location filename="../app/MainLayout.qml" line="951"/>
+        <location filename="../app/MainLayout.qml" line="962"/>
+        <location filename="../app/MainLayout.qml" line="997"/>
+        <location filename="../app/MainLayout.qml" line="1013"/>
+        <location filename="../app/MainLayout.qml" line="1022"/>
+        <location filename="../app/MainLayout.qml" line="1056"/>
+        <location filename="../app/MainLayout.qml" line="1067"/>
         <source>Back</source>
         <translation>Назад</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="855"/>
-        <location filename="../app/MainLayout.qml" line="902"/>
-        <location filename="../app/MainLayout.qml" line="1007"/>
+        <location filename="../app/MainLayout.qml" line="891"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="1043"/>
         <source>Page</source>
         <translation>Сторінка</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="862"/>
-        <location filename="../app/MainLayout.qml" line="911"/>
-        <location filename="../app/MainLayout.qml" line="1016"/>
+        <location filename="../app/MainLayout.qml" line="898"/>
+        <location filename="../app/MainLayout.qml" line="947"/>
+        <location filename="../app/MainLayout.qml" line="1052"/>
         <source>Options</source>
         <translation>Параметри</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="751"/>
-        <location filename="../app/MainLayout.qml" line="872"/>
-        <location filename="../app/MainLayout.qml" line="922"/>
-        <location filename="../app/MainLayout.qml" line="1027"/>
+        <location filename="../app/MainLayout.qml" line="787"/>
+        <location filename="../app/MainLayout.qml" line="908"/>
+        <location filename="../app/MainLayout.qml" line="958"/>
+        <location filename="../app/MainLayout.qml" line="1063"/>
         <source>Retry</source>
         <translation>Повторити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="946"/>
+        <location filename="../app/MainLayout.qml" line="982"/>
         <source>Change</source>
         <translation>Змінити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="952"/>
+        <location filename="../app/MainLayout.qml" line="988"/>
         <source>Toggle</source>
         <translation>Перемкнути</translation>
     </message>
@@ -690,12 +700,12 @@
         <translation type="unfinished">Завантаження…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="295"/>
+        <location filename="../screens/MediaListScreen.qml" line="306"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 записів</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="296"/>
+        <location filename="../screens/MediaListScreen.qml" line="307"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -763,23 +773,23 @@
     <name>SettingsScreen</name>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="73"/>
-        <location filename="../screens/SettingsScreen.qml" line="432"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Language</source>
         <translation>Мова</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78"/>
-        <location filename="../screens/SettingsScreen.qml" line="441"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="516"/>
         <source>Browsing layout</source>
         <translation>Режим перегляду</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116"/>
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
         <source>Mouse support</source>
         <translation>Підтримка миші</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="112"/>
         <source>Update media database</source>
         <translation>Оновити базу медіа</translation>
     </message>
@@ -789,267 +799,360 @@
         <translation>Загальні</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="450"/>
+        <location filename="../screens/SettingsScreen.qml" line="78"/>
+        <location filename="../screens/SettingsScreen.qml" line="507"/>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="88"/>
+        <location filename="../screens/SettingsScreen.qml" line="525"/>
         <source>Button style</source>
         <translation>Стиль кнопок</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88"/>
-        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <location filename="../screens/SettingsScreen.qml" line="93"/>
+        <location filename="../screens/SettingsScreen.qml" line="534"/>
         <source>Screensaver</source>
         <translation>Заставка</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="92"/>
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
         <source>Library</source>
         <translation>Бібліотека</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
+        <location filename="../screens/SettingsScreen.qml" line="543"/>
+        <source>Preferred artwork</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
         <source>Scrape metadata</source>
         <translation>Отримати метадані</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <source>Re-scrape existing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Advanced</source>
         <translation>Розширені</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121"/>
+        <location filename="../screens/SettingsScreen.qml" line="136"/>
         <source>Debug logging</source>
         <translation>Журнал відлагодження</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
+        <location filename="../screens/SettingsScreen.qml" line="141"/>
         <source>Upload log file</source>
         <translation>Завантажити файл журналу</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="146"/>
         <source>About / License</source>
         <translation>Про програму / Ліцензія</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147"/>
+        <location filename="../screens/SettingsScreen.qml" line="162"/>
         <source>Optimizing</source>
         <translation>Оптимізація</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149"/>
-        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="173"/>
         <source>Paused</source>
         <translation>Призупинено</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149"/>
-        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="173"/>
         <source>In progress</source>
         <translation>Виконується</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152"/>
+        <location filename="../screens/SettingsScreen.qml" line="167"/>
         <source>%1 indexed</source>
         <translation>%1 проіндексовано</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="161"/>
+        <location filename="../screens/SettingsScreen.qml" line="176"/>
         <source>%1 scraped</source>
         <translation>%1 зібрано</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="266"/>
+        <location filename="../screens/SettingsScreen.qml" line="284"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="266"/>
+        <location filename="../screens/SettingsScreen.qml" line="284"/>
         <source>Start</source>
         <translation>Почати</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="268"/>
+        <location filename="../screens/SettingsScreen.qml" line="286"/>
         <source>Upload</source>
         <translation>Вивантажити</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <location filename="../screens/SettingsScreen.qml" line="288"/>
         <source>Open</source>
         <translation>Відкрити</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="342"/>
+        <location filename="../screens/SettingsScreen.qml" line="365"/>
         <source>English</source>
         <translation>Англійська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="344"/>
+        <location filename="../screens/SettingsScreen.qml" line="367"/>
         <source>Italian</source>
         <translation>Італійська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="346"/>
+        <location filename="../screens/SettingsScreen.qml" line="369"/>
         <source>German</source>
         <translation>Німецька</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="348"/>
+        <location filename="../screens/SettingsScreen.qml" line="371"/>
         <source>Greek</source>
         <translation>Грецька</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="350"/>
+        <location filename="../screens/SettingsScreen.qml" line="373"/>
         <source>Japanese</source>
         <translation>Японська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="352"/>
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Korean</source>
         <translation>Корейська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
         <source>Dutch</source>
         <translation>Нідерландська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="356"/>
+        <location filename="../screens/SettingsScreen.qml" line="379"/>
         <source>Romanian</source>
         <translation>Румунська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="358"/>
+        <location filename="../screens/SettingsScreen.qml" line="381"/>
         <source>Slovak</source>
         <translation>Словацька</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="360"/>
+        <location filename="../screens/SettingsScreen.qml" line="383"/>
         <source>Ukrainian</source>
         <translation>Українська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="362"/>
+        <location filename="../screens/SettingsScreen.qml" line="385"/>
         <source>Chinese (Simplified)</source>
         <translation>Китайська (спрощена)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="364"/>
+        <location filename="../screens/SettingsScreen.qml" line="387"/>
         <source>Hebrew</source>
         <translation>Іврит</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="366"/>
+        <location filename="../screens/SettingsScreen.qml" line="389"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="368"/>
+        <location filename="../screens/SettingsScreen.qml" line="391"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="392"/>
+        <location filename="../screens/SettingsScreen.qml" line="451"/>
         <source>Auto</source>
         <translation>Автоматично</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="374"/>
+        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <source>Rotated CW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <source>Rotated CCW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="400"/>
+        <source>Horizontal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="405"/>
         <source>Detailed list view</source>
         <translation>Детальний перегляд списку</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="375"/>
+        <location filename="../screens/SettingsScreen.qml" line="406"/>
         <source>Grid view</source>
         <translation>Перегляд сіткою</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="411"/>
         <source>Style B</source>
         <translation>Стиль B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="382"/>
+        <location filename="../screens/SettingsScreen.qml" line="413"/>
         <source>Style C</source>
         <translation>Стиль C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="384"/>
+        <location filename="../screens/SettingsScreen.qml" line="415"/>
         <source>Style D</source>
         <translation>Стиль D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="385"/>
+        <location filename="../screens/SettingsScreen.qml" line="416"/>
         <source>Style A</source>
         <translation>Стиль A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="322"/>
+        <location filename="../screens/SettingsScreen.qml" line="340"/>
         <source>Default</source>
         <translation>Типовий</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="395"/>
+        <location filename="../screens/SettingsScreen.qml" line="431"/>
         <source>Off</source>
         <translation>Вимкнено</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <location filename="../screens/SettingsScreen.qml" line="433"/>
         <source>1 second (testing)</source>
         <translation>1 секунда (тест)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <location filename="../screens/SettingsScreen.qml" line="435"/>
         <source>1 minute</source>
         <translation>1 хвилина</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="401"/>
+        <location filename="../screens/SettingsScreen.qml" line="437"/>
         <source>2 minutes</source>
         <translation>2 хвилини</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="403"/>
+        <location filename="../screens/SettingsScreen.qml" line="439"/>
         <source>5 minutes</source>
         <translation>5 хвилин</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405"/>
+        <location filename="../screens/SettingsScreen.qml" line="441"/>
         <source>10 minutes</source>
         <translation>10 хвилин</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="407"/>
+        <location filename="../screens/SettingsScreen.qml" line="443"/>
         <source>15 minutes</source>
         <translation>15 хвилин</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="409"/>
+        <location filename="../screens/SettingsScreen.qml" line="445"/>
         <source>30 minutes</source>
         <translation>30 хвилин</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="410"/>
+        <location filename="../screens/SettingsScreen.qml" line="446"/>
         <source>%1 seconds</source>
         <translation>%1 секунд</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="423"/>
+        <location filename="../screens/SettingsScreen.qml" line="489"/>
         <source>Resolution</source>
         <translation>Роздільна здатність</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="563"/>
+        <location filename="../screens/SettingsScreen.qml" line="453"/>
+        <source>Image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="455"/>
+        <source>Thumbnail</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="457"/>
+        <source>Box art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <source>3D box art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="461"/>
+        <source>Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="463"/>
+        <source>Wheel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="465"/>
+        <source>Title screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="467"/>
+        <source>Map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="469"/>
+        <source>Marquee</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="471"/>
+        <source>Fan art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="473"/>
+        <source>Box side</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <source>Box back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="663"/>
         <source>Settings</source>
         <translation>Налаштування</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="755"/>
+        <location filename="../screens/SettingsScreen.qml" line="857"/>
         <source>No settings available on this platform</source>
         <translation>На цій платформі налаштування недоступні</translation>
     </message>
@@ -1057,24 +1160,24 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="185"/>
-        <location filename="../screens/SystemsScreen.qml" line="285"/>
+        <location filename="../screens/SystemsScreen.qml" line="195"/>
+        <location filename="../screens/SystemsScreen.qml" line="292"/>
         <source>%1 systems</source>
         <translation>%1 систем</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="189"/>
-        <location filename="../screens/SystemsScreen.qml" line="302"/>
+        <location filename="../screens/SystemsScreen.qml" line="196"/>
+        <location filename="../screens/SystemsScreen.qml" line="309"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="317"/>
+        <location filename="../screens/SystemsScreen.qml" line="324"/>
         <source>No systems in this category</source>
         <translation>У цій категорії немає систем</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="318"/>
+        <location filename="../screens/SystemsScreen.qml" line="325"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -90,47 +90,47 @@
         <translation type="unfinished">正在加载…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="47"/>
+        <location filename="../components/BrowseDetailPane.qml" line="77"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="49"/>
+        <location filename="../components/BrowseDetailPane.qml" line="79"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="51"/>
+        <location filename="../components/BrowseDetailPane.qml" line="81"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="53"/>
+        <location filename="../components/BrowseDetailPane.qml" line="83"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="55"/>
+        <location filename="../components/BrowseDetailPane.qml" line="85"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="57"/>
+        <location filename="../components/BrowseDetailPane.qml" line="87"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="59"/>
+        <location filename="../components/BrowseDetailPane.qml" line="89"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="61"/>
+        <location filename="../components/BrowseDetailPane.qml" line="91"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="63"/>
+        <location filename="../components/BrowseDetailPane.qml" line="93"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
@@ -329,34 +329,34 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="109"/>
-        <location filename="../screens/GamesScreen.qml" line="138"/>
+        <location filename="../screens/GamesScreen.qml" line="117"/>
+        <location filename="../screens/GamesScreen.qml" line="145"/>
         <source>%1 files</source>
         <translation>%1 个文件</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="40"/>
+        <location filename="../screens/GamesScreen.qml" line="51"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="118"/>
-        <location filename="../screens/GamesScreen.qml" line="139"/>
+        <location filename="../screens/GamesScreen.qml" line="126"/>
+        <location filename="../screens/GamesScreen.qml" line="146"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="33"/>
+        <location filename="../screens/GamesScreen.qml" line="44"/>
         <source>No games in this system</source>
         <translation>此系统中没有游戏</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="34"/>
+        <location filename="../screens/GamesScreen.qml" line="45"/>
         <source>Loading games…</source>
         <translation>正在加载游戏…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="114"/>
+        <location filename="../screens/GamesScreen.qml" line="122"/>
         <source>Loading more…</source>
         <translation>正在加载更多…</translation>
     </message>
@@ -434,7 +434,7 @@
     </message>
     <message>
         <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="955"/>
+        <location filename="../app/Main.qml" line="958"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
@@ -465,67 +465,67 @@
         <translation>二维码</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="951"/>
+        <location filename="../app/Main.qml" line="954"/>
         <source>Default</source>
         <translation type="unfinished">默认</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="951"/>
+        <location filename="../app/Main.qml" line="954"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1227"/>
+        <location filename="../app/Main.qml" line="1230"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1231"/>
+        <location filename="../app/Main.qml" line="1234"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1245"/>
+        <location filename="../app/Main.qml" line="1248"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1249"/>
+        <location filename="../app/Main.qml" line="1252"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1253"/>
+        <location filename="../app/Main.qml" line="1256"/>
         <source>Retry</source>
         <translation type="unfinished">重试</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1257"/>
+        <location filename="../app/Main.qml" line="1260"/>
         <source>Cancel</source>
         <translation type="unfinished">取消</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1769"/>
+        <location filename="../app/Main.qml" line="1776"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1771"/>
+        <location filename="../app/Main.qml" line="1778"/>
         <source>Loading games…</source>
         <translation>正在加载游戏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1773"/>
+        <location filename="../app/Main.qml" line="1780"/>
         <source>Loading favorites…</source>
         <translation>正在加载收藏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
+        <location filename="../app/Main.qml" line="1782"/>
         <source>Loading recently played…</source>
         <translation>正在加载最近游玩…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1777"/>
+        <location filename="../app/Main.qml" line="1784"/>
         <source>Loading…</source>
         <translation>正在加载…</translation>
     </message>
@@ -533,12 +533,12 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="545"/>
+        <location filename="../app/MainLayout.qml" line="581"/>
         <source>Writing failed</source>
         <translation>写入失败</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="545"/>
+        <location filename="../app/MainLayout.qml" line="581"/>
         <source>Put a writable card near the reader</source>
         <translation>将可写卡片放在读卡器附近</translation>
     </message>
@@ -548,136 +548,146 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="556"/>
+        <location filename="../app/MainLayout.qml" line="323"/>
+        <source>Favorites</source>
+        <translation type="unfinished">收藏</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="325"/>
+        <source>Recently Played</source>
+        <translation type="unfinished">最近游玩</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="592"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="557"/>
+        <location filename="../app/MainLayout.qml" line="593"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="632"/>
+        <location filename="../app/MainLayout.qml" line="668"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="633"/>
+        <location filename="../app/MainLayout.qml" line="669"/>
         <source>Are you sure you want to exit?</source>
         <translation>确定要退出吗？</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="705"/>
-        <location filename="../app/MainLayout.qml" line="777"/>
-        <location filename="../app/MainLayout.qml" line="820"/>
-        <location filename="../app/MainLayout.qml" line="849"/>
-        <location filename="../app/MainLayout.qml" line="896"/>
-        <location filename="../app/MainLayout.qml" line="937"/>
-        <location filename="../app/MainLayout.qml" line="1001"/>
+        <location filename="../app/MainLayout.qml" line="741"/>
+        <location filename="../app/MainLayout.qml" line="813"/>
+        <location filename="../app/MainLayout.qml" line="856"/>
+        <location filename="../app/MainLayout.qml" line="885"/>
+        <location filename="../app/MainLayout.qml" line="932"/>
+        <location filename="../app/MainLayout.qml" line="973"/>
+        <location filename="../app/MainLayout.qml" line="1037"/>
         <source>Move</source>
         <translation>移动</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="709"/>
-        <location filename="../app/MainLayout.qml" line="781"/>
+        <location filename="../app/MainLayout.qml" line="745"/>
+        <location filename="../app/MainLayout.qml" line="817"/>
         <source>Select</source>
         <translation>选择</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="713"/>
-        <location filename="../app/MainLayout.qml" line="717"/>
-        <location filename="../app/MainLayout.qml" line="731"/>
-        <location filename="../app/MainLayout.qml" line="744"/>
-        <location filename="../app/MainLayout.qml" line="755"/>
+        <location filename="../app/MainLayout.qml" line="749"/>
+        <location filename="../app/MainLayout.qml" line="753"/>
+        <location filename="../app/MainLayout.qml" line="767"/>
+        <location filename="../app/MainLayout.qml" line="780"/>
+        <location filename="../app/MainLayout.qml" line="791"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="724"/>
-        <location filename="../app/MainLayout.qml" line="762"/>
-        <location filename="../app/MainLayout.qml" line="785"/>
-        <location filename="../app/MainLayout.qml" line="796"/>
+        <location filename="../app/MainLayout.qml" line="760"/>
+        <location filename="../app/MainLayout.qml" line="798"/>
+        <location filename="../app/MainLayout.qml" line="821"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="740"/>
+        <location filename="../app/MainLayout.qml" line="776"/>
         <source>Done</source>
         <translation>完成</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="751"/>
-        <location filename="../app/MainLayout.qml" line="872"/>
-        <location filename="../app/MainLayout.qml" line="922"/>
-        <location filename="../app/MainLayout.qml" line="1027"/>
+        <location filename="../app/MainLayout.qml" line="787"/>
+        <location filename="../app/MainLayout.qml" line="908"/>
+        <location filename="../app/MainLayout.qml" line="958"/>
+        <location filename="../app/MainLayout.qml" line="1063"/>
         <source>Retry</source>
         <translation>重试</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="770"/>
+        <location filename="../app/MainLayout.qml" line="806"/>
         <source>I understand</source>
         <translation>我明白了</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="804"/>
+        <location filename="../app/MainLayout.qml" line="840"/>
         <source>Start</source>
         <translation>开始</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
-        <location filename="../app/MainLayout.qml" line="859"/>
-        <location filename="../app/MainLayout.qml" line="906"/>
-        <location filename="../app/MainLayout.qml" line="1011"/>
+        <location filename="../app/MainLayout.qml" line="860"/>
+        <location filename="../app/MainLayout.qml" line="895"/>
+        <location filename="../app/MainLayout.qml" line="942"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
         <source>Open</source>
         <translation>打开</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="828"/>
+        <location filename="../app/MainLayout.qml" line="864"/>
         <source>Quit</source>
         <translation>退出</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="837"/>
-        <location filename="../app/MainLayout.qml" line="865"/>
-        <location filename="../app/MainLayout.qml" line="876"/>
-        <location filename="../app/MainLayout.qml" line="888"/>
-        <location filename="../app/MainLayout.qml" line="915"/>
-        <location filename="../app/MainLayout.qml" line="926"/>
-        <location filename="../app/MainLayout.qml" line="961"/>
-        <location filename="../app/MainLayout.qml" line="977"/>
-        <location filename="../app/MainLayout.qml" line="986"/>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1031"/>
+        <location filename="../app/MainLayout.qml" line="873"/>
+        <location filename="../app/MainLayout.qml" line="901"/>
+        <location filename="../app/MainLayout.qml" line="912"/>
+        <location filename="../app/MainLayout.qml" line="924"/>
+        <location filename="../app/MainLayout.qml" line="951"/>
+        <location filename="../app/MainLayout.qml" line="962"/>
+        <location filename="../app/MainLayout.qml" line="997"/>
+        <location filename="../app/MainLayout.qml" line="1013"/>
+        <location filename="../app/MainLayout.qml" line="1022"/>
+        <location filename="../app/MainLayout.qml" line="1056"/>
+        <location filename="../app/MainLayout.qml" line="1067"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="855"/>
-        <location filename="../app/MainLayout.qml" line="902"/>
-        <location filename="../app/MainLayout.qml" line="1007"/>
+        <location filename="../app/MainLayout.qml" line="891"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="1043"/>
         <source>Page</source>
         <translation>页面</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="862"/>
-        <location filename="../app/MainLayout.qml" line="911"/>
-        <location filename="../app/MainLayout.qml" line="1016"/>
+        <location filename="../app/MainLayout.qml" line="898"/>
+        <location filename="../app/MainLayout.qml" line="947"/>
+        <location filename="../app/MainLayout.qml" line="1052"/>
         <source>Options</source>
         <translation>选项</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="946"/>
+        <location filename="../app/MainLayout.qml" line="982"/>
         <source>Change</source>
         <translation>更改</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="952"/>
+        <location filename="../app/MainLayout.qml" line="988"/>
         <source>Toggle</source>
         <translation>切换</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="973"/>
+        <location filename="../app/MainLayout.qml" line="1009"/>
         <source>Scroll</source>
         <translation>滚动</translation>
     </message>
@@ -690,12 +700,12 @@
         <translation type="unfinished">正在加载…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="295"/>
+        <location filename="../screens/MediaListScreen.qml" line="306"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 个条目</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="296"/>
+        <location filename="../screens/MediaListScreen.qml" line="307"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -768,288 +778,381 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="73"/>
-        <location filename="../screens/SettingsScreen.qml" line="432"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Language</source>
         <translation>语言</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="78"/>
-        <location filename="../screens/SettingsScreen.qml" line="441"/>
+        <location filename="../screens/SettingsScreen.qml" line="507"/>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="516"/>
         <source>Browsing layout</source>
         <translation>浏览布局</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="450"/>
+        <location filename="../screens/SettingsScreen.qml" line="88"/>
+        <location filename="../screens/SettingsScreen.qml" line="525"/>
         <source>Button style</source>
         <translation>按钮样式</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88"/>
-        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <location filename="../screens/SettingsScreen.qml" line="93"/>
+        <location filename="../screens/SettingsScreen.qml" line="534"/>
         <source>Screensaver</source>
         <translation>屏幕保护程序</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="92"/>
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
         <source>Library</source>
         <translation>资料库</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="107"/>
+        <location filename="../screens/SettingsScreen.qml" line="543"/>
+        <source>Preferred artwork</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="112"/>
         <source>Update media database</source>
         <translation>更新媒体数据库</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="107"/>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
         <source>Scrape metadata</source>
         <translation>抓取元数据</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <source>Re-scrape existing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Advanced</source>
         <translation>高级</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116"/>
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
         <source>Mouse support</source>
         <translation>鼠标支持</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121"/>
+        <location filename="../screens/SettingsScreen.qml" line="136"/>
         <source>Debug logging</source>
         <translation>调试日志</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
+        <location filename="../screens/SettingsScreen.qml" line="141"/>
         <source>Upload log file</source>
         <translation>上传日志文件</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="146"/>
         <source>About / License</source>
         <translation>关于 / 许可</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147"/>
+        <location filename="../screens/SettingsScreen.qml" line="162"/>
         <source>Optimizing</source>
         <translation>正在优化</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149"/>
-        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="173"/>
         <source>Paused</source>
         <translation>已暂停</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="149"/>
-        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="173"/>
         <source>In progress</source>
         <translation>进行中</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152"/>
+        <location filename="../screens/SettingsScreen.qml" line="167"/>
         <source>%1 indexed</source>
         <translation>已索引 %1 个</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="161"/>
+        <location filename="../screens/SettingsScreen.qml" line="176"/>
         <source>%1 scraped</source>
         <translation>已抓取 %1 个</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="266"/>
+        <location filename="../screens/SettingsScreen.qml" line="284"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="266"/>
+        <location filename="../screens/SettingsScreen.qml" line="284"/>
         <source>Start</source>
         <translation>开始</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="268"/>
+        <location filename="../screens/SettingsScreen.qml" line="286"/>
         <source>Upload</source>
         <translation>上传</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <location filename="../screens/SettingsScreen.qml" line="288"/>
         <source>Open</source>
         <translation>打开</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="322"/>
+        <location filename="../screens/SettingsScreen.qml" line="340"/>
         <source>Default</source>
         <translation>默认</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="342"/>
+        <location filename="../screens/SettingsScreen.qml" line="365"/>
         <source>English</source>
         <translation>英语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="344"/>
+        <location filename="../screens/SettingsScreen.qml" line="367"/>
         <source>Italian</source>
         <translation>意大利语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="346"/>
+        <location filename="../screens/SettingsScreen.qml" line="369"/>
         <source>German</source>
         <translation>德语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="348"/>
+        <location filename="../screens/SettingsScreen.qml" line="371"/>
         <source>Greek</source>
         <translation>希腊语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="350"/>
+        <location filename="../screens/SettingsScreen.qml" line="373"/>
         <source>Japanese</source>
         <translation>日语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="352"/>
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Korean</source>
         <translation>韩语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
         <source>Dutch</source>
         <translation>荷兰语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="356"/>
+        <location filename="../screens/SettingsScreen.qml" line="379"/>
         <source>Romanian</source>
         <translation>罗马尼亚语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="358"/>
+        <location filename="../screens/SettingsScreen.qml" line="381"/>
         <source>Slovak</source>
         <translation>斯洛伐克语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="360"/>
+        <location filename="../screens/SettingsScreen.qml" line="383"/>
         <source>Ukrainian</source>
         <translation>乌克兰语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="362"/>
+        <location filename="../screens/SettingsScreen.qml" line="385"/>
         <source>Chinese (Simplified)</source>
         <translation>简体中文</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="364"/>
+        <location filename="../screens/SettingsScreen.qml" line="387"/>
         <source>Hebrew</source>
         <translation>希伯来语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="366"/>
+        <location filename="../screens/SettingsScreen.qml" line="389"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="368"/>
+        <location filename="../screens/SettingsScreen.qml" line="391"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="392"/>
+        <location filename="../screens/SettingsScreen.qml" line="451"/>
         <source>Auto</source>
         <translation>自动</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="374"/>
+        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <source>Rotated CW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <source>Rotated CCW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="400"/>
+        <source>Horizontal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="405"/>
         <source>Detailed list view</source>
         <translation>详细列表视图</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="375"/>
+        <location filename="../screens/SettingsScreen.qml" line="406"/>
         <source>Grid view</source>
         <translation>网格视图</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="411"/>
         <source>Style B</source>
         <translation>样式 B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="382"/>
+        <location filename="../screens/SettingsScreen.qml" line="413"/>
         <source>Style C</source>
         <translation>样式 C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="384"/>
+        <location filename="../screens/SettingsScreen.qml" line="415"/>
         <source>Style D</source>
         <translation>样式 D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="385"/>
+        <location filename="../screens/SettingsScreen.qml" line="416"/>
         <source>Style A</source>
         <translation>样式 A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="395"/>
+        <location filename="../screens/SettingsScreen.qml" line="431"/>
         <source>Off</source>
         <translation>关闭</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <location filename="../screens/SettingsScreen.qml" line="433"/>
         <source>1 second (testing)</source>
         <translation>1 秒（测试）</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <location filename="../screens/SettingsScreen.qml" line="435"/>
         <source>1 minute</source>
         <translation>1 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="401"/>
+        <location filename="../screens/SettingsScreen.qml" line="437"/>
         <source>2 minutes</source>
         <translation>2 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="403"/>
+        <location filename="../screens/SettingsScreen.qml" line="439"/>
         <source>5 minutes</source>
         <translation>5 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405"/>
+        <location filename="../screens/SettingsScreen.qml" line="441"/>
         <source>10 minutes</source>
         <translation>10 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="407"/>
+        <location filename="../screens/SettingsScreen.qml" line="443"/>
         <source>15 minutes</source>
         <translation>15 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="409"/>
+        <location filename="../screens/SettingsScreen.qml" line="445"/>
         <source>30 minutes</source>
         <translation>30 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="410"/>
+        <location filename="../screens/SettingsScreen.qml" line="446"/>
         <source>%1 seconds</source>
         <translation>%1 秒</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="423"/>
+        <location filename="../screens/SettingsScreen.qml" line="489"/>
         <source>Resolution</source>
         <translation>分辨率</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="563"/>
+        <location filename="../screens/SettingsScreen.qml" line="453"/>
+        <source>Image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="455"/>
+        <source>Thumbnail</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="457"/>
+        <source>Box art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <source>3D box art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="461"/>
+        <source>Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="463"/>
+        <source>Wheel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="465"/>
+        <source>Title screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="467"/>
+        <source>Map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="469"/>
+        <source>Marquee</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="471"/>
+        <source>Fan art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="473"/>
+        <source>Box side</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <source>Box back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="663"/>
         <source>Settings</source>
         <translation>设置</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="755"/>
+        <location filename="../screens/SettingsScreen.qml" line="857"/>
         <source>No settings available on this platform</source>
         <translation>此平台上没有可用设置</translation>
     </message>
@@ -1057,24 +1160,24 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="185"/>
-        <location filename="../screens/SystemsScreen.qml" line="285"/>
+        <location filename="../screens/SystemsScreen.qml" line="195"/>
+        <location filename="../screens/SystemsScreen.qml" line="292"/>
         <source>%1 systems</source>
         <translation>%1 个系统</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="189"/>
-        <location filename="../screens/SystemsScreen.qml" line="302"/>
+        <location filename="../screens/SystemsScreen.qml" line="196"/>
+        <location filename="../screens/SystemsScreen.qml" line="309"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="317"/>
+        <location filename="../screens/SystemsScreen.qml" line="324"/>
         <source>No systems in this category</source>
         <translation>此类别中没有系统</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="318"/>
+        <location filename="../screens/SystemsScreen.qml" line="325"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>

--- a/tests/ui/tst_navigation.qml
+++ b/tests/ui/tst_navigation.qml
@@ -372,7 +372,7 @@ TestCase {
 
     function test_context_menu_systems_owner_is_single_launch_core(): void {
         // qmllint disable compiler
-        const entries = main.buildContextMenuEntries("systems", "", false, false);
+        const entries = main.buildContextMenuEntries("systems", "", false, false, false, "");
         compare(_idsOf(entries), ["launch_system"], "Systems context menu is just Launch core regardless of has_nfc");
         verify(entries[0].label.length > 0, "Launch core label is set (not asserted in English for translation)");
     // qmllint enable compiler
@@ -380,62 +380,62 @@ TestCase {
 
     function test_context_menu_systems_has_nfc_does_not_add_entries(): void {
         // qmllint disable compiler
-        const entries = main.buildContextMenuEntries("systems", "", true, false);
+        const entries = main.buildContextMenuEntries("systems", "", false, true, false, "");
         compare(_idsOf(entries), ["launch_system"], "has_nfc must not affect the systems menu");
     // qmllint enable compiler
     }
 
     function test_context_menu_games_directory_returns_empty(): void {
         // qmllint disable compiler
-        compare(main.buildContextMenuEntries("games", "directory", true, false), [], "Folder tiles have no context menu, even with reader attached");
+        compare(main.buildContextMenuEntries("games", "directory", false, true, false, ""), [], "Folder tiles have no context menu, even with reader attached");
     // qmllint enable compiler
     }
 
     function test_context_menu_games_root_returns_empty(): void {
         // qmllint disable compiler
-        compare(main.buildContextMenuEntries("games", "root", true, false), []);
+        compare(main.buildContextMenuEntries("games", "root", false, true, false, ""), []);
     // qmllint enable compiler
     }
 
     function test_context_menu_games_no_reader_omits_write_card(): void {
         // qmllint disable compiler
-        const entries = main.buildContextMenuEntries("games", "media", false, false);
+        const entries = main.buildContextMenuEntries("games", "media", true, false, false, "");
         compare(_idsOf(entries), ["toggle_favorite", "qr_code", "launch_game"], "Write to NFC token must be hidden when no reader is reported");
     // qmllint enable compiler
     }
 
     function test_context_menu_games_with_reader_includes_write_card(): void {
         // qmllint disable compiler
-        const entries = main.buildContextMenuEntries("games", "media", true, false);
+        const entries = main.buildContextMenuEntries("games", "media", true, true, false, "");
         compare(_idsOf(entries), ["toggle_favorite", "write_card", "qr_code", "launch_game"]);
     // qmllint enable compiler
     }
 
     function test_context_menu_favorites_matches_games_media_entries(): void {
         // qmllint disable compiler
-        const entries = main.buildContextMenuEntries("favorites", "", true, true);
+        const entries = main.buildContextMenuEntries("favorites", "", true, true, true, "");
         compare(_idsOf(entries), ["toggle_favorite", "write_card", "qr_code", "launch_game"]);
     // qmllint enable compiler
     }
 
     function test_context_menu_favorites_no_reader_omits_write_card(): void {
         // qmllint disable compiler
-        const entries = main.buildContextMenuEntries("favorites", "", false, true);
+        const entries = main.buildContextMenuEntries("favorites", "", true, false, true, "");
         compare(_idsOf(entries), ["toggle_favorite", "qr_code", "launch_game"]);
     // qmllint enable compiler
     }
 
     function test_context_menu_recents_omits_more_info(): void {
         // qmllint disable compiler
-        const entries = main.buildContextMenuEntries("recents", "", false, false);
+        const entries = main.buildContextMenuEntries("recents", "", false, false, false, "");
         compare(_idsOf(entries), ["launch_game"]);
     // qmllint enable compiler
     }
 
     function test_context_menu_games_favorite_label_toggles(): void {
         // qmllint disable compiler
-        const addEntries = main.buildContextMenuEntries("games", "media", false, false);
-        const removeEntries = main.buildContextMenuEntries("games", "media", false, true);
+        const addEntries = main.buildContextMenuEntries("games", "media", true, false, false, "");
+        const removeEntries = main.buildContextMenuEntries("games", "media", true, false, true, "");
         compare(addEntries[0].id, "toggle_favorite");
         compare(removeEntries[0].id, "toggle_favorite");
         verify(addEntries[0].label.length > 0);
@@ -446,7 +446,7 @@ TestCase {
 
     function test_context_menu_unknown_owner_returns_empty(): void {
         // qmllint disable compiler
-        compare(main.buildContextMenuEntries("nope", "", true, false), [], "Unknown owners get no entries — safe default");
+        compare(main.buildContextMenuEntries("nope", "", false, true, false, ""), [], "Unknown owners get no entries — safe default");
     // qmllint enable compiler
     }
 


### PR DESCRIPTION
## Summary
- show scraper progress from Core scrape steps and add one-shot re-scrape existing toggle
- support singleton media directories/zips for metadata, covers, details, and launch
- add preferred artwork setting and use selected cover type before Core fallback
- prefer exact paths for runtime launch while keeping QR/card writes portable
- update translation catalogs

## Validation
- just fmt
- just lint-rust
- just test-rust
- just lint
- just test-qml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preferred artwork picker ("Preferred artwork") with persisted selection.
  * Scrape progress now shows state, error, step counters and display text; scrape can be forced.

* **Improvements**
  * "Re-scrape existing" toggle to re-index media.
  * Cover/artwork caching, prefetching and loading honor the chosen artwork preference.
  * Better media-aware gating for launches, context menus and cover behavior across lists.
  * Large UI layout and translation refresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->