### PR TITLE
Improve rapid navigation and cover prefetching

### DIFF
--- a/rust/frontend/src/media_image_cache.rs
+++ b/rust/frontend/src/media_image_cache.rs
@@ -76,25 +76,17 @@ const CACHE_CAP_BYTES: usize = 64 * 1024 * 1024;
 const MAX_FETCH_ATTEMPTS: u8 = 3;
 
 /// Number of fetch worker tasks pulling from the shared LIFO queue.
-/// Keep this single-flight against Core: fast list scrolling on `MiSTer`
-/// can otherwise stack multiple large `media.image` bulk requests on
-/// top of Core's image handler and reset the WebSocket. The queue is
-/// already LIFO and capped, so one in-flight batch is enough to keep
-/// the visible work moving without turning cover fetches into a Core
-/// `DoS` vector.
-const FETCH_DRIVER_WORKERS: usize = 1;
+/// Two workers let visible pages fill more than one cover at a time
+/// while keeping Core/WebSocket pressure low on `MiSTer`. If runtime
+/// logs show resets or media.image rate-limit errors, drop this back
+/// to one before trying any broader queue changes.
+const FETCH_DRIVER_WORKERS: usize = 2;
 
-/// Hard cap on pending enqueues in the LIFO fetch queue. New pushes
-/// spill the **oldest** entry off the front, on the assumption that
-/// whatever the user enqueued ~2 pages ago is no longer interesting
-/// (re-fetch on scroll-back is cheap, and the model's role-data path
-/// re-enqueues uncached visible tiles automatically). Combined with
-/// LIFO drain, this means the queue always reflects the user's recent
-/// navigation, not their entire session — older requests neither
-/// block the wire nor accumulate memory. Sized at 2× a typical
-/// 30-tile page so a full look-ahead prefetch can overlap the
-/// current page without dropping anything.
-const MAX_QUEUE_LEN: usize = 60;
+/// Hard cap on pending enqueues in the fetch queue. Sized for three
+/// dense visual pages (current, next, previous) plus margin, so an
+/// explicit page-window rebuild does not drop the previous-page warm
+/// on a 30-tile layout while still bounding stale queue memory.
+const MAX_QUEUE_LEN: usize = 96;
 
 /// MIME content-type → on-disk extension for the formats we are willing
 /// to cache. Falls back to inspecting `MediaImageResult.extension` when
@@ -596,29 +588,13 @@ impl CacheState {
 pub struct MediaImageCache {
     state: Arc<RwLock<CacheState>>,
     /// LIFO queue of pending fetches. `enqueue` pushes to the back,
-    /// the fetch driver pops from the back: newest enqueues drain
-    /// first, while enqueues from a page the user has already
-    /// navigated past wait at the front rather than blocking the
-    /// work the user can see. Plain `std::sync::Mutex` because every
-    /// critical section is a single `push_back`/`pop_back` with no
+    /// the fetch driver pops from the back: newest ad-hoc enqueues
+    /// drain first. Games page prefetch uses
+    /// `replace_pending_requests_ordered`, which clears queued stale
+    /// work and pushes the supplied page window in reverse so public
+    /// order is still drain order. Plain `std::sync::Mutex` because
+    /// every critical section is a bounded queue mutation with no
     /// awaits in between.
-    ///
-    /// **Look-ahead intentionally rides the same queue at the same
-    /// priority.** Under Core's current ~250–400 ms serial cadence
-    /// for `media.image`, the LIFO drain order ends up servicing
-    /// page N+1's prefetched covers between page N's first burst
-    /// (the visual top of the page, enqueued in reverse so it pops
-    /// first) and page N's tail (the bottom rows the user is least
-    /// likely to read before paginating). By the time the user
-    /// navigates forward, page N+1 is warm; the few unfilled tiles
-    /// at the bottom of page N continue to land in the background.
-    /// Treating look-ahead as a "low priority" lane that drains
-    /// *after* the visible page strictly worsens the experience: the
-    /// visible page consumes the entire serial throughput in front
-    /// of the user (which reads as "covers loading slowly one at a
-    /// time"), and page N+1 doesn't start until the visible page is
-    /// fully cached, which is well after a fast-moving user has
-    /// already paginated. Don't reintroduce a priority split here.
     queue: Arc<Mutex<VecDeque<QueueEntry>>>,
     /// Single-permit signal that wakes the driver when a fresh key
     /// hits the queue. Drained by `notified().await` and rearmed by
@@ -743,6 +719,103 @@ impl MediaImageCache {
         page_size: u32,
     ) {
         self.enqueue_with_policy(key, media_id, page_size, NoImagePolicy::SoftMiss);
+    }
+
+    /// Drop queued-but-not-in-flight cover requests. Cached bytes,
+    /// negative memos, and the single request currently being fetched
+    /// stay untouched. Drained keys leave `pending` so final-page
+    /// prefetch after rapid navigation can re-enqueue them.
+    pub fn clear_pending_requests(&self) {
+        let drained = self.drain_queue();
+        if drained.is_empty() {
+            return;
+        }
+        self.release_drained_pending(&drained);
+        debug!(
+            dropped = drained.len(),
+            "media_image_cache: cleared queued cover requests"
+        );
+    }
+
+    /// Replace queued-but-not-in-flight cover requests with an explicit
+    /// ordered page window. `entries` is public drain order: the first
+    /// key supplied is the next key the driver should fetch after any
+    /// current in-flight request finishes.
+    pub fn replace_pending_requests_ordered(
+        &self,
+        entries: Vec<(MediaKey, Option<i64>)>,
+        page_size: u32,
+    ) {
+        let drained = self.drain_queue();
+        if !drained.is_empty() {
+            self.release_drained_pending(&drained);
+        }
+
+        let page_size = page_size.max(1);
+        let mut queued = Vec::new();
+        let mut seen = HashSet::new();
+        {
+            #[allow(clippy::unwrap_used, reason = "RwLock poisoning is unrecoverable")]
+            let mut guard = self.state.write().unwrap();
+            for (mut key, media_id) in entries.into_iter().take(MAX_QUEUE_LEN) {
+                if key.media_id.is_none() {
+                    if let Some(id) = media_id {
+                        key.media_id = Some(id);
+                    }
+                }
+                if key.system_id.is_empty() || key.path.is_empty() || !seen.insert(key.clone()) {
+                    continue;
+                }
+                if let Some(id) = media_id.or(key.media_id) {
+                    guard.media_ids.insert(key.clone(), id);
+                }
+                if guard.map.contains_key(&key)
+                    || guard.negative.contains(&key)
+                    || guard.pending.contains(&key)
+                {
+                    continue;
+                }
+                guard.attempts.remove(&key);
+                guard.pending.insert(key.clone());
+                queued.push(QueueEntry {
+                    key,
+                    page_size,
+                    no_image_policy: NoImagePolicy::Memoize,
+                });
+            }
+        }
+        if queued.is_empty() {
+            return;
+        }
+        let queued_len = queued.len();
+        {
+            #[allow(clippy::unwrap_used, reason = "Mutex poisoning is unrecoverable")]
+            let mut q = self.queue.lock().unwrap();
+            for entry in queued.into_iter().rev() {
+                q.push_back(entry);
+            }
+        }
+        debug!(
+            dropped = drained.len(),
+            queued = queued_len,
+            "media_image_cache: replaced queued cover requests"
+        );
+        self.queue_notify.notify_one();
+    }
+
+    fn drain_queue(&self) -> Vec<MediaKey> {
+        #[allow(clippy::unwrap_used, reason = "Mutex poisoning is unrecoverable")]
+        let mut q = self.queue.lock().unwrap();
+        q.drain(..).map(|entry| entry.key).collect::<Vec<_>>()
+    }
+
+    fn release_drained_pending(&self, drained: &[MediaKey]) {
+        #[allow(clippy::unwrap_used, reason = "RwLock poisoning is unrecoverable")]
+        let mut guard = self.state.write().unwrap();
+        for key in drained {
+            guard.pending.remove(key);
+            guard.attempts.remove(key);
+        }
     }
 
     fn enqueue_with_policy(
@@ -1398,6 +1471,56 @@ mod tests {
             queue_notify,
             updates_tx,
         }
+    }
+
+    #[test]
+    fn clear_pending_requests_drops_queue_and_releases_pending_keys() {
+        let cache = cache_for_test();
+        let first = key("SNES", "/old");
+        let second = key("NES", "/new");
+        cache.enqueue_with_media_id(first.clone(), None, 1);
+        cache.enqueue_with_media_id(second.clone(), None, 1);
+
+        cache.clear_pending_requests();
+
+        assert!(cache.queue.lock().unwrap().is_empty());
+        let guard = cache.state.read().unwrap();
+        assert!(!guard.pending.contains(&first));
+        assert!(!guard.pending.contains(&second));
+        drop(guard);
+        cache.enqueue_with_media_id(first.clone(), None, 1);
+        assert_eq!(cache.queue.lock().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn replace_pending_requests_ordered_drops_stale_and_preserves_public_order() {
+        let cache = cache_for_test();
+        let stale = key("NES", "/stale");
+        let first = key("NES", "/first");
+        let second = key("NES", "/second");
+        let third = key("NES", "/third");
+        cache.enqueue_with_media_id(stale.clone(), None, 1);
+
+        cache.replace_pending_requests_ordered(
+            vec![
+                (first.clone(), None),
+                (second.clone(), None),
+                (third.clone(), None),
+            ],
+            1,
+        );
+
+        let guard = cache.state.read().unwrap();
+        assert!(!guard.pending.contains(&stale));
+        assert!(guard.pending.contains(&first));
+        assert!(guard.pending.contains(&second));
+        assert!(guard.pending.contains(&third));
+        drop(guard);
+
+        assert_eq!(pop_one(&cache.queue).expect("first").key, first);
+        assert_eq!(pop_one(&cache.queue).expect("second").key, second);
+        assert_eq!(pop_one(&cache.queue).expect("third").key, third);
+        assert!(pop_one(&cache.queue).is_none());
     }
 
     #[test]

--- a/rust/frontend/src/media_image_cache.rs
+++ b/rust/frontend/src/media_image_cache.rs
@@ -800,7 +800,9 @@ impl MediaImageCache {
             queued = queued_len,
             "media_image_cache: replaced queued cover requests"
         );
-        self.queue_notify.notify_one();
+        for _ in 0..FETCH_DRIVER_WORKERS {
+            self.queue_notify.notify_one();
+        }
     }
 
     fn drain_queue(&self) -> Vec<MediaKey> {
@@ -1005,13 +1007,11 @@ fn process_batch_outcomes(
                 *counter
             };
             if attempts < MAX_FETCH_ATTEMPTS {
-                // Re-enter `pending` and re-enqueue at the back,
-                // preserving the original `page_size` so the retry
-                // batches alongside its own page. The next batch
-                // picks it up alongside whatever the user has
-                // enqueued in the meantime; LIFO drain order means
-                // the fresh page lands first while this retry tags
-                // along behind it.
+                // Re-enter `pending` and re-enqueue at the front,
+                // preserving the original `page_size` while keeping
+                // retries behind any freshly-installed ordered page
+                // window. The driver pops from the back, so front-side
+                // retries cannot jump ahead of current-page work.
                 {
                     #[allow(clippy::unwrap_used, reason = "RwLock poisoning is unrecoverable")]
                     let mut s = state.write().unwrap();
@@ -1020,7 +1020,7 @@ fn process_batch_outcomes(
                 let dropped = {
                     #[allow(clippy::unwrap_used, reason = "Mutex poisoning is unrecoverable")]
                     let mut q = queue.lock().unwrap();
-                    q.push_back(entry);
+                    q.push_front(entry);
                     // Mirror the `enqueue_with_media_id` cap: a
                     // long-running burst of transient failures can
                     // push the queue past `MAX_QUEUE_LEN` if we
@@ -1448,8 +1448,9 @@ mod tests {
 
     use super::{
         ext_for_content_type, ext_from_extension_field, finish_fetch, is_connection_down_error,
-        pop_one, CacheState, FetchOutcome, MediaImageCache, MediaImageUpdate, MediaKey,
-        NegativeMemo, NoImagePolicy, QueueEntry, MAX_QUEUE_LEN, NEGATIVE_MEMO_CAP,
+        pop_one, process_batch_outcomes, CacheState, FetchOutcome, MediaImageCache,
+        MediaImageUpdate, MediaKey, NegativeMemo, NoImagePolicy, QueueEntry, MAX_QUEUE_LEN,
+        NEGATIVE_MEMO_CAP,
     };
     use std::collections::VecDeque;
     use std::sync::{Arc, Mutex, RwLock};
@@ -2091,6 +2092,48 @@ mod tests {
         assert!(!g.negative.contains(&k), "no negative memo on Transient");
         assert!(!g.pending.contains(&k), "pending must be cleared");
         assert_eq!(g.total_bytes, 0);
+    }
+
+    #[test]
+    fn transient_retry_queues_behind_ordered_window() {
+        let state = Arc::new(RwLock::new(CacheState::new()));
+        let queue: Arc<Mutex<VecDeque<QueueEntry>>> = Arc::new(Mutex::new(VecDeque::new()));
+        let queue_notify = Arc::new(Notify::new());
+        let (updates_tx, _) = broadcast::channel::<MediaImageUpdate>(64);
+        let first = key("NES", "/first");
+        let second = key("NES", "/second");
+        let retry = QueueEntry {
+            key: key("NES", "/retry"),
+            page_size: 15,
+            no_image_policy: NoImagePolicy::Memoize,
+        };
+        {
+            let mut q = queue.lock().unwrap();
+            q.push_back(QueueEntry {
+                key: second.clone(),
+                page_size: 15,
+                no_image_policy: NoImagePolicy::Memoize,
+            });
+            q.push_back(QueueEntry {
+                key: first.clone(),
+                page_size: 15,
+                no_image_policy: NoImagePolicy::Memoize,
+            });
+        }
+        state.write().unwrap().pending.insert(retry.key.clone());
+
+        process_batch_outcomes(
+            &state,
+            usize::MAX,
+            &updates_tx,
+            &queue,
+            &queue_notify,
+            vec![(retry.clone(), FetchOutcome::Transient)],
+        );
+
+        assert_eq!(pop_one(&queue).expect("first").key, first);
+        assert_eq!(pop_one(&queue).expect("second").key, second);
+        assert_eq!(pop_one(&queue).expect("retry").key, retry.key);
     }
 
     #[test]

--- a/rust/frontend/src/models/favorites.rs
+++ b/rust/frontend/src/models/favorites.rs
@@ -82,6 +82,7 @@ pub struct FavoritesModelRust {
     current_detail_loading: bool,
     current_detail_tags: QString,
     current_detail_image_key: QString,
+    cover_requests_paused: bool,
     current_detail_media_key: Option<MediaKey>,
     current_detail_media_id: Option<i64>,
     card_write_seq: Arc<AtomicU64>,
@@ -144,6 +145,7 @@ pub mod ffi {
         #[qproperty(bool, current_detail_loading)]
         #[qproperty(QString, current_detail_tags)]
         #[qproperty(QString, current_detail_image_key)]
+        #[qproperty(bool, cover_requests_paused)]
         type FavoritesModel = super::FavoritesModelRust;
 
         #[qinvokable]
@@ -181,6 +183,12 @@ pub mod ffi {
 
         #[qinvokable]
         fn clear_current_detail(self: Pin<&mut FavoritesModel>);
+
+        #[qinvokable]
+        fn refresh_cover_keys(self: Pin<&mut FavoritesModel>, first_row: i32, count: i32);
+
+        #[qinvokable]
+        fn clear_pending_cover_requests(self: Pin<&mut FavoritesModel>);
 
         #[qinvokable]
         fn index_for_path(self: &FavoritesModel, path: &QString) -> i32;
@@ -276,7 +284,9 @@ fn apply_state(
         // any in-flight `fetch_more` sees a stale ticket and bails.
         model.as_mut().rust_mut().seq.fetch_add(1, Ordering::SeqCst);
         model.as_mut().ensure_cover_subscription();
-        enqueue_favorites_covers(&entries);
+        if !model.cover_requests_paused {
+            enqueue_favorites_covers(&entries);
+        }
         let count = i32::try_from(entries.len()).unwrap_or(i32::MAX);
         clear_current_detail_state(model.as_mut());
         model.as_mut().begin_reset_model();
@@ -362,7 +372,9 @@ impl ffi::FavoritesModel {
             NAME_ROLE => QVariant::from(&QString::from(entry.name.as_str())),
             PATH_ROLE => QVariant::from(&QString::from(entry.path.as_str())),
             SYSTEM_ID_ROLE => QVariant::from(&QString::from(entry.system.id.as_str())),
-            COVER_KEY_ROLE => QVariant::from(&QString::from(cover_key_for(entry).as_str())),
+            COVER_KEY_ROLE => QVariant::from(&QString::from(
+                cover_key_for(entry, !self.cover_requests_paused).as_str(),
+            )),
             ZAP_SCRIPT_ROLE => QVariant::from(&QString::from(entry.zap_script.as_str())),
             FAVORITE_ROLE => QVariant::from(&favorite_role_value(&entry.tags)),
             FILE_STEM_ROLE => {
@@ -412,6 +424,14 @@ impl ffi::FavoritesModel {
                 apply_append_page(model, result, expected_prev_cursor.as_deref());
             });
         });
+    }
+
+    fn refresh_cover_keys(mut self: Pin<&mut Self>, first_row: i32, count: i32) {
+        emit_cover_key_range(self.as_mut(), first_row, count);
+    }
+
+    fn clear_pending_cover_requests(self: Pin<&mut Self>) {
+        global_media_image_cache().clear_pending_requests();
     }
 
     fn launch_at(self: Pin<&mut Self>, index: i32) {
@@ -661,7 +681,7 @@ impl ffi::FavoritesModel {
 /// `QQuickImageProvider` resolves to RAM bytes; otherwise we enqueue a
 /// fetch (carrying the optional `mediaId` hint) and fall back to the
 /// system logo as a nicer placeholder than the generic file glyph.
-fn cover_key_for(entry: &MediaItem) -> String {
+fn cover_key_for(entry: &MediaItem, requests_enabled: bool) -> String {
     if entry.system.id.is_empty() {
         return "icons/File".to_string();
     }
@@ -672,7 +692,7 @@ fn cover_key_for(entry: &MediaItem) -> String {
     let soft_no_image = media_key
         .as_ref()
         .is_some_and(|k| cache.is_soft_no_image(k));
-    if !cached && !negative && !soft_no_image {
+    if requests_enabled && !cached && !negative && !soft_no_image {
         // Miss-driven re-enqueue, same rationale as GamesModel's
         // `cover_key_for`: tiles re-bound after LRU eviction or stale-
         // enqueue truncation will hit this branch and re-arm the fetch.
@@ -680,7 +700,32 @@ fn cover_key_for(entry: &MediaItem) -> String {
             cache.enqueue_search_cover_with_media_id(k.clone(), entry.media_id, PAGE_SIZE);
         }
     }
-    cover_key_for_with(entry, media_key.as_ref(), cached, negative, soft_no_image)
+    cover_key_for_with(
+        entry,
+        media_key.as_ref(),
+        cached,
+        negative,
+        soft_no_image || !requests_enabled,
+    )
+}
+
+fn emit_cover_key_range(mut model: Pin<&mut ffi::FavoritesModel>, first_row: i32, count: i32) {
+    if model.count <= 0 || count <= 0 {
+        return;
+    }
+    let first = first_row.clamp(0, model.count - 1);
+    let last = first.saturating_add(count - 1).min(model.count - 1);
+    if last < first {
+        return;
+    }
+    let mut roles = QList::<i32>::default();
+    roles.append(COVER_KEY_ROLE);
+    let parent = QModelIndex::default();
+    let top_left = model.index(first, 0, &parent);
+    let bottom_right = model.index(last, 0, &parent);
+    model
+        .as_mut()
+        .data_changed(&top_left, &bottom_right, &roles);
 }
 
 /// Build the canonical `(systemId, mediaPath)` identifier for a search
@@ -1116,7 +1161,9 @@ fn apply_append_page(
             let has_next_page = result.has_next_page();
             let next_cursor = result.next_cursor();
             let new_count = i32::try_from(result.results.len()).unwrap_or(i32::MAX - model.count);
-            enqueue_favorites_covers(&result.results);
+            if !model.cover_requests_paused {
+                enqueue_favorites_covers(&result.results);
+            }
             if new_count > 0 {
                 let first = model.count;
                 let last = first.saturating_add(new_count).saturating_sub(1);

--- a/rust/frontend/src/models/games.rs
+++ b/rust/frontend/src/models/games.rs
@@ -159,6 +159,7 @@ pub struct GamesModelRust {
     current_detail_image_can_prev: bool,
     current_detail_image_can_next: bool,
     cover_key_roles_enabled: bool,
+    cover_requests_paused: bool,
     detail_image_keys: Vec<MediaKey>,
     // Watcher for the current initial-page subscription. Aborted on
     // every path swap so the prior watcher stops enqueuing callbacks
@@ -261,6 +262,7 @@ impl Default for GamesModelRust {
             current_detail_image_can_prev: false,
             current_detail_image_can_next: false,
             cover_key_roles_enabled: true,
+            cover_requests_paused: false,
             detail_image_keys: Vec::new(),
             watcher: None,
             seq: Arc::new(AtomicU64::new(0)),
@@ -321,6 +323,7 @@ pub mod ffi {
         #[qproperty(bool, current_detail_image_can_prev)]
         #[qproperty(bool, current_detail_image_can_next)]
         #[qproperty(bool, cover_key_roles_enabled)]
+        #[qproperty(bool, cover_requests_paused)]
         #[qproperty(i32, visible_first_row)]
         type GamesModel = super::GamesModelRust;
 
@@ -335,6 +338,12 @@ pub mod ffi {
 
         #[qinvokable]
         fn prefetch_around(self: Pin<&mut GamesModel>, first_visible_row: i32);
+
+        #[qinvokable]
+        fn refresh_cover_keys(self: Pin<&mut GamesModel>, first_row: i32, count: i32);
+
+        #[qinvokable]
+        fn clear_pending_cover_requests(self: Pin<&mut GamesModel>);
 
         #[qinvokable]
         fn launch_at(self: Pin<&mut GamesModel>, index: i32);
@@ -454,7 +463,11 @@ impl ffi::GamesModel {
             SYSTEM_ID_ROLE => QVariant::from(&QString::from(entry_system_id(entry).as_str())),
             COVER_KEY_ROLE => QVariant::from(&QString::from(
                 if self.cover_key_roles_enabled {
-                    cover_key_for(entry, u32::try_from(self.page_size.max(1)).unwrap_or(1))
+                    cover_key_for(
+                        entry,
+                        u32::try_from(self.page_size.max(1)).unwrap_or(1),
+                        !self.cover_requests_paused,
+                    )
                 } else {
                     cover_placeholder_for(entry)
                 }
@@ -576,31 +589,27 @@ impl ffi::GamesModel {
         });
     }
 
-    /// Enqueue covers for the visible page and the next page, with the
-    /// visible page winning LIFO drain order.
+    /// Rebuild the cover queue around the current visual page.
     ///
     /// `first_visible_row` is the row index of the topmost visible
     /// tile (`gamesGrid.currentPage * gamesGrid.pageSize` from QML).
-    /// We push the next page's rows in reverse order first, then the
-    /// current page's rows in reverse, so the LIFO queue drains the
-    /// current page top-to-bottom before any next-page cover starts.
-    ///
-    /// Idempotent: already-cached rows skip via the cache's existing
-    /// dedupe; folders and entries without a `media_key` skip too.
-    /// Uncached rows that are not currently visible are not touched
-    /// here — `cover_key_for` enqueues those on demand when QML
-    /// materialises a tile and reads its `coverKey` role.
+    /// The replacement queue drains current page first, then next
+    /// page, then previous page. Queued stale requests are dropped so
+    /// a page change immediately makes the new visible page win.
     fn prefetch_around(self: Pin<&mut Self>, first_visible_row: i32) {
         let plan =
             prefetch_around_plan(&self.entries, self.count, self.page_size, first_visible_row);
-        if plan.is_empty() {
-            return;
-        }
         let cache = global_media_image_cache();
         let ps = u32::try_from(self.page_size.max(1)).unwrap_or(1);
-        for (key, media_id) in plan {
-            cache.enqueue_with_media_id(key, media_id, ps);
-        }
+        cache.replace_pending_requests_ordered(plan, ps);
+    }
+
+    fn refresh_cover_keys(mut self: Pin<&mut Self>, first_row: i32, count: i32) {
+        emit_cover_key_range(self.as_mut(), first_row, count);
+    }
+
+    fn clear_pending_cover_requests(self: Pin<&mut Self>) {
+        global_media_image_cache().clear_pending_requests();
     }
 
     fn launch_at(self: Pin<&mut Self>, index: i32) {
@@ -1070,9 +1079,7 @@ fn entry_system_id(entry: &BrowseEntry) -> String {
 fn is_media_capable_entry(entry: &BrowseEntry) -> bool {
     entry.entry_type == "media"
         || (entry.entry_type == "directory"
-            && (entry.media_id.is_some()
-                || !entry.zap_script.is_empty()
-                || !entry_system_id(entry).is_empty()))
+            && (entry.media_id.is_some() || !entry.zap_script.is_empty()))
 }
 
 fn run_text_for_entry(entry: &BrowseEntry) -> String {
@@ -1313,7 +1320,7 @@ fn cover_placeholder_for(entry: &BrowseEntry) -> String {
     }
 }
 
-fn cover_key_for(entry: &BrowseEntry, page_size: u32) -> String {
+fn cover_key_for(entry: &BrowseEntry, page_size: u32, requests_enabled: bool) -> String {
     if !is_media_capable_entry(entry) && entry.is_folder() {
         return "icons/Folder".to_string();
     }
@@ -1324,7 +1331,7 @@ fn cover_key_for(entry: &BrowseEntry, page_size: u32) -> String {
     let soft_no_image = media_key
         .as_ref()
         .is_some_and(|k| cache.is_soft_no_image(k));
-    if !cached && !negative && !soft_no_image {
+    if requests_enabled && !cached && !negative && !soft_no_image {
         // Miss-driven re-enqueue: when QML asks for the cover URL of
         // a media entry whose bytes aren't in the cache, kick a fetch
         // right here. This is the only implicit path covers reach the
@@ -1338,7 +1345,31 @@ fn cover_key_for(entry: &BrowseEntry, page_size: u32) -> String {
             cache.enqueue_with_media_id(k.clone(), entry.media_id, page_size);
         }
     }
-    cover_key_for_with(entry, media_key.as_ref(), cached, negative || soft_no_image)
+    cover_key_for_with(
+        entry,
+        media_key.as_ref(),
+        cached,
+        negative || soft_no_image || !requests_enabled,
+    )
+}
+
+fn emit_cover_key_range(mut model: Pin<&mut ffi::GamesModel>, first_row: i32, count: i32) {
+    if model.count <= 0 || count <= 0 {
+        return;
+    }
+    let first = first_row.clamp(0, model.count - 1);
+    let last = first.saturating_add(count - 1).min(model.count - 1);
+    if last < first {
+        return;
+    }
+    let mut roles = QList::<i32>::default();
+    roles.append(COVER_KEY_ROLE);
+    let parent = QModelIndex::default();
+    let top_left = model.index(first, 0, &parent);
+    let bottom_right = model.index(last, 0, &parent);
+    model
+        .as_mut()
+        .data_changed(&top_left, &bottom_right, &roles);
 }
 
 /// Build the canonical `(systemId, path)` identifier for a media
@@ -1362,15 +1393,10 @@ fn media_key_for(entry: &BrowseEntry) -> Option<MediaKey> {
     }
 }
 
-/// Pure ordering helper for `prefetch_around`. Returns the
-/// (`MediaKey`, `media_id`) pairs to push onto the cover cache's
-/// LIFO queue, in push order.
-///
-/// Push order: next-page rows in reverse, then current-page rows in
-/// reverse. The LIFO drain (`pop_back`) then pops current-page row 0
-/// first, then row 1, ..., row N-1, then next-page row 0, ..., so
-/// the visible page wins drain order with the next page warming
-/// behind it. Folders and entries without a `media_key` are skipped.
+/// Pure ordering helper for `prefetch_around`. Returns
+/// (`MediaKey`, `media_id`) pairs in desired fetch order: current page
+/// top-to-bottom, then next page, then previous page. Folders and
+/// entries without a `media_key` are skipped.
 fn prefetch_around_plan(
     entries: &[BrowseEntry],
     count: i32,
@@ -1382,28 +1408,28 @@ fn prefetch_around_plan(
     }
     let page_size = page_size.max(1);
     let first = first_visible_row.clamp(0, count.saturating_sub(1));
-    let next_start = first.saturating_add(page_size).min(count);
-    let next_end = first.saturating_add(page_size.saturating_mul(2)).min(count);
-    let cur_end = next_start;
+    let current_end = first.saturating_add(page_size).min(count);
+    let next_end = current_end.saturating_add(page_size).min(count);
+    let previous_start = first.saturating_sub(page_size);
     let mut plan: Vec<(MediaKey, Option<i64>)> =
-        Vec::with_capacity(((next_end - first) as usize).min(entries.len()));
+        Vec::with_capacity(((next_end - previous_start) as usize).min(entries.len()));
     let push = |row: i32, plan: &mut Vec<(MediaKey, Option<i64>)>| {
         let idx = row as usize;
         if idx >= entries.len() {
             return;
         }
         let entry = &entries[idx];
-        if !is_media_capable_entry(entry) {
-            return;
-        }
         if let Some(key) = media_key_for(entry) {
             plan.push((key.with_current_cover_preference(), entry.media_id));
         }
     };
-    for row in (next_start..next_end).rev() {
+    for row in first..current_end {
         push(row, &mut plan);
     }
-    for row in (first..cur_end).rev() {
+    for row in current_end..next_end {
+        push(row, &mut plan);
+    }
+    for row in previous_start..first {
         push(row, &mut plan);
     }
     plan
@@ -2064,26 +2090,11 @@ fn apply_initial_page(mut model: Pin<&mut ffi::GamesModel>, result: MediaBrowseR
     if !model.error_message.is_empty() {
         model.as_mut().set_error_message(QString::default());
     }
-    // Look-ahead prefetch: keep the user one page ahead of the highlight
-    // so a page advance never triggers a visible "Loading more…" pause.
-    // `fetch_more` is itself guarded by `has_next_page` and
-    // `loading_more`, so a no-op call is cheap and safe.
-    //
-    // Look-ahead intentionally enqueues onto the same LIFO queue as
-    // the visible page at the same priority. Core serializes
-    // `media.image` responses at ~one per 250–400 ms; with that
-    // cadence, the LIFO drain order (newest-pushed pops first) ends
-    // up servicing page N+1's covers *between* page N's first burst
-    // and its tail. By the time the user navigates forward, page N+1
-    // is warm, while the bottom couple of tiles on page N — which
-    // the user is least likely to dwell on before paginating —
-    // continue to land in the background. Treating look-ahead as a
-    // low-priority lane that drains *after* the visible page strictly
-    // worsens this: page N then consumes the entire serial throughput
-    // before page N+1 begins, which is exactly what shipped briefly
-    // and looked like "covers loading slowly one at a time" with the
-    // next page no longer instant on navigate. See the doc comment on
-    // `MediaImageCache::queue` for the full rationale.
+    // Metadata look-ahead: keep rows one chunk ahead of the highlight
+    // so a page advance does not pause on "Loading more…". Cover
+    // prefetch is separate: `prefetch_around` rebuilds the queue in
+    // current → next → previous order whenever rows land or the page
+    // changes.
     if will_lookahead {
         model.as_mut().fetch_more();
     }
@@ -2309,10 +2320,10 @@ mod tests {
     use super::{
         chunk_for_subbatching, compute_unresolved_keys, cover_key_for_with, cover_placeholder_for,
         decide_initial, dedup_roots_drop_ancestors, detail_tags_from_tags, display_name,
-        entry_system_id, is_strict_ancestor_path, leading_dir_count, media_key_for,
-        meta_params_for_entry, position_of_game_path, prefetch_around_plan, project_status,
-        run_text_for_entry, singleton_directory_needs_launch_resolution, transform_entries,
-        InitialAction, Projection,
+        entry_system_id, is_media_capable_entry, is_strict_ancestor_path, leading_dir_count,
+        media_key_for, meta_params_for_entry, position_of_game_path, prefetch_around_plan,
+        project_status, run_text_for_entry, singleton_directory_needs_launch_resolution,
+        transform_entries, InitialAction, Projection,
     };
     use crate::media_image_cache::{MediaImageCache, MediaKey};
     use std::collections::HashSet;
@@ -2349,6 +2360,43 @@ mod tests {
             zap_script: format!("@{system_id}/{name}"),
             ..BrowseEntry::default()
         }
+    }
+
+    #[test]
+    fn media_entry_is_media_capable() {
+        assert!(is_media_capable_entry(&media(
+            "smb",
+            "/games/NES/smb.nes",
+            "NES"
+        )));
+    }
+
+    #[test]
+    fn directory_with_only_system_id_is_not_media_capable() {
+        let mut entry = folder("Archive", "/games/GB/archive.zip");
+        entry.system_id = "Gameboy".into();
+        assert!(!is_media_capable_entry(&entry));
+    }
+
+    #[test]
+    fn directory_with_media_id_is_media_capable() {
+        let mut entry = folder("Single", "/games/GB/single.zip");
+        entry.system_id = "Gameboy".into();
+        entry.media_id = Some(42);
+        assert!(is_media_capable_entry(&entry));
+    }
+
+    #[test]
+    fn directory_with_zap_script_is_media_capable() {
+        let mut entry = folder("Single", "/games/GB/single.zip");
+        entry.system_id = "Gameboy".into();
+        entry.zap_script = "@Gameboy/Single".into();
+        assert!(is_media_capable_entry(&entry));
+    }
+
+    #[test]
+    fn root_with_system_id_is_not_media_capable() {
+        assert!(!is_media_capable_entry(&root("GB", "/games/GB", "Gameboy")));
     }
 
     #[test]
@@ -3025,18 +3073,15 @@ mod tests {
     }
 
     #[test]
-    fn prefetch_around_plan_pushes_next_page_then_current_in_reverse() {
-        // Visible page: rows 15..30 (15 rows). Next page: 30..45.
-        // Push next first reversed: 44, 43, ..., 30.
-        // Push current next reversed: 29, 28, ..., 15.
-        // pop_back order: 15, 16, ..., 29, 30, 31, ..., 44.
+    fn prefetch_around_plan_orders_current_next_previous() {
         let entries: Vec<BrowseEntry> = (0..45)
             .map(|i| media(&format!("g{i}"), &format!("/g/{i}"), "NES"))
             .collect();
         let plan = prefetch_around_plan(&entries, 45, 15, 15);
         let paths: Vec<String> = plan.iter().map(|(k, _)| k.path.to_string()).collect();
-        let mut expected: Vec<String> = (30..45).rev().map(|i| format!("/g/{i}")).collect();
-        expected.extend((15..30).rev().map(|i| format!("/g/{i}")));
+        let mut expected: Vec<String> = (15..30).map(|i| format!("/g/{i}")).collect();
+        expected.extend((30..45).map(|i| format!("/g/{i}")));
+        expected.extend((0..15).map(|i| format!("/g/{i}")));
         assert_eq!(paths, expected);
     }
 
@@ -3052,22 +3097,20 @@ mod tests {
         ];
         let plan = prefetch_around_plan(&entries, 4, 4, 0);
         let paths: Vec<String> = plan.iter().map(|(k, _)| k.path.to_string()).collect();
-        // Only media rows; reverse push order across the visible page.
-        assert_eq!(paths, vec!["/g/1".to_string(), "/g/0".to_string()]);
+        assert_eq!(paths, vec!["/g/0".to_string(), "/g/1".to_string()]);
     }
 
     #[test]
     fn prefetch_around_plan_handles_short_tail() {
-        // 20 rows, page 1 visible (15..20). Next page would be 30..45
-        // but count clamps it: next_start=30 -> clamped to 20,
-        // next_end=45 -> 20. Plan only contains the partial visible
-        // page rows 15..20 in reverse.
+        // 20 rows, page 1 visible (15..20). No next page; previous
+        // page follows the visible tail.
         let entries: Vec<BrowseEntry> = (0..20)
             .map(|i| media(&format!("g{i}"), &format!("/g/{i}"), "NES"))
             .collect();
         let plan = prefetch_around_plan(&entries, 20, 15, 15);
         let paths: Vec<String> = plan.iter().map(|(k, _)| k.path.to_string()).collect();
-        let expected: Vec<String> = (15..20).rev().map(|i| format!("/g/{i}")).collect();
+        let mut expected: Vec<String> = (15..20).map(|i| format!("/g/{i}")).collect();
+        expected.extend((0..15).map(|i| format!("/g/{i}")));
         assert_eq!(paths, expected);
     }
 
@@ -3086,8 +3129,8 @@ mod tests {
         let plan = prefetch_around_plan(&entries, 30, 15, -100);
         let paths: Vec<String> = plan.iter().map(|(k, _)| k.path.to_string()).collect();
         // Clamped to 0: visible rows 0..15, next 15..30.
-        let mut expected: Vec<String> = (15..30).rev().map(|i| format!("/g/{i}")).collect();
-        expected.extend((0..15).rev().map(|i| format!("/g/{i}")));
+        let mut expected: Vec<String> = (0..15).map(|i| format!("/g/{i}")).collect();
+        expected.extend((15..30).map(|i| format!("/g/{i}")));
         assert_eq!(paths, expected);
     }
 

--- a/rust/frontend/src/models/recents.rs
+++ b/rust/frontend/src/models/recents.rs
@@ -79,6 +79,7 @@ pub struct RecentsModelRust {
     current_detail_loading: bool,
     current_detail_tags: QString,
     current_detail_image_key: QString,
+    cover_requests_paused: bool,
     current_detail_media_key: Option<MediaKey>,
     current_detail_media_id: Option<i64>,
     detail_seq: Arc<AtomicU64>,
@@ -138,6 +139,7 @@ pub mod ffi {
         #[qproperty(bool, current_detail_loading)]
         #[qproperty(QString, current_detail_tags)]
         #[qproperty(QString, current_detail_image_key)]
+        #[qproperty(bool, cover_requests_paused)]
         type RecentsModel = super::RecentsModelRust;
 
         #[qinvokable]
@@ -160,6 +162,12 @@ pub mod ffi {
 
         #[qinvokable]
         fn clear_current_detail(self: Pin<&mut RecentsModel>);
+
+        #[qinvokable]
+        fn refresh_cover_keys(self: Pin<&mut RecentsModel>, first_row: i32, count: i32);
+
+        #[qinvokable]
+        fn clear_pending_cover_requests(self: Pin<&mut RecentsModel>);
 
         #[qinvokable]
         fn index_for_path(self: &RecentsModel, path: &QString) -> i32;
@@ -254,7 +262,9 @@ fn apply_state(
         // any in-flight `fetch_more` sees a stale ticket and bails.
         model.as_mut().rust_mut().seq.fetch_add(1, Ordering::SeqCst);
         model.as_mut().ensure_cover_subscription();
-        enqueue_recents_covers(&entries);
+        if !model.cover_requests_paused {
+            enqueue_recents_covers(&entries);
+        }
         let count = i32::try_from(entries.len()).unwrap_or(i32::MAX);
         clear_current_detail_state(model.as_mut());
         model.as_mut().begin_reset_model();
@@ -340,7 +350,9 @@ impl ffi::RecentsModel {
             NAME_ROLE => QVariant::from(&QString::from(entry.media_name.as_str())),
             PATH_ROLE => QVariant::from(&QString::from(entry.media_path.as_str())),
             SYSTEM_ID_ROLE => QVariant::from(&QString::from(entry.system_id.as_str())),
-            COVER_KEY_ROLE => QVariant::from(&QString::from(cover_key_for(entry).as_str())),
+            COVER_KEY_ROLE => QVariant::from(&QString::from(
+                cover_key_for(entry, !self.cover_requests_paused).as_str(),
+            )),
             LAUNCHER_ID_ROLE => QVariant::from(&QString::from(entry.launcher_id.as_str())),
             FAVORITE_ROLE => QVariant::from(&0_i32),
             FILE_STEM_ROLE => QVariant::from(&QString::from(file_stem_or_name(
@@ -390,6 +402,14 @@ impl ffi::RecentsModel {
                 apply_append_page(model, result, expected_prev_cursor.as_deref());
             });
         });
+    }
+
+    fn refresh_cover_keys(mut self: Pin<&mut Self>, first_row: i32, count: i32) {
+        emit_cover_key_range(self.as_mut(), first_row, count);
+    }
+
+    fn clear_pending_cover_requests(self: Pin<&mut Self>) {
+        global_media_image_cache().clear_pending_requests();
     }
 
     fn launch_at(self: Pin<&mut Self>, index: i32) {
@@ -532,7 +552,7 @@ impl ffi::RecentsModel {
 /// `QQuickImageProvider` resolves to RAM bytes; otherwise we enqueue a
 /// fetch (carrying the optional `mediaId` hint) and fall back to the
 /// system logo as a nicer placeholder than the generic file glyph.
-fn cover_key_for(entry: &MediaHistoryEntry) -> String {
+fn cover_key_for(entry: &MediaHistoryEntry, requests_enabled: bool) -> String {
     if entry.system_id.is_empty() {
         return "icons/File".to_string();
     }
@@ -543,7 +563,7 @@ fn cover_key_for(entry: &MediaHistoryEntry) -> String {
     let soft_no_image = media_key
         .as_ref()
         .is_some_and(|k| cache.is_soft_no_image(k));
-    if !cached && !negative && !soft_no_image {
+    if requests_enabled && !cached && !negative && !soft_no_image {
         // Miss-driven re-enqueue, same rationale as GamesModel's
         // `cover_key_for`: tiles re-bound after LRU eviction or stale-
         // enqueue truncation will hit this branch and re-arm the fetch.
@@ -551,7 +571,32 @@ fn cover_key_for(entry: &MediaHistoryEntry) -> String {
             cache.enqueue_search_cover_with_media_id(k.clone(), entry.media_id, PAGE_SIZE);
         }
     }
-    cover_key_for_with(entry, media_key.as_ref(), cached, negative, soft_no_image)
+    cover_key_for_with(
+        entry,
+        media_key.as_ref(),
+        cached,
+        negative,
+        soft_no_image || !requests_enabled,
+    )
+}
+
+fn emit_cover_key_range(mut model: Pin<&mut ffi::RecentsModel>, first_row: i32, count: i32) {
+    if model.count <= 0 || count <= 0 {
+        return;
+    }
+    let first = first_row.clamp(0, model.count - 1);
+    let last = first.saturating_add(count - 1).min(model.count - 1);
+    if last < first {
+        return;
+    }
+    let mut roles = QList::<i32>::default();
+    roles.append(COVER_KEY_ROLE);
+    let parent = QModelIndex::default();
+    let top_left = model.index(first, 0, &parent);
+    let bottom_right = model.index(last, 0, &parent);
+    model
+        .as_mut()
+        .data_changed(&top_left, &bottom_right, &roles);
 }
 
 /// Build the canonical `(systemId, mediaPath)` identifier for a history
@@ -924,7 +969,9 @@ fn apply_append_page(
             let has_next_page = result.has_next_page();
             let next_cursor = result.next_cursor();
             let new_count = i32::try_from(result.entries.len()).unwrap_or(i32::MAX - model.count);
-            enqueue_recents_covers(&result.entries);
+            if !model.cover_requests_paused {
+                enqueue_recents_covers(&result.entries);
+            }
             if new_count > 0 {
                 let first = model.count;
                 let last = first.saturating_add(new_count).saturating_sub(1);

--- a/rust/frontend/src/models/recents.rs
+++ b/rust/frontend/src/models/recents.rs
@@ -581,7 +581,7 @@ fn cover_key_for(entry: &MediaHistoryEntry, requests_enabled: bool) -> String {
 }
 
 fn emit_cover_key_range(mut model: Pin<&mut ffi::RecentsModel>, first_row: i32, count: i32) {
-    if model.count <= 0 || count <= 0 {
+    if model.count <= 0 || count <= 0 || first_row >= model.count {
         return;
     }
     let first = first_row.clamp(0, model.count - 1);

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -1475,6 +1475,7 @@ MainLayout {
             // above rather than leak it to the root screen.
             return;
         }
+        root._noteRapidNavigationAction(action, false);
         if (root.activeScreen === root.screenGames) {
             root.gamesScreen.handleAction(action);
         } else if (root.activeScreen === root.screenSystems) {
@@ -1492,20 +1493,22 @@ MainLayout {
         }
     }
 
-    // Hold-to-repeat for dpad directions. Qt's OS-level auto-repeat is
+    // Hold-to-repeat for navigation actions. Qt's OS-level auto-repeat is
     // dropped (see Keys.onPressed below) because it bursts unpredictably
     // on heavy UI loads and isn't tunable on MiSTer's framebuffer build.
-    // Instead, on a real press of one of the four dpad actions we start
-    // an initial-delay timer; on its first fire we hand over to a steady
+    // Instead, on a real press of a repeatable action we start an
+    // initial-delay timer; on its first fire we hand over to a steady
     // tick. Both fire `handleAction(heldAction)`, which means the existing
     // transition gate, modal routing, and screen dispatch all apply
     // unchanged — repeats land on whichever screen / modal is currently
     // active, just like fresh presses.
     readonly property int _repeatInitialMs: 350
     readonly property int _repeatTickMs: 90
+    readonly property int _rapidNavigationQuietMs: 260
     property string _heldAction: ""
     property int _heldKey: 0
-    readonly property bool _listDetailRapidScrollActive: root._repeatTicking && (root._heldAction === "up" || root._heldAction === "down")
+    property bool rapidNavigationActive: false
+    property string rapidNavigationAction: ""
     // Aliased so tst_navigation.qml can observe the repeat state machine
     // — child Timer ids are file-scoped and aren't reachable otherwise.
     property alias _repeatPending: repeatInitial.running
@@ -1529,23 +1532,60 @@ MainLayout {
     Binding {
         target: root.gamesScreen
         property: "detailRapidScrollActive"
-        value: root.activeScreen === root.screenGames && root._listDetailRapidScrollActive
+        value: root.activeScreen === root.screenGames && root.rapidNavigationActive
+    }
+
+    Binding {
+        target: root.gamesScreen
+        property: "detailRapidScrollAction"
+        value: root.activeScreen === root.screenGames ? root.rapidNavigationAction : ""
     }
 
     Binding {
         target: root.favoritesScreen
         property: "detailRapidScrollActive"
-        value: root.activeScreen === root.screenFavorites && root._listDetailRapidScrollActive
+        value: root.activeScreen === root.screenFavorites && root.rapidNavigationActive
+    }
+
+    Binding {
+        target: root.favoritesScreen
+        property: "detailRapidScrollAction"
+        value: root.activeScreen === root.screenFavorites ? root.rapidNavigationAction : ""
     }
 
     Binding {
         target: root.recentsScreen
         property: "detailRapidScrollActive"
-        value: root.activeScreen === root.screenRecents && root._listDetailRapidScrollActive
+        value: root.activeScreen === root.screenRecents && root.rapidNavigationActive
+    }
+
+    Binding {
+        target: root.recentsScreen
+        property: "detailRapidScrollAction"
+        value: root.activeScreen === root.screenRecents ? root.rapidNavigationAction : ""
+    }
+
+    function _isRapidNavigationAction(action: string): bool {
+        return action === "up" || action === "down" || action === "page_prev" || action === "page_next";
+    }
+
+    function _noteRapidNavigationAction(action: string, forceActive: bool): void {
+        if (!root._isRapidNavigationAction(action))
+            return;
+        root.rapidNavigationAction = action;
+        if (forceActive || rapidNavigationQuiet.running)
+            root.rapidNavigationActive = true;
+        rapidNavigationQuiet.restart();
+    }
+
+    function _resetRapidNavigation(): void {
+        rapidNavigationQuiet.stop();
+        root.rapidNavigationActive = false;
+        root.rapidNavigationAction = "";
     }
 
     function _isRepeatableAction(action: string): bool {
-        return action === "up" || action === "down" || action === "left" || action === "right";
+        return action === "up" || action === "down" || action === "left" || action === "right" || action === "page_prev" || action === "page_next";
     }
 
     // State-machine half of handleKey: records the held key/action and
@@ -1693,6 +1733,7 @@ MainLayout {
     }
 
     function _handleRepeatAction(): void {
+        root._noteRapidNavigationAction(root._heldAction, true);
         root.handleAction(root._heldAction);
     }
 
@@ -1701,6 +1742,16 @@ MainLayout {
         interval: 1500
         repeat: false
         onTriggered: root.hideCardWriteModal()
+    }
+
+    Timer {
+        id: rapidNavigationQuiet
+        interval: root._rapidNavigationQuietMs
+        repeat: false
+        onTriggered: {
+            root.rapidNavigationActive = false;
+            root.rapidNavigationAction = "";
+        }
     }
 
     Timer {

--- a/src/ui/components/CMakeLists.txt
+++ b/src/ui/components/CMakeLists.txt
@@ -28,6 +28,7 @@ qt_add_qml_module(
         Modal.qml
         PagedGrid.qml
         QrCodeModal.qml
+        RapidScrollIndicator.qml
         ScreensaverOverlay.qml
         ScreenStateOverlay.qml
         SettingsField.qml

--- a/src/ui/components/ContextMenu.qml
+++ b/src/ui/components/ContextMenu.qml
@@ -39,8 +39,12 @@ Item {
     readonly property int rowHeight: Sizing.pctH(6)
     readonly property int rowSpacing: Sizing.pctH(1)
     readonly property int horizontalPadding: Sizing.pctW(2)
+    readonly property int panelSideMargin: Sizing.pctW(1)
+    readonly property string _longestLabel: _longestEntryLabel(entries)
     readonly property int _usableBottom: Math.max(menu.margin, height - menu.bottomUnsafeHeight - menu.margin)
-    readonly property int panelWidth: Math.min(Math.max(Sizing.pctW(42), Sizing.pctH(56)), Math.max(0, width - 2 * margin))
+    readonly property int _minPanelWidth: Math.max(Sizing.pctW(24), Sizing.pctH(32))
+    readonly property int _desiredPanelWidth: Math.ceil(labelMetrics.advanceWidth) + 2 * horizontalPadding + 2 * panelSideMargin + 2 * Sizing.stroke(2)
+    readonly property int panelWidth: Math.min(Math.max(_minPanelWidth, _desiredPanelWidth), Math.max(0, width - 2 * margin))
     // Top/bottom margins inside the panel are sized to the panel
     // radius so a focused row's accent ring never intersects the
     // rounded corners — see the panel `Rectangle` below.
@@ -72,6 +76,18 @@ Item {
             currentIndex = menu.entries.length - 1;
     }
 
+    function _longestEntryLabel(source: var): string {
+        let longest = "";
+        if (source === null || source === undefined)
+            return longest;
+        for (let i = 0; i < source.length; ++i) {
+            const label = source[i] && source[i].label !== undefined ? String(source[i].label) : "";
+            if (label.length > longest.length)
+                longest = label;
+        }
+        return longest;
+    }
+
     function move(delta: int): void {
         if (menu.entries.length <= 0)
             return;
@@ -88,6 +104,13 @@ Item {
                 menu.accepted(menu.entries[menu.currentIndex].id);
         } else if (action === "cancel" || action === "write_card")
             menu.closeRequested();
+    }
+
+    TextMetrics {
+        id: labelMetrics
+        text: menu._longestLabel
+        font.family: Theme.fontUi
+        font.pixelSize: Sizing.fontSize(2.4)
     }
 
     // Catches dismiss-clicks on the dimmed area around the anchor.
@@ -163,8 +186,8 @@ Item {
             anchors.fill: parent
             anchors.topMargin: menu.panelRadius
             anchors.bottomMargin: menu.panelRadius
-            anchors.leftMargin: Sizing.pctW(1)
-            anchors.rightMargin: Sizing.pctW(1)
+            anchors.leftMargin: menu.panelSideMargin
+            anchors.rightMargin: menu.panelSideMargin
             spacing: menu.rowSpacing
 
             Repeater {

--- a/src/ui/components/ContextMenu.qml
+++ b/src/ui/components/ContextMenu.qml
@@ -40,10 +40,10 @@ Item {
     readonly property int rowSpacing: Sizing.pctH(1)
     readonly property int horizontalPadding: Sizing.pctW(2)
     readonly property int panelSideMargin: Sizing.pctW(1)
-    readonly property string _longestLabel: _longestEntryLabel(entries)
+    readonly property int _widestLabelWidth: _widestEntryLabelWidth(entries)
     readonly property int _usableBottom: Math.max(menu.margin, height - menu.bottomUnsafeHeight - menu.margin)
     readonly property int _minPanelWidth: Math.max(Sizing.pctW(24), Sizing.pctH(32))
-    readonly property int _desiredPanelWidth: Math.ceil(labelMetrics.advanceWidth) + 2 * horizontalPadding + 2 * panelSideMargin + 2 * Sizing.stroke(2)
+    readonly property int _desiredPanelWidth: _widestLabelWidth + 2 * horizontalPadding + 2 * panelSideMargin + 2 * Sizing.stroke(2)
     readonly property int panelWidth: Math.min(Math.max(_minPanelWidth, _desiredPanelWidth), Math.max(0, width - 2 * margin))
     // Top/bottom margins inside the panel are sized to the panel
     // radius so a focused row's accent ring never intersects the
@@ -76,16 +76,15 @@ Item {
             currentIndex = menu.entries.length - 1;
     }
 
-    function _longestEntryLabel(source: var): string {
-        let longest = "";
+    function _widestEntryLabelWidth(source: var): int {
+        let widest = 0;
         if (source === null || source === undefined)
-            return longest;
+            return widest;
         for (let i = 0; i < source.length; ++i) {
             const label = source[i] && source[i].label !== undefined ? String(source[i].label) : "";
-            if (label.length > longest.length)
-                longest = label;
+            widest = Math.max(widest, Math.ceil(labelMetrics.advanceWidth(label)));
         }
-        return longest;
+        return widest;
     }
 
     function move(delta: int): void {
@@ -106,9 +105,8 @@ Item {
             menu.closeRequested();
     }
 
-    TextMetrics {
+    FontMetrics {
         id: labelMetrics
-        text: menu._longestLabel
         font.family: Theme.fontUi
         font.pixelSize: Sizing.fontSize(2.4)
     }

--- a/src/ui/components/PagedGrid.qml
+++ b/src/ui/components/PagedGrid.qml
@@ -50,6 +50,7 @@ Item {
     // Defaults to true so call sites that don't care keep working
     // untouched.
     property bool focused: true
+    property bool coverLoadingPaused: false
     property var layoutProfile: null
     readonly property var _gridProfile: root.layoutProfile && root.layoutProfile.grid ? root.layoutProfile.grid : null
 
@@ -522,11 +523,10 @@ Item {
                 // row at construction. Two-tier gate, both anchored on
                 // distance from `root.currentPage`:
                 //
-                //   - request range (±2 pages): cells inside this
-                //     radius fire image-provider requests. Bounds the
-                //     initial fanout to a fixed ~50 covers while still
-                //     pre-decoding pages N+1 and N+2 so a forward PgDn
-                //     lands on already-cached pixmaps.
+                //   - request range (current page only): visible cells
+                //     fire image-provider requests. Rust owns ordered
+                //     current/next/previous page prefetch so hidden QML
+                //     delegates do not fight the explicit queue.
                 //   - retention range (±5 pages): cells inside this
                 //     radius keep their TileLoader.active=true so the
                 //     Tile delegate stays materialised, AND cells that
@@ -553,8 +553,8 @@ Item {
                 // after crossing past the retention edge runs at
                 // nice +10 (see media_image_provider.cpp) and is
                 // invisible to the renderer.
-                readonly property bool _coverInRange: Math.abs(cellPage - root.currentPage) <= 2
-                readonly property bool _coverInRetentionRange: Math.abs(cellPage - root.currentPage) <= 5
+                readonly property bool _coverInRange: cellPage === root.currentPage
+                readonly property bool _coverInRetentionRange: Math.abs(cellPage - root.currentPage) <= (root.coverLoadingPaused ? 1 : 5)
                 property bool _coverEverRequested: false
                 Binding on _coverEverRequested {
                     when: cellItem._coverInRange

--- a/src/ui/components/RapidScrollIndicator.qml
+++ b/src/ui/components/RapidScrollIndicator.qml
@@ -1,0 +1,49 @@
+// Zaparoo Frontend
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+import QtQuick
+import Zaparoo.Theme
+
+Item {
+    id: root
+
+    property string title: ""
+
+    readonly property string _trimmedTitle: title.trim()
+    readonly property string _letter: _trimmedTitle === "" ? "#" : _trimmedTitle.charAt(0).toUpperCase()
+
+    width: Sizing.pctH(18)
+    height: width
+
+    Rectangle {
+        anchors.fill: parent
+        color: Theme.surfaceCard
+        border.color: Theme.borderMid
+        border.width: Sizing.stroke(1)
+        radius: Sizing.cornerRadius
+    }
+
+    Text {
+        id: letterText
+
+        x: Sizing.center(parent.width, width)
+        y: Sizing.center(parent.height, height)
+        width: Math.min(parent.width, Math.ceil(letterMetrics.advanceWidth) + 2)
+        height: Sizing.fontSize(10)
+        text: root._letter
+        color: Theme.textPrimary
+        font.family: Theme.fontUi
+        font.pixelSize: Sizing.fontSize(10)
+        horizontalAlignment: Text.AlignLeft
+        verticalAlignment: Text.AlignVCenter
+        renderType: Text.NativeRendering
+    }
+
+    TextMetrics {
+        id: letterMetrics
+        text: letterText.text
+        font.family: letterText.font.family
+        font.pixelSize: letterText.font.pixelSize
+    }
+}

--- a/src/ui/components/RapidScrollIndicator.qml
+++ b/src/ui/components/RapidScrollIndicator.qml
@@ -29,7 +29,7 @@ Item {
 
         x: Sizing.center(parent.width, width)
         y: Sizing.center(parent.height, height)
-        width: Math.min(parent.width, Math.ceil(letterMetrics.advanceWidth) + 2)
+        width: Math.min(parent.width, Math.ceil(letterMetrics.advanceWidth) + Sizing.px(2))
         height: Sizing.fontSize(10)
         text: root._letter
         color: Theme.textPrimary

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -130,7 +130,7 @@ MediaListScreen {
         const total = Math.max(1, Browse.GamesModel.dir_count + Browse.GamesModel.total_files);
         return qsTr("%1 / %2").arg(games.gamesGrid.currentIndex + 1).arg(total);
     }
-    gridBottomMargin: games._footerProfile ? games._footerProfile.gridBottomMargin : (Sizing.pctH(6) + Sizing.pctH(8) + Sizing.pctH(7))
+    gridBottomMargin: games._footerProfile ? games._footerProfile.gridBottomMargin : (Sizing.pctH(8) + Sizing.pctH(7))
     gridColumnsOverride: games._gridColumns
     gridRowsOverride: games._gridRows
     gridTotalItemsOverride: Browse.GamesModel.dir_count + Browse.GamesModel.total_files

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -53,6 +53,7 @@ MediaListScreen {
     detailShowDescription: false
     detailShowTitle: false
     detailLoadingText: qsTr("Loading game…")
+    pauseCoverRequestsDuringRapid: false
     detailCanPreviousImage: Browse.GamesModel.current_detail_image_can_prev
     detailCanNextImage: Browse.GamesModel.current_detail_image_can_next
     detailIdentityForIndex: function (index) {

--- a/src/ui/screens/MediaListScreen.qml
+++ b/src/ui/screens/MediaListScreen.qml
@@ -68,6 +68,8 @@ Item {
     property bool transitioning: false
     property bool gridFocused: true
     property bool detailRapidScrollActive: false
+    property string detailRapidScrollAction: ""
+    property bool pauseCoverRequestsDuringRapid: true
     property bool forceListLayout: false
     property bool renderGridLayout: true
     property bool showTopStrip: true
@@ -86,6 +88,8 @@ Item {
     property string bottomStatusRightText: ""
     property int gridTotalItemsOverride: -1
     property bool gridHasMorePages: false
+    readonly property bool _listRapidLineMove: root._listLayout && (root.detailRapidScrollAction === "up" || root.detailRapidScrollAction === "down")
+    readonly property bool _showRapidScrollIndicator: root.detailRapidScrollActive && !root._listRapidLineMove
     readonly property bool _listLayout: root.forceListLayout || Browse.Settings.current_browse_layout === "list"
     readonly property bool _tateListLayout: root._listLayout && Browse.Settings.current_orientation !== "horizontal"
     readonly property string _activeListViewId: root._tateListLayout ? root.tateListViewId : root.listViewId
@@ -189,6 +193,44 @@ Item {
         root._persistFocus();
         if (next >= count - 2)
             root.mediaModel.fetch_more();
+    }
+
+    function _coverRefreshFirstRow(): int {
+        if (!root._listLayout)
+            return mediaGrid.currentPage * mediaGrid.pageSize;
+        return Math.max(0, mediaGrid.currentIndex - listCard.visibleRowCount);
+    }
+
+    function _coverRefreshRowCount(): int {
+        if (!root._listLayout)
+            return mediaGrid.pageSize * 2;
+        return Math.max(1, listCard.visibleRowCount * 3);
+    }
+
+    function _resumeCoverRequests(): void {
+        if (root.mediaModel === null)
+            return;
+        if (root.pauseCoverRequestsDuringRapid)
+            root.mediaModel.cover_requests_paused = false;
+        if (typeof root.mediaModel.refresh_cover_keys === "function")
+            root.mediaModel.refresh_cover_keys(root._coverRefreshFirstRow(), root._coverRefreshRowCount());
+        if (!root._listLayout && typeof root.gridCurrentPageChangedAction === "function")
+            root.gridCurrentPageChangedAction();
+    }
+
+    function _pauseCoverRequests(): void {
+        if (root.mediaModel === null || !root.pauseCoverRequestsDuringRapid)
+            return;
+        root.mediaModel.cover_requests_paused = true;
+        if (typeof root.mediaModel.clear_pending_cover_requests === "function")
+            root.mediaModel.clear_pending_cover_requests();
+    }
+
+    onDetailRapidScrollActiveChanged: {
+        if (root.detailRapidScrollActive)
+            root._pauseCoverRequests();
+        else
+            root._resumeCoverRequests();
     }
 
     function _performPage(delta: int): void {
@@ -370,6 +412,7 @@ Item {
         rowsOverride: root.gridRowsOverride
         totalItemsOverride: root.gridTotalItemsOverride
         hasMorePages: root.gridHasMorePages
+        coverLoadingPaused: root.detailRapidScrollActive
         onLoadMoreRequested: {
             if (typeof root.gridLoadMoreAction === "function")
                 root.gridLoadMoreAction();
@@ -450,6 +493,14 @@ Item {
         anchors.left: activeLabel.left
         anchors.leftMargin: root.pageLoadingLeftMargin
         anchors.verticalCenter: activeLabel.verticalCenter
+    }
+
+    RapidScrollIndicator {
+        visible: !root._gateHide && root._showRapidScrollIndicator && mediaGrid.itemCount > 0
+        x: Sizing.center(parent.width, width)
+        y: root._listLayout ? Sizing.center(parent.height, height) : Sizing.center(mediaGrid.height, height) + mediaGrid.y
+        title: typeof root.activeLabelTextProvider === "function" ? root.activeLabelTextProvider() : (mediaGrid.itemCount > 0 && root.mediaModel !== null ? root.mediaModel.name_at(mediaGrid.currentIndex) : "")
+        z: 20
     }
 
     ScreenStateOverlay {

--- a/src/ui/screens/SystemsScreen.qml
+++ b/src/ui/screens/SystemsScreen.qml
@@ -230,9 +230,8 @@ Item {
     }
 
     // Grid fills the safe zone between the top strip and the active
-    // label. bottomMargin = MainLayout's instructionsBar height
-    // (pctH(6)) + pctH(2) gap + the active label's pctH(7). If you
-    // change the help-bar height or the label height, update this too.
+    // label. The bottom margin reserves the label's own bottom margin
+    // plus its height; the global help bar is handled separately.
     PagedGrid {
         id: systemsGrid
 
@@ -240,7 +239,7 @@ Item {
         anchors.right: parent.right
         anchors.top: topStrip.bottom
         anchors.bottom: parent.bottom
-        anchors.bottomMargin: systems._footerProfile ? systems._footerProfile.gridBottomMargin : (Sizing.pctH(6) + Sizing.pctH(8) + Sizing.pctH(7))
+        anchors.bottomMargin: systems._footerProfile ? systems._footerProfile.gridBottomMargin : (Sizing.pctH(8) + Sizing.pctH(7))
         focused: systems.gridFocused
         model: Browse.SystemsModel
         layoutProfile: systems._viewProfile

--- a/src/ui/theme/BrowseLayouts.qml
+++ b/src/ui/theme/BrowseLayouts.qml
@@ -48,7 +48,7 @@ QtObject {
                         "bottomStatusVisible": false,
                         "bottomStatusLeftMargin": "pctW:5",
                         "bottomStatusRightMargin": "pctW:5",
-                        "gridBottomMargin": "sum(pctH:6,pctH:8,pctH:7)",
+                        "gridBottomMargin": "sum(pctH:8,pctH:7)",
                         "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
                     },
                     "surface": {
@@ -232,7 +232,7 @@ QtObject {
                         "bottomStatusVisible": false,
                         "bottomStatusLeftMargin": "pctW:5",
                         "bottomStatusRightMargin": "pctW:5",
-                        "gridBottomMargin": "sum(pctH:6,pctH:8,pctH:7)",
+                        "gridBottomMargin": "sum(pctH:8,pctH:7)",
                         "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
                     },
                     "surface": {

--- a/src/ui/theme/BrowseLayouts.qml
+++ b/src/ui/theme/BrowseLayouts.qml
@@ -10,748 +10,752 @@ import Zaparoo.Theme
 // integer geometry through Sizing.
 QtObject {
     readonly property string currentThemeId: Theme.crtNativePath ? "crt" : "default"
-    readonly property var _themes: ({
-        "default": {
-            "systemsGrid": {
-                "header": {
-                    "titleInHeader": false,
-                    "hudBottomAligned": false,
-                    "statusPillPinnedTop": false
+    readonly property var _themes: _builtInThemes()
+
+    function _builtInThemes(): var {
+        return {
+            "default": {
+                "systemsGrid": {
+                    "header": {
+                        "titleInHeader": false,
+                        "hudBottomAligned": false,
+                        "statusPillPinnedTop": false
+                    },
+                    "status": {
+                        "topStripVisible": true,
+                        "stripHeight": "pctH:7",
+                        "slotMargin": "pctW:5",
+                        "topMargin": "pctH:1"
+                    },
+                    "grid": {
+                        "leftInset": "pctW:5",
+                        "rightInset": "pctW:5",
+                        "gutterWidth": "pctW:3",
+                        "gutterGap": "pctW:1.5",
+                        "columnGap": "pctW:3",
+                        "topInset": "pctH:2",
+                        "bottomInset": "pctH:2",
+                        "rowGap": "pctH:4",
+                        "scrollThumbWidth": "pctW:1.2",
+                        "scrollThumbRightInset": 0,
+                        "scrollThumbRightAligned": false,
+                        "scrollArrowSize": "min(pctW:3,pctH:4)",
+                        "gutterFollowsContentWidth": false
+                    },
+                    "footer": {
+                        "activeLabelHeight": "pctH:7",
+                        "activeLabelBottomMargin": "pctH:8",
+                        "bottomStatusVisible": false,
+                        "bottomStatusLeftMargin": "pctW:5",
+                        "bottomStatusRightMargin": "pctW:5",
+                        "gridBottomMargin": "sum(pctH:6,pctH:8,pctH:7)",
+                        "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
+                    },
+                    "surface": {
+                        "cornerRadius": "cornerRadius"
+                    }
                 },
-                "status": {
-                    "topStripVisible": true,
-                    "stripHeight": "pctH:7",
-                    "slotMargin": "pctW:5",
-                    "topMargin": "pctH:1"
+                "systemsList": {
+                    "header": {
+                        "titleInHeader": false,
+                        "hudBottomAligned": false,
+                        "statusPillPinnedTop": false
+                    },
+                    "status": {
+                        "topStripVisible": true,
+                        "stripHeight": "pctH:7",
+                        "slotMargin": "pctW:5",
+                        "topMargin": "pctH:1"
+                    },
+                    "list": {
+                        "contentAxis": "horizontal",
+                        "listShare": 2,
+                        "detailShare": 1,
+                        "dividerWidth": 1,
+                        "dividerMargin": 0,
+                        "cardSideMargin": "pctW:5",
+                        "cardTopMargin": "pctH:2",
+                        "cardBottomMargin": "pctH:8",
+                        "cardPaddingLeft": "pctW:2",
+                        "cardPaddingRight": "pctW:2",
+                        "cardPaddingTop": "pctH:2",
+                        "cardPaddingBottom": "pctH:2",
+                        "rowHeight": 0,
+                        "rowSpacing": "pctH:0.7",
+                        "centerSlot": -1,
+                        "scrollbarGap": "pctW:1.5",
+                        "selectionAccentWidth": "pctW:0.45",
+                        "rowTextLeftPadding": "pctW:1.6",
+                        "rowTextRightPadding": "pctW:1.6",
+                        "favoriteRightPadding": "pctW:1.6",
+                        "overlayBottomMargin": "pctH:15"
+                    },
+                    "detail": {
+                        "contentAxis": "vertical",
+                        "sectionGap": "pctH:2",
+                        "imageShare": 2,
+                        "metadataShare": 1,
+                        "imageHeightRatioWithTitle": 48,
+                        "imageReservedWidth": 0,
+                        "imageReservedHeight": 0,
+                        "imageBottomMargin": 0,
+                        "panePaddingLeft": "pctW:2",
+                        "panePaddingRight": "pctW:2",
+                        "panePaddingTop": "pctH:2",
+                        "panePaddingBottom": "pctH:2",
+                        "imagePaddingLeft": 0,
+                        "imagePaddingRight": 0,
+                        "imagePaddingTop": 0,
+                        "imagePaddingBottom": 0,
+                        "metadataPaddingLeft": 0,
+                        "metadataPaddingRight": 0,
+                        "metadataPaddingTop": 0,
+                        "metadataPaddingBottom": 0,
+                        "metadataTopMargin": 12,
+                        "metadataLeftMargin": 0,
+                        "metadataRightMargin": 0,
+                        "metadataHeightAdjustment": 0,
+                        "metadataBottomAligned": false,
+                        "titleBottomMargin": "pctH:2",
+                        "tagRowHeight": "pctH:3",
+                        "tagRowSpacing": "pctH:0.55"
+                    },
+                    "footer": {
+                        "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
+                    },
+                    "surface": {
+                        "cornerRadius": "cornerRadius"
+                    }
                 },
-                "grid": {
-                    "leftInset": "pctW:5",
-                    "rightInset": "pctW:5",
-                    "gutterWidth": "pctW:3",
-                    "gutterGap": "pctW:1.5",
-                    "columnGap": "pctW:3",
-                    "topInset": "pctH:2",
-                    "bottomInset": "pctH:2",
-                    "rowGap": "pctH:4",
-                    "scrollThumbWidth": "pctW:1.2",
-                    "scrollThumbRightInset": 0,
-                    "scrollThumbRightAligned": false,
-                    "scrollArrowSize": "min(pctW:3,pctH:4)",
-                    "gutterFollowsContentWidth": false
+                "systemsListTate": {
+                    "header": {
+                        "titleInHeader": false,
+                        "hudBottomAligned": false,
+                        "statusPillPinnedTop": false
+                    },
+                    "status": {
+                        "topStripVisible": true,
+                        "stripHeight": "pctH:7",
+                        "slotMargin": "pctW:5",
+                        "topMargin": "pctH:1"
+                    },
+                    "list": {
+                        "contentAxis": "vertical",
+                        "listShare": 11,
+                        "detailShare": 5,
+                        "dividerWidth": 1,
+                        "dividerMargin": 0,
+                        "cardSideMargin": "pctW:5",
+                        "cardTopMargin": "pctH:2",
+                        "cardBottomMargin": "pctH:8",
+                        "cardPaddingLeft": "pctW:2",
+                        "cardPaddingRight": "pctW:2",
+                        "cardPaddingTop": "pctH:2",
+                        "cardPaddingBottom": "pctH:2",
+                        "rowHeight": 0,
+                        "rowSpacing": "pctH:0.3",
+                        "centerSlot": -1,
+                        "scrollbarGap": "pctW:1.5",
+                        "selectionAccentWidth": "pctW:0.45",
+                        "rowTextLeftPadding": "pctW:1.6",
+                        "rowTextRightPadding": "pctW:1.6",
+                        "favoriteRightPadding": "pctW:1.6",
+                        "overlayBottomMargin": "pctH:15"
+                    },
+                    "detail": {
+                        "contentAxis": "horizontal",
+                        "sectionGap": "pctW:3",
+                        "imageShare": 4,
+                        "metadataShare": 8,
+                        "imageHeightRatioWithTitle": 48,
+                        "imageReservedWidth": 0,
+                        "imageReservedHeight": 0,
+                        "imageBottomMargin": 0,
+                        "panePaddingLeft": "pctW:3",
+                        "panePaddingRight": "pctW:3",
+                        "panePaddingTop": "pctH:1.2",
+                        "panePaddingBottom": "pctH:1.2",
+                        "imagePaddingLeft": 0,
+                        "imagePaddingRight": "pctW:1",
+                        "imagePaddingTop": "pctH:0.8",
+                        "imagePaddingBottom": "pctH:0.8",
+                        "metadataPaddingLeft": "pctW:1.5",
+                        "metadataPaddingRight": "pctW:0.5",
+                        "metadataPaddingTop": "pctH:0.8",
+                        "metadataPaddingBottom": "pctH:0.8",
+                        "metadataTopMargin": 12,
+                        "metadataLeftMargin": 0,
+                        "metadataRightMargin": 0,
+                        "metadataHeightAdjustment": 0,
+                        "metadataBottomAligned": false,
+                        "titleBottomMargin": "pctH:1",
+                        "tagRowHeight": "pctH:2.6",
+                        "tagRowSpacing": "pctH:0.35"
+                    },
+                    "footer": {
+                        "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
+                    },
+                    "surface": {
+                        "cornerRadius": "cornerRadius"
+                    }
                 },
-                "footer": {
-                    "activeLabelHeight": "pctH:7",
-                    "activeLabelBottomMargin": "pctH:8",
-                    "bottomStatusVisible": false,
-                    "bottomStatusLeftMargin": "pctW:5",
-                    "bottomStatusRightMargin": "pctW:5",
-                    "gridBottomMargin": "sum(pctH:6,pctH:8,pctH:7)",
-                    "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
+                "gamesGrid": {
+                    "header": {
+                        "titleInHeader": false,
+                        "hudBottomAligned": false,
+                        "statusPillPinnedTop": false
+                    },
+                    "status": {
+                        "topStripVisible": true,
+                        "stripHeight": "pctH:7",
+                        "slotMargin": "pctW:5",
+                        "topMargin": "pctH:1"
+                    },
+                    "grid": {
+                        "leftInset": "pctW:5",
+                        "rightInset": "pctW:5",
+                        "gutterWidth": "pctW:3",
+                        "gutterGap": "pctW:1.5",
+                        "columnGap": "pctW:3",
+                        "topInset": "pctH:2",
+                        "bottomInset": "pctH:2",
+                        "rowGap": "pctH:4",
+                        "scrollThumbWidth": "pctW:1.2",
+                        "scrollThumbRightInset": 0,
+                        "scrollThumbRightAligned": false,
+                        "scrollArrowSize": "min(pctW:3,pctH:4)",
+                        "gutterFollowsContentWidth": false
+                    },
+                    "footer": {
+                        "activeLabelHeight": "pctH:7",
+                        "activeLabelBottomMargin": "pctH:8",
+                        "bottomStatusVisible": false,
+                        "bottomStatusLeftMargin": "pctW:5",
+                        "bottomStatusRightMargin": "pctW:5",
+                        "gridBottomMargin": "sum(pctH:6,pctH:8,pctH:7)",
+                        "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
+                    },
+                    "surface": {
+                        "cornerRadius": "cornerRadius"
+                    }
                 },
-                "surface": {
-                    "cornerRadius": "cornerRadius"
+                "gamesList": {
+                    "header": {
+                        "titleInHeader": false,
+                        "hudBottomAligned": false,
+                        "statusPillPinnedTop": false
+                    },
+                    "status": {
+                        "topStripVisible": true,
+                        "stripHeight": "pctH:7",
+                        "slotMargin": "pctW:5",
+                        "topMargin": "pctH:1"
+                    },
+                    "list": {
+                        "contentAxis": "horizontal",
+                        "listShare": 2,
+                        "detailShare": 1,
+                        "dividerWidth": 1,
+                        "dividerMargin": 0,
+                        "cardSideMargin": "pctW:5",
+                        "cardTopMargin": "pctH:2",
+                        "cardBottomMargin": "pctH:8",
+                        "cardPaddingLeft": "pctW:2",
+                        "cardPaddingRight": "pctW:2",
+                        "cardPaddingTop": "pctH:2",
+                        "cardPaddingBottom": "pctH:2",
+                        "rowHeight": 0,
+                        "rowSpacing": "pctH:0.7",
+                        "centerSlot": -1,
+                        "scrollbarGap": "pctW:1.5",
+                        "selectionAccentWidth": "pctW:0.45",
+                        "rowTextLeftPadding": "pctW:1.6",
+                        "rowTextRightPadding": "pctW:1.6",
+                        "favoriteRightPadding": "pctW:1.6",
+                        "overlayBottomMargin": "pctH:15"
+                    },
+                    "detail": {
+                        "contentAxis": "vertical",
+                        "sectionGap": "pctH:2",
+                        "imageShare": 2,
+                        "metadataShare": 1,
+                        "imageHeightRatioWithTitle": 48,
+                        "imageReservedWidth": 0,
+                        "imageReservedHeight": 0,
+                        "imageBottomMargin": 0,
+                        "panePaddingLeft": "pctW:2",
+                        "panePaddingRight": "pctW:2",
+                        "panePaddingTop": "pctH:2",
+                        "panePaddingBottom": "pctH:2",
+                        "imagePaddingLeft": 0,
+                        "imagePaddingRight": 0,
+                        "imagePaddingTop": 0,
+                        "imagePaddingBottom": 0,
+                        "metadataPaddingLeft": 0,
+                        "metadataPaddingRight": 0,
+                        "metadataPaddingTop": 0,
+                        "metadataPaddingBottom": 0,
+                        "metadataTopMargin": 12,
+                        "metadataLeftMargin": 0,
+                        "metadataRightMargin": 0,
+                        "metadataHeightAdjustment": 0,
+                        "metadataBottomAligned": true,
+                        "titleBottomMargin": "pctH:2",
+                        "tagRowHeight": "pctH:3",
+                        "tagRowSpacing": "pctH:0.55"
+                    },
+                    "footer": {
+                        "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
+                    },
+                    "surface": {
+                        "cornerRadius": "cornerRadius"
+                    }
+                },
+                "gamesListTate": {
+                    "header": {
+                        "titleInHeader": false,
+                        "hudBottomAligned": false,
+                        "statusPillPinnedTop": false
+                    },
+                    "status": {
+                        "topStripVisible": true,
+                        "stripHeight": "pctH:7",
+                        "slotMargin": "pctW:5",
+                        "topMargin": "pctH:1"
+                    },
+                    "list": {
+                        "contentAxis": "vertical",
+                        "listShare": 11,
+                        "detailShare": 5,
+                        "dividerWidth": 1,
+                        "dividerMargin": 0,
+                        "cardSideMargin": "pctW:5",
+                        "cardTopMargin": "pctH:2",
+                        "cardBottomMargin": "pctH:8",
+                        "cardPaddingLeft": "pctW:2",
+                        "cardPaddingRight": "pctW:2",
+                        "cardPaddingTop": "pctH:2",
+                        "cardPaddingBottom": "pctH:2",
+                        "rowHeight": 0,
+                        "rowSpacing": "pctH:0.3",
+                        "centerSlot": -1,
+                        "scrollbarGap": "pctW:1.5",
+                        "selectionAccentWidth": "pctW:0.45",
+                        "rowTextLeftPadding": "pctW:1.6",
+                        "rowTextRightPadding": "pctW:1.6",
+                        "favoriteRightPadding": "pctW:1.6",
+                        "overlayBottomMargin": "pctH:15"
+                    },
+                    "detail": {
+                        "contentAxis": "horizontal",
+                        "sectionGap": "pctW:3",
+                        "imageShare": 4,
+                        "metadataShare": 8,
+                        "imageHeightRatioWithTitle": 48,
+                        "imageReservedWidth": 0,
+                        "imageReservedHeight": 0,
+                        "imageBottomMargin": 0,
+                        "panePaddingLeft": "pctW:3",
+                        "panePaddingRight": "pctW:3",
+                        "panePaddingTop": "pctH:1.2",
+                        "panePaddingBottom": "pctH:1.2",
+                        "imagePaddingLeft": 0,
+                        "imagePaddingRight": "pctW:1",
+                        "imagePaddingTop": "pctH:0.8",
+                        "imagePaddingBottom": "pctH:0.8",
+                        "metadataPaddingLeft": "pctW:1.5",
+                        "metadataPaddingRight": "pctW:0.5",
+                        "metadataPaddingTop": "pctH:0.8",
+                        "metadataPaddingBottom": "pctH:0.8",
+                        "metadataTopMargin": 12,
+                        "metadataLeftMargin": 0,
+                        "metadataRightMargin": 0,
+                        "metadataHeightAdjustment": 0,
+                        "metadataBottomAligned": false,
+                        "titleBottomMargin": "pctH:1",
+                        "tagRowHeight": "pctH:2.6",
+                        "tagRowSpacing": "pctH:0.35"
+                    },
+                    "footer": {
+                        "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
+                    },
+                    "surface": {
+                        "cornerRadius": "cornerRadius"
+                    }
                 }
             },
-            "systemsList": {
-                "header": {
-                    "titleInHeader": false,
-                    "hudBottomAligned": false,
-                    "statusPillPinnedTop": false
+            "crt": {
+                "systemsGrid": {
+                    "header": {
+                        "titleInHeader": true,
+                        "hudBottomAligned": true,
+                        "statusPillPinnedTop": true
+                    },
+                    "status": {
+                        "topStripVisible": false,
+                        "stripHeight": 0,
+                        "slotMargin": "headerSideMargin",
+                        "topMargin": "pctH:1"
+                    },
+                    "grid": {
+                        "leftInset": 4,
+                        "rightInset": 0,
+                        "gutterWidth": 8,
+                        "gutterGap": 4,
+                        "columnGap": 4,
+                        "topInset": 2,
+                        "bottomInset": 4,
+                        "rowGap": 4,
+                        "scrollThumbWidth": 4,
+                        "scrollThumbRightInset": 2,
+                        "scrollThumbRightAligned": false,
+                        "scrollArrowSize": 8,
+                        "gutterFollowsContentWidth": true
+                    },
+                    "footer": {
+                        "activeLabelHeight": 8,
+                        "activeLabelBottomMargin": "pctH:6",
+                        "bottomStatusVisible": true,
+                        "bottomStatusLeftMargin": 4,
+                        "bottomStatusRightMargin": "pctW:5",
+                        "gridBottomMargin": "sum(pctH:6,8)",
+                        "bottomUnsafeHeight": 16
+                    },
+                    "surface": {
+                        "cornerRadius": 4
+                    }
                 },
-                "status": {
-                    "topStripVisible": true,
-                    "stripHeight": "pctH:7",
-                    "slotMargin": "pctW:5",
-                    "topMargin": "pctH:1"
+                "systemsList": {
+                    "header": {
+                        "titleInHeader": true,
+                        "hudBottomAligned": true,
+                        "statusPillPinnedTop": true
+                    },
+                    "status": {
+                        "topStripVisible": true,
+                        "stripHeight": 8,
+                        "slotMargin": "headerSideMargin",
+                        "topMargin": "pctH:1"
+                    },
+                    "list": {
+                        "contentAxis": "horizontal",
+                        "listShare": 2,
+                        "detailShare": 1,
+                        "dividerWidth": 1,
+                        "dividerMargin": -16,
+                        "cardSideMargin": 4,
+                        "cardTopMargin": "pctH:2",
+                        "cardBottomMargin": "pctH:8",
+                        "cardPaddingLeft": 3,
+                        "cardPaddingRight": 2,
+                        "cardPaddingTop": 3,
+                        "cardPaddingBottom": 2,
+                        "rowHeight": 12,
+                        "rowSpacing": 0,
+                        "centerSlot": 7,
+                        "scrollbarGap": 2,
+                        "selectionAccentWidth": 2,
+                        "rowTextLeftPadding": 4,
+                        "rowTextRightPadding": 2,
+                        "favoriteRightPadding": 2,
+                        "overlayBottomMargin": "pctH:14"
+                    },
+                    "detail": {
+                        "contentAxis": "vertical",
+                        "sectionGap": 2,
+                        "imageShare": 2,
+                        "metadataShare": 1,
+                        "imageHeightRatioWithTitle": 48,
+                        "imageReservedWidth": 16,
+                        "imageReservedHeight": 0,
+                        "imageBottomMargin": 2,
+                        "panePaddingLeft": 1,
+                        "panePaddingRight": 1,
+                        "panePaddingTop": 3,
+                        "panePaddingBottom": 2,
+                        "imagePaddingLeft": 2,
+                        "imagePaddingRight": 2,
+                        "imagePaddingTop": 0,
+                        "imagePaddingBottom": 2,
+                        "metadataPaddingLeft": 2,
+                        "metadataPaddingRight": 1,
+                        "metadataPaddingTop": 0,
+                        "metadataPaddingBottom": 0,
+                        "metadataTopMargin": 0,
+                        "metadataLeftMargin": 2,
+                        "metadataRightMargin": 1,
+                        "metadataHeightAdjustment": 2,
+                        "metadataBottomAligned": false,
+                        "titleBottomMargin": 2,
+                        "tagRowHeight": 9,
+                        "tagRowSpacing": 0
+                    },
+                    "footer": {
+                        "bottomUnsafeHeight": 16
+                    },
+                    "surface": {
+                        "cornerRadius": 4
+                    }
                 },
-                "list": {
-                    "contentAxis": "horizontal",
-                    "listShare": 2,
-                    "detailShare": 1,
-                    "dividerWidth": 1,
-                    "dividerMargin": 0,
-                    "cardSideMargin": "pctW:5",
-                    "cardTopMargin": "pctH:2",
-                    "cardBottomMargin": "pctH:8",
-                    "cardPaddingLeft": "pctW:2",
-                    "cardPaddingRight": "pctW:2",
-                    "cardPaddingTop": "pctH:2",
-                    "cardPaddingBottom": "pctH:2",
-                    "rowHeight": 0,
-                    "rowSpacing": "pctH:0.7",
-                    "centerSlot": -1,
-                    "scrollbarGap": "pctW:1.5",
-                    "selectionAccentWidth": "pctW:0.45",
-                    "rowTextLeftPadding": "pctW:1.6",
-                    "rowTextRightPadding": "pctW:1.6",
-                    "favoriteRightPadding": "pctW:1.6",
-                    "overlayBottomMargin": "pctH:15"
+                "systemsListTate": {
+                    "header": {
+                        "titleInHeader": true,
+                        "hudBottomAligned": true,
+                        "statusPillPinnedTop": true
+                    },
+                    "status": {
+                        "topStripVisible": true,
+                        "stripHeight": 8,
+                        "slotMargin": "headerSideMargin",
+                        "topMargin": "pctH:1"
+                    },
+                    "list": {
+                        "contentAxis": "vertical",
+                        "listShare": 11,
+                        "detailShare": 5,
+                        "dividerWidth": 1,
+                        "dividerMargin": 0,
+                        "cardSideMargin": 4,
+                        "cardTopMargin": "pctH:2",
+                        "cardBottomMargin": "pctH:8",
+                        "cardPaddingLeft": 3,
+                        "cardPaddingRight": 2,
+                        "cardPaddingTop": 3,
+                        "cardPaddingBottom": 2,
+                        "rowHeight": 12,
+                        "rowSpacing": 0,
+                        "centerSlot": 7,
+                        "scrollbarGap": 2,
+                        "selectionAccentWidth": 2,
+                        "rowTextLeftPadding": 4,
+                        "rowTextRightPadding": 2,
+                        "favoriteRightPadding": 2,
+                        "overlayBottomMargin": "pctH:14"
+                    },
+                    "detail": {
+                        "contentAxis": "horizontal",
+                        "sectionGap": 2,
+                        "imageShare": 4,
+                        "metadataShare": 8,
+                        "imageHeightRatioWithTitle": 48,
+                        "imageReservedWidth": 16,
+                        "imageReservedHeight": 0,
+                        "imageBottomMargin": 2,
+                        "panePaddingLeft": 2,
+                        "panePaddingRight": 1,
+                        "panePaddingTop": 1,
+                        "panePaddingBottom": 1,
+                        "imagePaddingLeft": 1,
+                        "imagePaddingRight": 2,
+                        "imagePaddingTop": 0,
+                        "imagePaddingBottom": 1,
+                        "metadataPaddingLeft": 2,
+                        "metadataPaddingRight": 1,
+                        "metadataPaddingTop": 1,
+                        "metadataPaddingBottom": 0,
+                        "metadataTopMargin": 12,
+                        "metadataLeftMargin": 0,
+                        "metadataRightMargin": 0,
+                        "metadataHeightAdjustment": 0,
+                        "metadataBottomAligned": false,
+                        "titleBottomMargin": 1,
+                        "tagRowHeight": 8,
+                        "tagRowSpacing": 0
+                    },
+                    "footer": {
+                        "bottomUnsafeHeight": 16
+                    },
+                    "surface": {
+                        "cornerRadius": 4
+                    }
                 },
-                "detail": {
-                    "contentAxis": "vertical",
-                    "sectionGap": "pctH:2",
-                    "imageShare": 2,
-                    "metadataShare": 1,
-                    "imageHeightRatioWithTitle": 48,
-                    "imageReservedWidth": 0,
-                    "imageReservedHeight": 0,
-                    "imageBottomMargin": 0,
-                    "panePaddingLeft": "pctW:2",
-                    "panePaddingRight": "pctW:2",
-                    "panePaddingTop": "pctH:2",
-                    "panePaddingBottom": "pctH:2",
-                    "imagePaddingLeft": 0,
-                    "imagePaddingRight": 0,
-                    "imagePaddingTop": 0,
-                    "imagePaddingBottom": 0,
-                    "metadataPaddingLeft": 0,
-                    "metadataPaddingRight": 0,
-                    "metadataPaddingTop": 0,
-                    "metadataPaddingBottom": 0,
-                    "metadataTopMargin": 12,
-                    "metadataLeftMargin": 0,
-                    "metadataRightMargin": 0,
-                    "metadataHeightAdjustment": 0,
-                    "metadataBottomAligned": false,
-                    "titleBottomMargin": "pctH:2",
-                    "tagRowHeight": "pctH:3",
-                    "tagRowSpacing": "pctH:0.55"
+                "gamesGrid": {
+                    "header": {
+                        "titleInHeader": true,
+                        "hudBottomAligned": true,
+                        "statusPillPinnedTop": true
+                    },
+                    "status": {
+                        "topStripVisible": false,
+                        "stripHeight": 0,
+                        "slotMargin": "headerSideMargin",
+                        "topMargin": "pctH:1"
+                    },
+                    "grid": {
+                        "leftInset": 4,
+                        "rightInset": 0,
+                        "gutterWidth": 8,
+                        "gutterGap": 4,
+                        "columnGap": 4,
+                        "topInset": 2,
+                        "bottomInset": 4,
+                        "rowGap": 4,
+                        "scrollThumbWidth": 4,
+                        "scrollThumbRightInset": 2,
+                        "scrollThumbRightAligned": false,
+                        "scrollArrowSize": 8,
+                        "gutterFollowsContentWidth": true
+                    },
+                    "footer": {
+                        "activeLabelHeight": 8,
+                        "activeLabelBottomMargin": "pctH:6",
+                        "bottomStatusVisible": true,
+                        "bottomStatusLeftMargin": 4,
+                        "bottomStatusRightMargin": "pctW:5",
+                        "gridBottomMargin": "sum(pctH:6,8)",
+                        "bottomUnsafeHeight": 16
+                    },
+                    "surface": {
+                        "cornerRadius": 4
+                    }
                 },
-                "footer": {
-                    "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
+                "gamesList": {
+                    "header": {
+                        "titleInHeader": true,
+                        "hudBottomAligned": true,
+                        "statusPillPinnedTop": true
+                    },
+                    "status": {
+                        "topStripVisible": true,
+                        "stripHeight": 8,
+                        "slotMargin": "headerSideMargin",
+                        "topMargin": "pctH:1"
+                    },
+                    "list": {
+                        "contentAxis": "horizontal",
+                        "listShare": 2,
+                        "detailShare": 1,
+                        "dividerWidth": 1,
+                        "dividerMargin": -16,
+                        "cardSideMargin": 4,
+                        "cardTopMargin": "pctH:2",
+                        "cardBottomMargin": "pctH:8",
+                        "cardPaddingLeft": 3,
+                        "cardPaddingRight": 2,
+                        "cardPaddingTop": 3,
+                        "cardPaddingBottom": 2,
+                        "rowHeight": 12,
+                        "rowSpacing": 0,
+                        "centerSlot": 7,
+                        "scrollbarGap": 2,
+                        "selectionAccentWidth": 2,
+                        "rowTextLeftPadding": 4,
+                        "rowTextRightPadding": 2,
+                        "favoriteRightPadding": 2,
+                        "overlayBottomMargin": "pctH:14"
+                    },
+                    "detail": {
+                        "contentAxis": "vertical",
+                        "sectionGap": 2,
+                        "imageShare": 2,
+                        "metadataShare": 1,
+                        "imageHeightRatioWithTitle": 48,
+                        "imageReservedWidth": 16,
+                        "imageReservedHeight": 0,
+                        "imageBottomMargin": 2,
+                        "panePaddingLeft": 1,
+                        "panePaddingRight": 1,
+                        "panePaddingTop": 3,
+                        "panePaddingBottom": 2,
+                        "imagePaddingLeft": 2,
+                        "imagePaddingRight": 2,
+                        "imagePaddingTop": 0,
+                        "imagePaddingBottom": 2,
+                        "metadataPaddingLeft": 2,
+                        "metadataPaddingRight": 1,
+                        "metadataPaddingTop": 0,
+                        "metadataPaddingBottom": 0,
+                        "metadataTopMargin": 0,
+                        "metadataLeftMargin": 2,
+                        "metadataRightMargin": 1,
+                        "metadataHeightAdjustment": 2,
+                        "metadataBottomAligned": true,
+                        "titleBottomMargin": 2,
+                        "tagRowHeight": 9,
+                        "tagRowSpacing": 0
+                    },
+                    "footer": {
+                        "bottomUnsafeHeight": 16
+                    },
+                    "surface": {
+                        "cornerRadius": 4
+                    }
                 },
-                "surface": {
-                    "cornerRadius": "cornerRadius"
-                }
-            },
-            "systemsListTate": {
-                "header": {
-                    "titleInHeader": false,
-                    "hudBottomAligned": false,
-                    "statusPillPinnedTop": false
-                },
-                "status": {
-                    "topStripVisible": true,
-                    "stripHeight": "pctH:7",
-                    "slotMargin": "pctW:5",
-                    "topMargin": "pctH:1"
-                },
-                "list": {
-                    "contentAxis": "vertical",
-                    "listShare": 11,
-                    "detailShare": 5,
-                    "dividerWidth": 1,
-                    "dividerMargin": 0,
-                    "cardSideMargin": "pctW:5",
-                    "cardTopMargin": "pctH:2",
-                    "cardBottomMargin": "pctH:8",
-                    "cardPaddingLeft": "pctW:2",
-                    "cardPaddingRight": "pctW:2",
-                    "cardPaddingTop": "pctH:2",
-                    "cardPaddingBottom": "pctH:2",
-                    "rowHeight": 0,
-                    "rowSpacing": "pctH:0.3",
-                    "centerSlot": -1,
-                    "scrollbarGap": "pctW:1.5",
-                    "selectionAccentWidth": "pctW:0.45",
-                    "rowTextLeftPadding": "pctW:1.6",
-                    "rowTextRightPadding": "pctW:1.6",
-                    "favoriteRightPadding": "pctW:1.6",
-                    "overlayBottomMargin": "pctH:15"
-                },
-                "detail": {
-                    "contentAxis": "horizontal",
-                    "sectionGap": "pctW:3",
-                    "imageShare": 4,
-                    "metadataShare": 8,
-                    "imageHeightRatioWithTitle": 48,
-                    "imageReservedWidth": 0,
-                    "imageReservedHeight": 0,
-                    "imageBottomMargin": 0,
-                    "panePaddingLeft": "pctW:3",
-                    "panePaddingRight": "pctW:3",
-                    "panePaddingTop": "pctH:1.2",
-                    "panePaddingBottom": "pctH:1.2",
-                    "imagePaddingLeft": 0,
-                    "imagePaddingRight": "pctW:1",
-                    "imagePaddingTop": "pctH:0.8",
-                    "imagePaddingBottom": "pctH:0.8",
-                    "metadataPaddingLeft": "pctW:1.5",
-                    "metadataPaddingRight": "pctW:0.5",
-                    "metadataPaddingTop": "pctH:0.8",
-                    "metadataPaddingBottom": "pctH:0.8",
-                    "metadataTopMargin": 12,
-                    "metadataLeftMargin": 0,
-                    "metadataRightMargin": 0,
-                    "metadataHeightAdjustment": 0,
-                    "metadataBottomAligned": false,
-                    "titleBottomMargin": "pctH:1",
-                    "tagRowHeight": "pctH:2.6",
-                    "tagRowSpacing": "pctH:0.35"
-                },
-                "footer": {
-                    "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
-                },
-                "surface": {
-                    "cornerRadius": "cornerRadius"
-                }
-            },
-            "gamesGrid": {
-                "header": {
-                    "titleInHeader": false,
-                    "hudBottomAligned": false,
-                    "statusPillPinnedTop": false
-                },
-                "status": {
-                    "topStripVisible": true,
-                    "stripHeight": "pctH:7",
-                    "slotMargin": "pctW:5",
-                    "topMargin": "pctH:1"
-                },
-                "grid": {
-                    "leftInset": "pctW:5",
-                    "rightInset": "pctW:5",
-                    "gutterWidth": "pctW:3",
-                    "gutterGap": "pctW:1.5",
-                    "columnGap": "pctW:3",
-                    "topInset": "pctH:2",
-                    "bottomInset": "pctH:2",
-                    "rowGap": "pctH:4",
-                    "scrollThumbWidth": "pctW:1.2",
-                    "scrollThumbRightInset": 0,
-                    "scrollThumbRightAligned": false,
-                    "scrollArrowSize": "min(pctW:3,pctH:4)",
-                    "gutterFollowsContentWidth": false
-                },
-                "footer": {
-                    "activeLabelHeight": "pctH:7",
-                    "activeLabelBottomMargin": "pctH:8",
-                    "bottomStatusVisible": false,
-                    "bottomStatusLeftMargin": "pctW:5",
-                    "bottomStatusRightMargin": "pctW:5",
-                    "gridBottomMargin": "sum(pctH:6,pctH:8,pctH:7)",
-                    "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
-                },
-                "surface": {
-                    "cornerRadius": "cornerRadius"
-                }
-            },
-            "gamesList": {
-                "header": {
-                    "titleInHeader": false,
-                    "hudBottomAligned": false,
-                    "statusPillPinnedTop": false
-                },
-                "status": {
-                    "topStripVisible": true,
-                    "stripHeight": "pctH:7",
-                    "slotMargin": "pctW:5",
-                    "topMargin": "pctH:1"
-                },
-                "list": {
-                    "contentAxis": "horizontal",
-                    "listShare": 2,
-                    "detailShare": 1,
-                    "dividerWidth": 1,
-                    "dividerMargin": 0,
-                    "cardSideMargin": "pctW:5",
-                    "cardTopMargin": "pctH:2",
-                    "cardBottomMargin": "pctH:8",
-                    "cardPaddingLeft": "pctW:2",
-                    "cardPaddingRight": "pctW:2",
-                    "cardPaddingTop": "pctH:2",
-                    "cardPaddingBottom": "pctH:2",
-                    "rowHeight": 0,
-                    "rowSpacing": "pctH:0.7",
-                    "centerSlot": -1,
-                    "scrollbarGap": "pctW:1.5",
-                    "selectionAccentWidth": "pctW:0.45",
-                    "rowTextLeftPadding": "pctW:1.6",
-                    "rowTextRightPadding": "pctW:1.6",
-                    "favoriteRightPadding": "pctW:1.6",
-                    "overlayBottomMargin": "pctH:15"
-                },
-                "detail": {
-                    "contentAxis": "vertical",
-                    "sectionGap": "pctH:2",
-                    "imageShare": 2,
-                    "metadataShare": 1,
-                    "imageHeightRatioWithTitle": 48,
-                    "imageReservedWidth": 0,
-                    "imageReservedHeight": 0,
-                    "imageBottomMargin": 0,
-                    "panePaddingLeft": "pctW:2",
-                    "panePaddingRight": "pctW:2",
-                    "panePaddingTop": "pctH:2",
-                    "panePaddingBottom": "pctH:2",
-                    "imagePaddingLeft": 0,
-                    "imagePaddingRight": 0,
-                    "imagePaddingTop": 0,
-                    "imagePaddingBottom": 0,
-                    "metadataPaddingLeft": 0,
-                    "metadataPaddingRight": 0,
-                    "metadataPaddingTop": 0,
-                    "metadataPaddingBottom": 0,
-                    "metadataTopMargin": 12,
-                    "metadataLeftMargin": 0,
-                    "metadataRightMargin": 0,
-                    "metadataHeightAdjustment": 0,
-                    "metadataBottomAligned": true,
-                    "titleBottomMargin": "pctH:2",
-                    "tagRowHeight": "pctH:3",
-                    "tagRowSpacing": "pctH:0.55"
-                },
-                "footer": {
-                    "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
-                },
-                "surface": {
-                    "cornerRadius": "cornerRadius"
-                }
-            },
-            "gamesListTate": {
-                "header": {
-                    "titleInHeader": false,
-                    "hudBottomAligned": false,
-                    "statusPillPinnedTop": false
-                },
-                "status": {
-                    "topStripVisible": true,
-                    "stripHeight": "pctH:7",
-                    "slotMargin": "pctW:5",
-                    "topMargin": "pctH:1"
-                },
-                "list": {
-                    "contentAxis": "vertical",
-                    "listShare": 11,
-                    "detailShare": 5,
-                    "dividerWidth": 1,
-                    "dividerMargin": 0,
-                    "cardSideMargin": "pctW:5",
-                    "cardTopMargin": "pctH:2",
-                    "cardBottomMargin": "pctH:8",
-                    "cardPaddingLeft": "pctW:2",
-                    "cardPaddingRight": "pctW:2",
-                    "cardPaddingTop": "pctH:2",
-                    "cardPaddingBottom": "pctH:2",
-                    "rowHeight": 0,
-                    "rowSpacing": "pctH:0.3",
-                    "centerSlot": -1,
-                    "scrollbarGap": "pctW:1.5",
-                    "selectionAccentWidth": "pctW:0.45",
-                    "rowTextLeftPadding": "pctW:1.6",
-                    "rowTextRightPadding": "pctW:1.6",
-                    "favoriteRightPadding": "pctW:1.6",
-                    "overlayBottomMargin": "pctH:15"
-                },
-                "detail": {
-                    "contentAxis": "horizontal",
-                    "sectionGap": "pctW:3",
-                    "imageShare": 4,
-                    "metadataShare": 8,
-                    "imageHeightRatioWithTitle": 48,
-                    "imageReservedWidth": 0,
-                    "imageReservedHeight": 0,
-                    "imageBottomMargin": 0,
-                    "panePaddingLeft": "pctW:3",
-                    "panePaddingRight": "pctW:3",
-                    "panePaddingTop": "pctH:1.2",
-                    "panePaddingBottom": "pctH:1.2",
-                    "imagePaddingLeft": 0,
-                    "imagePaddingRight": "pctW:1",
-                    "imagePaddingTop": "pctH:0.8",
-                    "imagePaddingBottom": "pctH:0.8",
-                    "metadataPaddingLeft": "pctW:1.5",
-                    "metadataPaddingRight": "pctW:0.5",
-                    "metadataPaddingTop": "pctH:0.8",
-                    "metadataPaddingBottom": "pctH:0.8",
-                    "metadataTopMargin": 12,
-                    "metadataLeftMargin": 0,
-                    "metadataRightMargin": 0,
-                    "metadataHeightAdjustment": 0,
-                    "metadataBottomAligned": false,
-                    "titleBottomMargin": "pctH:1",
-                    "tagRowHeight": "pctH:2.6",
-                    "tagRowSpacing": "pctH:0.35"
-                },
-                "footer": {
-                    "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
-                },
-                "surface": {
-                    "cornerRadius": "cornerRadius"
+                "gamesListTate": {
+                    "header": {
+                        "titleInHeader": true,
+                        "hudBottomAligned": true,
+                        "statusPillPinnedTop": true
+                    },
+                    "status": {
+                        "topStripVisible": true,
+                        "stripHeight": 8,
+                        "slotMargin": "headerSideMargin",
+                        "topMargin": "pctH:1"
+                    },
+                    "list": {
+                        "contentAxis": "vertical",
+                        "listShare": 11,
+                        "detailShare": 5,
+                        "dividerWidth": 1,
+                        "dividerMargin": 0,
+                        "cardSideMargin": 4,
+                        "cardTopMargin": "pctH:2",
+                        "cardBottomMargin": "pctH:8",
+                        "cardPaddingLeft": 3,
+                        "cardPaddingRight": 2,
+                        "cardPaddingTop": 3,
+                        "cardPaddingBottom": 2,
+                        "rowHeight": 12,
+                        "rowSpacing": 0,
+                        "centerSlot": 7,
+                        "scrollbarGap": 2,
+                        "selectionAccentWidth": 2,
+                        "rowTextLeftPadding": 4,
+                        "rowTextRightPadding": 2,
+                        "favoriteRightPadding": 2,
+                        "overlayBottomMargin": "pctH:14"
+                    },
+                    "detail": {
+                        "contentAxis": "horizontal",
+                        "sectionGap": 2,
+                        "imageShare": 4,
+                        "metadataShare": 8,
+                        "imageHeightRatioWithTitle": 48,
+                        "imageReservedWidth": 16,
+                        "imageReservedHeight": 0,
+                        "imageBottomMargin": 2,
+                        "panePaddingLeft": 2,
+                        "panePaddingRight": 1,
+                        "panePaddingTop": 1,
+                        "panePaddingBottom": 1,
+                        "imagePaddingLeft": 1,
+                        "imagePaddingRight": 2,
+                        "imagePaddingTop": 0,
+                        "imagePaddingBottom": 1,
+                        "metadataPaddingLeft": 2,
+                        "metadataPaddingRight": 1,
+                        "metadataPaddingTop": 1,
+                        "metadataPaddingBottom": 0,
+                        "metadataTopMargin": 12,
+                        "metadataLeftMargin": 0,
+                        "metadataRightMargin": 0,
+                        "metadataHeightAdjustment": 0,
+                        "metadataBottomAligned": false,
+                        "titleBottomMargin": 1,
+                        "tagRowHeight": 8,
+                        "tagRowSpacing": 0
+                    },
+                    "footer": {
+                        "bottomUnsafeHeight": 16
+                    },
+                    "surface": {
+                        "cornerRadius": 4
+                    }
                 }
             }
-        },
-        "crt": {
-            "systemsGrid": {
-                "header": {
-                    "titleInHeader": true,
-                    "hudBottomAligned": true,
-                    "statusPillPinnedTop": true
-                },
-                "status": {
-                    "topStripVisible": false,
-                    "stripHeight": 0,
-                    "slotMargin": "headerSideMargin",
-                    "topMargin": "pctH:1"
-                },
-                "grid": {
-                    "leftInset": 4,
-                    "rightInset": 0,
-                    "gutterWidth": 8,
-                    "gutterGap": 4,
-                    "columnGap": 4,
-                    "topInset": 2,
-                    "bottomInset": 4,
-                    "rowGap": 4,
-                    "scrollThumbWidth": 4,
-                    "scrollThumbRightInset": 2,
-                    "scrollThumbRightAligned": false,
-                    "scrollArrowSize": 8,
-                    "gutterFollowsContentWidth": true
-                },
-                "footer": {
-                    "activeLabelHeight": 8,
-                    "activeLabelBottomMargin": "pctH:6",
-                    "bottomStatusVisible": true,
-                    "bottomStatusLeftMargin": 4,
-                    "bottomStatusRightMargin": "pctW:5",
-                    "gridBottomMargin": "sum(pctH:6,8)",
-                    "bottomUnsafeHeight": 16
-                },
-                "surface": {
-                    "cornerRadius": 4
-                }
-            },
-            "systemsList": {
-                "header": {
-                    "titleInHeader": true,
-                    "hudBottomAligned": true,
-                    "statusPillPinnedTop": true
-                },
-                "status": {
-                    "topStripVisible": true,
-                    "stripHeight": 8,
-                    "slotMargin": "headerSideMargin",
-                    "topMargin": "pctH:1"
-                },
-                "list": {
-                    "contentAxis": "horizontal",
-                    "listShare": 2,
-                    "detailShare": 1,
-                    "dividerWidth": 1,
-                    "dividerMargin": -16,
-                    "cardSideMargin": 4,
-                    "cardTopMargin": "pctH:2",
-                    "cardBottomMargin": "pctH:8",
-                    "cardPaddingLeft": 3,
-                    "cardPaddingRight": 2,
-                    "cardPaddingTop": 3,
-                    "cardPaddingBottom": 2,
-                    "rowHeight": 12,
-                    "rowSpacing": 0,
-                    "centerSlot": 7,
-                    "scrollbarGap": 2,
-                    "selectionAccentWidth": 2,
-                    "rowTextLeftPadding": 4,
-                    "rowTextRightPadding": 2,
-                    "favoriteRightPadding": 2,
-                    "overlayBottomMargin": "pctH:14"
-                },
-                "detail": {
-                    "contentAxis": "vertical",
-                    "sectionGap": 2,
-                    "imageShare": 2,
-                    "metadataShare": 1,
-                    "imageHeightRatioWithTitle": 48,
-                    "imageReservedWidth": 16,
-                    "imageReservedHeight": 0,
-                    "imageBottomMargin": 2,
-                    "panePaddingLeft": 1,
-                    "panePaddingRight": 1,
-                    "panePaddingTop": 3,
-                    "panePaddingBottom": 2,
-                    "imagePaddingLeft": 2,
-                    "imagePaddingRight": 2,
-                    "imagePaddingTop": 0,
-                    "imagePaddingBottom": 2,
-                    "metadataPaddingLeft": 2,
-                    "metadataPaddingRight": 1,
-                    "metadataPaddingTop": 0,
-                    "metadataPaddingBottom": 0,
-                    "metadataTopMargin": 0,
-                    "metadataLeftMargin": 2,
-                    "metadataRightMargin": 1,
-                    "metadataHeightAdjustment": 2,
-                    "metadataBottomAligned": false,
-                    "titleBottomMargin": 2,
-                    "tagRowHeight": 9,
-                    "tagRowSpacing": 0
-                },
-                "footer": {
-                    "bottomUnsafeHeight": 16
-                },
-                "surface": {
-                    "cornerRadius": 4
-                }
-            },
-            "systemsListTate": {
-                "header": {
-                    "titleInHeader": true,
-                    "hudBottomAligned": true,
-                    "statusPillPinnedTop": true
-                },
-                "status": {
-                    "topStripVisible": true,
-                    "stripHeight": 8,
-                    "slotMargin": "headerSideMargin",
-                    "topMargin": "pctH:1"
-                },
-                "list": {
-                    "contentAxis": "vertical",
-                    "listShare": 11,
-                    "detailShare": 5,
-                    "dividerWidth": 1,
-                    "dividerMargin": 0,
-                    "cardSideMargin": 4,
-                    "cardTopMargin": "pctH:2",
-                    "cardBottomMargin": "pctH:8",
-                    "cardPaddingLeft": 3,
-                    "cardPaddingRight": 2,
-                    "cardPaddingTop": 3,
-                    "cardPaddingBottom": 2,
-                    "rowHeight": 12,
-                    "rowSpacing": 0,
-                    "centerSlot": 7,
-                    "scrollbarGap": 2,
-                    "selectionAccentWidth": 2,
-                    "rowTextLeftPadding": 4,
-                    "rowTextRightPadding": 2,
-                    "favoriteRightPadding": 2,
-                    "overlayBottomMargin": "pctH:14"
-                },
-                "detail": {
-                    "contentAxis": "horizontal",
-                    "sectionGap": 2,
-                    "imageShare": 4,
-                    "metadataShare": 8,
-                    "imageHeightRatioWithTitle": 48,
-                    "imageReservedWidth": 16,
-                    "imageReservedHeight": 0,
-                    "imageBottomMargin": 2,
-                    "panePaddingLeft": 2,
-                    "panePaddingRight": 1,
-                    "panePaddingTop": 1,
-                    "panePaddingBottom": 1,
-                    "imagePaddingLeft": 1,
-                    "imagePaddingRight": 2,
-                    "imagePaddingTop": 0,
-                    "imagePaddingBottom": 1,
-                    "metadataPaddingLeft": 2,
-                    "metadataPaddingRight": 1,
-                    "metadataPaddingTop": 1,
-                    "metadataPaddingBottom": 0,
-                    "metadataTopMargin": 12,
-                    "metadataLeftMargin": 0,
-                    "metadataRightMargin": 0,
-                    "metadataHeightAdjustment": 0,
-                    "metadataBottomAligned": false,
-                    "titleBottomMargin": 1,
-                    "tagRowHeight": 8,
-                    "tagRowSpacing": 0
-                },
-                "footer": {
-                    "bottomUnsafeHeight": 16
-                },
-                "surface": {
-                    "cornerRadius": 4
-                }
-            },
-            "gamesGrid": {
-                "header": {
-                    "titleInHeader": true,
-                    "hudBottomAligned": true,
-                    "statusPillPinnedTop": true
-                },
-                "status": {
-                    "topStripVisible": false,
-                    "stripHeight": 0,
-                    "slotMargin": "headerSideMargin",
-                    "topMargin": "pctH:1"
-                },
-                "grid": {
-                    "leftInset": 4,
-                    "rightInset": 0,
-                    "gutterWidth": 8,
-                    "gutterGap": 4,
-                    "columnGap": 4,
-                    "topInset": 2,
-                    "bottomInset": 4,
-                    "rowGap": 4,
-                    "scrollThumbWidth": 4,
-                    "scrollThumbRightInset": 2,
-                    "scrollThumbRightAligned": false,
-                    "scrollArrowSize": 8,
-                    "gutterFollowsContentWidth": true
-                },
-                "footer": {
-                    "activeLabelHeight": 8,
-                    "activeLabelBottomMargin": "pctH:6",
-                    "bottomStatusVisible": true,
-                    "bottomStatusLeftMargin": 4,
-                    "bottomStatusRightMargin": "pctW:5",
-                    "gridBottomMargin": "sum(pctH:6,8)",
-                    "bottomUnsafeHeight": 16
-                },
-                "surface": {
-                    "cornerRadius": 4
-                }
-            },
-            "gamesList": {
-                "header": {
-                    "titleInHeader": true,
-                    "hudBottomAligned": true,
-                    "statusPillPinnedTop": true
-                },
-                "status": {
-                    "topStripVisible": true,
-                    "stripHeight": 8,
-                    "slotMargin": "headerSideMargin",
-                    "topMargin": "pctH:1"
-                },
-                "list": {
-                    "contentAxis": "horizontal",
-                    "listShare": 2,
-                    "detailShare": 1,
-                    "dividerWidth": 1,
-                    "dividerMargin": -16,
-                    "cardSideMargin": 4,
-                    "cardTopMargin": "pctH:2",
-                    "cardBottomMargin": "pctH:8",
-                    "cardPaddingLeft": 3,
-                    "cardPaddingRight": 2,
-                    "cardPaddingTop": 3,
-                    "cardPaddingBottom": 2,
-                    "rowHeight": 12,
-                    "rowSpacing": 0,
-                    "centerSlot": 7,
-                    "scrollbarGap": 2,
-                    "selectionAccentWidth": 2,
-                    "rowTextLeftPadding": 4,
-                    "rowTextRightPadding": 2,
-                    "favoriteRightPadding": 2,
-                    "overlayBottomMargin": "pctH:14"
-                },
-                "detail": {
-                    "contentAxis": "vertical",
-                    "sectionGap": 2,
-                    "imageShare": 2,
-                    "metadataShare": 1,
-                    "imageHeightRatioWithTitle": 48,
-                    "imageReservedWidth": 16,
-                    "imageReservedHeight": 0,
-                    "imageBottomMargin": 2,
-                    "panePaddingLeft": 1,
-                    "panePaddingRight": 1,
-                    "panePaddingTop": 3,
-                    "panePaddingBottom": 2,
-                    "imagePaddingLeft": 2,
-                    "imagePaddingRight": 2,
-                    "imagePaddingTop": 0,
-                    "imagePaddingBottom": 2,
-                    "metadataPaddingLeft": 2,
-                    "metadataPaddingRight": 1,
-                    "metadataPaddingTop": 0,
-                    "metadataPaddingBottom": 0,
-                    "metadataTopMargin": 0,
-                    "metadataLeftMargin": 2,
-                    "metadataRightMargin": 1,
-                    "metadataHeightAdjustment": 2,
-                    "metadataBottomAligned": true,
-                    "titleBottomMargin": 2,
-                    "tagRowHeight": 9,
-                    "tagRowSpacing": 0
-                },
-                "footer": {
-                    "bottomUnsafeHeight": 16
-                },
-                "surface": {
-                    "cornerRadius": 4
-                }
-            },
-            "gamesListTate": {
-                "header": {
-                    "titleInHeader": true,
-                    "hudBottomAligned": true,
-                    "statusPillPinnedTop": true
-                },
-                "status": {
-                    "topStripVisible": true,
-                    "stripHeight": 8,
-                    "slotMargin": "headerSideMargin",
-                    "topMargin": "pctH:1"
-                },
-                "list": {
-                    "contentAxis": "vertical",
-                    "listShare": 11,
-                    "detailShare": 5,
-                    "dividerWidth": 1,
-                    "dividerMargin": 0,
-                    "cardSideMargin": 4,
-                    "cardTopMargin": "pctH:2",
-                    "cardBottomMargin": "pctH:8",
-                    "cardPaddingLeft": 3,
-                    "cardPaddingRight": 2,
-                    "cardPaddingTop": 3,
-                    "cardPaddingBottom": 2,
-                    "rowHeight": 12,
-                    "rowSpacing": 0,
-                    "centerSlot": 7,
-                    "scrollbarGap": 2,
-                    "selectionAccentWidth": 2,
-                    "rowTextLeftPadding": 4,
-                    "rowTextRightPadding": 2,
-                    "favoriteRightPadding": 2,
-                    "overlayBottomMargin": "pctH:14"
-                },
-                "detail": {
-                    "contentAxis": "horizontal",
-                    "sectionGap": 2,
-                    "imageShare": 4,
-                    "metadataShare": 8,
-                    "imageHeightRatioWithTitle": 48,
-                    "imageReservedWidth": 16,
-                    "imageReservedHeight": 0,
-                    "imageBottomMargin": 2,
-                    "panePaddingLeft": 2,
-                    "panePaddingRight": 1,
-                    "panePaddingTop": 1,
-                    "panePaddingBottom": 1,
-                    "imagePaddingLeft": 1,
-                    "imagePaddingRight": 2,
-                    "imagePaddingTop": 0,
-                    "imagePaddingBottom": 1,
-                    "metadataPaddingLeft": 2,
-                    "metadataPaddingRight": 1,
-                    "metadataPaddingTop": 1,
-                    "metadataPaddingBottom": 0,
-                    "metadataTopMargin": 12,
-                    "metadataLeftMargin": 0,
-                    "metadataRightMargin": 0,
-                    "metadataHeightAdjustment": 0,
-                    "metadataBottomAligned": false,
-                    "titleBottomMargin": 1,
-                    "tagRowHeight": 8,
-                    "tagRowSpacing": 0
-                },
-                "footer": {
-                    "bottomUnsafeHeight": 16
-                },
-                "surface": {
-                    "cornerRadius": 4
-                }
-            }
-        }
-    })
+        };
+    }
 
     function currentProfile(viewId: string): var {
         return BrowseLayouts.themeProfile(BrowseLayouts.currentThemeId, viewId);

--- a/src/ui/theme/Sizing.qml
+++ b/src/ui/theme/Sizing.qml
@@ -21,14 +21,7 @@ QtObject {
     // Shared browse-grid bounds. Systems and games both solve the same
     // viewport-fit problem now, so the common limits live here and the
     // per-surface configs only override what is materially different.
-    readonly property var _browseGridBaseConfig: ({
-        "minCellWidth": crtNativePath ? 72 : 160,
-        "preferredPageSize": crtNativePath ? 6 : 10,
-        "minColumns": 2,
-        "maxColumns": crtNativePath ? 3 : 5,
-        "minRows": 2,
-        "maxRows": crtNativePath ? 3 : 5
-    })
+    readonly property var _browseGridBaseConfig: _browseGridBaseConfigForTheme()
     // Systems grid uses the same viewport-driven shape selection as
     // games so both browse screens present a similar amount of content.
     // Systems tiles are squarer than box-art tiles, so they target a
@@ -69,6 +62,17 @@ QtObject {
     readonly property int headerSideMargin: pctW(2)
     readonly property int headerHeight: 2 * headerRowHeight + headerStackGap
     readonly property int headerBottom: headerTopMargin + headerHeight
+
+    function _browseGridBaseConfigForTheme(): var {
+        return {
+            "minCellWidth": crtNativePath ? 72 : 160,
+            "preferredPageSize": crtNativePath ? 6 : 10,
+            "minColumns": 2,
+            "maxColumns": crtNativePath ? 3 : 5,
+            "minRows": 2,
+            "maxRows": crtNativePath ? 3 : 5
+        };
+    }
 
     function pctH(percent: real): int {
         return Math.round((swapPercentageAxes ? screenWidth : screenHeight) * percent / 100);

--- a/src/ui/theme/browse-profiles/default.json
+++ b/src/ui/theme/browse-profiles/default.json
@@ -32,7 +32,7 @@
       "bottomStatusVisible": false,
       "bottomStatusLeftMargin": "pctW:5",
       "bottomStatusRightMargin": "pctW:5",
-      "gridBottomMargin": "sum(pctH:6,pctH:8,pctH:7)",
+      "gridBottomMargin": "sum(pctH:8,pctH:7)",
       "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
     },
     "surface": {
@@ -216,7 +216,7 @@
       "bottomStatusVisible": false,
       "bottomStatusLeftMargin": "pctW:5",
       "bottomStatusRightMargin": "pctW:5",
-      "gridBottomMargin": "sum(pctH:6,pctH:8,pctH:7)",
+      "gridBottomMargin": "sum(pctH:8,pctH:7)",
       "bottomUnsafeHeight": "sum(pctH:6,pctH:2)"
     },
     "surface": {

--- a/tests/ui/tst_navigation.qml
+++ b/tests/ui/tst_navigation.qml
@@ -40,6 +40,7 @@ TestCase {
         // run in microseconds, so the pending fire would land on the
         // next test if we didn't reset it here.
         main._stopRepeat();
+        main._resetRapidNavigation();
     }
 
     function test_initial_state_is_hub(): void {
@@ -289,6 +290,8 @@ TestCase {
         compare(main._isRepeatableAction("down"), true);
         compare(main._isRepeatableAction("left"), true);
         compare(main._isRepeatableAction("right"), true);
+        compare(main._isRepeatableAction("page_prev"), true);
+        compare(main._isRepeatableAction("page_next"), true);
     // qmllint enable compiler
     }
 
@@ -296,8 +299,6 @@ TestCase {
         // qmllint disable compiler
         compare(main._isRepeatableAction("accept"), false);
         compare(main._isRepeatableAction("cancel"), false);
-        compare(main._isRepeatableAction("page_prev"), false);
-        compare(main._isRepeatableAction("page_next"), false);
         compare(main._isRepeatableAction("write_card"), false);
         compare(main._isRepeatableAction(""), false);
     // qmllint enable compiler
@@ -311,7 +312,7 @@ TestCase {
         compare(main._repeatTicking, false, "Steady tick must not start before the initial delay");
     }
 
-    function test_arm_repeat_with_non_dpad_action_is_noop(): void {
+    function test_arm_repeat_with_non_repeatable_action_is_noop(): void {
         main._armRepeat("accept", Qt.Key_Return);
         compare(main._heldAction, "");
         compare(main._heldKey, 0);
@@ -355,6 +356,38 @@ TestCase {
         compare(main._heldAction, "right");
         compare(main._heldKey, Qt.Key_Right);
         compare(main._repeatPending, true, "Re-arm restarts the initial-delay timer");
+    }
+
+    function test_rapid_navigation_taps_activate_on_second_press(): void {
+        // qmllint disable compiler
+        main._noteRapidNavigationAction("down", false);
+        compare(main.rapidNavigationAction, "down", "rapid action tracks latest rapid input even before active mode");
+        compare(main.rapidNavigationActive, false, "single isolated press should not enter rapid mode");
+        main._noteRapidNavigationAction("down", false);
+        compare(main.rapidNavigationActive, true, "second press inside quiet window enters rapid mode");
+        wait(main._rapidNavigationQuietMs + 40);
+        compare(main.rapidNavigationActive, false, "rapid mode clears after quiet window");
+        compare(main.rapidNavigationAction, "", "quiet reset clears rapid action");
+    // qmllint enable compiler
+    }
+
+    function test_rapid_navigation_ignores_non_rapid_action(): void {
+        // qmllint disable compiler
+        main._noteRapidNavigationAction("accept", true);
+        compare(main.rapidNavigationActive, false);
+        compare(main.rapidNavigationAction, "");
+    // qmllint enable compiler
+    }
+
+    function test_repeat_tick_forces_rapid_navigation_active(): void {
+        // qmllint disable compiler
+        main._armRepeat("page_next", Qt.Key_R);
+        main._handleRepeatAction();
+        compare(main.rapidNavigationActive, true, "held page action should enter rapid mode on first repeat tick");
+        main._stopRepeat();
+        wait(main._rapidNavigationQuietMs + 40);
+        compare(main.rapidNavigationActive, false);
+    // qmllint enable compiler
     }
 
     // Context-menu builder. Drives the pure helper directly per the QML


### PR DESCRIPTION
## Summary
- add a simple rapid-scroll letter indicator and suppress it for slow list up/down holds
- rebuild Games cover prefetching around current -> next -> previous pages and clear stale queued requests on page changes
- keep cover fetch concurrency at 2 workers after runtime testing, and fix zip directories with only system IDs opening as folders
- canonicalize QML object-literal formatting to stop BrowseLayouts/Sizing indentation churn

## Tests
- just test-rust
- just test-qml
- just lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rapid scroll indicator with contextual title.
  * UI controls to pause/resume cover/image requests and to refresh/clear pending cover requests.

* **Improvements**
  * Ordered, length-capped prefetching for predictable page-driven cover loads.
  * Retry/queue semantics tuned so retrying fetches don’t overtake ordered windows, reducing stutter.
  * Rapid-navigation detection refined for more responsive held-key behavior.

* **Tests**
  * Expanded unit/UI tests for cover prefetching, queue behavior, and rapid-navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->