### PR TITLE
Improve Arcade browsing responsiveness

### DIFF
--- a/rust/frontend/src/lib.rs
+++ b/rust/frontend/src/lib.rs
@@ -400,8 +400,9 @@ pub extern "C" fn zaparoo_rust_shutdown() {
     models::shutdown_runtime(Duration::from_secs(2));
 }
 
-/// Called by the C++ main after the QML engine has loaded but before `exec()`.
-/// Fires the Zaparoo Core service start (`MiSTer` only, no-op on desktop).
+/// Called by the C++ main immediately after Rust init. Fires the Zaparoo Core
+/// service start (`MiSTer` only, no-op on desktop) early enough to overlap Core
+/// boot with Qt/font/QML setup.
 #[no_mangle]
 pub extern "C" fn zaparoo_rust_post_qt_start() {
     mister_runtime::ensure_core_service_running();

--- a/rust/frontend/src/media_image_cache.rs
+++ b/rust/frontend/src/media_image_cache.rs
@@ -1073,7 +1073,7 @@ fn process_batch_outcomes(
         }
         if let Some(update) = update {
             if let Some(ext) = update.ext {
-                info!(
+                debug!(
                     system_id = %key.system_id,
                     path = %key.path,
                     ext,
@@ -1086,14 +1086,14 @@ fn process_batch_outcomes(
                 let soft_no_image = guard.soft_no_image.contains(&key);
                 let search_seen = guard.search_seen.contains(&key);
                 if negative {
-                    info!(
+                    debug!(
                         system_id = %key.system_id,
                         path = %key.path,
                         search_seen,
                         "media_image_cache: no image (negative memo)",
                     );
                 } else {
-                    info!(
+                    debug!(
                         system_id = %key.system_id,
                         path = %key.path,
                         policy = ?entry.no_image_policy,
@@ -1190,22 +1190,23 @@ fn classify_single_media_image_error(
         );
         return FetchOutcome::ConnectionDown;
     }
+    if is_stable_media_image_miss(message) {
+        debug!(
+            system_id = %key.system_id,
+            path = %key.path,
+            had_id_hint,
+            "media_image_cache: media.image stable miss: {message}",
+        );
+        return FetchOutcome::NoImage;
+    }
     if had_id_hint && !key.system_id.is_empty() && !key.path.is_empty() {
-        info!(
+        debug!(
             system_id = %key.system_id,
             path = %key.path,
             media_id = ?key.media_id,
             "media_image_cache: media.image error with media_id hint: {message} (transient, will retry with system/path)",
         );
         return FetchOutcome::Transient;
-    }
-    if is_stable_media_image_miss(message) {
-        debug!(
-            system_id = %key.system_id,
-            path = %key.path,
-            "media_image_cache: media.image stable miss: {message}",
-        );
-        return FetchOutcome::NoImage;
     }
     info!(
         system_id = %key.system_id,
@@ -1418,7 +1419,7 @@ pub unsafe extern "C" fn zaparoo_media_image_bytes_for(
     };
     let cache = global_media_image_cache();
     if let Some(bytes) = cache.get_bytes(&key) {
-        info!(
+        debug!(
             system_id = %key.system_id,
             path = %key.path,
             cache_hit = true,
@@ -1427,7 +1428,7 @@ pub unsafe extern "C" fn zaparoo_media_image_bytes_for(
         );
         callback(user_data, bytes.as_ptr(), bytes.len());
     } else {
-        info!(
+        debug!(
             system_id = %key.system_id,
             path = %key.path,
             cache_hit = false,
@@ -1447,10 +1448,10 @@ mod tests {
     )]
 
     use super::{
-        ext_for_content_type, ext_from_extension_field, finish_fetch, is_connection_down_error,
-        pop_one, process_batch_outcomes, CacheState, FetchOutcome, MediaImageCache,
-        MediaImageUpdate, MediaKey, NegativeMemo, NoImagePolicy, QueueEntry, MAX_QUEUE_LEN,
-        NEGATIVE_MEMO_CAP,
+        classify_single_media_image_error, ext_for_content_type, ext_from_extension_field,
+        finish_fetch, is_connection_down_error, pop_one, process_batch_outcomes, CacheState,
+        FetchOutcome, MediaImageCache, MediaImageUpdate, MediaKey, NegativeMemo, NoImagePolicy,
+        QueueEntry, MAX_QUEUE_LEN, NEGATIVE_MEMO_CAP,
     };
     use std::collections::VecDeque;
     use std::sync::{Arc, Mutex, RwLock};
@@ -1622,6 +1623,37 @@ mod tests {
         assert_eq!(decoded.system_id.as_ref(), "SNES");
         assert_eq!(decoded.path.as_ref(), "/p");
         assert_eq!(decoded.image_type.as_deref(), Some("boxart"));
+    }
+
+    #[test]
+    fn stable_media_image_miss_with_id_hint_is_not_retried() {
+        let key = MediaKey::with_media_id("Arcade", "/media/fat/_Arcade/Computer Space.mra", 14912);
+
+        let outcome = classify_single_media_image_error(
+            &key,
+            "no image found for media: system=\"Arcade\" path=\"/media/fat/_Arcade/Computer Space.mra\"",
+            true,
+        );
+
+        assert!(matches!(outcome, FetchOutcome::NoImage));
+    }
+
+    #[test]
+    fn non_stable_media_id_error_still_retries_without_hint() {
+        let key = MediaKey::with_media_id("SNES", "/p", 42);
+
+        let outcome = classify_single_media_image_error(&key, "stale media id", true);
+
+        assert!(matches!(outcome, FetchOutcome::Transient));
+    }
+
+    #[test]
+    fn connection_down_error_does_not_retry_immediately() {
+        let key = MediaKey::with_media_id("SNES", "/p", 42);
+
+        let outcome = classify_single_media_image_error(&key, "connection reset by peer", true);
+
+        assert!(matches!(outcome, FetchOutcome::ConnectionDown));
     }
 
     fn key(s: &str, p: &str) -> MediaKey {

--- a/rust/frontend/src/models/favorites.rs
+++ b/rust/frontend/src/models/favorites.rs
@@ -298,19 +298,28 @@ fn apply_state(
         if model.has_next_page != has_next_page {
             model.as_mut().set_has_next_page(has_next_page);
         }
-        // Decide whether to release `loading` immediately or hold it
-        // until covers are cached. `arm_cover_gate` flips loading off
-        // itself when the page has nothing to wait on (every cover
-        // already cached, or all rows unattributed); otherwise it
-        // leaves loading=true and arms the safety timer.
-        arm_cover_gate(model.as_mut());
+        // Hidden startup binding can pause cover requests so Hub paints without
+        // Favorites' off-screen cover gate. Screen entry resumes requests and
+        // refreshes visible cover roles.
+        if model.cover_requests_paused {
+            disarm_cover_gate(model.as_mut());
+            if model.loading {
+                model.as_mut().set_loading(false);
+            }
+        } else {
+            // Decide whether to release `loading` immediately or hold it until
+            // covers are cached. `arm_cover_gate` flips loading off itself when
+            // the page has nothing to wait on; otherwise it leaves loading=true
+            // and arms the safety timer.
+            arm_cover_gate(model.as_mut());
+        }
         if model.loading_more {
             model.as_mut().set_loading_more(false);
         }
         // Look-ahead prefetch: warm page 2 so the first scroll past the
         // initial page doesn't surface a "Loading more…" cue. `fetch_more`
         // is itself guarded by `has_next_page` and `loading_more`.
-        if has_next_page {
+        if has_next_page && !model.cover_requests_paused {
             model.as_mut().fetch_more();
         }
     } else if err.is_empty() {

--- a/rust/frontend/src/models/games.rs
+++ b/rust/frontend/src/models/games.rs
@@ -95,6 +95,7 @@ const DEFAULT_PAGE_SIZE: i32 = 15;
 // the visible and next pages, so a large `FETCH_MORE_CHUNK_SIZE` no
 // longer floods the cover queue.
 const FETCH_MORE_CHUNK_SIZE: i32 = 100;
+const FETCH_MORE_RAPID_CHUNK_SIZE: i32 = 300;
 
 // `apply_append_page` sub-batches the model insert into chunks of this
 // many rows so the Repeater's per-delegate `createObject` cost (the
@@ -104,12 +105,10 @@ const FETCH_MORE_CHUNK_SIZE: i32 = 100;
 // `_commitPendingTarget` fires within ~200 ms of the user's press; the
 // rest are posted from `global_handle()` with one frame of breathing
 // room (`SUB_BATCH_FRAME_GAP_MS`) between batches so input + paint can
-// drain in between. 25 is one full visual page on a 5x5 dense layout
-// and roughly 190 ms of insert work warm — detectable as a hitch but
-// well below the monolithic stall and short enough that the next user
-// press lands inside one batch's gap. Tunable: drop to 12-15 if a
-// single-batch hitch still feels chunky.
-const APPEND_SUB_BATCH_SIZE: usize = 25;
+// drain in between. 12 is intentionally below a full dense-grid page:
+// more batches trickle in, but each batch has less chance to monopolize
+// the Qt thread during a held Down/Up scroll.
+const APPEND_SUB_BATCH_SIZE: usize = 12;
 
 // One frame at 30 Hz, the MiSTer software renderer's effective frame
 // budget. Gives Qt one full frame to drain input + paint between
@@ -216,16 +215,11 @@ pub struct GamesModelRust {
     // the new one. Same race shape as `cover_gate_seq`, just for the
     // sub-batch fan-out.
     append_seq: Arc<AtomicU64>,
-    // True from the moment `apply_initial_page` queues its look-ahead
-    // `fetch_more` until the matching `apply_append_page` lands. While
-    // set, the cover-gate release paths (`arm_cover_gate`,
-    // `notify_cover_update`, `release_cover_gate_after_timeout` aside)
-    // hold `loading=true` even after first-paint covers cache, so the
-    // user sees a single full-screen "Loading…" overlay instead of
-    // `Loading…` followed immediately by `Loading more…`. Cleared on
-    // append (success or failure) and on every `start_initial_browse`.
-    // The 3 s safety timer is the bounded fall-through, so a stalled
-    // prefetch can't park the user on the overlay forever.
+    // True from the moment `apply_initial_page` queues its metadata
+    // look-ahead `fetch_more` until the matching `apply_append_page`
+    // lands. This is informational only: background look-ahead must
+    // not hold the full-screen loading gate after the visible page is
+    // ready.
     pending_initial_lookahead: bool,
     // First visible row in the grid. Bound from QML to
     // `gamesGrid.currentPage * gamesGrid.pageSize` so the model knows
@@ -335,6 +329,9 @@ pub mod ffi {
 
         #[qinvokable]
         fn fetch_more(self: Pin<&mut GamesModel>);
+
+        #[qinvokable]
+        fn fetch_more_rapid(self: Pin<&mut GamesModel>);
 
         #[qinvokable]
         fn prefetch_around(self: Pin<&mut GamesModel>, first_visible_row: i32);
@@ -527,7 +524,15 @@ impl ffi::GamesModel {
         self.start_initial_browse(p, systems, false);
     }
 
-    fn fetch_more(mut self: Pin<&mut Self>) {
+    fn fetch_more(self: Pin<&mut Self>) {
+        self.fetch_more_with_limit(FETCH_MORE_CHUNK_SIZE);
+    }
+
+    fn fetch_more_rapid(self: Pin<&mut Self>) {
+        self.fetch_more_with_limit(FETCH_MORE_RAPID_CHUNK_SIZE);
+    }
+
+    fn fetch_more_with_limit(mut self: Pin<&mut Self>, limit: i32) {
         // Debounce: PagedGrid fires `loadMoreRequested` once per page
         // turn, but a fast spinner on the last loaded page can fire
         // twice before the first follow-up returns. All three guards
@@ -557,8 +562,7 @@ impl ffi::GamesModel {
         // `set_path` invalidate the prior cursor sequence.
         let seq = self.seq.clone();
         let ticket = seq.load(Ordering::SeqCst);
-        let max_results =
-            u32::try_from(FETCH_MORE_CHUNK_SIZE.max(1)).unwrap_or(u32::from(u16::MAX));
+        let max_results = u32::try_from(limit.max(1)).unwrap_or(u32::from(u16::MAX));
         self.as_mut().set_loading_more(true);
         let qt_thread = self.qt_thread();
         let store = global_store();
@@ -597,9 +601,13 @@ impl ffi::GamesModel {
     /// page, then previous page. Queued stale requests are dropped so
     /// a page change immediately makes the new visible page win.
     fn prefetch_around(self: Pin<&mut Self>, first_visible_row: i32) {
+        let cache = global_media_image_cache();
+        if self.cover_requests_paused {
+            cache.clear_pending_requests();
+            return;
+        }
         let plan =
             prefetch_around_plan(&self.entries, self.count, self.page_size, first_visible_row);
-        let cache = global_media_image_cache();
         let ps = u32::try_from(self.page_size.max(1)).unwrap_or(1);
         cache.replace_pending_requests_ordered(plan, ps);
     }
@@ -1593,12 +1601,7 @@ fn notify_cover_update(mut model: Pin<&mut ffi::GamesModel>, key: &MediaKey) {
                     return;
                 }
                 model.as_mut().rust_mut().cover_gate_timer = None;
-                // Same hold rule as the immediate-cached path in
-                // `arm_cover_gate`: if the look-ahead prefetch still
-                // owes us, leave loading=true. `apply_append_page`
-                // will release once the prefetch lands (or the safety
-                // timer in `release_cover_gate_after_timeout` will).
-                if model.loading && !model.pending_initial_lookahead {
+                if model.loading {
                     info!("games: cover gate released after decode-settle window");
                     model.as_mut().set_loading(false);
                 }
@@ -1669,11 +1672,7 @@ fn arm_cover_gate(mut model: Pin<&mut ffi::GamesModel>) {
     );
     if unresolved.is_empty() {
         model.as_mut().rust_mut().pending_first_paint_keys.clear();
-        // Hold loading=true if we still owe the user a look-ahead
-        // prefetch — `apply_append_page` will release once that lands
-        // (or `release_cover_gate_after_timeout` will, as a safety
-        // net).
-        if model.loading && !model.pending_initial_lookahead {
+        if model.loading {
             model.as_mut().set_loading(false);
         }
         return;
@@ -1698,37 +1697,11 @@ fn arm_cover_gate(mut model: Pin<&mut ffi::GamesModel>) {
     model.as_mut().rust_mut().cover_gate_timer = Some(handle);
 }
 
-/// Clear `pending_initial_lookahead` and, if the cover gate has
-/// already drained (no waiting keys, no decode-settle timer running),
-/// release loading=false. Called from `apply_append_page` on both
-/// success and error: the look-ahead has done its job, so any cover
-/// gate that was holding for the prefetch should now flip.
-///
-/// Three orderings produce three branches here:
-/// - Covers landed and decode-settle fired before the prefetch
-///   landed: timer is None, `pending_first_paint_keys` is empty, we
-///   release immediately.
-/// - Covers all cached on arm: `pending_first_paint_keys` was empty
-///   from the start, no timer was armed beyond the 3 s safety, but
-///   `arm_cover_gate`'s immediate-release path was skipped because
-///   the flag was set. Same as above — release.
-/// - Covers still in flight: `pending_first_paint_keys` non-empty;
-///   leave the gate alone, `notify_cover_update` will release once
-///   they drain (and the flag-clear we just did frees its check).
+/// Clear `pending_initial_lookahead` after the background prefetch
+/// lands. Look-ahead no longer participates in full-screen loading:
+/// visible page readiness and cover first-paint own that gate.
 fn release_initial_lookahead_gate(mut model: Pin<&mut ffi::GamesModel>) {
-    if !model.pending_initial_lookahead {
-        return;
-    }
     model.as_mut().rust_mut().pending_initial_lookahead = false;
-    if !model.loading {
-        return;
-    }
-    let covers_drained = model.pending_first_paint_keys.is_empty();
-    let timer_idle = model.cover_gate_timer.is_none();
-    if covers_drained && timer_idle {
-        info!("games: cover gate released after look-ahead prefetch landed");
-        model.as_mut().set_loading(false);
-    }
 }
 
 /// Force-release the cover gate from the safety timer. Called only via
@@ -2073,19 +2046,17 @@ fn apply_initial_page(mut model: Pin<&mut ffi::GamesModel>, result: MediaBrowseR
     // re-issues this through `onCurrentPageChanged` in QML.
     model.as_mut().rust_mut().visible_first_row = 0;
     model.as_mut().prefetch_around(0);
-    // Arm the initial-look-ahead gate BEFORE arm_cover_gate so the
-    // gate's "no covers to wait on" fast path also waits on the
-    // pending append rather than flipping loading=false right away.
-    // Cleared by the matching `apply_append_page` (success or failure)
-    // or by the cover_gate safety timer.
+    // Metadata look-ahead runs in the background. Track it only so
+    // stale follow-up completions can clear their own bookkeeping; do
+    // not let it hold the first visible page behind the full-screen
+    // loading overlay.
     let will_lookahead = has_next_page && !model.loading_more;
     if will_lookahead {
         model.as_mut().rust_mut().pending_initial_lookahead = true;
     }
     // Decide whether to release `loading` immediately or hold it until
-    // covers are cached. `arm_cover_gate` flips loading off itself when
-    // the page has nothing to wait on AND the look-ahead gate is
-    // clear; otherwise it leaves loading=true and arms the timer.
+    // visible-page covers are cached. Background metadata look-ahead
+    // does not participate in this gate.
     arm_cover_gate(model.as_mut());
     if !model.error_message.is_empty() {
         model.as_mut().set_error_message(QString::default());

--- a/rust/frontend/src/models/log_upload.rs
+++ b/rust/frontend/src/models/log_upload.rs
@@ -45,8 +45,8 @@ const UPLOAD_URL: &str = "https://logs.zaparoo.org/";
 const UPLOAD_TIMEOUT_SECS: u32 = 30;
 
 const SUPPORT_SUMMARY_LIMIT_BYTES: usize = 64 * 1024;
-const PER_LOG_LIMIT_BYTES: usize = 512 * 1024;
-const UPLOAD_LIMIT_BYTES: usize = 1024 * 1024;
+const PER_LOG_LIMIT_BYTES: usize = 256 * 1024;
+const UPLOAD_LIMIT_BYTES: usize = 768 * 1024;
 const UPLOAD_HEADROOM_BYTES: usize = 4 * 1024;
 const PAYLOAD_LIMIT_BYTES: usize = UPLOAD_LIMIT_BYTES - UPLOAD_HEADROOM_BYTES;
 
@@ -412,6 +412,8 @@ fn yes_no(value: bool) -> &'static str {
 }
 
 fn upload_payload(payload: &[u8]) -> UploadOutcome {
+    let payload_len = payload.len();
+    info!(payload_len, "log upload payload prepared");
     let timeout_arg = UPLOAD_TIMEOUT_SECS.to_string();
     // MiSTer commonly has an outdated CA bundle and incorrect clock before NTP sync.
     // Keep support log upload usable there.
@@ -459,7 +461,8 @@ fn upload_payload(payload: &[u8]) -> UploadOutcome {
         } else {
             stderr
         };
-        return UploadOutcome::Error(message);
+        warn!(payload_len, "log upload curl failed: {message}");
+        return UploadOutcome::Error(format!("{message} (payload {payload_len} bytes)"));
     }
 
     let url = String::from_utf8_lossy(&output.stdout).trim().to_string();

--- a/rust/frontend/src/models/recents.rs
+++ b/rust/frontend/src/models/recents.rs
@@ -292,19 +292,28 @@ fn apply_state(
         if model.has_next_page != has_next_page {
             model.as_mut().set_has_next_page(has_next_page);
         }
-        // Decide whether to release `loading` immediately or hold it
-        // until covers are cached. `arm_cover_gate` flips loading off
-        // itself when the page has nothing to wait on (every cover
-        // already cached, or all rows unattributed); otherwise it
-        // leaves loading=true and arms the safety timer.
-        arm_cover_gate(model.as_mut());
+        // Hidden startup binding can pause cover requests so Hub paints without
+        // Recents' off-screen cover gate. Screen entry resumes requests and
+        // refreshes visible cover roles.
+        if model.cover_requests_paused {
+            disarm_cover_gate(model.as_mut());
+            if model.loading {
+                model.as_mut().set_loading(false);
+            }
+        } else {
+            // Decide whether to release `loading` immediately or hold it until
+            // covers are cached. `arm_cover_gate` flips loading off itself when
+            // the page has nothing to wait on; otherwise it leaves loading=true
+            // and arms the safety timer.
+            arm_cover_gate(model.as_mut());
+        }
         if model.loading_more {
             model.as_mut().set_loading_more(false);
         }
         // Look-ahead prefetch: warm page 2 so the first scroll past the
         // initial page doesn't surface a "Loading more…" cue. `fetch_more`
         // is itself guarded by `has_next_page` and `loading_more`.
-        if has_next_page {
+        if has_next_page && !model.cover_requests_paused {
             model.as_mut().fetch_more();
         }
     } else if err.is_empty() {

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -159,6 +159,10 @@ int main(int argc, char* argv[]) // NOLINT
         return EXIT_FAILURE;
     }
 
+    // Start Core before Qt/font/QML setup so service boot overlaps the
+    // frontend's own construction work. On desktop this is a no-op.
+    zaparoo_rust_post_qt_start();
+
     // Install after zaparoo_rust_init() so tracing is live before any Qt
     // messages are emitted.
     qInstallMessageHandler(qtMessageHandler);
@@ -391,7 +395,6 @@ int main(int argc, char* argv[]) // NOLINT
                          qInstallMessageHandler(nullptr);
                      });
 
-    zaparoo_rust_post_qt_start();
     const int exitCode = QGuiApplication::exec();
     if (exitCode != kRestartExitCode)
     {

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -109,6 +109,8 @@ MainLayout {
         const savedScreen = Browse.AppState.active_screen;
         if (savedScreen === root.screenGames || savedScreen === root.screenSystems || savedScreen === root.screenHub || savedScreen === root.screenFavorites || savedScreen === root.screenRecents || savedScreen === root.screenSettings || savedScreen === root.screenAbout)
             root.activeScreen = savedScreen;
+        Browse.FavoritesModel.cover_requests_paused = root.activeScreen !== root.screenFavorites;
+        Browse.RecentsModel.cover_requests_paused = root.activeScreen !== root.screenRecents;
         // If the catalog is already ready, fire the restore here so
         // the cascade (set_category → SystemsModel reset → seed
         // currentIndex → set_system → GamesModel reset) lands before
@@ -127,6 +129,7 @@ MainLayout {
         // otherwise the grid lands on index 0 and ignores persisted
         // selected_path.
         if (savedScreen === root.screenFavorites) {
+            root._resumeFavoritesCovers();
             if (Browse.FavoritesModel.loading) {
                 root._favoritesReadyCallback = function () {
                     root.favoritesScreen.restoreSelection();
@@ -136,6 +139,7 @@ MainLayout {
             }
         }
         if (savedScreen === root.screenRecents) {
+            root._resumeRecentsCovers();
             if (Browse.RecentsModel.loading) {
                 root._recentsReadyCallback = function () {
                     root.recentsScreen.restoreSelection();
@@ -383,6 +387,7 @@ MainLayout {
             root._recentsReadyCallback = null;
             cb();
         }
+
         function onResume_availableChanged(): void {
             if (!root._resumeStartupFocusPending || !Browse.RecentsModel.resume_available)
                 return;
@@ -486,6 +491,7 @@ MainLayout {
 
     function _navigateToFavorites(): void {
         root.pendingTransition = "favorites";
+        root._resumeFavoritesCovers();
         if (!Browse.FavoritesModel.loading) {
             root.favoritesScreen.restoreSelection();
             root._completeTransition(root.screenFavorites);
@@ -504,6 +510,7 @@ MainLayout {
     // sees the centred "Loading…" cue rather than an empty grid.
     function _navigateToRecents(): void {
         root.pendingTransition = "recents";
+        root._resumeRecentsCovers();
         if (!Browse.RecentsModel.loading) {
             root.recentsScreen.restoreSelection();
             root._completeTransition(root.screenRecents);
@@ -513,6 +520,18 @@ MainLayout {
             root.recentsScreen.restoreSelection();
             root._completeTransition(root.screenRecents);
         };
+    }
+
+    function _resumeFavoritesCovers(): void {
+        Browse.FavoritesModel.cover_requests_paused = false;
+        const first = root.favoritesScreen.mediaGrid.currentPage * root.favoritesScreen.mediaGrid.pageSize;
+        Browse.FavoritesModel.refresh_cover_keys(first, root.favoritesScreen.mediaGrid.pageSize * 2);
+    }
+
+    function _resumeRecentsCovers(): void {
+        Browse.RecentsModel.cover_requests_paused = false;
+        const first = root.recentsScreen.mediaGrid.currentPage * root.recentsScreen.mediaGrid.pageSize;
+        Browse.RecentsModel.refresh_cover_keys(first, root.recentsScreen.mediaGrid.pageSize * 2);
     }
 
     // Hub → Settings transition. The Settings screen has no async
@@ -1528,7 +1547,9 @@ MainLayout {
     property string _heldAction: ""
     property int _heldKey: 0
     property bool rapidNavigationActive: false
+    property bool rapidNavigationIndicatorActive: false
     property string rapidNavigationAction: ""
+    property int _rapidNavigationTapCount: 0
     // Aliased so tst_navigation.qml can observe the repeat state machine
     // — child Timer ids are file-scoped and aren't reachable otherwise.
     property alias _repeatPending: repeatInitial.running
@@ -1557,6 +1578,12 @@ MainLayout {
 
     Binding {
         target: root.gamesScreen
+        property: "detailRapidIndicatorActive"
+        value: root.activeScreen === root.screenGames && root.rapidNavigationIndicatorActive
+    }
+
+    Binding {
+        target: root.gamesScreen
         property: "detailRapidScrollAction"
         value: root.activeScreen === root.screenGames ? root.rapidNavigationAction : ""
     }
@@ -1565,6 +1592,12 @@ MainLayout {
         target: root.favoritesScreen
         property: "detailRapidScrollActive"
         value: root.activeScreen === root.screenFavorites && root.rapidNavigationActive
+    }
+
+    Binding {
+        target: root.favoritesScreen
+        property: "detailRapidIndicatorActive"
+        value: root.activeScreen === root.screenFavorites && root.rapidNavigationIndicatorActive
     }
 
     Binding {
@@ -1581,6 +1614,12 @@ MainLayout {
 
     Binding {
         target: root.recentsScreen
+        property: "detailRapidIndicatorActive"
+        value: root.activeScreen === root.screenRecents && root.rapidNavigationIndicatorActive
+    }
+
+    Binding {
+        target: root.recentsScreen
         property: "detailRapidScrollAction"
         value: root.activeScreen === root.screenRecents ? root.rapidNavigationAction : ""
     }
@@ -1592,16 +1631,22 @@ MainLayout {
     function _noteRapidNavigationAction(action: string, forceActive: bool): void {
         if (!root._isRapidNavigationAction(action))
             return;
+        const sameBurst = rapidNavigationQuiet.running && root.rapidNavigationAction === action;
+        root._rapidNavigationTapCount = sameBurst ? root._rapidNavigationTapCount + 1 : 1;
         root.rapidNavigationAction = action;
         if (forceActive || rapidNavigationQuiet.running)
             root.rapidNavigationActive = true;
+        if (forceActive || action === "page_prev" || action === "page_next" || root._rapidNavigationTapCount >= 3)
+            root.rapidNavigationIndicatorActive = true;
         rapidNavigationQuiet.restart();
     }
 
     function _resetRapidNavigation(): void {
         rapidNavigationQuiet.stop();
         root.rapidNavigationActive = false;
+        root.rapidNavigationIndicatorActive = false;
         root.rapidNavigationAction = "";
+        root._rapidNavigationTapCount = 0;
     }
 
     function _isRepeatableAction(action: string): bool {
@@ -1770,7 +1815,9 @@ MainLayout {
         repeat: false
         onTriggered: {
             root.rapidNavigationActive = false;
+            root.rapidNavigationIndicatorActive = false;
             root.rapidNavigationAction = "";
+            root._rapidNavigationTapCount = 0;
         }
     }
 

--- a/src/ui/components/BrowseList.qml
+++ b/src/ui/components/BrowseList.qml
@@ -74,6 +74,13 @@ Item {
         return Qt.rect(p.x, p.y, listView.width, root.rowHeight);
     }
 
+    function _syncContentY(): void {
+        const maxY = Math.max(0, listView.contentHeight - listView.height);
+        const targetY = Math.min(root._targetContentY, maxY);
+        if (listView.contentY !== targetY)
+            listView.contentY = targetY;
+    }
+
     clip: true
 
     Rectangle {
@@ -90,7 +97,9 @@ Item {
             root.currentName = "";
             root.currentCoverKey = "";
         }
+        root._syncContentY();
     }
+    on_TargetContentYChanged: root._syncContentY()
 
     MouseArea {
         anchors.fill: parent
@@ -112,11 +121,13 @@ Item {
         anchors.rightMargin: root.totalItems > root.visibleRowCount ? root._gutterWidth + root._gutterGap + root.cardPaddingRight : root.cardPaddingRight
         model: root.model
         currentIndex: root.currentIndex
-        contentY: Math.min(root._targetContentY, Math.max(0, contentHeight - height))
         boundsBehavior: Flickable.StopAtBounds
         interactive: false
         spacing: root.rowSpacing
         highlightFollowsCurrentItem: false
+        Component.onCompleted: root._syncContentY()
+        onContentHeightChanged: root._syncContentY()
+        onHeightChanged: root._syncContentY()
 
         delegate: Item {
             id: row

--- a/src/ui/components/PagedGrid.qml
+++ b/src/ui/components/PagedGrid.qml
@@ -51,6 +51,7 @@ Item {
     // untouched.
     property bool focused: true
     property bool coverLoadingPaused: false
+    property bool rapidRenderMode: false
     property var layoutProfile: null
     readonly property var _gridProfile: root.layoutProfile && root.layoutProfile.grid ? root.layoutProfile.grid : null
 
@@ -59,7 +60,7 @@ Item {
     // response; models without ignore it. The grid does not know
     // whether the model has more data — that is a model concern, kept
     // out of this component so it stays generic.
-    signal loadMoreRequested
+    signal loadMoreRequested(bool urgent)
     // Mouse entry points. Screens own persistence and activation side
     // effects, so the grid only updates its focused index and reports the
     // row the pointer targeted.
@@ -235,7 +236,7 @@ Item {
             root._pendingTargetPage = targetPage;
             root._pendingTargetRow = root.currentRow;
             root._pendingTargetCol = root.currentColumn;
-            root.loadMoreRequested();
+            root.loadMoreRequested(true);
             return false;
         }
         root._pendingTargetPage = -1;
@@ -251,7 +252,7 @@ Item {
         // `loadAheadPages` of the loaded edge, kick a fetch so the next
         // page boundary lands on freshly loaded rows.
         if (root.currentPage >= root.pageCount - root.loadAheadPages - 1)
-            root.loadMoreRequested();
+            root.loadMoreRequested(false);
         return true;
     }
 
@@ -283,7 +284,7 @@ Item {
                 // Keep the chain going; `fetch_more` is debounced
                 // model-side via `loading_more`, so a redundant emit
                 // is cheap.
-                root.loadMoreRequested();
+                root.loadMoreRequested(true);
                 return;
             }
             // Model says no more pages are coming. Settle on the
@@ -383,7 +384,7 @@ Item {
                     root._pendingTargetPage = targetPage;
                     root._pendingTargetRow = root.rows - 1;
                     root._pendingTargetCol = root.currentColumn;
-                    root.loadMoreRequested();
+                    root.loadMoreRequested(true);
                     return false;
                 }
                 newPage = targetPage;
@@ -395,7 +396,7 @@ Item {
                     root._pendingTargetPage = targetPage;
                     root._pendingTargetRow = 0;
                     root._pendingTargetCol = root.currentColumn;
-                    root.loadMoreRequested();
+                    root.loadMoreRequested(true);
                     return false;
                 }
                 newPage = targetPage;
@@ -423,7 +424,7 @@ Item {
             // fetch more so a subsequent press can land on freshly-
             // loaded rows.
             if (root.currentPage >= root.pageCount - root.loadAheadPages - 1)
-                root.loadMoreRequested();
+                root.loadMoreRequested(false);
             return false;
         }
         // Successful directional move clears any pending wrap-target;
@@ -437,7 +438,7 @@ Item {
         // model's own debounce (`loading_more` guard) collapses
         // repeated emissions while a fetch is in flight.
         if (root.currentPage >= root.pageCount - root.loadAheadPages - 1)
-            root.loadMoreRequested();
+            root.loadMoreRequested(false);
         return true;
     }
 
@@ -553,8 +554,8 @@ Item {
                 // after crossing past the retention edge runs at
                 // nice +10 (see media_image_provider.cpp) and is
                 // invisible to the renderer.
-                readonly property bool _coverInRange: cellPage === root.currentPage
-                readonly property bool _coverInRetentionRange: Math.abs(cellPage - root.currentPage) <= (root.coverLoadingPaused ? 1 : 5)
+                readonly property bool _coverInRange: !root.rapidRenderMode && cellPage === root.currentPage
+                readonly property bool _coverInRetentionRange: !root.rapidRenderMode && Math.abs(cellPage - root.currentPage) <= (root.coverLoadingPaused ? 1 : 5)
                 property bool _coverEverRequested: false
                 Binding on _coverEverRequested {
                     when: cellItem._coverInRange
@@ -590,7 +591,9 @@ Item {
                 Rectangle {
                     anchors.fill: parent
                     radius: Sizing.cornerRadius
-                    color: Theme.surfaceCard
+                    color: cellItem.isSelected && root.rapidRenderMode ? Theme.selectionSurface : Theme.surfaceCard
+                    border.width: cellItem.isSelected && root.rapidRenderMode ? Sizing.stroke(2) : 0
+                    border.color: Theme.accent
                 }
 
                 TileLoader {
@@ -606,7 +609,7 @@ Item {
                     // ~110 active tiles instead of N, per-press
                     // binding cost stays roughly constant as the
                     // dataset grows.
-                    active: cellItem._coverInRetentionRange
+                    active: cellItem._coverInRetentionRange && !root.rapidRenderMode
                     // Incubate Tile construction on background frames
                     // so a retention-edge crossing (10 cells flipping
                     // active) doesn't block the main thread. The

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -53,7 +53,7 @@ MediaListScreen {
     detailShowDescription: false
     detailShowTitle: false
     detailLoadingText: qsTr("Loading game…")
-    pauseCoverRequestsDuringRapid: false
+    pauseCoverRequestsDuringRapid: true
     detailCanPreviousImage: Browse.GamesModel.current_detail_image_can_prev
     detailCanNextImage: Browse.GamesModel.current_detail_image_can_next
     detailIdentityForIndex: function (index) {
@@ -135,11 +135,16 @@ MediaListScreen {
     gridRowsOverride: games._gridRows
     gridTotalItemsOverride: Browse.GamesModel.dir_count + Browse.GamesModel.total_files
     gridHasMorePages: Browse.GamesModel.has_next_page
-    gridLoadMoreAction: () => Browse.GamesModel.fetch_more()
+    gridLoadMoreAction: urgent => {
+        if (urgent || games.detailRapidScrollActive)
+            Browse.GamesModel.fetch_more_rapid();
+        else
+            Browse.GamesModel.fetch_more();
+    }
     gridCurrentPageChangedAction: () => {
         const first = games.gamesGrid.currentPage * games.gamesGrid.pageSize;
         Browse.GamesModel.visible_first_row = first;
-        if (!games._listLayout)
+        if (!games._listLayout && !games.detailRapidScrollActive)
             Browse.GamesModel.prefetch_around(first);
     }
     activeLabelTextProvider: () => games.gamesGrid.itemCount > 0 ? Browse.GamesModel.name_at(games.gamesGrid.currentIndex) : ""
@@ -221,8 +226,7 @@ MediaListScreen {
     // directions have a row-edge escape branch, so all four cardinal
     // actions share this exact body.
     function _performGridMove(dx: int, dy: int): void {
-        if (games.gamesGrid.moveSelection(dx, dy))
-            games._scheduleSelectedPersist(Browse.GamesModel.path_at(games.gamesGrid.currentIndex));
+        games.gamesGrid.moveSelection(dx, dy);
     }
 
     function _performLinearMove(delta: int): void {
@@ -246,7 +250,6 @@ MediaListScreen {
             return;
         }
         games.gamesGrid.currentIndex = next;
-        games._scheduleSelectedPersist(Browse.GamesModel.path_at(games.gamesGrid.currentIndex));
         if (next >= count - 2 && Browse.GamesModel.has_next_page)
             Browse.GamesModel.fetch_more();
         games._prefetchListTail(next);
@@ -281,8 +284,7 @@ MediaListScreen {
             games._performLinearMove(delta * games._browsePageSize);
             return;
         }
-        if (games.gamesGrid.pageBy(delta))
-            games._scheduleSelectedPersist(Browse.GamesModel.path_at(games.gamesGrid.currentIndex));
+        games.gamesGrid.pageBy(delta);
     }
 
     // True when we're inside a navigated folder (path_stack length > 1).

--- a/src/ui/screens/MediaListScreen.qml
+++ b/src/ui/screens/MediaListScreen.qml
@@ -68,6 +68,7 @@ Item {
     property bool transitioning: false
     property bool gridFocused: true
     property bool detailRapidScrollActive: false
+    property bool detailRapidIndicatorActive: detailRapidScrollActive
     property string detailRapidScrollAction: ""
     property bool pauseCoverRequestsDuringRapid: true
     property bool forceListLayout: false
@@ -89,7 +90,7 @@ Item {
     property int gridTotalItemsOverride: -1
     property bool gridHasMorePages: false
     readonly property bool _listRapidLineMove: root._listLayout && (root.detailRapidScrollAction === "up" || root.detailRapidScrollAction === "down")
-    readonly property bool _showRapidScrollIndicator: root.detailRapidScrollActive && !root._listRapidLineMove
+    readonly property bool _showRapidScrollIndicator: root.detailRapidIndicatorActive && !root._listRapidLineMove
     readonly property bool _listLayout: root.forceListLayout || Browse.Settings.current_browse_layout === "list"
     readonly property bool _tateListLayout: root._listLayout && Browse.Settings.current_orientation !== "horizontal"
     readonly property string _activeListViewId: root._tateListLayout ? root.tateListViewId : root.listViewId
@@ -168,7 +169,6 @@ Item {
         if (index < 0 || index >= mediaGrid.itemCount)
             return;
         mediaGrid.currentIndex = index;
-        root._persistFocus();
     }
 
     function _performLinearMove(delta: int): void {
@@ -190,7 +190,6 @@ Item {
             return;
         }
         mediaGrid.currentIndex = next;
-        root._persistFocus();
         if (next >= count - 2)
             root.mediaModel.fetch_more();
     }
@@ -413,9 +412,10 @@ Item {
         totalItemsOverride: root.gridTotalItemsOverride
         hasMorePages: root.gridHasMorePages
         coverLoadingPaused: root.detailRapidScrollActive
-        onLoadMoreRequested: {
+        rapidRenderMode: root.detailRapidScrollActive
+        onLoadMoreRequested: urgent => {
             if (typeof root.gridLoadMoreAction === "function")
-                root.gridLoadMoreAction();
+                root.gridLoadMoreAction(urgent);
             else
                 root.mediaModel.fetch_more();
         }


### PR DESCRIPTION
## Summary
- start local Core earlier and avoid off-screen cover gates during startup
- pause/skip cover work during rapid Games browsing and use larger urgent fetch chunks
- add rapid grid render mode to keep navigation responsive while covers hydrate after input quiets
- reduce media image log noise and avoid retrying stable no-image misses

## Tests
- `just lint`
- `just test-qml`
- `just test-rust`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added rapid pagination support for faster content browsing.
  * Introduced rapid navigation indicator for visual feedback during fast interactions.

* **Improvements**
  * Enhanced cover image loading management—requests now intelligently pause/resume based on active screen.
  * Optimized scrolling synchronization in lists for better UI responsiveness.
  * Improved error diagnostics for upload failures with detailed logging.
  * Reduced log upload size limits to prevent content truncation.

* **Bug Fixes**
  * Improved handling of rapid scrolling interactions across games and media screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->