### PR TITLE
Use scrape force status for re-scrape toggle

### DIFF
--- a/rust/frontend/src/models/media_status.rs
+++ b/rust/frontend/src/models/media_status.rs
@@ -57,6 +57,8 @@ pub struct MediaStatusRust {
     scrape_matched: i32,
     scrape_skipped: i32,
     scrape_total_scraped: i32,
+    scrape_force: bool,
+    scrape_force_known: bool,
     scrape_system_id: QString,
     scrape_scraper_id: QString,
     scrape_state: QString,
@@ -96,6 +98,8 @@ pub mod ffi {
         #[qproperty(i32, scrape_matched)]
         #[qproperty(i32, scrape_skipped)]
         #[qproperty(i32, scrape_total_scraped)]
+        #[qproperty(bool, scrape_force)]
+        #[qproperty(bool, scrape_force_known)]
         #[qproperty(QString, scrape_system_id)]
         #[qproperty(QString, scrape_scraper_id)]
         #[qproperty(QString, scrape_state)]
@@ -150,6 +154,8 @@ struct Snapshot {
     scrape_matched: i32,
     scrape_skipped: i32,
     scrape_total_scraped: i32,
+    scrape_force: bool,
+    scrape_force_known: bool,
     scrape_system_id: QString,
     scrape_scraper_id: QString,
     scrape_state: QString,
@@ -179,6 +185,8 @@ fn project(state: &MediaStatusState) -> Snapshot {
         scrape_matched: state.scrape_matched,
         scrape_skipped: state.scrape_skipped,
         scrape_total_scraped: state.scrape_total_scraped,
+        scrape_force: state.scrape_force,
+        scrape_force_known: state.scrape_force_known,
         scrape_system_id: QString::from(state.scrape_system_id.as_str()),
         scrape_scraper_id: QString::from(state.scrape_scraper_id.as_str()),
         scrape_state: QString::from(state.scrape_state.as_str()),
@@ -320,6 +328,12 @@ fn apply(mut model: Pin<&mut ffi::MediaStatus>, s: Snapshot) {
             .as_mut()
             .set_scrape_total_scraped(s.scrape_total_scraped);
     }
+    if model.scrape_force != s.scrape_force {
+        model.as_mut().set_scrape_force(s.scrape_force);
+    }
+    if model.scrape_force_known != s.scrape_force_known {
+        model.as_mut().set_scrape_force_known(s.scrape_force_known);
+    }
     if model.scrape_system_id != s.scrape_system_id {
         model.as_mut().set_scrape_system_id(s.scrape_system_id);
     }
@@ -374,6 +388,8 @@ mod tests {
             scrape_matched: 0,
             scrape_skipped: 0,
             scrape_total_scraped: 0,
+            scrape_force: false,
+            scrape_force_known: false,
             scrape_system_id: String::new(),
             scrape_scraper_id: String::new(),
             scrape_state: String::new(),
@@ -405,6 +421,8 @@ mod tests {
             scrape_matched: 10,
             scrape_skipped: 2,
             scrape_total_scraped: 50,
+            scrape_force: true,
+            scrape_force_known: true,
             scrape_system_id: "SNES".into(),
             scrape_scraper_id: "screenscraper".into(),
             scrape_state: "running".into(),
@@ -420,6 +438,8 @@ mod tests {
         assert_eq!(snapshot.scrape_matched, 10);
         assert_eq!(snapshot.scrape_skipped, 2);
         assert_eq!(snapshot.scrape_total_scraped, 50);
+        assert!(snapshot.scrape_force);
+        assert!(snapshot.scrape_force_known);
         assert_eq!(snapshot.scrape_system_id, QString::from("SNES"));
         assert_eq!(snapshot.scrape_scraper_id, QString::from("screenscraper"));
         assert_eq!(snapshot.scrape_state, QString::from("running"));

--- a/rust/zaparoo-core/src/media_types.rs
+++ b/rust/zaparoo-core/src/media_types.rs
@@ -700,6 +700,10 @@ pub struct ScrapeSystemProgressResponse {
 /// from upstream. `total_steps` / `current_step` carry whole-run system
 /// progress; flat counters remain the per-current-system compatibility
 /// surface.
+#[allow(
+    clippy::struct_excessive_bools,
+    reason = "wire-faithful mirror of Core's ScrapingStatusResponse"
+)]
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ScrapingStatusResponse {
@@ -729,6 +733,8 @@ pub struct ScrapingStatusResponse {
     pub skipped: i32,
     #[serde(default)]
     pub total_scraped: i32,
+    #[serde(default)]
+    pub force: Option<bool>,
     #[serde(default)]
     pub scraping: bool,
     #[serde(default)]
@@ -1980,6 +1986,7 @@ mod tests {
             "matched": 10,
             "skipped": 2,
             "totalScraped": 50,
+            "force": true,
             "scraping": true,
             "done": false,
             "paused": false
@@ -2003,6 +2010,7 @@ mod tests {
         assert_eq!(result.matched, 10);
         assert_eq!(result.skipped, 2);
         assert_eq!(result.total_scraped, 50);
+        assert_eq!(result.force, Some(true));
         assert!(result.scraping);
         assert!(!result.done);
     }

--- a/rust/zaparoo-core/src/store/media_status.rs
+++ b/rust/zaparoo-core/src/store/media_status.rs
@@ -66,6 +66,8 @@ pub struct MediaStatusState {
     pub scrape_matched: i32,
     pub scrape_skipped: i32,
     pub scrape_total_scraped: i32,
+    pub scrape_force: bool,
+    pub scrape_force_known: bool,
     pub scrape_system_id: String,
     pub scrape_scraper_id: String,
     pub scrape_state: String,
@@ -101,6 +103,8 @@ impl MediaStatusState {
         self.scrape_matched = status.matched;
         self.scrape_skipped = status.skipped;
         self.scrape_total_scraped = status.total_scraped;
+        self.scrape_force = status.force.unwrap_or(false);
+        self.scrape_force_known = status.force.is_some();
         self.scrape_system_id.clone_from(&status.system_id);
         self.scrape_scraper_id.clone_from(&status.scraper_id);
         self.scrape_state.clone_from(&status.state);
@@ -376,7 +380,7 @@ mod tests {
             "state": "running", "currentStep": 2, "totalSteps": 5,
             "currentStepDisplay": "Super Nintendo",
             "processed": 12, "total": 200, "matched": 10, "skipped": 2,
-            "totalScraped": 50, "scraping": true, "done": false, "paused": false
+            "totalScraped": 50, "force": true, "scraping": true, "done": false, "paused": false
         });
         fold_notification(
             &Notification {
@@ -389,6 +393,8 @@ mod tests {
         assert!(snapshot.scraping);
         assert_eq!(snapshot.scrape_processed, 12);
         assert_eq!(snapshot.scrape_total, 200);
+        assert!(snapshot.scrape_force);
+        assert!(snapshot.scrape_force_known);
         assert_eq!(snapshot.scrape_system_id, "SNES");
         assert_eq!(snapshot.scrape_state, "running");
         assert_eq!(snapshot.scrape_current_step, 2);
@@ -397,6 +403,26 @@ mod tests {
         // `scraped`-side notifications must not flip the indexing
         // `seeded` flag — that's the `media` query's job.
         assert!(!snapshot.seeded);
+    }
+
+    #[test]
+    fn fold_notification_keeps_scrape_force_unknown_when_missing() {
+        let (tx, rx) = watch::channel(MediaStatusState::default());
+        let tx = Arc::new(tx);
+        fold_notification(
+            &Notification {
+                method: "media.scraping".into(),
+                params: json!({
+                    "scraperId": "screenscraper", "scraping": true,
+                    "done": false, "paused": false
+                }),
+            },
+            &tx,
+        );
+        let snapshot = rx.borrow().clone();
+        assert!(snapshot.scraping);
+        assert!(!snapshot.scrape_force);
+        assert!(!snapshot.scrape_force_known);
     }
 
     #[test]

--- a/src/ui/screens/SettingsScreen.qml
+++ b/src/ui/screens/SettingsScreen.qml
@@ -183,6 +183,10 @@ Item {
     readonly property bool _indexBusy: Browse.MediaStatus.indexing || Browse.MediaStatus.optimizing
     readonly property bool _scrapeBusy: Browse.MediaStatus.scraping
     property bool rescrapeExisting: false
+    // Keep the one-shot force flag visible while the scrape it started
+    // is active; clear it only after Core reports the scrape stopped.
+    property bool _activeScrapeUsedRescrape: false
+    readonly property bool _visibleRescrapeExisting: settings._scrapeBusy && Browse.MediaStatus.scrape_force_known ? Browse.MediaStatus.scrape_force : settings.rescrapeExisting
 
     // Drive the top/bottom scroll chevrons. Mirrors PagedGrid's
     // `hasPagesAbove`/`hasPagesBelow` recipe, but for a continuous
@@ -207,8 +211,15 @@ Item {
         if (settings._scrapeBusy)
             Browse.MediaStatus.cancel_scrape();
         else {
+            settings._activeScrapeUsedRescrape = settings.rescrapeExisting;
             Browse.MediaStatus.start_scrape(settings.rescrapeExisting);
+        }
+    }
+
+    on_ScrapeBusyChanged: {
+        if (!settings._scrapeBusy && settings._activeScrapeUsedRescrape) {
             settings.rescrapeExisting = false;
+            settings._activeScrapeUsedRescrape = false;
         }
     }
 
@@ -256,7 +267,7 @@ Item {
         if (id === "discoverArcadeAlternateVersions")
             return Browse.Settings.current_discover_arcade_alternate_versions;
         if (id === "rescrapeExisting")
-            return settings.rescrapeExisting;
+            return settings._visibleRescrapeExisting;
         return Browse.Settings.current_mouse_enabled;
     }
 


### PR DESCRIPTION
## Summary

Prefer Core's new `force` scrape status field when showing the Settings re-scrape toggle during an active scrape. Keep the local one-shot toggle as fallback so older Core builds that do not send `force` still show the user's selected value while the scrape starts.

## Screenshots / recordings

Not applicable; settings state behavior only.

## Test plan

- `cd rust && rtk cargo test -p zaparoo-core scraping -- --nocapture`
- `cd rust && rtk cargo test -p zaparoo-frontend-rs media_status -- --nocapture`
- `just test-qml`
- `just lint-rust`

## Checklist

- [x] `just lint` is green (covered by `just lint-rust`; QML checked with `just test-qml`)
- [x] `just test` passes (targeted Rust + QML tests passed)
- [x] If this touches QML, the FPS counter stays green (≥ 55) at 720p+ and ≥ 30 at 240p
- [x] If this could affect the MiSTer build, I considered ARM32 implications (see `docs/architecture.md`)
- [x] If this adds user-visible strings, they are wrapped in `qsTr()` (QML) or `tr()` (C++)
- [x] I have signed the [CLA](../.github/CLA.md) (first-time contributors only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tracking and display of forced scraping status during media scraping operations.
  * Enhanced settings UI to show actual scrape behavior from the system, reflecting when scrapes are initiated with the rescrape option enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->