### PR TITLE
Create frontend_eu.ts

### DIFF
--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="en" sourcelanguage="en">
+<TS version="2.1" language="eu" sourcelanguage="en">
 <context>
     <name>AboutScreen</name>
     <message>
@@ -122,12 +122,12 @@
     <message>
         <location filename="../components/BrowseDetailPane.qml" line="89"/>
         <source>Category</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Kategoria</translation>
     </message>
     <message>
         <location filename="../components/BrowseDetailPane.qml" line="91"/>
         <source>Release date</source>
-        <translation type="unfinished">Kategoria</translation>
+        <translation type="unfinished">Argitaratze data</translation>
     </message>
     <message>
         <location filename="../components/BrowseDetailPane.qml" line="93"/>
@@ -577,7 +577,8 @@
         <location filename="../app/MainLayout.qml" line="798"/>
         <location filename="../app/MainLayout.qml" line="821"/>
         <location filename="../app/MainLayout.qml" line="832"/>
-        <source>Utzi</translation>
+        <source>Cancel</source>
+        <translation>Utzi</translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="776"/>
@@ -697,8 +698,8 @@
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="988"/>
-        <source>Txandakatu</source>
-        <translation>Toggle</translation>
+        <source>Toggle</source>
+        <translation>Txandakatu</translation>
     </message>
 </context>
 <context>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -1,0 +1,1202 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="en" sourcelanguage="en">
+<context>
+    <name>AboutScreen</name>
+    <message>
+        <location filename="../screens/AboutScreen.qml" line="71"/>
+        <source>About / License</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/AboutScreen.qml" line="153"/>
+        <source>Zaparoo Frontend</source>
+        <translation type="unfinished">Zaparoo Frontend-a</translation>
+    </message>
+    <message>
+        <location filename="../screens/AboutScreen.qml" line="164"/>
+        <source>Version %1 · %2 · %3</source>
+        <translation type="unfinished">%1 · %2 · %3 Bertsioa</translation>
+    </message>
+    <message>
+        <location filename="../screens/AboutScreen.qml" line="174"/>
+        <source>Built %1</source>
+        <translation type="unfinished">%1 Eraikuntza</translation>
+    </message>
+    <message>
+        <location filename="../screens/AboutScreen.qml" line="185"/>
+        <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
+        <translation type="unfinished">Copyright 2026 Wizzo Pty Ltd eta Zaparoo Project-eko laguntzaileak</translation>
+    </message>
+    <message>
+        <location filename="../screens/AboutScreen.qml" line="196"/>
+        <source>Source available under the PolyForm Noncommercial License 1.0.0. Free for personal, non-commercial use. Commercial use requires a separate license.</source>
+        <translation type="unfinished">Kodea PolyForm Noncommercial License 1.0.0. lizentziapean eskuragai dago. Doan erabilera pertsonal, ez komertzialerako. Erabilera komertzialak aparteko lizentzia eskatzen du.</translation>
+    </message>
+    <message>
+        <location filename="../screens/AboutScreen.qml" line="207"/>
+        <source>Commercial licensing: legal@zaparoo.org</source>
+        <translation type="unfinished">Lizentziazio komertizala: legal@zaparoo.org</translation>
+    </message>
+    <message>
+        <location filename="../screens/AboutScreen.qml" line="218"/>
+        <source>Project: https://zaparoo.org</source>
+        <translation type="unfinished">Proiektua: https://zaparoo.org</translation>
+    </message>
+    <message>
+        <location filename="../screens/AboutScreen.qml" line="228"/>
+        <source>Created by</source>
+        <translation type="unfinished">Honek sortua</translation>
+    </message>
+    <message>
+        <location filename="../screens/AboutScreen.qml" line="252"/>
+        <source>Translations</source>
+        <translation type="unfinished">Itzulpenak</translation>
+    </message>
+    <message>
+        <location filename="../screens/AboutScreen.qml" line="276"/>
+        <source>Full license text in COPYING.</source>
+        <translation type="unfinished">Lizentziaren testu osoa KOPIAn</translation>
+    </message>
+</context>
+<context>
+    <name>BootOverlay</name>
+    <message>
+        <location filename="../components/BootOverlay.qml" line="76"/>
+        <source>Can&apos;t reach Zaparoo Core. Check your connection.</source>
+        <translation type="unfinished">Ezin dut Zaparoo Core atzitu. Egiaztatu konekxioa.</translation>
+    </message>
+    <message>
+        <location filename="../components/BootOverlay.qml" line="78"/>
+        <source>Reconnecting…</source>
+        <translation type="unfinished">Berkonektatzen...</translation>
+    </message>
+    <message>
+        <location filename="../components/BootOverlay.qml" line="80"/>
+        <source>Loading library…</source>
+        <translation type="unfinished">Liburutegia kargatzen...</translation>
+    </message>
+    <message>
+        <location filename="../components/BootOverlay.qml" line="85"/>
+        <source>Connecting to Zaparoo Core…</source>
+        <translation type="unfinished">Zaparoo Core-ra konektatzen…</translation>
+    </message>
+</context>
+<context>
+    <name>BrowseDetailPane</name>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="23"/>
+        <source>Loading…</source>
+        <translation type="unfinished">Kargatzen…</translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="77"/>
+        <source>Year</source>
+        <translation type="unfinished">Urtea</translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="79"/>
+        <source>Genre</source>
+        <translation type="unfinished">Mota</translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="81"/>
+        <source>Players</source>
+        <translation type="unfinished">Jokalariak</translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="83"/>
+        <source>Developer</source>
+        <translation type="unfinished">Garatzailea</translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="85"/>
+        <source>Publisher</source>
+        <translation type="unfinished">Argitaratzailea</translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="87"/>
+        <source>Rating</source>
+        <translation type="unfinished">Balorazioa</translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="89"/>
+        <source>Category</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="91"/>
+        <source>Release date</source>
+        <translation type="unfinished">Kategoria</translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="93"/>
+        <source>Manufacturer</source>
+        <translation type="unfinished">Fabrikatzailea</translation>
+    </message>
+</context>
+<context>
+    <name>CommercialNoticeModal</name>
+    <message>
+        <location filename="../components/CommercialNoticeModal.qml" line="59"/>
+        <source>Welcome to Zaparoo Frontend</source>
+        <translation type="unfinished">Ongi etorri Zaparro Frontend-era</translation>
+    </message>
+    <message>
+        <location filename="../components/CommercialNoticeModal.qml" line="68"/>
+        <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
+        <translation type="unfinished">Copyright 2026 Wizzo Pty Ltd eta Zaparoo Project laguntzaileak</translation>
+    </message>
+    <message>
+        <location filename="../components/CommercialNoticeModal.qml" line="79"/>
+        <source>This free source-available build is for personal and non-commercial use only. Commercial use requires a separate license.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CommercialNoticeModal.qml" line="90"/>
+        <source>Contact: legal@zaparoo.org</source>
+        <translation type="unfinished">Kontaktua: legal@zaparoo.org</translation>
+    </message>
+    <message>
+        <location filename="../components/CommercialNoticeModal.qml" line="101"/>
+        <source>Full details available any time under Settings &gt; About / License.</source>
+        <translation type="unfinished">Xehetasun osoak uneoro eskuragarri daude Ezarpenak &gt; Buruz / Lizentzia</translation>
+    </message>
+    <message>
+        <location filename="../components/CommercialNoticeModal.qml" line="119"/>
+        <source>Created by</source>
+        <translation type="unfinished">Honek sortua</translation>
+    </message>
+    <message>
+        <location filename="../components/CommercialNoticeModal.qml" line="162"/>
+        <source>I understand</source>
+        <translation type="unfinished">Ulertzen dut</translation>
+    </message>
+</context>
+<context>
+    <name>CoreStatusPill</name>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="44"/>
+        <location filename="../components/CoreStatusPill.qml" line="50"/>
+        <source>Disconnected</source>
+        <translation type="unfinished">Deskonektatuta</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="47"/>
+        <source>Reconnecting…</source>
+        <translation type="unfinished">Berkonektatzen...</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="53"/>
+        <source>Connecting…</source>
+        <translation type="unfinished">Konektatzen...</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="56"/>
+        <source>Core error</source>
+        <translation type="unfinished">Nukleo errorea</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="60"/>
+        <source>Optimizing database</source>
+        <translation type="unfinished">Datu basea optimizatzen</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="67"/>
+        <source>Indexing paused</source>
+        <translation type="unfinished">Indexatzea pausatuta</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="70"/>
+        <source>Indexing %1/%2 - %3</source>
+        <translation type="unfinished">Indexatzen %1/%2 - %3</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="86"/>
+        <source>Scraping %1/%2 - %3</source>
+        <translation type="unfinished">Scrapeatzen %1/%2 - %3</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="73"/>
+        <source>Indexing %1/%2</source>
+        <translation type="unfinished">Indexatzen %1/%2</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <source>Indexing…</source>
+        <translation type="unfinished">Indexatzen...</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
+        <source>Scrape paused</source>
+        <translation type="unfinished">Scrapeatzea pausatuta</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
+        <source>Scraping %1/%2</source>
+        <translation type="unfinished">Scrapeatzen %1/%2</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="91"/>
+        <source>Scraping…</source>
+        <translation type="unfinished">Scrapeatzen...</translation>
+    </message>
+</context>
+<context>
+    <name>FavoritesScreen</name>
+    <message>
+        <location filename="../screens/FavoritesScreen.qml" line="24"/>
+        <source>Favorites</source>
+        <translation>Gogokoak</translation>
+    </message>
+    <message>
+        <location filename="../screens/FavoritesScreen.qml" line="25"/>
+        <source>No favorites yet</source>
+        <translation>Ez duzu gogokorik oraindik</translation>
+    </message>
+    <message>
+        <location filename="../screens/FavoritesScreen.qml" line="26"/>
+        <source>Loading favorites…</source>
+        <translation type="unfinished">Gogokoak kargatzen...</translation>
+    </message>
+</context>
+<context>
+    <name>FirstRunIndexModal</name>
+    <message>
+        <location filename="../components/FirstRunIndexModal.qml" line="127"/>
+        <source>First-time setup</source>
+        <translation type="unfinished">Lehenengo aldiko konfigurazioa</translation>
+    </message>
+    <message>
+        <location filename="../components/FirstRunIndexModal.qml" line="211"/>
+        <source>Indexing paused</source>
+        <translation type="unfinished">Indexatzea pausatuta</translation>
+    </message>
+    <message>
+        <location filename="../components/FirstRunIndexModal.qml" line="158"/>
+        <source>Optimizing database - almost done</source>
+        <translation type="unfinished">Datu base optimizazioa - ia amaituta</translation>
+    </message>
+    <message>
+        <location filename="../components/FirstRunIndexModal.qml" line="136"/>
+        <source>Zaparoo needs to scan your games before you can use the frontend. This usually takes a few minutes.</source>
+        <translation type="unfinished">Zaparoo-k zure jokuak eskanetu beharra dauka frontend-a erabili aurretik. Honek normaleak minutu gutxi batzuk hartzen ditu.</translation>
+    </message>
+    <message>
+        <location filename="../components/FirstRunIndexModal.qml" line="213"/>
+        <source>Step %1 of %2 - %3</source>
+        <translation type="unfinished">%1 pausoa %2tik  - %3 </translation>
+    </message>
+    <message>
+        <location filename="../components/FirstRunIndexModal.qml" line="215"/>
+        <source>Step %1 of %2</source>
+        <translation type="unfinished">%1 pausoa %2tik</translation>
+    </message>
+    <message>
+        <location filename="../components/FirstRunIndexModal.qml" line="216"/>
+        <source>Preparing…</source>
+        <translation type="unfinished">Prestatzen</translation>
+    </message>
+    <message>
+        <location filename="../components/FirstRunIndexModal.qml" line="233"/>
+        <source>Done. %1 files indexed.</source>
+        <translation type="unfinished">Eginda. %1 fitxategi indexatuta</translation>
+    </message>
+    <message>
+        <location filename="../components/FirstRunIndexModal.qml" line="263"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Bertan behera utzi</translation>
+    </message>
+    <message>
+        <location filename="../components/FirstRunIndexModal.qml" line="263"/>
+        <source>Start scan</source>
+        <translation type="unfinished">Hasi eskaneoa</translation>
+    </message>
+</context>
+<context>
+    <name>GameInfoModal</name>
+    <message>
+        <location filename="../components/GameInfoModal.qml" line="106"/>
+        <source>Loading details…</source>
+        <translation type="unfinished">Xehetasunak kargatzen...</translation>
+    </message>
+    <message>
+        <location filename="../components/GameInfoModal.qml" line="166"/>
+        <source>Loading image…</source>
+        <translation type="unfinished">Irudia kargatzen...</translation>
+    </message>
+</context>
+<context>
+    <name>GamesScreen</name>
+    <message>
+        <location filename="../screens/GamesScreen.qml" line="117"/>
+        <location filename="../screens/GamesScreen.qml" line="145"/>
+        <source>%1 files</source>
+        <translation>%1 fitxategi</translation>
+    </message>
+    <message>
+        <location filename="../screens/GamesScreen.qml" line="51"/>
+        <source>Loading game…</source>
+        <translation type="unfinished">Jokua kargatzen...</translation>
+    </message>
+    <message>
+        <location filename="../screens/GamesScreen.qml" line="126"/>
+        <location filename="../screens/GamesScreen.qml" line="146"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished">%1 / %2</translation>
+    </message>
+    <message>
+        <location filename="../screens/GamesScreen.qml" line="45"/>
+        <source>Loading games…</source>
+        <translation type="unfinished">Jokuak kargatzen</translation>
+    </message>
+    <message>
+        <location filename="../screens/GamesScreen.qml" line="122"/>
+        <source>Loading more…</source>
+        <translation type="unfinished">Gehiago kargatzen...</translation>
+    </message>
+    <message>
+        <location filename="../screens/GamesScreen.qml" line="44"/>
+        <source>No games in this system</source>
+        <translation>Sistema honek ez du jokurik</translation>
+    </message>
+</context>
+<context>
+    <name>HubScreen</name>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="91"/>
+        <source>Resume: %1</source>
+        <translation>Berrekin: %1</translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="91"/>
+        <source>Resume Game</source>
+        <translation>Jokua berrekin</translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="91"/>
+        <source>Favorites</source>
+        <translation>Gogokoak</translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="96"/>
+        <source>Recently Played</source>
+        <translation>Duela gutxi jolastuta</translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="101"/>
+        <source>Settings</source>
+        <translation>Ezarpenak</translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="537"/>
+        <source>No systems available. Run Update media database from Settings.</source>
+        <translation type="unfinished">Ez dago sistemarik eskuragarri. Exekutatu Eguneratu baliabide datubasea Aukeretatik</translation>
+    </message>
+</context>
+<context>
+    <name>LoadingIndicator</name>
+    <message>
+        <location filename="../components/LoadingIndicator.qml" line="26"/>
+        <source>Loading…</source>
+        <translation>Kargatzen…</translation>
+    </message>
+</context>
+<context>
+    <name>LogUploadModal</name>
+    <message>
+        <location filename="../components/LogUploadModal.qml" line="87"/>
+        <source>Upload log file</source>
+        <translation type="unfinished">Igo log fitxategia</translation>
+    </message>
+    <message>
+        <location filename="../components/LogUploadModal.qml" line="97"/>
+        <source>Uploading log file - this may take a moment.</source>
+        <translation type="unfinished">Fitxategia igotzen - honek momentu bat eraman dezake.</translation>
+    </message>
+    <message>
+        <location filename="../components/LogUploadModal.qml" line="197"/>
+        <source>Upload failed: %1</source>
+        <translation type="unfinished">Igoerak huts egin du: %1</translation>
+    </message>
+    <message>
+        <location filename="../components/LogUploadModal.qml" line="197"/>
+        <source>Upload failed.</source>
+        <translation type="unfinished">Igoerak huts egin du</translation>
+    </message>
+    <message>
+        <location filename="../components/LogUploadModal.qml" line="227"/>
+        <source>Retry</source>
+        <translation type="unfinished">Berriro saiatu</translation>
+    </message>
+    <message>
+        <location filename="../components/LogUploadModal.qml" line="227"/>
+        <source>Done</source>
+        <translation type="unfinished">Eginda</translation>
+    </message>
+</context>
+<context>
+    <name>Main</name>
+    <message>
+        <location filename="../app/Main.qml" line="755"/>
+        <source>Launch core</source>
+        <translation type="unfinished">Exekutatu nukleoa</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="761"/>
+        <location filename="../app/Main.qml" line="958"/>
+        <source>Change launcher</source>
+        <translation type="unfinished">Aldatu abiarazlea</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="786"/>
+        <source>Remove from favorites</source>
+        <translation type="unfinished">Kendu gogokoetatik</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="786"/>
+        <source>Add to favorites</source>
+        <translation type="unfinished">Gehitu gogokoetan</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="791"/>
+        <source>Write to NFC token</source>
+        <translation type="unfinished">Idatzi NFC token-a</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="795"/>
+        <source>QR code</source>
+        <translation type="unfinished">QR kodea</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="770"/>
+        <location filename="../app/Main.qml" line="805"/>
+        <source>Launch game</source>
+        <translation type="unfinished">Abiarazi jokua</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1776"/>
+        <source>Loading systems…</source>
+        <translation type="unfinished">Sistemak kargatzen</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1780"/>
+        <source>Loading favorites…</source>
+        <translation type="unfinished">Gogokoak kargatzen</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1778"/>
+        <source>Loading games…</source>
+        <translation type="unfinished">Jokoak kargatzen</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="954"/>
+        <source>Default</source>
+        <translation type="unfinished">Lehenetsia</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="954"/>
+        <source>Current: %1</source>
+        <translation type="unfinished">Unekoa: %1</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1230"/>
+        <source>Saving launcher</source>
+        <translation type="unfinished">Abiarazlea gordetzen</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1234"/>
+        <source>Saving…</source>
+        <translation type="unfinished">Gordetzen...</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1248"/>
+        <source>Launcher update failed</source>
+        <translation type="unfinished">Abiarazle egukeraketak huts egin du</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1252"/>
+        <source>Error: %1</source>
+        <translation type="unfinished">Errorea: %1</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1256"/>
+        <source>Retry</source>
+        <translation type="unfinished">Berriro saiatu</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1260"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Utzi</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1782"/>
+        <source>Loading recently played…</source>
+        <translation type="unfinished">Duela gutxi jokatutakoak kargatzen...</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1784"/>
+        <source>Loading…</source>
+        <translation type="unfinished">Kargatzen…</translation>
+    </message>
+</context>
+<context>
+    <name>MainLayout</name>
+    <message>
+        <location filename="../app/MainLayout.qml" line="581"/>
+        <source>Writing failed</source>
+        <translation>Idazketak huts egin du</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="581"/>
+        <source>Put a writable card near the reader</source>
+        <translation>Jarri idatzi daitekeen txartel bat irakurlearen ondoan</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="669"/>
+        <source>Are you sure you want to exit?</source>
+        <translation type="unfinished">Ziur zaude irten nahi duzula?</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="745"/>
+        <location filename="../app/MainLayout.qml" line="817"/>
+        <source>Select</source>
+        <translation>Aukeratu</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="749"/>
+        <location filename="../app/MainLayout.qml" line="753"/>
+        <location filename="../app/MainLayout.qml" line="767"/>
+        <location filename="../app/MainLayout.qml" line="780"/>
+        <location filename="../app/MainLayout.qml" line="791"/>
+        <source>Close</source>
+        <translation>Itxi</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="760"/>
+        <location filename="../app/MainLayout.qml" line="798"/>
+        <location filename="../app/MainLayout.qml" line="821"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
+        <source>Utzi</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="776"/>
+        <source>Done</source>
+        <translation type="unfinished">Eginda</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="806"/>
+        <source>I understand</source>
+        <translation type="unfinished">Ulertzen dut</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="840"/>
+        <source>Start</source>
+        <translation type="unfinished">Hasi</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="1009"/>
+        <source>Scroll</source>
+        <translation type="unfinished">Scroll-a egin</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="741"/>
+        <location filename="../app/MainLayout.qml" line="813"/>
+        <location filename="../app/MainLayout.qml" line="856"/>
+        <location filename="../app/MainLayout.qml" line="885"/>
+        <location filename="../app/MainLayout.qml" line="932"/>
+        <location filename="../app/MainLayout.qml" line="973"/>
+        <location filename="../app/MainLayout.qml" line="1037"/>
+        <source>Move</source>
+        <translation>Mugitu</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="141"/>
+        <source>Zaparoo Frontend</source>
+        <translation type="unfinished">Zaparoo Frontend</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="323"/>
+        <source>Favorites</source>
+        <translation type="unfinished">Gogokoak</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="325"/>
+        <source>Recently Played</source>
+        <translation type="unfinished">Duela gutxi jokatuak</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="592"/>
+        <source>Quit and restart Zaparoo Frontend?</source>
+        <translation type="unfinished">Itxi eta Zaparoo Frontend berabiarazi</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="593"/>
+        <source>In order to apply this setting we need to restart the frontend.</source>
+        <translation type="unfinished">Ezarpenak indarrean jartzeko frontend-a berrabiarazi behar dugu</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="668"/>
+        <source>Quit Zaparoo Frontend?</source>
+        <translation type="unfinished">Itxi Zaparoo Frontend?</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="860"/>
+        <location filename="../app/MainLayout.qml" line="895"/>
+        <location filename="../app/MainLayout.qml" line="942"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
+        <source>Open</source>
+        <translation>Ireki</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="864"/>
+        <source>Quit</source>
+        <translation>Irten</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="873"/>
+        <location filename="../app/MainLayout.qml" line="901"/>
+        <location filename="../app/MainLayout.qml" line="912"/>
+        <location filename="../app/MainLayout.qml" line="924"/>
+        <location filename="../app/MainLayout.qml" line="951"/>
+        <location filename="../app/MainLayout.qml" line="962"/>
+        <location filename="../app/MainLayout.qml" line="997"/>
+        <location filename="../app/MainLayout.qml" line="1013"/>
+        <location filename="../app/MainLayout.qml" line="1022"/>
+        <location filename="../app/MainLayout.qml" line="1056"/>
+        <location filename="../app/MainLayout.qml" line="1067"/>
+        <source>Back</source>
+        <translation>Atzera</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="891"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="1043"/>
+        <source>Page</source>
+        <translation type="unfinished">Orria</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="898"/>
+        <location filename="../app/MainLayout.qml" line="947"/>
+        <location filename="../app/MainLayout.qml" line="1052"/>
+        <source>Options</source>
+        <translation type="unfinished">Aukerak</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="787"/>
+        <location filename="../app/MainLayout.qml" line="908"/>
+        <location filename="../app/MainLayout.qml" line="958"/>
+        <location filename="../app/MainLayout.qml" line="1063"/>
+        <source>Retry</source>
+        <translation>Berriro saiatu</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="982"/>
+        <source>Change</source>
+        <translation>Aldatu</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="988"/>
+        <source>Txandakatu</source>
+        <translation>Toggle</translation>
+    </message>
+</context>
+<context>
+    <name>MediaListScreen</name>
+    <message>
+        <location filename="../screens/MediaListScreen.qml" line="32"/>
+        <source>Loading…</source>
+        <translation type="unfinished">Kargatzen…</translation>
+    </message>
+    <message>
+        <location filename="../screens/MediaListScreen.qml" line="306"/>
+        <source>%1 entries</source>
+        <translation type="unfinished">%1 sarrera</translation>
+    </message>
+    <message>
+        <location filename="../screens/MediaListScreen.qml" line="307"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Modal</name>
+    <message>
+        <location filename="../components/Modal.qml" line="49"/>
+        <source>OK</source>
+        <translation>Ados</translation>
+    </message>
+    <message>
+        <location filename="../components/Modal.qml" line="50"/>
+        <source>Yes</source>
+        <translation type="unfinished">Bai</translation>
+    </message>
+    <message>
+        <location filename="../components/Modal.qml" line="51"/>
+        <source>No</source>
+        <translation type="unfinished">Ez</translation>
+    </message>
+    <message>
+        <location filename="../components/Modal.qml" line="198"/>
+        <source>Cancel</source>
+        <translation>Utzi</translation>
+    </message>
+</context>
+<context>
+    <name>RecentsScreen</name>
+    <message>
+        <location filename="../screens/RecentsScreen.qml" line="24"/>
+        <source>Recently Played</source>
+        <translation>Duela gutxi jolastuta</translation>
+    </message>
+    <message>
+        <location filename="../screens/RecentsScreen.qml" line="26"/>
+        <source>Loading recently played…</source>
+        <translation type="unfinished">Duela gutxi jolastuta kargatzen...</translation>
+    </message>
+    <message>
+        <location filename="../screens/RecentsScreen.qml" line="25"/>
+        <source>Nothing played yet</source>
+        <translation>Oraindik ez da ezertara jolastu</translation>
+    </message>
+</context>
+<context>
+    <name>ScreenStateOverlay</name>
+    <message>
+        <location filename="../components/ScreenStateOverlay.qml" line="26"/>
+        <source>Nothing here</source>
+        <translation>Ez dago ezer hemen</translation>
+    </message>
+    <message>
+        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
+        <source>Loading…</source>
+        <translation type="unfinished">Kargatzen…</translation>
+    </message>
+    <message>
+        <location filename="../components/ScreenStateOverlay.qml" line="57"/>
+        <source>Failed to load</source>
+        <translation>Ezin izan da kargatu</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsScreen</name>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="73"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <source>Language</source>
+        <translation>Hizkuntza</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="516"/>
+        <source>Browsing layout</source>
+        <translation>Nabigazio diseinua</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <source>Mouse support</source>
+        <translation>Saguaren euskarria</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="112"/>
+        <source>Update media database</source>
+        <translation type="unfinished">Eguneratu multimedia datu-basea</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="61"/>
+        <source>General</source>
+        <translation type="unfinished">Orokorra</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="78"/>
+        <location filename="../screens/SettingsScreen.qml" line="507"/>
+        <source>Orientation</source>
+        <translation type="unfinished">Orientazioa</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="88"/>
+        <location filename="../screens/SettingsScreen.qml" line="525"/>
+        <source>Button style</source>
+        <translation type="unfinished">Botoi estiloa</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="93"/>
+        <location filename="../screens/SettingsScreen.qml" line="534"/>
+        <source>Screensaver</source>
+        <translation type="unfinished">Pantaila babeslea</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <source>Library</source>
+        <translation type="unfinished">Liburutegia</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <source>Discover arcade alternate versions</source>
+        <translation type="unfinished">Aurkitu arcade bertsio alternatiboak</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="107"/>
+        <location filename="../screens/SettingsScreen.qml" line="543"/>
+        <source>Preferred artwork</source>
+        <translation type="unfinished">Hobetsitako artelana</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <source>Scrape metadata</source>
+        <translation type="unfinished">Metadatuak scrapeatu</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <source>Re-scrape existing</source>
+        <translation type="unfinished">Berriro scrapeatzea existitzen da</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
+        <source>Advanced</source>
+        <translation type="unfinished">Aurreratua</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="136"/>
+        <source>Debug logging</source>
+        <translation type="unfinished">Arazte erregistroa</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="141"/>
+        <source>Upload log file</source>
+        <translation type="unfinished">Igo erregistro fitxategia</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="146"/>
+        <source>About / License</source>
+        <translation type="unfinished">Buruz / Lizentzia</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="162"/>
+        <source>Optimizing</source>
+        <translation type="unfinished">Optimizatzen</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="173"/>
+        <source>Paused</source>
+        <translation type="unfinished">Geldituta</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="173"/>
+        <source>In progress</source>
+        <translation type="unfinished">Abian</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="167"/>
+        <source>%1 indexed</source>
+        <translation type="unfinished">%1 indexatuta</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="176"/>
+        <source>%1 scraped</source>
+        <translation type="unfinished">%1 scrapetatuta</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="284"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Utzi</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="284"/>
+        <source>Start</source>
+        <translation type="unfinished">Hasi</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="286"/>
+        <source>Upload</source>
+        <translation type="unfinished">Igo</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="288"/>
+        <source>Open</source>
+        <translation type="unfinished">Ireki</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="365"/>
+        <source>English</source>
+        <translation>Ingelera</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="367"/>
+        <source>Italian</source>
+        <translation>Italiera</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <source>German</source>
+        <translation type="unfinished">Alemaniera</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="371"/>
+        <source>Greek</source>
+        <translation type="unfinished">Grekoa</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="373"/>
+        <source>Japanese</source>
+        <translation type="unfinished">Japoniera</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
+        <source>Korean</source>
+        <translation type="unfinished">Koreera</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <source>Dutch</source>
+        <translation type="unfinished">Holandera</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="379"/>
+        <source>Romanian</source>
+        <translation type="unfinished">Errumaniera</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="381"/>
+        <source>Slovak</source>
+        <translation type="unfinished">eslovakiera</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="383"/>
+        <source>Ukrainian</source>
+        <translation type="unfinished">Ukraniera</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="385"/>
+        <source>Chinese (Simplified)</source>
+        <translation type="unfinished">Txinera (sinplifikatua)</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="387"/>
+        <source>Hebrew</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="389"/>
+        <source>Arabic</source>
+        <translation type="unfinished">Arabiera</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="391"/>
+        <source>Hindi</source>
+        <translation type="unfinished">HIndia</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="392"/>
+        <location filename="../screens/SettingsScreen.qml" line="451"/>
+        <source>Auto</source>
+        <translation>Auto</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <source>Rotated CW</source>
+        <translation type="unfinished">CW biratua</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <source>Rotated CCW</source>
+        <translation type="unfinished">CCW biratua</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="400"/>
+        <source>Horizontal</source>
+        <translation type="unfinished">Horizontala</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="405"/>
+        <source>Detailed list view</source>
+        <translation>Xehetasun listaren ikuspegia</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="406"/>
+        <source>Grid view</source>
+        <translation>Sarearen ikuspegia</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="411"/>
+        <source>Style B</source>
+        <translation type="unfinished">B estiloa</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="413"/>
+        <source>Style C</source>
+        <translation type="unfinished">C estiloa</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="415"/>
+        <source>Style D</source>
+        <translation type="unfinished">D estiloa</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="416"/>
+        <source>Style A</source>
+        <translation type="unfinished">A estiloa</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="340"/>
+        <source>Default</source>
+        <translation>Lehenetsia</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="431"/>
+        <source>Off</source>
+        <translation type="unfinished">Desaktibatuta</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="433"/>
+        <source>1 second (testing)</source>
+        <translation type="unfinished">segundu 1 (frogatzen)</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="435"/>
+        <source>1 minute</source>
+        <translation type="unfinished">minutu 1</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="437"/>
+        <source>2 minutes</source>
+        <translation type="unfinished">2 minutu</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="439"/>
+        <source>5 minutes</source>
+        <translation type="unfinished">5 minutu</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="441"/>
+        <source>10 minutes</source>
+        <translation type="unfinished">10 minutu</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="443"/>
+        <source>15 minutes</source>
+        <translation type="unfinished">15 minutu</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="445"/>
+        <source>30 minutes</source>
+        <translation type="unfinished">30 minutu</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="446"/>
+        <source>%1 seconds</source>
+        <translation type="unfinished">%1 segundu</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="489"/>
+        <source>Resolution</source>
+        <translation type="unfinished">Bereizmena</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="453"/>
+        <source>Image</source>
+        <translation type="unfinished">Irudia</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="455"/>
+        <source>Thumbnail</source>
+        <translation type="unfinished">Miniatura</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="457"/>
+        <source>Box art</source>
+        <translation type="unfinished">Kaxaren artelana</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <source>3D box art</source>
+        <translation type="unfinished">Kaxaren 3D artelana</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="461"/>
+        <source>Screenshot</source>
+        <translation type="unfinished">Pantaila argazkoa</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="463"/>
+        <source>Wheel</source>
+        <translation type="unfinished">Gurpila</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="465"/>
+        <source>Title screen</source>
+        <translation type="unfinished">Izenburu pantaila</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="467"/>
+        <source>Map</source>
+        <translation type="unfinished">Mapa</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="469"/>
+        <source>Marquee</source>
+        <translation type="unfinished">Karpa</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="471"/>
+        <source>Fan art</source>
+        <translation type="unfinished">Fan artelana</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="473"/>
+        <source>Box side</source>
+        <translation type="unfinished">Kaxa alboa</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <source>Box back</source>
+        <translation type="unfinished">Kaxa atzekaldea</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="663"/>
+        <source>Settings</source>
+        <translation>Ezarpenak</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="857"/>
+        <source>No settings available on this platform</source>
+        <translation>Ez dago ezarpenik plataforma honetan</translation>
+    </message>
+</context>
+<context>
+    <name>SystemsScreen</name>
+    <message>
+        <location filename="../screens/SystemsScreen.qml" line="195"/>
+        <location filename="../screens/SystemsScreen.qml" line="292"/>
+        <source>%1 systems</source>
+        <translation>%1 sistema</translation>
+    </message>
+    <message>
+        <location filename="../screens/SystemsScreen.qml" line="196"/>
+        <location filename="../screens/SystemsScreen.qml" line="309"/>
+        <source>%1 / %2</source>
+        <translation type="unfinished">%1 / %2</translation>
+    </message>
+    <message>
+        <location filename="../screens/SystemsScreen.qml" line="324"/>
+        <source>No systems in this category</source>
+        <translation>Ez dago sistemarik kategoria honetan</translation>
+    </message>
+    <message>
+        <location filename="../screens/SystemsScreen.qml" line="325"/>
+        <source>Loading systems…</source>
+        <translation type="unfinished">Sistemak kargatzen</translation>
+    </message>
+</context>
+<context>
+    <name>TopStatusStrip</name>
+    <message>
+        <location filename="../components/TopStatusStrip.qml" line="91"/>
+        <source>Page %1 / %2</source>
+        <translation> %1 orria / %2tik</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
Basque translation


## Summary
Adds the translation file for Basque

## Motivation
I want to use Zaparoo in Basque



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Basque language support across the UI, covering About, overlays, browse/detail screens, dialogs, settings, status strip, and launcher actions.
  * Many strings are translated; several entries remain unfinished or empty and will be completed in follow-ups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->