### PR TITLE
Improve support log uploads

### DIFF
--- a/rust/frontend/src/models/log_upload.rs
+++ b/rust/frontend/src/models/log_upload.rs
@@ -20,13 +20,12 @@
 // is plain text plus a QR code generated through `Browse.QrCode`.
 
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
-use base64::Engine as _;
 use cxx_qt::Threading;
 use cxx_qt_lib::QString;
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::pin::Pin;
-use std::process::{Command, Stdio};
+use std::process::{Child, Command, Stdio};
 use std::thread;
 use tracing::{error, info, warn};
 use zaparoo_core::client::Client;
@@ -161,14 +160,16 @@ fn run_upload(runtime: &tokio::runtime::Handle, client: &Client) -> UploadOutcom
     let (support_summary, core_log) = runtime.block_on(async {
         let summary = gather_support_summary(client).await;
         let core_log = match client.settings_logs_download().await {
-            Ok(result) => match BASE64_STANDARD.decode(result.content.as_bytes()) {
-                Ok(bytes) => CoreLogSource::Available(bytes),
-                Err(e) => {
-                    let message = format!("core log decode failed: {e}");
-                    warn!("{message}");
-                    CoreLogSource::Unavailable(message)
+            Ok(result) => {
+                match decode_base64_tail(result.content.as_bytes(), PER_LOG_LIMIT_BYTES) {
+                    Ok(bytes) => CoreLogSource::Available(bytes),
+                    Err(e) => {
+                        let message = format!("core log decode failed: {e}");
+                        warn!("{message}");
+                        CoreLogSource::Unavailable(message)
+                    }
                 }
-            },
+            }
             Err(e) => {
                 let message = format!("core log download failed: {e}");
                 warn!("{message}");
@@ -214,6 +215,26 @@ fn tail_bytes(bytes: &[u8], max_bytes: usize) -> &[u8] {
     } else {
         &bytes[bytes.len() - max_bytes..]
     }
+}
+
+fn decode_base64_tail(encoded: &[u8], max_bytes: usize) -> Result<Vec<u8>, std::io::Error> {
+    let mut reader = base64::read::DecoderReader::new(encoded, &BASE64_STANDARD);
+    let mut tail = Vec::with_capacity(max_bytes.min(8 * 1024));
+    let mut chunk = [0_u8; 8 * 1024];
+
+    loop {
+        let read = reader.read(&mut chunk)?;
+        if read == 0 {
+            break;
+        }
+        tail.extend_from_slice(&chunk[..read]);
+        if tail.len() > max_bytes {
+            let excess = tail.len() - max_bytes;
+            tail.drain(..excess);
+        }
+    }
+
+    Ok(tail)
 }
 
 async fn gather_support_summary(client: &Client) -> String {
@@ -392,12 +413,8 @@ fn yes_no(value: bool) -> &'static str {
 
 fn upload_payload(payload: &[u8]) -> UploadOutcome {
     let timeout_arg = UPLOAD_TIMEOUT_SECS.to_string();
-    // `--insecure` skips TLS verification. MiSTer ships with an outdated
-    // CA bundle and a clock that's wrong until NTP syncs minutes after
-    // boot, both of which make standard verification fail. The frontend
-    // is uploading a log to a known endpoint owned by the project — the
-    // payload is not sensitive and the destination is hard-coded — so
-    // accepting any cert is the right trade-off.
+    // MiSTer commonly has an outdated CA bundle and incorrect clock before NTP sync.
+    // Keep support log upload usable there.
     let mut child = match Command::new("curl")
         .args([
             "--silent",
@@ -421,9 +438,12 @@ fn upload_payload(payload: &[u8]) -> UploadOutcome {
 
     if let Some(mut stdin) = child.stdin.take() {
         if let Err(e) = stdin.write_all(payload) {
+            drop(stdin);
+            reap_child_after_stdin_failure(&mut child);
             return UploadOutcome::Error(format!("curl upload write failed: {e}"));
         }
     } else {
+        reap_child_after_stdin_failure(&mut child);
         return UploadOutcome::Error("curl stdin was not available".into());
     }
 
@@ -452,6 +472,15 @@ fn upload_payload(payload: &[u8]) -> UploadOutcome {
     UploadOutcome::Success(url)
 }
 
+fn reap_child_after_stdin_failure(child: &mut Child) {
+    if let Err(e) = child.kill() {
+        warn!("failed to stop curl after stdin failure: {e}");
+    }
+    if let Err(e) = child.wait() {
+        warn!("failed to reap curl after stdin failure: {e}");
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(
@@ -461,9 +490,10 @@ mod tests {
     )]
 
     use super::{
-        build_upload_payload, read_file_tail, CoreLogSource, PAYLOAD_LIMIT_BYTES,
-        PER_LOG_LIMIT_BYTES, SUPPORT_SUMMARY_LIMIT_BYTES,
+        build_upload_payload, decode_base64_tail, read_file_tail, CoreLogSource,
+        PAYLOAD_LIMIT_BYTES, PER_LOG_LIMIT_BYTES, SUPPORT_SUMMARY_LIMIT_BYTES,
     };
+    use base64::Engine as _;
     use std::io::Write;
 
     #[test]
@@ -525,5 +555,14 @@ mod tests {
 
         assert!(text.contains("front"));
         assert!(text.contains("core.log unavailable: not connected"));
+    }
+
+    #[test]
+    fn decode_base64_tail_keeps_only_capped_decoded_tail() {
+        let encoded = base64::engine::general_purpose::STANDARD.encode(b"0123456789");
+
+        let bytes = decode_base64_tail(encoded.as_bytes(), 4).expect("decode tail");
+
+        assert_eq!(bytes, b"6789");
     }
 }

--- a/rust/frontend/src/models/log_upload.rs
+++ b/rust/frontend/src/models/log_upload.rs
@@ -5,9 +5,10 @@
 // `Browse.LogUpload` — drives the "Upload log" affordance in Settings.
 //
 // The user kicks the flow with `upload()`; the singleton spawns a worker
-// thread that POSTs `frontend.log` as multipart/form-data to
-// `https://logs.zaparoo.org/` (mirroring Core's TUI exportlog flow), then
-// queues the result back onto the Qt thread.
+// thread that builds one capped payload from a support summary,
+// `frontend.log`, and Core's API-downloaded log, then POSTs it as
+// multipart/form-data to `https://logs.zaparoo.org/` and queues the result
+// back onto the Qt thread.
 //
 // HTTP via shelled-out curl: the frontend otherwise has no HTTPS client
 // (tokio-tungstenite is built without TLS to keep the MiSTer ARM32 binary
@@ -18,13 +19,21 @@
 // renders one of three views in `LogUploadModal.qml`. On success the URL
 // is plain text plus a QR code generated through `Browse.QrCode`.
 
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use base64::Engine as _;
 use cxx_qt::Threading;
 use cxx_qt_lib::QString;
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::pin::Pin;
 use std::process::{Command, Stdio};
 use std::thread;
 use tracing::{error, info, warn};
+use zaparoo_core::client::Client;
+use zaparoo_core::media_types::{LaunchEntry, MediaResult, ScrapingStatusResponse, TokenInfo};
 use zaparoo_core::platform_paths::log_file_path;
+
+use crate::models::{build_info, global_handle, global_store, system_status};
 
 /// Public endpoint used by Core's TUI for the same flow. Hardcoded
 /// because it is the only place this frontend uploads anything and the
@@ -35,6 +44,12 @@ const UPLOAD_URL: &str = "https://logs.zaparoo.org/";
 /// log file is small but the upload service occasionally stalls and we
 /// don't want to block the modal forever.
 const UPLOAD_TIMEOUT_SECS: u32 = 30;
+
+const SUPPORT_SUMMARY_LIMIT_BYTES: usize = 64 * 1024;
+const PER_LOG_LIMIT_BYTES: usize = 512 * 1024;
+const UPLOAD_LIMIT_BYTES: usize = 1024 * 1024;
+const UPLOAD_HEADROOM_BYTES: usize = 4 * 1024;
+const PAYLOAD_LIMIT_BYTES: usize = UPLOAD_LIMIT_BYTES - UPLOAD_HEADROOM_BYTES;
 
 /// State machine values exposed to QML. Kept as integers because
 /// cxx-qt 0.8 does not surface Rust enums to QML cleanly; the QML side
@@ -90,10 +105,12 @@ impl ffi::LogUpload {
         self.as_mut().set_error_message(QString::default());
 
         let qt_thread = self.qt_thread();
+        let runtime = global_handle();
+        let client = global_store().client();
         if let Err(e) = thread::Builder::new()
             .name("zaparoo-log-upload".into())
             .spawn(move || {
-                let outcome = run_upload();
+                let outcome = run_upload(&runtime, &client);
                 let _ = qt_thread.queue(move |model| apply_outcome(model, outcome));
             })
         {
@@ -134,13 +151,246 @@ fn apply_outcome(mut model: Pin<&mut ffi::LogUpload>, outcome: UploadOutcome) {
     }
 }
 
-fn run_upload() -> UploadOutcome {
+fn run_upload(runtime: &tokio::runtime::Handle, client: &Client) -> UploadOutcome {
     let log_path = log_file_path();
-    if !log_path.exists() {
-        return UploadOutcome::Error(format!("Log file not found at {}", log_path.display()));
+    let frontend_log = match read_file_tail(&log_path, PER_LOG_LIMIT_BYTES) {
+        Ok(bytes) => bytes,
+        Err(message) => return UploadOutcome::Error(message),
+    };
+
+    let (support_summary, core_log) = runtime.block_on(async {
+        let summary = gather_support_summary(client).await;
+        let core_log = match client.settings_logs_download().await {
+            Ok(result) => match BASE64_STANDARD.decode(result.content.as_bytes()) {
+                Ok(bytes) => CoreLogSource::Available(bytes),
+                Err(e) => {
+                    let message = format!("core log decode failed: {e}");
+                    warn!("{message}");
+                    CoreLogSource::Unavailable(message)
+                }
+            },
+            Err(e) => {
+                let message = format!("core log download failed: {e}");
+                warn!("{message}");
+                CoreLogSource::Unavailable(message)
+            }
+        };
+        (summary, core_log)
+    });
+
+    upload_payload(&build_upload_payload(
+        support_summary.as_bytes(),
+        &frontend_log,
+        core_log,
+    ))
+}
+
+#[derive(Debug)]
+enum CoreLogSource {
+    Available(Vec<u8>),
+    Unavailable(String),
+}
+
+fn read_file_tail(path: &std::path::Path, max_bytes: usize) -> Result<Vec<u8>, String> {
+    let mut file =
+        File::open(path).map_err(|e| format!("Log file not found at {}: {e}", path.display()))?;
+    let len = file
+        .metadata()
+        .map_err(|e| format!("Could not inspect log file at {}: {e}", path.display()))?
+        .len();
+    let start = len.saturating_sub(max_bytes as u64);
+    file.seek(SeekFrom::Start(start))
+        .map_err(|e| format!("Could not read log file at {}: {e}", path.display()))?;
+
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)
+        .map_err(|e| format!("Could not read log file at {}: {e}", path.display()))?;
+    Ok(bytes)
+}
+
+fn tail_bytes(bytes: &[u8], max_bytes: usize) -> &[u8] {
+    if bytes.len() <= max_bytes {
+        bytes
+    } else {
+        &bytes[bytes.len() - max_bytes..]
+    }
+}
+
+async fn gather_support_summary(client: &Client) -> String {
+    let mut lines = vec!["===== support summary =====".to_string()];
+
+    lines.push(format!(
+        "Frontend: {}",
+        build_info::provenance_string(env!("CARGO_PKG_VERSION"))
+    ));
+
+    match client.health().await {
+        Ok(result) => push_non_empty(&mut lines, "Core API", &result.status),
+        Err(e) => lines.push(format!("Core API: unavailable ({})", e.message)),
+    }
+    match client.version().await {
+        Ok(result) => {
+            push_non_empty(&mut lines, "Core version", &result.version);
+            push_non_empty(&mut lines, "Core platform", &result.platform);
+        }
+        Err(e) => lines.push(format!("Core version: unavailable ({})", e.message)),
     }
 
-    let log_arg = format!("file=@{}", log_path.display());
+    lines.push("-- system --".into());
+    lines.extend(system_status::support_summary_lines());
+
+    match client.readers().await {
+        Ok(result) => lines.push(format!("Readers: {}", result.readers.len())),
+        Err(e) => lines.push(format!("Readers: unavailable ({})", e.message)),
+    }
+    match client.tokens().await {
+        Ok(result) => {
+            if let Some(token) = result.last.as_ref() {
+                lines.push(format!("Last token: {}", token_display(token)));
+            }
+        }
+        Err(e) => lines.push(format!("Last token: unavailable ({})", e.message)),
+    }
+    match client.tokens_history().await {
+        Ok(result) => {
+            if let Some(entry) = result.entries.first() {
+                lines.push(format!("Last launch: {}", launch_display(entry)));
+            }
+        }
+        Err(e) => lines.push(format!("Last launch: unavailable ({})", e.message)),
+    }
+
+    lines.push("-- library --".into());
+    match client.media().await {
+        Ok(result) => lines.extend(media_summary(&result)),
+        Err(e) => lines.push(format!("Media: unavailable ({})", e.message)),
+    }
+    match client.media_scrape_status().await {
+        Ok(result) => lines.extend(scrape_summary(&result)),
+        Err(e) => lines.push(format!("Scrape status: unavailable ({})", e.message)),
+    }
+
+    lines.push(String::new());
+    lines.join("\n")
+}
+
+fn push_non_empty(lines: &mut Vec<String>, label: &str, value: &str) {
+    if !value.is_empty() {
+        lines.push(format!("{label}: {value}"));
+    }
+}
+
+fn push_non_zero(lines: &mut Vec<String>, label: &str, value: i32) {
+    if value != 0 {
+        lines.push(format!("{label}: {value}"));
+    }
+}
+
+fn build_upload_payload(
+    support_summary: &[u8],
+    frontend_log: &[u8],
+    core_log: CoreLogSource,
+) -> Vec<u8> {
+    let mut payload = Vec::with_capacity(PAYLOAD_LIMIT_BYTES.min(frontend_log.len() * 2));
+    payload.extend_from_slice(tail_bytes(support_summary, SUPPORT_SUMMARY_LIMIT_BYTES));
+    if !payload.ends_with(b"\n") {
+        payload.push(b'\n');
+    }
+    payload.extend_from_slice(b"===== frontend.log (tail) =====\n");
+    let remaining = PAYLOAD_LIMIT_BYTES.saturating_sub(payload.len());
+    let frontend_limit = PER_LOG_LIMIT_BYTES.min(remaining);
+    payload.extend_from_slice(tail_bytes(frontend_log, frontend_limit));
+    if !payload.ends_with(b"\n") {
+        payload.push(b'\n');
+    }
+    payload.extend_from_slice(b"\n===== core.log (tail) =====\n");
+
+    match core_log {
+        CoreLogSource::Available(bytes) => {
+            let remaining = PAYLOAD_LIMIT_BYTES.saturating_sub(payload.len());
+            let core_limit = PER_LOG_LIMIT_BYTES.min(remaining);
+            payload.extend_from_slice(tail_bytes(&bytes, core_limit));
+        }
+        CoreLogSource::Unavailable(message) => {
+            payload.extend_from_slice(format!("core.log unavailable: {message}\n").as_bytes());
+        }
+    }
+
+    payload.truncate(PAYLOAD_LIMIT_BYTES);
+    payload
+}
+
+fn media_summary(result: &MediaResult) -> Vec<String> {
+    let db = &result.database;
+    let mut lines = vec![
+        format!("Media DB exists: {}", yes_no(db.exists)),
+        format!("Indexing: {}", yes_no(db.indexing)),
+        format!("Optimizing: {}", yes_no(db.optimizing)),
+        format!("Active media: {}", yes_no(!result.active.is_empty())),
+    ];
+    if let Some(total_files) = db.total_files {
+        lines.push(format!("Total files: {total_files}"));
+    }
+    if let Some(total_media) = db.total_media {
+        lines.push(format!("Total media: {total_media}"));
+    }
+    if let Some(active) = result.active.first() {
+        push_non_empty(&mut lines, "Active game", &active.media_name);
+        push_non_empty(&mut lines, "Active system", &active.system_name);
+        push_non_empty(&mut lines, "Active launcher", &active.launcher_id);
+    }
+    lines
+}
+
+fn scrape_summary(result: &ScrapingStatusResponse) -> Vec<String> {
+    let mut lines = vec![
+        format!("Scraping: {}", yes_no(result.scraping)),
+        format!("Scrape done: {}", yes_no(result.done)),
+        format!("Scrape paused: {}", yes_no(result.paused)),
+    ];
+    push_non_empty(&mut lines, "Scrape state", &result.state);
+    push_non_empty(&mut lines, "Scraper", &result.scraper_id);
+    push_non_empty(&mut lines, "Scrape system", &result.system_id);
+    push_non_zero(&mut lines, "Scrape processed", result.processed);
+    push_non_zero(&mut lines, "Scrape total", result.total);
+    push_non_zero(&mut lines, "Scrape matched", result.matched);
+    push_non_zero(&mut lines, "Scrape skipped", result.skipped);
+    push_non_zero(&mut lines, "Total scraped", result.total_scraped);
+    push_non_empty(&mut lines, "Scrape error", &result.error);
+    lines
+}
+
+fn token_display(token: &TokenInfo) -> String {
+    if !token.text.is_empty() {
+        token.text.clone()
+    } else if !token.uid.is_empty() {
+        format!("uid:{}", token.uid)
+    } else if !token.data.is_empty() {
+        format!("data:{}", token.data)
+    } else {
+        "(empty)".into()
+    }
+}
+
+fn launch_display(entry: &LaunchEntry) -> String {
+    let state = if entry.success { "success" } else { "failed" };
+    let text = if entry.text.is_empty() {
+        "(empty)"
+    } else {
+        entry.text.as_str()
+    };
+    format!("{text} ({state})")
+}
+
+fn yes_no(value: bool) -> &'static str {
+    if value {
+        "yes"
+    } else {
+        "no"
+    }
+}
+
+fn upload_payload(payload: &[u8]) -> UploadOutcome {
     let timeout_arg = UPLOAD_TIMEOUT_SECS.to_string();
     // `--insecure` skips TLS verification. MiSTer ships with an outdated
     // CA bundle and a clock that's wrong until NTP syncs minutes after
@@ -148,7 +398,7 @@ fn run_upload() -> UploadOutcome {
     // is uploading a log to a known endpoint owned by the project — the
     // payload is not sensitive and the destination is hard-coded — so
     // accepting any cert is the right trade-off.
-    let output = match Command::new("curl")
+    let mut child = match Command::new("curl")
         .args([
             "--silent",
             "--show-error",
@@ -157,18 +407,29 @@ fn run_upload() -> UploadOutcome {
             "--max-time",
             timeout_arg.as_str(),
             "-F",
-            log_arg.as_str(),
+            "file=@-;filename=zaparoo.log",
             UPLOAD_URL,
         ])
-        .stdin(Stdio::null())
+        .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .output()
+        .spawn()
     {
-        Ok(out) => out,
-        Err(e) => {
-            return UploadOutcome::Error(format!("curl failed to start: {e}"));
+        Ok(child) => child,
+        Err(e) => return UploadOutcome::Error(format!("curl failed to start: {e}")),
+    };
+
+    if let Some(mut stdin) = child.stdin.take() {
+        if let Err(e) = stdin.write_all(payload) {
+            return UploadOutcome::Error(format!("curl upload write failed: {e}"));
         }
+    } else {
+        return UploadOutcome::Error("curl stdin was not available".into());
+    }
+
+    let output = match child.wait_with_output() {
+        Ok(out) => out,
+        Err(e) => return UploadOutcome::Error(format!("curl failed: {e}")),
     };
 
     if !output.status.success() {
@@ -189,4 +450,80 @@ fn run_upload() -> UploadOutcome {
         return UploadOutcome::Error(format!("Unexpected upload response: {url}"));
     }
     UploadOutcome::Success(url)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(
+        clippy::expect_used,
+        clippy::unwrap_used,
+        reason = "tests should fail-fast on unexpected errors"
+    )]
+
+    use super::{
+        build_upload_payload, read_file_tail, CoreLogSource, PAYLOAD_LIMIT_BYTES,
+        PER_LOG_LIMIT_BYTES, SUPPORT_SUMMARY_LIMIT_BYTES,
+    };
+    use std::io::Write;
+
+    #[test]
+    fn read_file_tail_returns_full_small_file() {
+        let mut file = tempfile::NamedTempFile::new().expect("temp file");
+        file.write_all(b"short log").expect("write log");
+
+        let bytes = read_file_tail(file.path(), 512).expect("read tail");
+
+        assert_eq!(bytes, b"short log");
+    }
+
+    #[test]
+    fn read_file_tail_returns_last_bytes_for_large_file() {
+        let mut file = tempfile::NamedTempFile::new().expect("temp file");
+        file.write_all(b"0123456789").expect("write log");
+
+        let bytes = read_file_tail(file.path(), 4).expect("read tail");
+
+        assert_eq!(bytes, b"6789");
+    }
+
+    #[test]
+    fn payload_places_summary_frontend_core_in_order() {
+        let payload = build_upload_payload(
+            b"summary",
+            b"front",
+            CoreLogSource::Available(b"core".to_vec()),
+        );
+        let text = String::from_utf8(payload).expect("utf8 payload");
+
+        let summary_pos = text.find("summary").expect("summary");
+        let frontend_pos = text.find("front").expect("frontend log");
+        let core_pos = text.find("core").expect("core log");
+        assert!(summary_pos < frontend_pos);
+        assert!(frontend_pos < core_pos);
+    }
+
+    #[test]
+    fn payload_stays_below_limit_with_full_logs() {
+        let frontend = vec![b'f'; PER_LOG_LIMIT_BYTES];
+        let core = vec![b'c'; PER_LOG_LIMIT_BYTES];
+
+        let summary = vec![b's'; SUPPORT_SUMMARY_LIMIT_BYTES];
+
+        let payload = build_upload_payload(&summary, &frontend, CoreLogSource::Available(core));
+
+        assert!(payload.len() <= PAYLOAD_LIMIT_BYTES);
+    }
+
+    #[test]
+    fn payload_marks_unavailable_core_log() {
+        let payload = build_upload_payload(
+            b"summary",
+            b"front",
+            CoreLogSource::Unavailable("not connected".into()),
+        );
+        let text = String::from_utf8(payload).expect("utf8 payload");
+
+        assert!(text.contains("front"));
+        assert!(text.contains("core.log unavailable: not connected"));
+    }
 }

--- a/rust/frontend/src/models/system_status.rs
+++ b/rust/frontend/src/models/system_status.rs
@@ -163,6 +163,23 @@ fn apply_local_status(mut model: Pin<&mut ffi::SystemStatus>, status: LocalStatu
     }
 }
 
+pub fn support_summary_lines() -> Vec<String> {
+    let status = probe_local_status();
+    vec![
+        format!("Wi-Fi internet: {}", yes_no(status.has_wifi_internet)),
+        format!("LAN internet: {}", yes_no(status.has_lan_internet)),
+        format!("Bluetooth: {}", yes_no(status.has_bluetooth)),
+    ]
+}
+
+fn yes_no(value: bool) -> &'static str {
+    if value {
+        "yes"
+    } else {
+        "no"
+    }
+}
+
 fn probe_local_status() -> LocalStatus {
     let network = default_network_kind()
         .filter(|_| internet_reachable())

--- a/rust/zaparoo-core/src/client.rs
+++ b/rust/zaparoo-core/src/client.rs
@@ -14,13 +14,14 @@
 // instead of disappearing into a queue.
 
 use crate::media_types::{
-    LaunchersResult, MediaBrowseParams, MediaBrowseResult, MediaHistoryParams, MediaHistoryResult,
-    MediaHistoryTopParams, MediaHistoryTopResult, MediaImageParams, MediaImageResult,
-    MediaIndexParams, MediaLookupParams, MediaLookupResult, MediaMetaParams, MediaMetaResult,
-    MediaResult, MediaScrapeParams, MediaSearchParams, MediaSearchResult, MediaTagsParams,
-    MediaTagsResult, MediaTagsUpdateParams, MediaTagsUpdateResult, ReadersResult,
-    ReadersWriteParams, RunParams, ScrapersResult, ScrapingStatusResponse, SettingsResult,
-    SystemsParams, SystemsResult, UpdateSettingsParams, VersionResult,
+    HealthResult, LaunchersResult, LogDownloadResult, MediaBrowseParams, MediaBrowseResult,
+    MediaHistoryParams, MediaHistoryResult, MediaHistoryTopParams, MediaHistoryTopResult,
+    MediaImageParams, MediaImageResult, MediaIndexParams, MediaLookupParams, MediaLookupResult,
+    MediaMetaParams, MediaMetaResult, MediaResult, MediaScrapeParams, MediaSearchParams,
+    MediaSearchResult, MediaTagsParams, MediaTagsResult, MediaTagsUpdateParams,
+    MediaTagsUpdateResult, ReadersResult, ReadersWriteParams, RunParams, ScrapersResult,
+    ScrapingStatusResponse, SettingsResult, SystemsParams, SystemsResult, TokensHistoryResult,
+    TokensResult, UpdateSettingsParams, VersionResult,
 };
 use futures_util::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
@@ -489,6 +490,33 @@ impl Client {
         })
     }
 
+    pub async fn health(&self) -> Result<HealthResult, ClientError> {
+        #[derive(Serialize)]
+        struct P {}
+        let val = self.call("health", &P {}).await?;
+        serde_json::from_value(val).map_err(|e| ClientError {
+            message: e.to_string(),
+        })
+    }
+
+    pub async fn tokens(&self) -> Result<TokensResult, ClientError> {
+        #[derive(Serialize)]
+        struct P {}
+        let val = self.call("tokens", &P {}).await?;
+        serde_json::from_value(val).map_err(|e| ClientError {
+            message: e.to_string(),
+        })
+    }
+
+    pub async fn tokens_history(&self) -> Result<TokensHistoryResult, ClientError> {
+        #[derive(Serialize)]
+        struct P {}
+        let val = self.call("tokens.history", &P {}).await?;
+        serde_json::from_value(val).map_err(|e| ClientError {
+            message: e.to_string(),
+        })
+    }
+
     pub async fn settings(&self) -> Result<SettingsResult, ClientError> {
         #[derive(Serialize)]
         struct P {}
@@ -501,6 +529,15 @@ impl Client {
     pub async fn settings_update(&self, params: UpdateSettingsParams) -> Result<(), ClientError> {
         self.call("settings.update", &params).await?;
         Ok(())
+    }
+
+    pub async fn settings_logs_download(&self) -> Result<LogDownloadResult, ClientError> {
+        #[derive(Serialize)]
+        struct P {}
+        let val = self.call("settings.logs.download", &P {}).await?;
+        serde_json::from_value(val).map_err(|e| ClientError {
+            message: e.to_string(),
+        })
     }
 
     pub async fn launchers(&self) -> Result<LaunchersResult, ClientError> {

--- a/rust/zaparoo-core/src/media_types.rs
+++ b/rust/zaparoo-core/src/media_types.rs
@@ -818,6 +818,69 @@ pub struct SettingsResult {
     pub system_defaults: Vec<SystemDefault>,
 }
 
+#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
+pub struct LogDownloadResult {
+    #[serde(default)]
+    pub filename: String,
+    #[serde(default)]
+    pub size: u64,
+    #[serde(default)]
+    pub content: String,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
+pub struct HealthResult {
+    #[serde(default)]
+    pub status: String,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TokenInfo {
+    #[serde(default, rename = "type")]
+    pub token_type: String,
+    #[serde(default)]
+    pub uid: String,
+    #[serde(default)]
+    pub text: String,
+    #[serde(default)]
+    pub data: String,
+    #[serde(default)]
+    pub scan_time: String,
+    #[serde(default)]
+    pub reader_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
+pub struct TokensResult {
+    #[serde(default)]
+    pub active: Vec<TokenInfo>,
+    #[serde(default)]
+    pub last: Option<TokenInfo>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
+pub struct LaunchEntry {
+    #[serde(default, rename = "type")]
+    pub token_type: String,
+    #[serde(default)]
+    pub uid: String,
+    #[serde(default)]
+    pub text: String,
+    #[serde(default)]
+    pub data: String,
+    #[serde(default)]
+    pub success: bool,
+    #[serde(default)]
+    pub time: String,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
+pub struct TokensHistoryResult {
+    #[serde(default)]
+    pub entries: Vec<LaunchEntry>,
+}
+
 #[derive(Debug, Clone, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UpdateSettingsParams {
@@ -925,12 +988,13 @@ mod tests {
     )]
 
     use super::{
-        BrowseEntry, IndexingStatusResponse, LaunchersResult, MediaBrowseParams, MediaBrowseResult,
-        MediaHistoryParams, MediaHistoryResult, MediaHistoryTopParams, MediaHistoryTopResult,
-        MediaImageParams, MediaImageResult, MediaIndexParams, MediaLookupParams, MediaLookupResult,
-        MediaMetaParams, MediaMetaResult, MediaResult, MediaScrapeParams, MediaSearchParams,
-        MediaSearchResult, MediaTagsParams, MediaTagsResult, ReaderInfo, ReadersResult,
-        ScrapersResult, ScrapingStatusResponse, SettingsResult, SystemDefault, SystemsResult,
+        BrowseEntry, HealthResult, IndexingStatusResponse, LaunchersResult, LogDownloadResult,
+        MediaBrowseParams, MediaBrowseResult, MediaHistoryParams, MediaHistoryResult,
+        MediaHistoryTopParams, MediaHistoryTopResult, MediaImageParams, MediaImageResult,
+        MediaIndexParams, MediaLookupParams, MediaLookupResult, MediaMetaParams, MediaMetaResult,
+        MediaResult, MediaScrapeParams, MediaSearchParams, MediaSearchResult, MediaTagsParams,
+        MediaTagsResult, ReaderInfo, ReadersResult, ScrapersResult, ScrapingStatusResponse,
+        SettingsResult, SystemDefault, SystemsResult, TokensHistoryResult, TokensResult,
         UpdateSettingsParams, VersionResult,
     };
 
@@ -1666,6 +1730,70 @@ mod tests {
         assert_eq!(result.system_defaults[0].launcher, "snes9x");
         assert_eq!(result.system_defaults[0].before_exit, "echo bye");
         assert_eq!(result.system_defaults[1].launcher, "");
+    }
+
+    #[test]
+    fn log_download_result_parses_documented_example() {
+        let json = r#"{
+            "filename": "zaparoo.log",
+            "size": 1024,
+            "content": "MjAyNC0wOS0yNFQxNzowMDowMC4wMDBaIElORk8="
+        }"#;
+
+        let result: LogDownloadResult = serde_json::from_str(json).expect("parse");
+
+        assert_eq!(result.filename, "zaparoo.log");
+        assert_eq!(result.size, 1024);
+        assert_eq!(result.content, "MjAyNC0wOS0yNFQxNzowMDowMC4wMDBaIElORk8=");
+    }
+
+    #[test]
+    fn health_result_parses_documented_example() {
+        let result: HealthResult = serde_json::from_str(r#"{"status":"ok"}"#).expect("parse");
+        assert_eq!(result.status, "ok");
+    }
+
+    #[test]
+    fn tokens_result_parses_documented_example() {
+        let json = r#"{
+            "active": [],
+            "last": {
+                "type": "",
+                "uid": "",
+                "text": "**launch.system:snes",
+                "data": "",
+                "scanTime": "2024-09-24T17:49:42.938167429+08:00"
+            }
+        }"#;
+
+        let result: TokensResult = serde_json::from_str(json).expect("parse");
+
+        assert!(result.active.is_empty());
+        let last = result.last.expect("last token");
+        assert_eq!(last.text, "**launch.system:snes");
+        assert_eq!(last.scan_time, "2024-09-24T17:49:42.938167429+08:00");
+    }
+
+    #[test]
+    fn tokens_history_result_parses_documented_example() {
+        let json = r#"{
+            "entries": [
+                {
+                    "data": "",
+                    "success": true,
+                    "text": "**launch.system:snes",
+                    "time": "2024-09-24T17:49:42.938167429+08:00",
+                    "type": "",
+                    "uid": ""
+                }
+            ]
+        }"#;
+
+        let result: TokensHistoryResult = serde_json::from_str(json).expect("parse");
+
+        assert_eq!(result.entries.len(), 1);
+        assert!(result.entries[0].success);
+        assert_eq!(result.entries[0].text, "**launch.system:snes");
     }
 
     #[test]

--- a/src/ui/screens/SettingsScreen.qml
+++ b/src/ui/screens/SettingsScreen.qml
@@ -283,14 +283,20 @@ Item {
     }
 
     // Walk from `from` in `direction` (±1) until we hit a focusable
-    // row or run off the registry. Headers are transparent — Up/Down
-    // skip across them so the user feels a single flat list.
+    // row. Headers are transparent, and edges wrap so Up on the first
+    // field lands on the last field (and vice versa).
     function _seekNavigable(from: int, direction: int): int {
-        let i = from + direction;
-        while (i >= 0 && i < settings.fieldCount) {
+        if (settings.fieldCount <= 0)
+            return from;
+        let i = from;
+        for (let steps = 0; steps < settings.fieldCount; steps++) {
+            i += direction;
+            if (i < 0)
+                i = settings.fieldCount - 1;
+            else if (i >= settings.fieldCount)
+                i = 0;
             if (settings.fields[i].kind === "field")
                 return i;
-            i += direction;
         }
         return from;
     }


### PR DESCRIPTION
## Summary
- prepend a compact support summary to uploaded logs, including frontend build, Core health/version, system connectivity, reader/token/launch, library, and scrape state
- upload tails of both frontend.log and Core log while keeping payload under the 1 MiB service limit
- stream the combined payload to logs.zaparoo.org without persisting Core/support data to disk

## Tests
- just fmt
- just lint-rust
- just lint
- just test-rust

Ref #172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced diagnostic log uploads: single capped payload with a generated support summary, local log tail, and Core log or “core.log unavailable” marker; upload streamed to the server.
  * Added system support summary lines reporting Wi‑Fi, LAN and Bluetooth status.

* **Bug Fixes**
  * Settings navigation now wraps correctly and handles empty registries.

* **Tests**
  * Added unit tests for payload building and new API response parsing.

* **Chores**
  * Added Core API endpoints and response models for health, tokens, history, and log download.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->