### PR TITLE
Add MiSTer release ZIP automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,211 @@
+# Zaparoo Frontend
+# Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+# SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+name: Build release ZIP
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag/version to build (e.g. v1.0.4)'
+        required: true
+        type: string
+      upload:
+        description: 'Upload to GitHub release'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  packages: read
+  id-token: write
+  attestations: write
+
+concurrency:
+  group: release-${{ inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
+env:
+  BUILD_TAG: ${{ inputs.tag || github.ref_name }}
+
+jobs:
+  ensure-toolchain:
+    uses: ./.github/workflows/toolchain-build.yml
+    permissions:
+      contents: read
+      packages: write
+
+  build-release-zip:
+    name: Build MiSTer release ZIP
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    needs: ensure-toolchain
+    if: ${{ !cancelled() && needs.ensure-toolchain.result == 'success' }}
+    permissions:
+      contents: write
+      packages: read
+    outputs:
+      archive-name: ${{ steps.archive.outputs.name }}
+      should-upload: ${{ steps.upload-policy.outputs.should-upload }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
+
+      - name: Verify tag is on main
+        if: github.event_name == 'push'
+        run: |
+          git fetch origin main
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+
+      - name: Set upload policy
+        id: upload-policy
+        env:
+          DISPATCH_UPLOAD: ${{ inputs.upload || false }}
+        run: |
+          if [ "${{ github.event_name }}" = "push" ] || [ "$DISPATCH_UPLOAD" = "true" ]; then
+            echo "should-upload=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should-upload=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install host build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            ca-certificates \
+            cmake \
+            git \
+            libdbus-1-3 \
+            libegl-dev \
+            libfontconfig1 \
+            libgl-dev \
+            libglib2.0-0t64 \
+            libxcb-cursor0 \
+            libxcb-icccm4 \
+            libxcb-image0 \
+            libxcb-keysyms1 \
+            libxcb-randr0 \
+            libxcb-render-util0 \
+            libxcb-shape0 \
+            libxcb-sync1 \
+            libxcb-xfixes0 \
+            libxcb-xkb1 \
+            libxkbcommon-dev \
+            libxkbcommon-x11-0 \
+            ninja-build \
+            pkg-config \
+            python3-pip \
+            rsync \
+            zip
+          python3 -m pip install --user --break-system-packages 'aqtinstall==3.3.0'
+          python3 -m aqt install-qt linux desktop 6.10.3 linux_gcc_64 \
+            --archives icu qtbase qtdeclarative qtsvg qttools \
+            -m qtshadertools \
+            -O "$RUNNER_TOOL_CACHE/qt"
+          {
+            echo "$RUNNER_TOOL_CACHE/qt/6.10.3/gcc_64/bin"
+            echo "$HOME/.cargo/bin"
+          } >> "$GITHUB_PATH"
+          {
+            echo "CMAKE_PREFIX_PATH=$RUNNER_TOOL_CACHE/qt/6.10.3/gcc_64/lib/cmake"
+            echo "LD_LIBRARY_PATH=$RUNNER_TOOL_CACHE/qt/6.10.3/gcc_64/lib:${LD_LIBRARY_PATH:-}"
+          } >> "$GITHUB_ENV"
+
+      - name: Install Rust and just
+        run: |
+          rustup toolchain install 1.90.0 \
+            --profile minimal \
+            --component rustfmt \
+            --component clippy \
+            --target armv7-unknown-linux-gnueabihf
+          cargo install --locked --version 1.50.0 just
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build release ZIP
+        run: ./scripts/package-mister-release.sh "$BUILD_TAG"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Record archive name
+        id: archive
+        run: echo "name=zaparoo-frontend-${BUILD_TAG}.zip" >> "$GITHUB_OUTPUT"
+
+      - name: Upload ZIP artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ steps.archive.outputs.name }}
+          path: output/release/${{ steps.archive.outputs.name }}
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Create draft release
+        if: steps.upload-policy.outputs.should-upload == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "$BUILD_TAG" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+            echo "Release $BUILD_TAG already exists"
+            exit 0
+          fi
+
+          version="${BUILD_TAG#v}"
+          prerelease=()
+          if [[ "$version" == *-* ]]; then
+            prerelease=(--prerelease)
+          fi
+
+          gh release create "$BUILD_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$BUILD_TAG" \
+            --draft \
+            "${prerelease[@]}" \
+            --notes ""
+
+      - name: Upload release ZIP
+        if: steps.upload-policy.outputs.should-upload == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "$BUILD_TAG" \
+            "output/release/${{ steps.archive.outputs.name }}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber
+
+  attest:
+    name: Attest release ZIP
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: build-release-zip
+    if: ${{ !cancelled() && needs.build-release-zip.result == 'success' && needs.build-release-zip.outputs.should-upload == 'true' }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    steps:
+      - name: Download release ZIP artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ needs.build-release-zip.outputs.archive-name }}
+          path: _release
+
+      - name: Attest build provenance
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
+        with:
+          subject-path: _release/${{ needs.build-release-zip.outputs.archive-name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,10 +59,10 @@ jobs:
           ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
 
       - name: Verify tag is on main
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.upload == 'true')
         run: |
           git fetch origin main
-          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+          git merge-base --is-ancestor "$(git rev-parse HEAD)" origin/main
 
       - name: Set upload policy
         id: upload-policy
@@ -74,6 +74,18 @@ jobs:
           else
             echo "should-upload=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Resolve Main_MiSTer release tag
+        id: main-mister
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag=$(gh api repos/ZaparooProject/Main_MiSTer/releases/latest --jq '.tag_name')
+          if [ -z "$tag" ] || [ "$tag" = "null" ]; then
+            echo "Could not resolve latest Main_MiSTer release" >&2
+            exit 1
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
       - name: Install host build dependencies
         run: |
@@ -142,6 +154,7 @@ jobs:
         run: ./scripts/package-mister-release.sh "$BUILD_TAG"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAIN_MISTER_TAG: ${{ steps.main-mister.outputs.tag }}
 
       - name: Record archive name
         id: archive

--- a/justfile
+++ b/justfile
@@ -32,6 +32,9 @@ release:
     ZAPAROO_OFFICIAL_BUILD=1 cmake --build --preset desktop-release
     ZAPAROO_OFFICIAL_BUILD=1 ./scripts/build-arm32.sh
 
+release-zip *args:
+    ./scripts/package-mister-release.sh {{args}}
+
 build-dev:
     cmake --preset desktop-dev
     cmake --build --preset desktop-dev

--- a/scripts/package-mister-release.sh
+++ b/scripts/package-mister-release.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+# Zaparoo Frontend
+# Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+# SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+OUTPUT_DIR="${PROJECT_ROOT}/output"
+RELEASE_DIR="${OUTPUT_DIR}/release"
+MENU_REPO="ZaparooProject/Menu_MiSTer"
+MENU_TAG="v20260510"
+MENU_ASSET="menu_zaparoo.rbf"
+MAIN_REPO="ZaparooProject/Main_MiSTer"
+MAIN_ASSET="MiSTer_Zaparoo"
+
+usage() {
+    cat >&2 <<'EOF_USAGE'
+Usage: scripts/package-mister-release.sh [vX.Y.Z]
+
+Builds the official MiSTer frontend binary, downloads the required MiSTer
+wrapper assets, and writes output/release/zaparoo-frontend-vX.Y.Z.zip.
+
+Set ZAPAROO_SKIP_FRONTEND_BUILD=1 to reuse output/frontend for packaging tests.
+EOF_USAGE
+}
+
+error() {
+    echo "Error: $*" >&2
+    exit 1
+}
+
+require_command() {
+    if ! command -v "$1" > /dev/null 2>&1; then
+        error "required command not found: $1"
+    fi
+}
+
+resolve_tag() {
+    if [ $# -gt 1 ]; then
+        usage
+        exit 2
+    fi
+
+    if [ $# -eq 1 ] && [ -n "$1" ]; then
+        printf '%s\n' "$1"
+        return
+    fi
+
+    if [ -n "${GITHUB_REF_NAME:-}" ]; then
+        printf '%s\n' "${GITHUB_REF_NAME}"
+        return
+    fi
+
+    if tag=$(git -C "${PROJECT_ROOT}" describe --tags --exact-match 2> /dev/null); then
+        printf '%s\n' "$tag"
+        return
+    fi
+
+    error "release tag not provided and HEAD is not on an exact tag"
+}
+
+extract_cmake_version() {
+    python3 - "$PROJECT_ROOT/CMakeLists.txt" <<'PY'
+import re
+import sys
+text = open(sys.argv[1], encoding="utf-8").read()
+match = re.search(r"\bproject\s*\([^)]*?\bVERSION\s+([0-9]+(?:\.[0-9]+){2})\b", text, re.S)
+if not match:
+    raise SystemExit("could not parse project VERSION from CMakeLists.txt")
+print(match.group(1))
+PY
+}
+
+extract_cargo_version() {
+    python3 - "$PROJECT_ROOT/rust/Cargo.toml" <<'PY'
+import re
+import sys
+text = open(sys.argv[1], encoding="utf-8").read()
+section = re.search(r"(?ms)^\[workspace\.package\]\s*(.*?)(?:^\[|\Z)", text)
+if not section:
+    raise SystemExit("could not parse [workspace.package] from rust/Cargo.toml")
+match = re.search(r'(?m)^version\s*=\s*"([^"]+)"', section.group(1))
+if not match:
+    raise SystemExit("could not parse workspace package version from rust/Cargo.toml")
+print(match.group(1))
+PY
+}
+
+write_readme() {
+    cat > "$1" <<'EOF_README'
+# Zaparoo Frontend
+
+1. Copy the `zaparoo` folder to root/top of SD card
+2. In `MiSTer.ini`, add following to the `[MiSTer]` or `[Menu]` section:
+
+```ini
+main=zaparoo/MiSTer_Zaparoo
+```
+
+3. Start or reboot your MiSTer, Frontend will start automatically
+EOF_README
+}
+
+TAG="$(resolve_tag "$@")"
+VERSION="${TAG#v}"
+BASE_VERSION="${VERSION%%-*}"
+BASE_VERSION="${BASE_VERSION%%+*}"
+
+if [ "$TAG" = "$VERSION" ]; then
+    error "release tag must start with v: $TAG"
+fi
+if ! printf '%s' "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?(\+[0-9A-Za-z][0-9A-Za-z.-]*)?$'; then
+    error "release tag must look like v1.2.3 or v1.2.3-rc.1: $TAG"
+fi
+
+require_command git
+require_command gh
+require_command python3
+require_command zip
+require_command install
+require_command rsync
+if [ "${ZAPAROO_SKIP_FRONTEND_BUILD:-0}" != "1" ]; then
+    require_command just
+fi
+
+CMAKE_VERSION="$(extract_cmake_version)"
+CARGO_VERSION="$(extract_cargo_version)"
+if [ "$BASE_VERSION" != "$CMAKE_VERSION" ]; then
+    error "tag base version $BASE_VERSION does not match CMake project version $CMAKE_VERSION"
+fi
+if [ "$BASE_VERSION" != "$CARGO_VERSION" ]; then
+    error "tag base version $BASE_VERSION does not match Rust workspace version $CARGO_VERSION"
+fi
+
+cd "$PROJECT_ROOT"
+if [ "${ZAPAROO_SKIP_FRONTEND_BUILD:-0}" = "1" ]; then
+    echo "Skipping frontend build; reusing ${OUTPUT_DIR}/frontend"
+else
+    just release
+fi
+
+FRONTEND_BIN="${OUTPUT_DIR}/frontend"
+if [ ! -f "$FRONTEND_BIN" ]; then
+    error "frontend binary not found at $FRONTEND_BIN"
+fi
+
+mkdir -p "$RELEASE_DIR"
+STAGE="${RELEASE_DIR}/zaparoo-frontend-${TAG}"
+ARCHIVE="${RELEASE_DIR}/zaparoo-frontend-${TAG}.zip"
+TMP_DIR="$(mktemp -d "${RELEASE_DIR}/download.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+rm -rf "$STAGE" "$ARCHIVE"
+mkdir -p "$STAGE/zaparoo"
+
+MENU_DIR="$TMP_DIR/menu"
+MAIN_DIR="$TMP_DIR/main"
+mkdir -p "$MENU_DIR" "$MAIN_DIR"
+
+echo "Downloading ${MENU_REPO}@${MENU_TAG}/${MENU_ASSET}"
+gh release download "$MENU_TAG" \
+    --repo "$MENU_REPO" \
+    --pattern "$MENU_ASSET" \
+    --dir "$MENU_DIR" \
+    --clobber
+
+MAIN_TAG="$(gh api "repos/${MAIN_REPO}/releases/latest" --jq '.tag_name')"
+if [ -z "$MAIN_TAG" ] || [ "$MAIN_TAG" = "null" ]; then
+    error "could not resolve latest release for $MAIN_REPO"
+fi
+
+echo "Downloading ${MAIN_REPO}@${MAIN_TAG}/${MAIN_ASSET}"
+gh release download "$MAIN_TAG" \
+    --repo "$MAIN_REPO" \
+    --pattern "$MAIN_ASSET" \
+    --dir "$MAIN_DIR" \
+    --clobber
+
+if [ ! -f "$MENU_DIR/$MENU_ASSET" ]; then
+    error "downloaded menu asset missing: $MENU_DIR/$MENU_ASSET"
+fi
+if [ ! -f "$MAIN_DIR/$MAIN_ASSET" ]; then
+    error "downloaded MiSTer wrapper missing: $MAIN_DIR/$MAIN_ASSET"
+fi
+
+install -m 0644 "$MENU_DIR/$MENU_ASSET" "$STAGE/zaparoo/menu_zaparoo.rbf"
+install -m 0755 "$MAIN_DIR/$MAIN_ASSET" "$STAGE/zaparoo/MiSTer_Zaparoo"
+install -m 0755 "$FRONTEND_BIN" "$STAGE/zaparoo/frontend"
+install -m 0644 "$PROJECT_ROOT/COPYING" "$STAGE/COPYING"
+rsync -a --delete "$PROJECT_ROOT/src/LICENSES/" "$STAGE/LICENSES/"
+write_readme "$STAGE/README.txt"
+
+(
+    cd "$STAGE"
+    zip -r "$ARCHIVE" zaparoo LICENSES README.txt COPYING
+)
+
+unzip -t "$ARCHIVE" > /dev/null
+
+echo "Release archive: $ARCHIVE"
+echo "Menu_MiSTer tag: $MENU_TAG"
+echo "Main_MiSTer tag: $MAIN_TAG"

--- a/scripts/package-mister-release.sh
+++ b/scripts/package-mister-release.sh
@@ -166,9 +166,9 @@ gh release download "$MENU_TAG" \
     --dir "$MENU_DIR" \
     --clobber
 
-MAIN_TAG="$(gh api "repos/${MAIN_REPO}/releases/latest" --jq '.tag_name')"
-if [ -z "$MAIN_TAG" ] || [ "$MAIN_TAG" = "null" ]; then
-    error "could not resolve latest release for $MAIN_REPO"
+MAIN_TAG="${MAIN_MISTER_TAG:-${MAIN_TAG:-}}"
+if [ -z "$MAIN_TAG" ]; then
+    error "MAIN_MISTER_TAG is required; pass the exact ${MAIN_REPO} release tag to package reproducibly"
 fi
 
 echo "Downloading ${MAIN_REPO}@${MAIN_TAG}/${MAIN_ASSET}"


### PR DESCRIPTION
## Summary
- add `scripts/package-mister-release.sh` to build the official ARM32 frontend, download required MiSTer assets, and package the release ZIP layout
- add `just release-zip`
- add tag/manual GitHub Actions release workflow with draft release upload and attestation

## Validation
- `bash -n scripts/package-mister-release.sh`
- `actionlint .github/workflows/release.yml`
- `just --list | grep -F 'release-zip'`
- `ZAPAROO_SKIP_FRONTEND_BUILD=1 ./scripts/package-mister-release.sh v1.0.3`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated release packaging and publishing workflows to build and upload release ZIPs.
  * Added build provenance attestation to verify authenticity and integrity of produced artifacts.
  * Introduced a release-packaging process that assembles frontend, binaries, wrappers and license files into a verified ZIP.
  * Added a convenience command to produce the release ZIP locally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->