### PR TITLE
Add Resume Game hub action

### DIFF
--- a/resources/images/icons/PlayOutline.svg
+++ b/resources/images/icons/PlayOutline.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+ <path d="M8 5.5v13l11-6.5-11-6.5Z" stroke="#fff" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -26,7 +26,7 @@ tokio-tungstenite = { version = "0.29", default-features = false, features = ["c
 tracing         = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter", "json", "local-time"] }
 tracing-appender = "0.2"
-time            = { version = "0.3", features = ["local-offset", "macros"] }
+time            = { version = "0.3", features = ["local-offset", "macros", "parsing"] }
 futures-util    = { version = "0.3", default-features = false, features = ["sink", "std"] }
 uuid            = { version = "1", features = ["v4"] }
 dirs-next       = "2"

--- a/rust/frontend/src/models/recents.rs
+++ b/rust/frontend/src/models/recents.rs
@@ -1006,11 +1006,10 @@ fn launch_entry(entry: &MediaHistoryEntry) {
     if text.is_empty() {
         return;
     }
-    let name = entry.media_name.clone();
     let store = global_store();
     global_handle().spawn(async move {
         if let Err(e) = store.run_mutation::<RunMutation>(RunParams { text }).await {
-            warn!("run failed for {name}: {}", e.message);
+            warn!("run failed: {}", e.message);
         }
     });
 }
@@ -1024,12 +1023,10 @@ fn launch_text_for(entry: &MediaHistoryEntry) -> String {
 }
 
 fn resume_entry(entries: &[MediaHistoryEntry]) -> Option<&MediaHistoryEntry> {
-    let entry = entries.first()?;
-    if launch_text_for(entry).is_empty() || !resume_entry_is_fresh(entry, OffsetDateTime::now_utc())
-    {
-        return None;
-    }
-    Some(entry)
+    let now = OffsetDateTime::now_utc();
+    entries
+        .iter()
+        .find(|entry| !launch_text_for(entry).is_empty() && resume_entry_is_fresh(entry, now))
 }
 
 fn resume_entry_is_fresh(entry: &MediaHistoryEntry, now: OffsetDateTime) -> bool {
@@ -1038,10 +1035,10 @@ fn resume_entry_is_fresh(entry: &MediaHistoryEntry, now: OffsetDateTime) -> bool
         .as_deref()
         .unwrap_or(entry.started_at.as_str());
     if timestamp.trim().is_empty() {
-        return true;
+        return false;
     }
     let Ok(played_at) = OffsetDateTime::parse(timestamp, &Rfc3339) else {
-        return true;
+        return false;
     };
     now - played_at <= TimeDuration::days(RESUME_MAX_AGE_DAYS)
 }
@@ -1131,17 +1128,22 @@ mod tests {
     }
 
     #[test]
-    fn resume_entry_requires_launchable_first_entry() {
+    fn resume_entry_requires_launchable_entry() {
         assert!(resume_entry(&[]).is_none());
         let e = entry("ghost", "", "NES", "NES");
         assert!(resume_entry(&[e]).is_none());
     }
 
     #[test]
-    fn resume_entry_accepts_launchable_entry_with_missing_timestamp() {
-        let e = entry("smb", "/p/smb", "NES", "NES");
+    fn resume_entry_skips_stale_or_malformed_entries() {
+        let mut stale = entry("old", "/p/old", "NES", "NES");
+        stale.started_at = "2026-05-01T00:00:00Z".into();
+        let mut malformed = entry("bad", "/p/bad", "NES", "NES");
+        malformed.started_at = "not-a-date".into();
+        let mut recent = entry("smb", "/p/smb", "NES", "NES");
+        recent.started_at = "2026-06-01T00:00:00Z".into();
         assert_eq!(
-            resume_entry(&[e]).map(|entry| entry.media_name.as_str()),
+            resume_entry(&[stale, malformed, recent]).map(|entry| entry.media_name.as_str()),
             Some("smb")
         );
     }
@@ -1169,11 +1171,11 @@ mod tests {
     }
 
     #[test]
-    fn resume_entry_freshness_accepts_missing_or_malformed_timestamp() {
+    fn resume_entry_freshness_rejects_missing_or_malformed_timestamp() {
         let mut e = entry("smb", "/p/smb", "NES", "NES");
-        assert!(resume_entry_is_fresh(&e, datetime!(2026-06-03 00:00 UTC)));
+        assert!(!resume_entry_is_fresh(&e, datetime!(2026-06-03 00:00 UTC)));
         e.started_at = "not-a-date".into();
-        assert!(resume_entry_is_fresh(&e, datetime!(2026-06-03 00:00 UTC)));
+        assert!(!resume_entry_is_fresh(&e, datetime!(2026-06-03 00:00 UTC)));
     }
 
     #[test]

--- a/rust/frontend/src/models/recents.rs
+++ b/rust/frontend/src/models/recents.rs
@@ -33,6 +33,7 @@ use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
+use time::{format_description::well_known::Rfc3339, Duration as TimeDuration, OffsetDateTime};
 use tokio::sync::broadcast::error::RecvError;
 use tokio::task::JoinHandle;
 use tracing::{info, warn};
@@ -59,6 +60,8 @@ const FILE_STEM_ROLE: i32 = 256 + 7;
 // over-the-wire payload. Bumping this only saves a round trip — it
 // doesn't change the UI cap.
 const PAGE_SIZE: u32 = 25;
+const RESUME_MAX_AGE_DAYS: i64 = 7;
+const RESUME_FALLBACK_COVER_KEY: &str = "icons/PlayOutline";
 
 #[derive(Default)]
 #[allow(
@@ -76,6 +79,9 @@ pub struct RecentsModelRust {
     error_message: QString,
     has_next_page: bool,
     next_cursor: Option<String>,
+    resume_available: bool,
+    resume_name: QString,
+    resume_cover_key: QString,
     current_detail_loading: bool,
     current_detail_tags: QString,
     current_detail_image_key: QString,
@@ -136,6 +142,9 @@ pub mod ffi {
         #[qproperty(bool, loading_more)]
         #[qproperty(QString, error_message)]
         #[qproperty(bool, has_next_page)]
+        #[qproperty(bool, resume_available)]
+        #[qproperty(QString, resume_name)]
+        #[qproperty(QString, resume_cover_key)]
         #[qproperty(bool, current_detail_loading)]
         #[qproperty(QString, current_detail_tags)]
         #[qproperty(QString, current_detail_image_key)]
@@ -147,6 +156,9 @@ pub mod ffi {
 
         #[qinvokable]
         fn launch_at(self: Pin<&mut RecentsModel>, index: i32);
+
+        #[qinvokable]
+        fn launch_resume(self: Pin<&mut RecentsModel>);
 
         #[qinvokable]
         fn name_at(self: &RecentsModel, index: i32) -> QString;
@@ -273,6 +285,7 @@ fn apply_state(
         model.as_mut().rust_mut().next_cursor = next_cursor;
         model.as_mut().end_reset_model();
         model.as_mut().count_changed();
+        sync_resume_state(model.as_mut());
         if model.has_next_page != has_next_page {
             model.as_mut().set_has_next_page(has_next_page);
         }
@@ -304,6 +317,7 @@ fn apply_state(
         clear_current_detail_state(model.as_mut());
         model.as_mut().rust_mut().seq.fetch_add(1, Ordering::SeqCst);
         model.as_mut().rust_mut().next_cursor = None;
+        sync_resume_state(model.as_mut());
         if !model.loading {
             model.as_mut().set_loading(true);
         }
@@ -319,6 +333,7 @@ fn apply_state(
         clear_current_detail_state(model.as_mut());
         model.as_mut().rust_mut().seq.fetch_add(1, Ordering::SeqCst);
         model.as_mut().rust_mut().next_cursor = None;
+        sync_resume_state(model.as_mut());
         if model.loading {
             model.as_mut().set_loading(false);
         }
@@ -416,18 +431,14 @@ impl ffi::RecentsModel {
         if index < 0 || index >= self.count {
             return;
         }
-        let entry = &self.entries[index as usize];
-        let text = launch_text_for(entry);
-        if text.is_empty() {
+        launch_entry(&self.entries[index as usize]);
+    }
+
+    fn launch_resume(self: Pin<&mut Self>) {
+        let Some(entry) = resume_entry(&self.entries) else {
             return;
-        }
-        let name = entry.media_name.clone();
-        let store = global_store();
-        global_handle().spawn(async move {
-            if let Err(e) = store.run_mutation::<RunMutation>(RunParams { text }).await {
-                warn!("run failed for {name}: {}", e.message);
-            }
-        });
+        };
+        launch_entry(entry);
     }
 
     fn name_at(&self, index: i32) -> QString {
@@ -578,6 +589,53 @@ fn cover_key_for(entry: &MediaHistoryEntry, requests_enabled: bool) -> String {
         negative,
         soft_no_image || !requests_enabled,
     )
+}
+
+fn resume_cover_key_for(entry: &MediaHistoryEntry, requests_enabled: bool) -> String {
+    let media_key = media_key_for(entry).map(MediaKey::with_current_cover_preference);
+    let cache = global_media_image_cache();
+    let cached = media_key.as_ref().is_some_and(|k| cache.is_cached(k));
+    let negative = media_key.as_ref().is_some_and(|k| cache.is_negative(k));
+    let soft_no_image = media_key
+        .as_ref()
+        .is_some_and(|k| cache.is_soft_no_image(k));
+    if requests_enabled && !cached && !negative && !soft_no_image {
+        if let Some(k) = media_key.as_ref() {
+            cache.enqueue_search_cover_with_media_id(k.clone(), entry.media_id, PAGE_SIZE);
+        }
+    }
+    resume_cover_key_for_with(media_key.as_ref(), cached)
+}
+
+fn resume_cover_key_for_with(key: Option<&MediaKey>, cached: bool) -> String {
+    match key {
+        Some(k) if cached => MediaImageCache::image_key_for(k),
+        _ => RESUME_FALLBACK_COVER_KEY.to_string(),
+    }
+}
+
+fn sync_resume_state(mut model: Pin<&mut ffi::RecentsModel>) {
+    let (available, name, cover_key) = match resume_entry(&model.entries) {
+        Some(entry) => (
+            true,
+            QString::from(entry.media_name.as_str()),
+            QString::from(resume_cover_key_for(entry, !model.cover_requests_paused).as_str()),
+        ),
+        None => (
+            false,
+            QString::default(),
+            QString::from(RESUME_FALLBACK_COVER_KEY),
+        ),
+    };
+    if model.resume_available != available {
+        model.as_mut().set_resume_available(available);
+    }
+    if model.resume_name != name {
+        model.as_mut().set_resume_name(name);
+    }
+    if model.resume_cover_key != cover_key {
+        model.as_mut().set_resume_cover_key(cover_key);
+    }
 }
 
 fn emit_cover_key_range(mut model: Pin<&mut ffi::RecentsModel>, first_row: i32, count: i32) {
@@ -799,6 +857,14 @@ fn notify_cover_update(mut model: Pin<&mut ffi::RecentsModel>, key: &MediaKey) {
     {
         sync_current_detail_image_key(model.as_mut());
     }
+    if resume_entry(&model.entries)
+        .and_then(media_key_for)
+        .map(MediaKey::with_current_cover_preference)
+        .as_ref()
+        .is_some_and(|current| current == key)
+    {
+        sync_resume_state(model.as_mut());
+    }
     // Tick the gate's pending set down. `remove` returns false if the
     // key wasn't gated (broadcast events fire for every cache update,
     // including miss-recovery enqueues from `cover_key_for`); we only
@@ -935,12 +1001,49 @@ fn release_cover_gate_after_timeout(mut model: Pin<&mut ffi::RecentsModel>) {
     }
 }
 
+fn launch_entry(entry: &MediaHistoryEntry) {
+    let text = launch_text_for(entry);
+    if text.is_empty() {
+        return;
+    }
+    let name = entry.media_name.clone();
+    let store = global_store();
+    global_handle().spawn(async move {
+        if let Err(e) = store.run_mutation::<RunMutation>(RunParams { text }).await {
+            warn!("run failed for {name}: {}", e.message);
+        }
+    });
+}
+
 /// Build the `text` payload sent to Core's `run` for a history entry.
 /// Runtime relaunches prefer the exact path Core recorded; portable
 /// `ZapScript` is not available on history rows and launcher affinity is
 /// less important than avoiding title-resolution ambiguity.
 fn launch_text_for(entry: &MediaHistoryEntry) -> String {
     entry.media_path.clone()
+}
+
+fn resume_entry(entries: &[MediaHistoryEntry]) -> Option<&MediaHistoryEntry> {
+    let entry = entries.first()?;
+    if launch_text_for(entry).is_empty() || !resume_entry_is_fresh(entry, OffsetDateTime::now_utc())
+    {
+        return None;
+    }
+    Some(entry)
+}
+
+fn resume_entry_is_fresh(entry: &MediaHistoryEntry, now: OffsetDateTime) -> bool {
+    let timestamp = entry
+        .ended_at
+        .as_deref()
+        .unwrap_or(entry.started_at.as_str());
+    if timestamp.trim().is_empty() {
+        return true;
+    }
+    let Ok(played_at) = OffsetDateTime::parse(timestamp, &Rfc3339) else {
+        return true;
+    };
+    now - played_at <= TimeDuration::days(RESUME_MAX_AGE_DAYS)
 }
 
 fn position_of_path(entries: &[MediaHistoryEntry], needle: &str) -> i32 {
@@ -981,6 +1084,7 @@ fn apply_append_page(
                 model.as_mut().rust_mut().count = first.saturating_add(new_count);
                 model.as_mut().end_insert_rows();
                 model.as_mut().count_changed();
+                sync_resume_state(model.as_mut());
             }
             model.as_mut().rust_mut().next_cursor = next_cursor;
             model.as_mut().set_has_next_page(has_next_page);
@@ -1007,10 +1111,12 @@ mod tests {
 
     use super::{
         compute_unresolved_keys, cover_key_for_with, launch_text_for, media_key_for,
-        position_of_path, project,
+        position_of_path, project, resume_cover_key_for_with, resume_entry, resume_entry_is_fresh,
+        RESUME_FALLBACK_COVER_KEY,
     };
     use crate::media_image_cache::{MediaImageCache, MediaKey};
     use std::collections::HashSet;
+    use time::macros::datetime;
     use zaparoo_core::media_types::{MediaHistoryEntry, MediaHistoryResult, Pagination};
     use zaparoo_core::remote_resource::ResourceStatus;
 
@@ -1022,6 +1128,70 @@ mod tests {
             launcher_id: launcher_id.into(),
             ..MediaHistoryEntry::default()
         }
+    }
+
+    #[test]
+    fn resume_entry_requires_launchable_first_entry() {
+        assert!(resume_entry(&[]).is_none());
+        let e = entry("ghost", "", "NES", "NES");
+        assert!(resume_entry(&[e]).is_none());
+    }
+
+    #[test]
+    fn resume_entry_accepts_launchable_entry_with_missing_timestamp() {
+        let e = entry("smb", "/p/smb", "NES", "NES");
+        assert_eq!(
+            resume_entry(&[e]).map(|entry| entry.media_name.as_str()),
+            Some("smb")
+        );
+    }
+
+    #[test]
+    fn resume_entry_freshness_accepts_recent_started_at() {
+        let mut e = entry("smb", "/p/smb", "NES", "NES");
+        e.started_at = "2026-06-01T00:00:00Z".into();
+        assert!(resume_entry_is_fresh(&e, datetime!(2026-06-03 00:00 UTC)));
+    }
+
+    #[test]
+    fn resume_entry_freshness_rejects_old_started_at() {
+        let mut e = entry("smb", "/p/smb", "NES", "NES");
+        e.started_at = "2026-05-01T00:00:00Z".into();
+        assert!(!resume_entry_is_fresh(&e, datetime!(2026-06-03 00:00 UTC)));
+    }
+
+    #[test]
+    fn resume_entry_freshness_prefers_ended_at() {
+        let mut e = entry("smb", "/p/smb", "NES", "NES");
+        e.started_at = "2026-05-01T00:00:00Z".into();
+        e.ended_at = Some("2026-06-01T00:00:00Z".into());
+        assert!(resume_entry_is_fresh(&e, datetime!(2026-06-03 00:00 UTC)));
+    }
+
+    #[test]
+    fn resume_entry_freshness_accepts_missing_or_malformed_timestamp() {
+        let mut e = entry("smb", "/p/smb", "NES", "NES");
+        assert!(resume_entry_is_fresh(&e, datetime!(2026-06-03 00:00 UTC)));
+        e.started_at = "not-a-date".into();
+        assert!(resume_entry_is_fresh(&e, datetime!(2026-06-03 00:00 UTC)));
+    }
+
+    #[test]
+    fn resume_cover_key_uses_play_outline_unless_cached() {
+        let e = entry("smb", "/p/smb", "NES", "NES");
+        let key = media_key_for(&e).expect("media has key");
+        assert_eq!(
+            resume_cover_key_for_with(Some(&key), false),
+            RESUME_FALLBACK_COVER_KEY
+        );
+        assert_eq!(
+            resume_cover_key_for_with(None, false),
+            RESUME_FALLBACK_COVER_KEY
+        );
+        assert_eq!(
+            resume_cover_key_for_with(Some(&key), true),
+            MediaImageCache::image_key_for(&key)
+        );
     }
 
     #[test]

--- a/rust/frontend/src/models/recents.rs
+++ b/rust/frontend/src/models/recents.rs
@@ -1040,6 +1040,9 @@ fn resume_entry_is_fresh(entry: &MediaHistoryEntry, now: OffsetDateTime) -> bool
     let Ok(played_at) = OffsetDateTime::parse(timestamp, &Rfc3339) else {
         return false;
     };
+    if played_at > now {
+        return false;
+    }
     now - played_at <= TimeDuration::days(RESUME_MAX_AGE_DAYS)
 }
 
@@ -1113,7 +1116,10 @@ mod tests {
     };
     use crate::media_image_cache::{MediaImageCache, MediaKey};
     use std::collections::HashSet;
-    use time::macros::datetime;
+    use time::{
+        format_description::well_known::Rfc3339, macros::datetime, Duration as TimeDuration,
+        OffsetDateTime,
+    };
     use zaparoo_core::media_types::{MediaHistoryEntry, MediaHistoryResult, Pagination};
     use zaparoo_core::remote_resource::ResourceStatus;
 
@@ -1136,12 +1142,13 @@ mod tests {
 
     #[test]
     fn resume_entry_skips_stale_or_malformed_entries() {
+        let now = OffsetDateTime::now_utc();
         let mut stale = entry("old", "/p/old", "NES", "NES");
-        stale.started_at = "2026-05-01T00:00:00Z".into();
+        stale.started_at = (now - TimeDuration::days(30)).format(&Rfc3339).unwrap();
         let mut malformed = entry("bad", "/p/bad", "NES", "NES");
         malformed.started_at = "not-a-date".into();
         let mut recent = entry("smb", "/p/smb", "NES", "NES");
-        recent.started_at = "2026-06-01T00:00:00Z".into();
+        recent.started_at = (now - TimeDuration::days(1)).format(&Rfc3339).unwrap();
         assert_eq!(
             resume_entry(&[stale, malformed, recent]).map(|entry| entry.media_name.as_str()),
             Some("smb")
@@ -1175,6 +1182,13 @@ mod tests {
         let mut e = entry("smb", "/p/smb", "NES", "NES");
         assert!(!resume_entry_is_fresh(&e, datetime!(2026-06-03 00:00 UTC)));
         e.started_at = "not-a-date".into();
+        assert!(!resume_entry_is_fresh(&e, datetime!(2026-06-03 00:00 UTC)));
+    }
+
+    #[test]
+    fn resume_entry_freshness_rejects_future_timestamp() {
+        let mut e = entry("smb", "/p/smb", "NES", "NES");
+        e.started_at = "2026-06-04T00:00:00Z".into();
         assert!(!resume_entry_is_fresh(&e, datetime!(2026-06-03 00:00 UTC)));
     }
 

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -115,6 +115,8 @@ MainLayout {
         // Connection below fires it on first delivery.
         if (Browse.CategoriesModel.count > 0)
             root.hubScreen.restoreFromCategoriesReset();
+        if (root.activeScreen === root.screenHub && Browse.RecentsModel.resume_available)
+            root.hubScreen.focusResumeIfAvailable();
         // Warm-start into Favorites/Recents needs the same
         // restore-on-ready dance the navigate helpers perform,
         // otherwise the grid lands on index 0 and ignores persisted
@@ -583,6 +585,9 @@ MainLayout {
         }
         function onRequestQuit(): void {
             root.openQuitConfirmModal();
+        }
+        function onRequestResumeGame(): void {
+            Browse.RecentsModel.launch_resume();
         }
         function onRequestFavoritesScreen(): void {
             root._navigateToFavorites();

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -435,14 +435,20 @@ MainLayout {
 
     // Hub Accept routing. Empty-row passthrough preserves the committed
     // "Enter on empty hub goes to Systems" behaviour and
-    // keeps the navigation test synchronous. Otherwise: tentatively
-    // pin the destination to Systems, fill the chosen category, then
-    // either bypass to Games (MiSTer Arcade singleton) or fall
-    // through to Systems with a cover-prefetch warmup so the
-    // destination paints with logos already in QPixmapCache.
+    // keeps the navigation test synchronous. The Resume action is a
+    // hub payload rather than a category and launches the latest
+    // resumable history row. Otherwise: tentatively pin the
+    // destination to Systems, fill the chosen category, then either
+    // bypass to Games (MiSTer Arcade singleton) or fall through to
+    // Systems with a cover-prefetch warmup so the destination paints
+    // with logos already in QPixmapCache.
     function _navigateFromHub(category: string): void {
         if (category === "") {
             root._goto(root.screenSystems);
+            return;
+        }
+        if (category === "resume") {
+            Browse.RecentsModel.launch_resume();
             return;
         }
         Browse.HubState.category = category;
@@ -585,9 +591,6 @@ MainLayout {
         }
         function onRequestQuit(): void {
             root.openQuitConfirmModal();
-        }
-        function onRequestResumeGame(): void {
-            Browse.RecentsModel.launch_resume();
         }
         function onRequestFavoritesScreen(): void {
             root._navigateToFavorites();

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -50,6 +50,7 @@ MainLayout {
     property string _pendingLanguageSelection: ""
     property string _pendingResolutionSelection: ""
     property bool _discoverMenuPending: false
+    property bool _resumeStartupFocusPending: false
     property var _discoverParentEntries: []
     property string _pendingLauncherSystemId: ""
     property string _pendingLauncherSelectionId: ""
@@ -115,8 +116,12 @@ MainLayout {
         // Connection below fires it on first delivery.
         if (Browse.CategoriesModel.count > 0)
             root.hubScreen.restoreFromCategoriesReset();
-        if (root.activeScreen === root.screenHub && Browse.RecentsModel.resume_available)
-            root.hubScreen.focusResumeIfAvailable();
+        if (root.activeScreen === root.screenHub) {
+            if (Browse.RecentsModel.resume_available)
+                root.hubScreen.focusResumeIfAvailable();
+            else
+                root._resumeStartupFocusPending = true;
+        }
         // Warm-start into Favorites/Recents needs the same
         // restore-on-ready dance the navigate helpers perform,
         // otherwise the grid lands on index 0 and ignores persisted
@@ -377,6 +382,13 @@ MainLayout {
                 return;
             root._recentsReadyCallback = null;
             cb();
+        }
+        function onResume_availableChanged(): void {
+            if (!root._resumeStartupFocusPending || !Browse.RecentsModel.resume_available)
+                return;
+            root._resumeStartupFocusPending = false;
+            if (root.activeScreen === root.screenHub)
+                root.hubScreen.focusResumeIfAvailable();
         }
     }
     Connections {

--- a/src/ui/screens/HubScreen.qml
+++ b/src/ui/screens/HubScreen.qml
@@ -37,9 +37,9 @@ import Zaparoo.Browse as Browse
 // clamped into the destination row. The formula is symmetric and
 // generalizes for any (topCount, bottomCount); see `_mapCrossRow`.
 //
-// Pure input dispatcher: emits one of `requestAccept(category)`,
-// `requestResumeGame`, `requestFavoritesScreen`,
-// `requestRecentsScreen`, `requestSettingsScreen`, or `requestQuit`.
+// Pure input dispatcher: emits one of `requestAccept(payload)`,
+// `requestFavoritesScreen`, `requestRecentsScreen`,
+// `requestSettingsScreen`, or `requestQuit`.
 //
 // All cross-screen orchestration (model fills, deferred set_category,
 // cover prefetch, transition overlay, screen flip) lives in Main.qml.
@@ -65,7 +65,6 @@ Item {
 
     signal requestAccept(category: string)
     signal requestQuit
-    signal requestResumeGame
     signal requestFavoritesScreen
     signal requestRecentsScreen
     signal requestSettingsScreen
@@ -323,7 +322,7 @@ Item {
 
         const id = hub.actionEntries[hub.currentIndex].id;
         if (id === "resume")
-            hub.requestResumeGame();
+            hub.requestAccept("resume");
         else if (id === "favorites")
             hub.requestFavoritesScreen();
         else if (id === "recents")

--- a/src/ui/screens/HubScreen.qml
+++ b/src/ui/screens/HubScreen.qml
@@ -20,7 +20,8 @@ import Zaparoo.Browse as Browse
 //
 //   * Top row: dynamic categories from Browse.CategoriesModel (Arcade,
 //     Computer, Console, Handheld).
-//   * Bottom row: fixed actions — Favorites, Recently Played and Settings.
+//   * Bottom row: actions — optional Resume Game, Favorites,
+//     Recently Played and Settings.
 //
 // Both rows wrap left/right modulo their own count, and Up/Down flip
 // between rows in a closed loop (Up from top wraps to bottom, Down
@@ -37,8 +38,8 @@ import Zaparoo.Browse as Browse
 // generalizes for any (topCount, bottomCount); see `_mapCrossRow`.
 //
 // Pure input dispatcher: emits one of `requestAccept(category)`,
-// `requestFavoritesScreen`, `requestRecentsScreen`,
-// `requestSettingsScreen`, or `requestQuit`.
+// `requestResumeGame`, `requestFavoritesScreen`,
+// `requestRecentsScreen`, `requestSettingsScreen`, or `requestQuit`.
 //
 // All cross-screen orchestration (model fills, deferred set_category,
 // cover prefetch, transition overlay, screen flip) lives in Main.qml.
@@ -64,6 +65,7 @@ Item {
 
     signal requestAccept(category: string)
     signal requestQuit
+    signal requestResumeGame
     signal requestFavoritesScreen
     signal requestRecentsScreen
     signal requestSettingsScreen
@@ -78,29 +80,36 @@ Item {
     readonly property int _blockHeight: 2 * (categoriesRow.cellHeight + 2 * categoriesRow.verticalPadding) + (categoriesRow.spacing - categoriesRow.verticalPadding - actionsRow.verticalPadding) + Sizing.pctH(3) + Sizing.pctH(7)
     readonly property int _blockY: Math.round((Sizing.headerBottom + hub.height - Sizing.pctH(6) - hub._blockHeight) / 2)
 
-    // Static action-row data. Three fixed entries; order matches
-    // left-to-right reading. The `qsTr()` calls live directly in this
-    // binding so a `LanguageChange` event re-evaluates `actionEntries`
-    // and rebuilds the array with newly-translated strings — consumers
-    // bound to `actionEntries[i].text` pick up the new values
-    // automatically.
-    readonly property var actionEntries: [
-        {
+    // Action-row data. Resume is prepended only when Core history has
+    // a fresh launchable row; the rest keep stable ids so persisted
+    // focus can remap across insertion/removal.
+    readonly property var actionEntries: {
+        const entries = [];
+        if (Browse.RecentsModel.resume_available) {
+            const resumeName = Browse.RecentsModel.resume_name;
+            entries.push({
+                id: "resume",
+                coverKey: Browse.RecentsModel.resume_cover_key || "icons/PlayOutline",
+                text: resumeName.length > 0 ? qsTr("Resume: %1").arg(resumeName) : qsTr("Resume Game")
+            });
+        }
+        entries.push({
             id: "favorites",
             coverKey: "icons/HeartOutline",
             text: qsTr("Favorites")
-        },
-        {
+        });
+        entries.push({
             id: "recents",
             coverKey: "icons/History",
             text: qsTr("Recently Played")
-        },
-        {
+        });
+        entries.push({
             id: "settings",
             coverKey: "icons/Settings",
             text: qsTr("Settings")
-        }
-    ]
+        });
+        return entries;
+    }
 
     function _actionIndexForId(id: string): int {
         for (let i = 0; i < hub.actionEntries.length; i++)
@@ -108,6 +117,24 @@ Item {
                 return i;
         return 0;
     }
+
+    function _remapActionFocus(): void {
+        if (hub.currentRow !== 1)
+            return;
+        hub.currentIndex = hub._actionIndexForId(Browse.HubState.selected_action);
+    }
+
+    function focusResumeIfAvailable(): void {
+        const resumeIndex = hub._actionIndexForId("resume");
+        if (!Browse.RecentsModel.resume_available || hub.actionEntries[resumeIndex].id !== "resume")
+            return;
+        hub.currentRow = 1;
+        hub.currentIndex = resumeIndex;
+        hub._crossSavedIndex = -1;
+        hub._commitActionSelection();
+    }
+
+    onActionEntriesChanged: hub._remapActionFocus()
 
     // Test-harness hook so `tst_navigation.qml` can reset both focus
     // axes between cases without poking individual properties through
@@ -295,7 +322,9 @@ Item {
         }
 
         const id = hub.actionEntries[hub.currentIndex].id;
-        if (id === "favorites")
+        if (id === "resume")
+            hub.requestResumeGame();
+        else if (id === "favorites")
             hub.requestFavoritesScreen();
         else if (id === "recents")
             hub.requestRecentsScreen();
@@ -418,7 +447,7 @@ Item {
 
     // Action row. Same cell geometry and centring formula as
     // categoriesRow so the two rows visually read as one grid; the
-    // only difference is a static three-entry array model. Positioned
+    // only difference is a small array model with optional Resume. Positioned
     // directly below categoriesRow with a vertical gap equal to
     // categoriesRow.spacing so the visual gutter between rows matches
     // the gutter between tiles within a row.

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -365,6 +365,16 @@
     <name>HubScreen</name>
     <message>
         <location filename="../screens/HubScreen.qml" line="91"/>
+        <source>Resume: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="91"/>
+        <source>Resume Game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="91"/>
         <source>Favorites</source>
         <translation>المفضلة</translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -365,6 +365,16 @@
     <name>HubScreen</name>
     <message>
         <location filename="../screens/HubScreen.qml" line="91"/>
+        <source>Resume: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="91"/>
+        <source>Resume Game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="91"/>
         <source>Favorites</source>
         <translation>Favoriten</translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -365,6 +365,16 @@
     <name>HubScreen</name>
     <message>
         <location filename="../screens/HubScreen.qml" line="91"/>
+        <source>Resume: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="91"/>
+        <source>Resume Game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="91"/>
         <source>Favorites</source>
         <translation>Αγαπημένα</translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -365,6 +365,16 @@
     <name>HubScreen</name>
     <message>
         <location filename="../screens/HubScreen.qml" line="91"/>
+        <source>Resume: %1</source>
+        <translation>Resume: %1</translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="91"/>
+        <source>Resume Game</source>
+        <translation>Resume Game</translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="91"/>
         <source>Favorites</source>
         <translation>Favorites</translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -365,6 +365,16 @@
     <name>HubScreen</name>
     <message>
         <location filename="../screens/HubScreen.qml" line="91"/>
+        <source>Resume: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="91"/>
+        <source>Resume Game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="91"/>
         <source>Favorites</source>
         <translation>Favoritos</translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -365,6 +365,16 @@
     <name>HubScreen</name>
     <message>
         <location filename="../screens/HubScreen.qml" line="91"/>
+        <source>Resume: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="91"/>
+        <source>Resume Game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="91"/>
         <source>Favorites</source>
         <translation>מועדפים</translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -365,6 +365,16 @@
     <name>HubScreen</name>
     <message>
         <location filename="../screens/HubScreen.qml" line="91"/>
+        <source>Resume: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="91"/>
+        <source>Resume Game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="91"/>
         <source>Favorites</source>
         <translation>पसंदीदा</translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -365,6 +365,16 @@
     <name>HubScreen</name>
     <message>
         <location filename="../screens/HubScreen.qml" line="91"/>
+        <source>Resume: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="91"/>
+        <source>Resume Game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="91"/>
         <source>Favorites</source>
         <translation>Preferiti</translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -365,6 +365,16 @@
     <name>HubScreen</name>
     <message>
         <location filename="../screens/HubScreen.qml" line="91"/>
+        <source>Resume: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="91"/>
+        <source>Resume Game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="91"/>
         <source>Favorites</source>
         <translation>お気に入り</translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -365,6 +365,16 @@
     <name>HubScreen</name>
     <message>
         <location filename="../screens/HubScreen.qml" line="91"/>
+        <source>Resume: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="91"/>
+        <source>Resume Game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="91"/>
         <source>Favorites</source>
         <translation>즐겨찾기</translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -365,6 +365,16 @@
     <name>HubScreen</name>
     <message>
         <location filename="../screens/HubScreen.qml" line="91"/>
+        <source>Resume: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="91"/>
+        <source>Resume Game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="91"/>
         <source>Favorites</source>
         <translation>Favorieten</translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -365,6 +365,16 @@
     <name>HubScreen</name>
     <message>
         <location filename="../screens/HubScreen.qml" line="91"/>
+        <source>Resume: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="91"/>
+        <source>Resume Game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="91"/>
         <source>Favorites</source>
         <translation>Favorite</translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -365,6 +365,16 @@
     <name>HubScreen</name>
     <message>
         <location filename="../screens/HubScreen.qml" line="91"/>
+        <source>Resume: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="91"/>
+        <source>Resume Game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="91"/>
         <source>Favorites</source>
         <translation>Obľúbené</translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -365,6 +365,16 @@
     <name>HubScreen</name>
     <message>
         <location filename="../screens/HubScreen.qml" line="91"/>
+        <source>Resume: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="91"/>
+        <source>Resume Game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="91"/>
         <source>Favorites</source>
         <translation>Вибране</translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -365,6 +365,16 @@
     <name>HubScreen</name>
     <message>
         <location filename="../screens/HubScreen.qml" line="91"/>
+        <source>Resume: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="91"/>
+        <source>Resume Game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="91"/>
         <source>Favorites</source>
         <translation>收藏</translation>
     </message>


### PR DESCRIPTION
## Summary
- add a conditional Resume Game tile to the hub action row
- surface resume availability, name, cover, and launch action from RecentsModel
- use a 7-day recency threshold with play-outline fallback art

## Tests
- just lint
- just test-qml
- just test-rust

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Resume Game" tile appears on the Hub when a recent, resumable session exists; hub can auto-focus it on startup and launch the resumed session directly.
  * Resume shows a cover image when available and falls back to a default cover otherwise.

* **Documentation**
  * Added translation entries for the Resume UI across multiple languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->