### PR TITLE
Fix CLA signature record and reopen checks

### DIFF
--- a/.github/contributors/signatures.json
+++ b/.github/contributors/signatures.json
@@ -27,6 +27,16 @@
       "created_at": "2026-05-04T18:47:41Z",
       "repoId": 1216829727,
       "pullRequestNo": 70
+    },
+    {
+      "name": "devilschile2",
+      "id": 106693100,
+      "comment_id": 4637970493,
+      "created_at": "2026-06-06T08:31:52Z",
+      "repoId": 1216829727,
+      "pullRequestNo": 201,
+      "cla_version": "1.0",
+      "cla_signed_at": "2026-06-06T08:31:52Z"
     }
   ]
 }

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -8,7 +8,9 @@ on:
   issue_comment:
     types: [created]
   pull_request_target:
-    types: [opened, closed, synchronize]
+    # Do not run on closed: contributor-assistant can report success on close/lock,
+    # leaving stale green status when PRs are later reopened.
+    types: [opened, reopened, synchronize]
 
 # pull_request_target is used (not pull_request) because the action needs
 # write access to commit signatures.json back to the repo. Contributor code


### PR DESCRIPTION
## Summary
- add devilschile2 CLA signature record from their PR #201 agreement comment
- cover earlier PR #191 compliance gap without fabricating PR #191 comment data
- run CLA checks on reopened PRs and stop running them on closed PRs to avoid stale success statuses

## Validation
- jq . .github/contributors/signatures.json
- python3 YAML parse for .github/workflows/cla.yml

Ref #191
Ref #201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new contributor record to signatures database
  * Updated CLA workflow trigger conditions to run on specific pull request events only

<!-- end of auto-generated comment: release notes by coderabbit.ai -->