### PR TITLE
Improve resume loading and detail metadata

### DIFF
--- a/rust/frontend/src/models/favorites.rs
+++ b/rust/frontend/src/models/favorites.rs
@@ -23,6 +23,7 @@
 // QR/card-write payloads prefer Core's portable ZapScript.
 
 use crate::media_image_cache::{global_media_image_cache, MediaImageCache, MediaKey};
+use crate::models::tag_utils::tag_display_value;
 use crate::models::{global_handle, global_store};
 use cxx_qt::{CxxQtType, Threading};
 use cxx_qt_lib::{
@@ -806,15 +807,6 @@ fn detail_value_for_aliases(source: &[TagInfo], aliases: &[&str]) -> String {
         .map(tag_display_value)
         .collect::<Vec<_>>()
         .join(", ")
-}
-
-fn tag_display_value(tag: &TagInfo) -> String {
-    let label = tag.label.trim();
-    if label.is_empty() {
-        tag.tag.trim().to_string()
-    } else {
-        label.to_string()
-    }
 }
 
 fn file_stem_or_name(path: &str, name: &str) -> String {

--- a/rust/frontend/src/models/favorites.rs
+++ b/rust/frontend/src/models/favorites.rs
@@ -801,11 +801,20 @@ fn detail_value_for_aliases(source: &[TagInfo], aliases: &[&str]) -> String {
             aliases
                 .iter()
                 .any(|alias| tag.tag_type.eq_ignore_ascii_case(alias))
-                && !tag.tag.trim().is_empty()
+                && !tag_display_value(tag).is_empty()
         })
-        .map(|tag| tag.tag.trim().to_string())
+        .map(tag_display_value)
         .collect::<Vec<_>>()
         .join(", ")
+}
+
+fn tag_display_value(tag: &TagInfo) -> String {
+    let label = tag.label.trim();
+    if label.is_empty() {
+        tag.tag.trim().to_string()
+    } else {
+        label.to_string()
+    }
 }
 
 fn file_stem_or_name(path: &str, name: &str) -> String {

--- a/rust/frontend/src/models/game_info.rs
+++ b/rust/frontend/src/models/game_info.rs
@@ -5,6 +5,7 @@
 use crate::media_image_cache::{
     global_media_image_cache, MediaImageCache, MediaImageUpdate, MediaKey,
 };
+use crate::models::tag_utils::tag_display_value;
 use crate::models::{global_handle, global_store};
 use cxx_qt::{CxxQtType, Threading};
 use cxx_qt_lib::QString;
@@ -15,7 +16,7 @@ use std::sync::Arc;
 use tokio::sync::broadcast::error::RecvError;
 use tokio::task::JoinHandle;
 use tracing::debug;
-use zaparoo_core::media_types::{MediaMeta, MediaMetaParams, TagInfo};
+use zaparoo_core::media_types::{MediaMeta, MediaMetaParams};
 
 #[derive(Default)]
 pub struct GameInfoRust {
@@ -247,15 +248,6 @@ fn detail_tags_from_meta(meta: &MediaMeta, path: &str) -> String {
         .map(|(label, value)| format!("{label}\t{value}"))
         .collect::<Vec<_>>()
         .join("\n")
-}
-
-fn tag_display_value(tag: &TagInfo) -> String {
-    let label = tag.label.trim();
-    if label.is_empty() {
-        tag.tag.trim().to_string()
-    } else {
-        label.to_string()
-    }
 }
 
 fn is_ordered_tag(tag_type: &str) -> bool {

--- a/rust/frontend/src/models/game_info.rs
+++ b/rust/frontend/src/models/game_info.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use tokio::sync::broadcast::error::RecvError;
 use tokio::task::JoinHandle;
 use tracing::debug;
-use zaparoo_core::media_types::{MediaMeta, MediaMetaParams};
+use zaparoo_core::media_types::{MediaMeta, MediaMetaParams, TagInfo};
 
 #[derive(Default)]
 pub struct GameInfoRust {
@@ -223,9 +223,10 @@ fn detail_tags_from_meta(meta: &MediaMeta, path: &str) -> String {
             source
                 .iter()
                 .filter(|tag| {
-                    tag.tag_type.eq_ignore_ascii_case(tag_type) && !tag.tag.trim().is_empty()
+                    tag.tag_type.eq_ignore_ascii_case(tag_type)
+                        && !tag_display_value(tag).is_empty()
                 })
-                .map(|tag| (display_label(&tag.tag_type), tag.tag.trim().to_string())),
+                .map(|tag| (display_label(&tag.tag_type), tag_display_value(tag))),
         );
     }
     rows.extend(
@@ -234,9 +235,9 @@ fn detail_tags_from_meta(meta: &MediaMeta, path: &str) -> String {
             .filter(|tag| {
                 !is_ordered_tag(&tag.tag_type)
                     && !tag.tag_type.trim().is_empty()
-                    && !tag.tag.trim().is_empty()
+                    && !tag_display_value(tag).is_empty()
             })
-            .map(|tag| (display_label(&tag.tag_type), tag.tag.trim().to_string())),
+            .map(|tag| (display_label(&tag.tag_type), tag_display_value(tag))),
     );
     let filename = file_stem_or_name(path);
     if !filename.is_empty() {
@@ -246,6 +247,15 @@ fn detail_tags_from_meta(meta: &MediaMeta, path: &str) -> String {
         .map(|(label, value)| format!("{label}\t{value}"))
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+fn tag_display_value(tag: &TagInfo) -> String {
+    let label = tag.label.trim();
+    if label.is_empty() {
+        tag.tag.trim().to_string()
+    } else {
+        label.to_string()
+    }
 }
 
 fn is_ordered_tag(tag_type: &str) -> bool {

--- a/rust/frontend/src/models/games.rs
+++ b/rust/frontend/src/models/games.rs
@@ -1217,11 +1217,20 @@ fn detail_value_for_aliases(source: &[TagInfo], aliases: &[&str]) -> String {
             aliases
                 .iter()
                 .any(|alias| tag.tag_type.eq_ignore_ascii_case(alias))
-                && !tag.tag.trim().is_empty()
+                && !tag_display_value(tag).is_empty()
         })
-        .map(|tag| tag.tag.trim().to_string())
+        .map(tag_display_value)
         .collect::<Vec<_>>()
         .join(", ")
+}
+
+fn tag_display_value(tag: &TagInfo) -> String {
+    let label = tag.label.trim();
+    if label.is_empty() {
+        tag.tag.trim().to_string()
+    } else {
+        label.to_string()
+    }
 }
 
 fn file_stem_or_name(path: &str, name: &str) -> String {
@@ -3123,6 +3132,7 @@ mod tests {
         let tags = vec![TagInfo {
             tag_type: "genre".into(),
             tag: "Platformer".into(),
+            label: String::new(),
         }];
         let detail = detail_tags_from_tags(&tags);
         let rows: Vec<&str> = detail.split('\n').collect();
@@ -3145,23 +3155,39 @@ mod tests {
             TagInfo {
                 tag_type: "platform".into(),
                 tag: "Arcade".into(),
+                label: String::new(),
             },
             TagInfo {
                 tag_type: "release_date".into(),
                 tag: "1984".into(),
+                label: String::new(),
             },
             TagInfo {
                 tag_type: "gamegenre".into(),
                 tag: "Action".into(),
+                label: String::new(),
             },
             TagInfo {
                 tag_type: "genre".into(),
                 tag: "Shooter".into(),
+                label: String::new(),
             },
         ];
         let detail = detail_tags_from_tags(&tags);
         let rows: Vec<&str> = detail.split('\n').collect();
         assert_eq!(rows[0], "Year\t1984");
         assert_eq!(rows[1], "Genre\tAction, Shooter");
+    }
+
+    #[test]
+    fn detail_tags_prefer_label_for_display() {
+        let tags = vec![TagInfo {
+            tag_type: "developer".into(),
+            tag: "nintendo".into(),
+            label: "Nintendo".into(),
+        }];
+        let detail = detail_tags_from_tags(&tags);
+        let rows: Vec<&str> = detail.split('\n').collect();
+        assert_eq!(rows[3], "Developer\tNintendo");
     }
 }

--- a/rust/frontend/src/models/games.rs
+++ b/rust/frontend/src/models/games.rs
@@ -31,6 +31,7 @@
 // when the user spams direction-arrow + Accept across a model swap.
 
 use crate::media_image_cache::{global_media_image_cache, MediaImageCache, MediaKey};
+use crate::models::tag_utils::tag_display_value;
 use crate::models::{global_handle, global_store};
 use cxx_qt::{CxxQtType, Threading};
 use cxx_qt_lib::{
@@ -1222,15 +1223,6 @@ fn detail_value_for_aliases(source: &[TagInfo], aliases: &[&str]) -> String {
         .map(tag_display_value)
         .collect::<Vec<_>>()
         .join(", ")
-}
-
-fn tag_display_value(tag: &TagInfo) -> String {
-    let label = tag.label.trim();
-    if label.is_empty() {
-        tag.tag.trim().to_string()
-    } else {
-        label.to_string()
-    }
 }
 
 fn file_stem_or_name(path: &str, name: &str) -> String {

--- a/rust/frontend/src/models/mod.rs
+++ b/rust/frontend/src/models/mod.rs
@@ -49,6 +49,7 @@ pub mod system_launchers;
 pub mod system_status;
 pub mod systems;
 pub mod systems_state;
+pub mod tag_utils;
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, OnceLock};

--- a/rust/frontend/src/models/recents.rs
+++ b/rust/frontend/src/models/recents.rs
@@ -23,6 +23,7 @@
 // recents launches by `run`-ing the entry's launcher route.
 
 use crate::media_image_cache::{global_media_image_cache, MediaImageCache, MediaKey};
+use crate::models::tag_utils::tag_display_value;
 use crate::models::{global_handle, global_store};
 use cxx_qt::{CxxQtType, Initialize, Threading};
 use cxx_qt_lib::{
@@ -85,6 +86,7 @@ pub struct RecentsModelRust {
     resume_requested: bool,
     resume_seq: Arc<AtomicU64>,
     history_requested: bool,
+    history_fetching: bool,
     history_subscription: Option<JoinHandle<()>>,
     current_detail_loading: bool,
     current_detail_tags: QString,
@@ -266,6 +268,9 @@ fn apply_state(
     (data, err): (Option<PageSnapshot>, String),
 ) {
     if let Some((entries, has_next_page, next_cursor)) = data {
+        model.as_mut().rust_mut().history_requested = true;
+        model.as_mut().rust_mut().history_fetching = false;
+        model.as_mut().rust_mut().history_subscription = None;
         // A fresh initial page resets the cursor chain — bump `seq` so
         // any in-flight `fetch_more` sees a stale ticket and bails.
         model.as_mut().rust_mut().seq.fetch_add(1, Ordering::SeqCst);
@@ -331,6 +336,9 @@ fn apply_state(
             model.as_mut().set_has_next_page(false);
         }
     } else {
+        model.as_mut().rust_mut().history_requested = false;
+        model.as_mut().rust_mut().history_fetching = false;
+        model.as_mut().rust_mut().history_subscription = None;
         // Same disarm as the Pending branch — an Errored transition
         // doesn't reset entries, so a callback queued during the prior
         // Ready could otherwise append rows that don't belong to the
@@ -410,10 +418,10 @@ impl ffi::RecentsModel {
     }
 
     fn ensure_loaded(mut self: Pin<&mut Self>) {
-        if self.history_requested {
+        if self.history_requested || self.history_fetching {
             return;
         }
-        self.as_mut().rust_mut().history_requested = true;
+        self.as_mut().rust_mut().history_fetching = true;
         if !self.loading {
             self.as_mut().set_loading(true);
         }
@@ -430,6 +438,13 @@ impl ffi::RecentsModel {
         let handle = global_handle().spawn(async move {
             loop {
                 if rx.changed().await.is_err() {
+                    let _ = qt_thread.queue(|mut model| {
+                        model.as_mut().rust_mut().history_fetching = false;
+                        model.as_mut().rust_mut().history_subscription = None;
+                        if model.loading {
+                            model.as_mut().set_loading(false);
+                        }
+                    });
                     break;
                 }
                 let state = rx.borrow_and_update().clone();
@@ -441,10 +456,18 @@ impl ffi::RecentsModel {
                         break;
                     }
                     ConnectionState::Unreachable(message) => {
-                        let _ = qt_thread.queue(move |model| {
-                            apply_state(model, (None, message));
+                        let _ = qt_thread.queue(move |mut model| {
+                            let qerr = QString::from(message.as_str());
+                            if model.error_message != qerr {
+                                model.as_mut().set_error_message(qerr);
+                            }
+                            if model.loading {
+                                model.as_mut().set_loading(false);
+                            }
+                            if model.has_next_page {
+                                model.as_mut().set_has_next_page(false);
+                            }
                         });
-                        break;
                     }
                     ConnectionState::Disconnected
                     | ConnectionState::Connecting
@@ -456,6 +479,13 @@ impl ffi::RecentsModel {
     }
 
     fn start_initial_history_fetch(mut self: Pin<&mut Self>) {
+        self.as_mut().rust_mut().history_subscription = None;
+        if !self.loading {
+            self.as_mut().set_loading(true);
+        }
+        if !self.error_message.is_empty() {
+            self.as_mut().set_error_message(QString::default());
+        }
         self.as_mut().ensure_cover_subscription();
         self.as_mut().rust_mut().seq.fetch_add(1, Ordering::SeqCst);
         clear_current_detail_state(self.as_mut());
@@ -734,7 +764,12 @@ fn apply_resume_latest_result(
         Ok(result) => result.entry,
         Err(e) => {
             debug!("media.history.latest failed: {}", e.message);
-            None
+            model.as_mut().rust_mut().resume_requested = false;
+            if model.resume_loading {
+                model.as_mut().set_resume_loading(false);
+            }
+            sync_resume_state(model);
+            return;
         }
     };
     model.as_mut().rust_mut().resume_entry =
@@ -891,15 +926,6 @@ fn detail_value_for_aliases(source: &[TagInfo], aliases: &[&str]) -> String {
         .map(tag_display_value)
         .collect::<Vec<_>>()
         .join(", ")
-}
-
-fn tag_display_value(tag: &TagInfo) -> String {
-    let label = tag.label.trim();
-    if label.is_empty() {
-        tag.tag.trim().to_string()
-    } else {
-        label.to_string()
-    }
 }
 
 fn clear_current_detail_state(mut model: Pin<&mut ffi::RecentsModel>) {

--- a/rust/frontend/src/models/recents.rs
+++ b/rust/frontend/src/models/recents.rs
@@ -7,16 +7,14 @@
 //
 // Two paths into the model:
 //
-//   * `bind_to_endpoint!` seeds page 1 from `MediaHistoryEndpoint` so
-//     a screen flip into Recents has data on the first paint when the
-//     resource is already `Ready`. The fixed args (`limit = 25`, no
-//     `systems` filter) match what the UI requests; if a future filter
-//     is added, switch to a per-arg pattern like `GamesModel`.
+//   * `ensure_loaded()` starts the initial page fetch lazily when the
+//     Recents screen is requested. Hub boot does not need the paginated
+//     history list, so it stays off the startup RPC burst.
 //
-//   * `fetch_more()` — cursor-driven follow-ups bypass the cache and
-//     call `Client::media_history` directly, just like games. The
-//     model owns the cursor, the in-flight `loading_more` debounce,
-//     and the seq ticket that disarms stale callbacks.
+//   * `fetch_more()` — cursor-driven follow-ups call
+//     `Client::media_history` directly, just like games. The model owns
+//     the cursor, the in-flight `loading_more` debounce, and the seq
+//     ticket that disarms stale callbacks.
 //
 // History is flat (no folder navigation, no auto-nav) so this model
 // stays a fraction of the size of `GamesModel`. Rows are deduplicated
@@ -26,7 +24,7 @@
 
 use crate::media_image_cache::{global_media_image_cache, MediaImageCache, MediaKey};
 use crate::models::{global_handle, global_store};
-use cxx_qt::{CxxQtType, Threading};
+use cxx_qt::{CxxQtType, Initialize, Threading};
 use cxx_qt_lib::{
     QByteArray, QHash, QHashPair_i32_QByteArray, QList, QModelIndex, QString, QVariant,
 };
@@ -38,15 +36,13 @@ use std::time::Duration;
 use time::{format_description::well_known::Rfc3339, Duration as TimeDuration, OffsetDateTime};
 use tokio::sync::broadcast::error::RecvError;
 use tokio::task::JoinHandle;
-use tracing::{info, warn};
-use zaparoo_core::client::ClientError;
-use zaparoo_core::endpoints::media_history::{HistoryArgs, MediaHistoryEndpoint};
+use tracing::{debug, info, warn};
+use zaparoo_core::client::{ClientError, ConnectionState};
 use zaparoo_core::endpoints::run::RunMutation;
 use zaparoo_core::media_types::{
-    MediaHistoryEntry, MediaHistoryParams, MediaHistoryResult, MediaMeta, MediaMetaParams,
-    RunParams, TagInfo,
+    MediaHistoryEntry, MediaHistoryLatestEntry, MediaHistoryParams, MediaHistoryResult, MediaMeta,
+    MediaMetaParams, RunParams, TagInfo,
 };
-use zaparoo_core::remote_resource::ResourceStatus;
 
 const NAME_ROLE: i32 = 256 + 1;
 const PATH_ROLE: i32 = 256 + 2;
@@ -82,8 +78,14 @@ pub struct RecentsModelRust {
     has_next_page: bool,
     next_cursor: Option<String>,
     resume_available: bool,
+    resume_loading: bool,
     resume_name: QString,
     resume_cover_key: QString,
+    resume_entry: Option<MediaHistoryEntry>,
+    resume_requested: bool,
+    resume_seq: Arc<AtomicU64>,
+    history_requested: bool,
+    history_subscription: Option<JoinHandle<()>>,
     current_detail_loading: bool,
     current_detail_tags: QString,
     current_detail_image_key: QString,
@@ -145,6 +147,7 @@ pub mod ffi {
         #[qproperty(QString, error_message)]
         #[qproperty(bool, has_next_page)]
         #[qproperty(bool, resume_available)]
+        #[qproperty(bool, resume_loading)]
         #[qproperty(QString, resume_name)]
         #[qproperty(QString, resume_cover_key)]
         #[qproperty(bool, current_detail_loading)]
@@ -152,6 +155,9 @@ pub mod ffi {
         #[qproperty(QString, current_detail_image_key)]
         #[qproperty(bool, cover_requests_paused)]
         type RecentsModel = super::RecentsModelRust;
+
+        #[qinvokable]
+        fn ensure_loaded(self: Pin<&mut RecentsModel>);
 
         #[qinvokable]
         fn fetch_more(self: Pin<&mut RecentsModel>);
@@ -236,12 +242,10 @@ pub mod ffi {
     impl cxx_qt::Initialize for RecentsModel {}
 }
 
-crate::bind_to_endpoint! {
-    for ffi::RecentsModel,
-    endpoint = MediaHistoryEndpoint,
-    args = HistoryArgs::new(Vec::new(), PAGE_SIZE),
-    select = project,
-    apply = apply_state,
+impl Initialize for ffi::RecentsModel {
+    fn initialize(mut self: Pin<&mut Self>) {
+        self.as_mut().bind_resume_to_connection();
+    }
 }
 
 /// Snapshot of a single page that `apply_state` can write onto the
@@ -249,22 +253,12 @@ crate::bind_to_endpoint! {
 /// `qt_thread` queue.
 type PageSnapshot = (Vec<MediaHistoryEntry>, bool, Option<String>);
 
-/// Project the resource status onto an `(Option<PageSnapshot>, error)`
-/// tuple. `Idle`/`Loading` map to the same `(None, "")` shape so the
-/// apply path can decide on its own whether to show the spinner.
-fn project(status: &ResourceStatus<MediaHistoryResult>) -> (Option<PageSnapshot>, String) {
-    match status {
-        ResourceStatus::Ready(data) => (
-            Some((
-                data.entries.clone(),
-                data.has_next_page(),
-                data.next_cursor(),
-            )),
-            String::new(),
-        ),
-        ResourceStatus::Errored { message, .. } => (None, message.clone()),
-        ResourceStatus::Idle | ResourceStatus::Loading => (None, String::new()),
-    }
+fn page_snapshot(result: &MediaHistoryResult) -> PageSnapshot {
+    (
+        result.entries.clone(),
+        result.has_next_page(),
+        result.next_cursor(),
+    )
 }
 
 fn apply_state(
@@ -402,6 +396,131 @@ impl ffi::RecentsModel {
         h
     }
 
+    fn bind_resume_to_connection(mut self: Pin<&mut Self>) {
+        self.as_mut().ensure_resume_fetch();
+        let mut rx = global_store().client().connection.subscribe();
+        let qt_thread = self.qt_thread();
+        global_handle().spawn(async move {
+            while rx.changed().await.is_ok() {
+                let _ = qt_thread.queue(|model| {
+                    model.ensure_resume_fetch();
+                });
+            }
+        });
+    }
+
+    fn ensure_loaded(mut self: Pin<&mut Self>) {
+        if self.history_requested {
+            return;
+        }
+        self.as_mut().rust_mut().history_requested = true;
+        if !self.loading {
+            self.as_mut().set_loading(true);
+        }
+        let store = global_store();
+        if matches!(
+            *store.client().connection.borrow(),
+            ConnectionState::Connected
+        ) {
+            self.as_mut().start_initial_history_fetch();
+            return;
+        }
+        let mut rx = store.client().connection.subscribe();
+        let qt_thread = self.qt_thread();
+        let handle = global_handle().spawn(async move {
+            loop {
+                if rx.changed().await.is_err() {
+                    break;
+                }
+                let state = rx.borrow_and_update().clone();
+                match state {
+                    ConnectionState::Connected => {
+                        let _ = qt_thread.queue(|model| {
+                            model.start_initial_history_fetch();
+                        });
+                        break;
+                    }
+                    ConnectionState::Unreachable(message) => {
+                        let _ = qt_thread.queue(move |model| {
+                            apply_state(model, (None, message));
+                        });
+                        break;
+                    }
+                    ConnectionState::Disconnected
+                    | ConnectionState::Connecting
+                    | ConnectionState::Reconnecting => {}
+                }
+            }
+        });
+        self.as_mut().rust_mut().history_subscription = Some(handle);
+    }
+
+    fn start_initial_history_fetch(mut self: Pin<&mut Self>) {
+        self.as_mut().ensure_cover_subscription();
+        self.as_mut().rust_mut().seq.fetch_add(1, Ordering::SeqCst);
+        clear_current_detail_state(self.as_mut());
+        let seq = self.rust().seq.clone();
+        let ticket = seq.load(Ordering::SeqCst);
+        let qt_thread = self.qt_thread();
+        let store = global_store();
+        global_handle().spawn(async move {
+            let result = store
+                .client()
+                .media_history(MediaHistoryParams {
+                    limit: Some(PAGE_SIZE),
+                    cursor: None,
+                    systems: Vec::new(),
+                })
+                .await;
+            let projected = match result {
+                Ok(result) => (Some(page_snapshot(&result)), String::new()),
+                Err(e) => (None, e.message),
+            };
+            let _ = qt_thread.queue(move |model| {
+                if seq.load(Ordering::SeqCst) != ticket {
+                    return;
+                }
+                apply_state(model, projected);
+            });
+        });
+    }
+
+    fn ensure_resume_fetch(mut self: Pin<&mut Self>) {
+        if self.resume_requested {
+            return;
+        }
+        let store = global_store();
+        if !matches!(
+            *store.client().connection.borrow(),
+            ConnectionState::Connected
+        ) {
+            if !self.resume_loading {
+                self.as_mut().set_resume_loading(true);
+            }
+            sync_resume_state(self);
+            return;
+        }
+        self.as_mut().rust_mut().resume_requested = true;
+        self.as_mut()
+            .rust()
+            .resume_seq
+            .fetch_add(1, Ordering::SeqCst);
+        self.as_mut().set_resume_loading(true);
+        sync_resume_state(self.as_mut());
+        let seq = self.rust().resume_seq.clone();
+        let ticket = seq.load(Ordering::SeqCst);
+        let qt_thread = self.qt_thread();
+        global_handle().spawn(async move {
+            let result = store.client().media_history_latest().await;
+            let _ = qt_thread.queue(move |model| {
+                if seq.load(Ordering::SeqCst) != ticket {
+                    return;
+                }
+                apply_resume_latest_result(model, result);
+            });
+        });
+    }
+
     fn fetch_more(mut self: Pin<&mut Self>) {
         if self.loading_more || !self.has_next_page {
             return;
@@ -447,7 +566,7 @@ impl ffi::RecentsModel {
     }
 
     fn launch_resume(self: Pin<&mut Self>) {
-        let Some(entry) = resume_entry(&self.entries) else {
+        let Some(entry) = self.resume_entry.as_ref() else {
             return;
         };
         launch_entry(entry);
@@ -607,8 +726,42 @@ fn resume_cover_key_for(_entry: &MediaHistoryEntry, _requests_enabled: bool) -> 
     RESUME_FALLBACK_COVER_KEY.to_string()
 }
 
+fn apply_resume_latest_result(
+    mut model: Pin<&mut ffi::RecentsModel>,
+    result: Result<zaparoo_core::media_types::MediaHistoryLatestResult, ClientError>,
+) {
+    let latest = match result {
+        Ok(result) => result.entry,
+        Err(e) => {
+            debug!("media.history.latest failed: {}", e.message);
+            None
+        }
+    };
+    model.as_mut().rust_mut().resume_entry =
+        latest.map(history_entry_from_latest).filter(|entry| {
+            !launch_text_for(entry).is_empty()
+                && resume_entry_is_fresh(entry, OffsetDateTime::now_utc())
+        });
+    if model.resume_loading {
+        model.as_mut().set_resume_loading(false);
+    }
+    sync_resume_state(model);
+}
+
+fn history_entry_from_latest(entry: MediaHistoryLatestEntry) -> MediaHistoryEntry {
+    MediaHistoryEntry {
+        system_id: entry.system_id,
+        system_name: entry.system_name,
+        media_name: entry.media_name,
+        media_path: entry.media_path,
+        launcher_id: entry.launcher_id,
+        started_at: entry.started_at,
+        ..MediaHistoryEntry::default()
+    }
+}
+
 fn sync_resume_state(mut model: Pin<&mut ffi::RecentsModel>) {
-    let (available, name, cover_key) = match resume_entry(&model.entries) {
+    let (available, name, cover_key) = match model.resume_entry.as_ref() {
         Some(entry) => (
             true,
             QString::from(entry.media_name.as_str()),
@@ -733,11 +886,20 @@ fn detail_value_for_aliases(source: &[TagInfo], aliases: &[&str]) -> String {
             aliases
                 .iter()
                 .any(|alias| tag.tag_type.eq_ignore_ascii_case(alias))
-                && !tag.tag.trim().is_empty()
+                && !tag_display_value(tag).is_empty()
         })
-        .map(|tag| tag.tag.trim().to_string())
+        .map(tag_display_value)
         .collect::<Vec<_>>()
         .join(", ")
+}
+
+fn tag_display_value(tag: &TagInfo) -> String {
+    let label = tag.label.trim();
+    if label.is_empty() {
+        tag.tag.trim().to_string()
+    } else {
+        label.to_string()
+    }
 }
 
 fn clear_current_detail_state(mut model: Pin<&mut ffi::RecentsModel>) {
@@ -1137,7 +1299,7 @@ mod tests {
 
     use super::{
         compute_unresolved_keys, cover_key_for_with, dedupe_latest_by_path, filter_entries_by_path,
-        launch_text_for, media_key_for, position_of_path, project, resume_cover_key_for,
+        launch_text_for, media_key_for, page_snapshot, position_of_path, resume_cover_key_for,
         resume_entry, resume_entry_is_fresh, RESUME_FALLBACK_COVER_KEY,
     };
     use crate::media_image_cache::{MediaImageCache, MediaKey};
@@ -1147,7 +1309,6 @@ mod tests {
         OffsetDateTime,
     };
     use zaparoo_core::media_types::{MediaHistoryEntry, MediaHistoryResult, Pagination};
-    use zaparoo_core::remote_resource::ResourceStatus;
 
     fn entry(name: &str, path: &str, system_id: &str, launcher_id: &str) -> MediaHistoryEntry {
         MediaHistoryEntry {
@@ -1398,21 +1559,7 @@ mod tests {
     }
 
     #[test]
-    fn project_idle_yields_empty_pending() {
-        let (page, err) = project(&ResourceStatus::Idle);
-        assert!(page.is_none());
-        assert!(err.is_empty());
-    }
-
-    #[test]
-    fn project_loading_yields_empty_pending() {
-        let (page, err) = project(&ResourceStatus::Loading);
-        assert!(page.is_none());
-        assert!(err.is_empty());
-    }
-
-    #[test]
-    fn project_ready_carries_entries_and_pagination() {
+    fn page_snapshot_carries_entries_and_pagination() {
         let result = MediaHistoryResult {
             entries: vec![entry("smb", "/p/smb", "NES", "NES")],
             pagination: Some(Pagination {
@@ -1421,9 +1568,7 @@ mod tests {
                 next_cursor: Some("cursor-2".into()),
             }),
         };
-        let (page, err) = project(&ResourceStatus::Ready(result));
-        assert!(err.is_empty());
-        let (entries, has_next, cursor) = page.expect("ready snapshot");
+        let (entries, has_next, cursor) = page_snapshot(&result);
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].media_path, "/p/smb");
         assert!(has_next);
@@ -1431,28 +1576,16 @@ mod tests {
     }
 
     #[test]
-    fn project_ready_without_pagination_disarms_next_page() {
+    fn page_snapshot_without_pagination_disarms_next_page() {
         // Core docs say pagination is omitted when no entries are
-        // returned. The projection must surface that as `has_next_page
+        // returned. The snapshot must surface that as `has_next_page
         // = false` so the model disarms `fetch_more` instead of looping
         // on a stale cursor.
         let result = MediaHistoryResult::default();
-        let (page, err) = project(&ResourceStatus::Ready(result));
-        assert!(err.is_empty());
-        let (entries, has_next, cursor) = page.expect("ready snapshot");
+        let (entries, has_next, cursor) = page_snapshot(&result);
         assert!(entries.is_empty());
         assert!(!has_next);
         assert!(cursor.is_none());
-    }
-
-    #[test]
-    fn project_errored_carries_message_with_no_snapshot() {
-        let (page, err) = project(&ResourceStatus::Errored {
-            message: "rpc kaboom".into(),
-            retrying: true,
-        });
-        assert!(page.is_none());
-        assert_eq!(err, "rpc kaboom");
     }
 
     #[test]

--- a/rust/frontend/src/models/tag_utils.rs
+++ b/rust/frontend/src/models/tag_utils.rs
@@ -1,0 +1,14 @@
+// Zaparoo Frontend
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+use zaparoo_core::media_types::TagInfo;
+
+pub fn tag_display_value(tag: &TagInfo) -> String {
+    let label = tag.label.trim();
+    if label.is_empty() {
+        tag.tag.trim().to_string()
+    } else {
+        label.to_string()
+    }
+}

--- a/rust/mock-core/src/fixtures.rs
+++ b/rust/mock-core/src/fixtures.rs
@@ -181,6 +181,20 @@ pub fn media_browse_response(params: &Value) -> Value {
     })
 }
 
+pub fn media_history_latest_response() -> Value {
+    let (name, file, system) = ALL_GAMES[0];
+    json!({
+        "entry": {
+            "systemId": system,
+            "systemName": system_display_for(system),
+            "mediaName": name,
+            "mediaPath": format!("/mock/{system}/{file}"),
+            "launcherId": system,
+            "startedAt": "2026-04-29T23:00:00Z",
+        }
+    })
+}
+
 pub fn media_history_response(params: &Value) -> Value {
     let systems = params
         .get("systems")

--- a/rust/mock-core/src/handler.rs
+++ b/rust/mock-core/src/handler.rs
@@ -64,6 +64,7 @@ pub fn dispatch(text: &str) -> String {
         "media.search" => Some(fixtures::media_search_response(&req.params)),
         "media.browse" => Some(fixtures::media_browse_response(&req.params)),
         "media.history" => Some(fixtures::media_history_response(&req.params)),
+        "media.history.latest" => Some(fixtures::media_history_latest_response()),
         "run" => {
             let zap_script = req.params.get("text").and_then(Value::as_str).unwrap_or("");
             info!(%zap_script, "run");
@@ -249,6 +250,19 @@ mod tests {
             .as_object()
             .expect("pagination object");
         assert_eq!(pagination["hasNextPage"], Value::Bool(false));
+    }
+
+    #[test]
+    fn media_history_latest_returns_latest_entry() {
+        let req = r#"{"jsonrpc":"2.0","id":"1","method":"media.history.latest"}"#;
+        let resp = parse(&dispatch(req));
+        let entry = resp["result"]["entry"].as_object().expect("entry object");
+        assert!(entry["mediaName"].is_string());
+        assert!(entry["mediaPath"].is_string());
+        assert!(entry["systemId"].is_string());
+        assert!(entry["systemName"].is_string());
+        assert!(entry["launcherId"].is_string());
+        assert!(entry["startedAt"].is_string());
     }
 
     #[test]

--- a/rust/zaparoo-core/src/client.rs
+++ b/rust/zaparoo-core/src/client.rs
@@ -15,10 +15,10 @@
 
 use crate::media_types::{
     HealthResult, LaunchersResult, LogDownloadResult, MediaBrowseParams, MediaBrowseResult,
-    MediaHistoryParams, MediaHistoryResult, MediaHistoryTopParams, MediaHistoryTopResult,
-    MediaImageParams, MediaImageResult, MediaIndexParams, MediaLookupParams, MediaLookupResult,
-    MediaMetaParams, MediaMetaResult, MediaResult, MediaScrapeParams, MediaSearchParams,
-    MediaSearchResult, MediaTagsParams, MediaTagsResult, MediaTagsUpdateParams,
+    MediaHistoryLatestResult, MediaHistoryParams, MediaHistoryResult, MediaHistoryTopParams,
+    MediaHistoryTopResult, MediaImageParams, MediaImageResult, MediaIndexParams, MediaLookupParams,
+    MediaLookupResult, MediaMetaParams, MediaMetaResult, MediaResult, MediaScrapeParams,
+    MediaSearchParams, MediaSearchResult, MediaTagsParams, MediaTagsResult, MediaTagsUpdateParams,
     MediaTagsUpdateResult, ReadersResult, ReadersWriteParams, RunParams, ScrapersResult,
     ScrapingStatusResponse, SettingsResult, SystemsParams, SystemsResult, TokensHistoryResult,
     TokensResult, UpdateSettingsParams, VersionResult,
@@ -634,6 +634,16 @@ impl Client {
             .and_then(Value::as_array)
             .map_or(0, Vec::len);
         debug!(entries_len, "media.history response");
+        serde_json::from_value(val).map_err(|e| ClientError {
+            message: e.to_string(),
+        })
+    }
+
+    /// Fetches the latest play-history row without media DB enrichment.
+    pub async fn media_history_latest(&self) -> Result<MediaHistoryLatestResult, ClientError> {
+        let val = self
+            .call("media.history.latest", &serde_json::json!({}))
+            .await?;
         serde_json::from_value(val).map_err(|e| ClientError {
             message: e.to_string(),
         })

--- a/rust/zaparoo-core/src/media_types.rs
+++ b/rust/zaparoo-core/src/media_types.rs
@@ -55,6 +55,8 @@ pub struct TagInfo {
     pub tag: String,
     #[serde(rename = "type", default)]
     pub tag_type: String,
+    #[serde(default)]
+    pub label: String,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -316,6 +318,30 @@ impl MediaHistoryResult {
     pub fn next_cursor(&self) -> Option<String> {
         self.pagination.as_ref().and_then(|p| p.next_cursor.clone())
     }
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MediaHistoryLatestEntry {
+    #[serde(default)]
+    pub system_id: String,
+    #[serde(default)]
+    pub system_name: String,
+    #[serde(default)]
+    pub media_name: String,
+    #[serde(default)]
+    pub media_path: String,
+    #[serde(default)]
+    pub launcher_id: String,
+    #[serde(default)]
+    pub started_at: String,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MediaHistoryLatestResult {
+    #[serde(default)]
+    pub entry: Option<MediaHistoryLatestEntry>,
 }
 
 /// Parameters for single-image `media.image`. Core identifies the
@@ -995,13 +1021,13 @@ mod tests {
 
     use super::{
         BrowseEntry, HealthResult, IndexingStatusResponse, LaunchersResult, LogDownloadResult,
-        MediaBrowseParams, MediaBrowseResult, MediaHistoryParams, MediaHistoryResult,
-        MediaHistoryTopParams, MediaHistoryTopResult, MediaImageParams, MediaImageResult,
-        MediaIndexParams, MediaLookupParams, MediaLookupResult, MediaMetaParams, MediaMetaResult,
-        MediaResult, MediaScrapeParams, MediaSearchParams, MediaSearchResult, MediaTagsParams,
-        MediaTagsResult, ReaderInfo, ReadersResult, ScrapersResult, ScrapingStatusResponse,
-        SettingsResult, SystemDefault, SystemsResult, TokensHistoryResult, TokensResult,
-        UpdateSettingsParams, VersionResult,
+        MediaBrowseParams, MediaBrowseResult, MediaHistoryLatestResult, MediaHistoryParams,
+        MediaHistoryResult, MediaHistoryTopParams, MediaHistoryTopResult, MediaImageParams,
+        MediaImageResult, MediaIndexParams, MediaLookupParams, MediaLookupResult, MediaMetaParams,
+        MediaMetaResult, MediaResult, MediaScrapeParams, MediaSearchParams, MediaSearchResult,
+        MediaTagsParams, MediaTagsResult, ReaderInfo, ReadersResult, ScrapersResult,
+        ScrapingStatusResponse, SettingsResult, SystemDefault, SystemsResult, TagInfo,
+        TokensHistoryResult, TokensResult, UpdateSettingsParams, VersionResult,
     };
 
     #[test]
@@ -1337,6 +1363,46 @@ mod tests {
         let result: MediaHistoryResult = serde_json::from_str("{}").expect("parse");
         assert!(result.entries.is_empty());
         assert!(result.pagination.is_none());
+    }
+
+    #[test]
+    fn media_history_latest_result_parses_documented_payload() {
+        let json = r#"{
+            "entry": {
+                "systemId": "SNES",
+                "systemName": "Super Nintendo Entertainment System",
+                "mediaName": "Super Mario World",
+                "mediaPath": "/roms/snes/Super Mario World (USA).sfc",
+                "launcherId": "SNES",
+                "startedAt": "2025-01-22T14:30:00Z"
+            }
+        }"#;
+        let result: MediaHistoryLatestResult = serde_json::from_str(json).expect("parse");
+        let entry = result.entry.expect("entry");
+        assert_eq!(entry.system_id, "SNES");
+        assert_eq!(entry.media_name, "Super Mario World");
+        assert_eq!(entry.media_path, "/roms/snes/Super Mario World (USA).sfc");
+        assert_eq!(entry.launcher_id, "SNES");
+        assert_eq!(entry.started_at, "2025-01-22T14:30:00Z");
+    }
+
+    #[test]
+    fn media_history_latest_result_handles_no_entry() {
+        let result: MediaHistoryLatestResult =
+            serde_json::from_str(r#"{"entry":null}"#).expect("parse");
+        assert!(result.entry.is_none());
+        let result: MediaHistoryLatestResult = serde_json::from_str("{}").expect("parse");
+        assert!(result.entry.is_none());
+    }
+
+    #[test]
+    fn tag_info_parses_label() {
+        let tag: TagInfo =
+            serde_json::from_str(r#"{"type":"developer","tag":"nintendo","label":"Nintendo"}"#)
+                .expect("parse");
+        assert_eq!(tag.tag_type, "developer");
+        assert_eq!(tag.tag, "nintendo");
+        assert_eq!(tag.label, "Nintendo");
     }
 
     #[test]

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -608,7 +608,7 @@ MainLayout {
     function _maybeCompletePendingResumeLaunch(): void {
         if (!root._pendingResumeLaunch || root.pendingTransition !== "resume")
             return;
-        if (Browse.RecentsModel.loading)
+        if (Browse.RecentsModel.resume_loading)
             return;
         if (Browse.RecentsModel.resume_available) {
             root._pendingResumeLaunch = false;
@@ -627,11 +627,11 @@ MainLayout {
     }
 
     function _navigateResumeFromHub(): void {
-        if (!Browse.RecentsModel.loading && Browse.RecentsModel.resume_available) {
+        if (!Browse.RecentsModel.resume_loading && Browse.RecentsModel.resume_available) {
             Browse.RecentsModel.launch_resume();
             return;
         }
-        if (Browse.RecentsModel.loading || Browse.AppStatus.connection_state !== 2) {
+        if (Browse.RecentsModel.resume_loading || Browse.AppStatus.connection_state !== 2) {
             root.pendingTransition = "resume";
             resumeLaunchTimer.restart();
             return;
@@ -675,17 +675,18 @@ MainLayout {
         root._completeTransition(root.screenRecents);
     }
 
-    // Hub → Recents transition. RecentsModel binds eagerly via
-    // bind_to_endpoint!, so on a warm launch the resource is already
-    // Ready and the callback fires synchronously. On a cold launch
-    // with a slow Core link we wait on `loadingChanged` so the user
-    // sees the centred "Loading…" cue rather than an empty grid.
+    // Hub → Recents transition. The paginated history load is lazy so
+    // Hub Resume does not pay for `media.history` during startup. Start
+    // it only once the Recents screen is actually requested, then wait
+    // on `loadingChanged` so the user sees the centred "Loading…" cue
+    // rather than an empty grid.
     function _startRecentsTransitionLoad(): void {
         if (root.pendingTransition !== "recents")
             return;
         root._whenScreenReady(root.screenRecents, function () {
             if (root.pendingTransition !== "recents")
                 return;
+            Browse.RecentsModel.ensure_loaded();
             root._resumeRecentsCovers();
             if (root._catalogStillBooting())
                 return;

--- a/src/ui/components/BrowseDetailPane.qml
+++ b/src/ui/components/BrowseDetailPane.qml
@@ -21,6 +21,7 @@ Item {
     property bool detailSuppressed: false
     property bool showChrome: true
     property string loadingText: qsTr("Loading…")
+    property int loadingDelayMs: 150
     property var layoutProfile: null
 
     readonly property var _detail: root.layoutProfile && root.layoutProfile.detail ? root.layoutProfile.detail : null
@@ -58,7 +59,10 @@ Item {
     readonly property int _carouselGutter: (canPreviousImage || canNextImage) ? Sizing.pctW(4) : 0
     readonly property bool _coverPending: coverKey === "icons/Loading"
     readonly property url _coverSource: _coverPending ? "" : Resources.coverUrl(coverKey)
+    readonly property bool _coverBusy: root._coverPending || cover.status === Image.Loading
     readonly property bool _paneLoading: root.loading
+    readonly property bool _delayedPaneLoading: root._paneLoading && root._paneLoadingDelayElapsed
+    readonly property bool _delayedCoverBusy: root._coverBusy && root._coverLoadingDelayElapsed
     readonly property bool _detailVisible: !root._paneLoading && !root.detailSuppressed
     readonly property bool _suppressedPlaceholderCover: root.detailSuppressed && coverKey.startsWith("icons/") && root._coverSource !== ""
     readonly property var _detailRows: _parseDetailTags(detailTags)
@@ -69,8 +73,56 @@ Item {
     readonly property int _compactMetadataHeight: Math.min(Sizing.px(content.height * 0.38), _metadataNaturalHeight)
 
     property int _labelColumnWidth: 0
+    property bool _paneLoadingDelayElapsed: false
+    property bool _coverLoadingDelayElapsed: false
 
     onDetailTagsChanged: root._labelColumnWidth = 0
+    onLoadingChanged: root._updatePaneLoadingDelay()
+    onLoadingDelayMsChanged: {
+        root._updatePaneLoadingDelay();
+        root._updateCoverLoadingDelay();
+    }
+    on_CoverBusyChanged: root._updateCoverLoadingDelay()
+
+    Timer {
+        id: paneLoadingDelayTimer
+
+        interval: Math.max(0, root.loadingDelayMs)
+        repeat: false
+        onTriggered: root._paneLoadingDelayElapsed = root._paneLoading
+    }
+
+    Timer {
+        id: coverLoadingDelayTimer
+
+        interval: Math.max(0, root.loadingDelayMs)
+        repeat: false
+        onTriggered: root._coverLoadingDelayElapsed = root._coverBusy
+    }
+
+    function _updatePaneLoadingDelay(): void {
+        paneLoadingDelayTimer.stop();
+        root._paneLoadingDelayElapsed = false;
+        if (!root._paneLoading)
+            return;
+        if (root.loadingDelayMs <= 0) {
+            root._paneLoadingDelayElapsed = true;
+            return;
+        }
+        paneLoadingDelayTimer.restart();
+    }
+
+    function _updateCoverLoadingDelay(): void {
+        coverLoadingDelayTimer.stop();
+        root._coverLoadingDelayElapsed = false;
+        if (!root._coverBusy)
+            return;
+        if (root.loadingDelayMs <= 0) {
+            root._coverLoadingDelayElapsed = true;
+            return;
+        }
+        coverLoadingDelayTimer.restart();
+    }
 
     function _localizedTagLabel(label: string): string {
         if (label === "Year")
@@ -183,13 +235,13 @@ Item {
                     y: Sizing.center(parent.height, height)
                     width: Math.min(Sizing.pctH(10), parent.width, parent.height)
                     height: width
-                    source: Resources.iconUrl(root._coverPending || cover.status === Image.Loading ? "Loading" : "File")
+                    source: Resources.iconUrl(root._coverBusy ? "Loading" : "File")
                     sourceSize.width: Sizing.px(width)
                     sourceSize.height: Sizing.px(height)
                     fillMode: Image.PreserveAspectFit
                     smooth: true
                     asynchronous: false
-                    visible: !root._paneLoading && !root._suppressedPlaceholderCover && (root.detailSuppressed || root._coverPending || cover.status === Image.Loading || root._coverSource === "" || cover.status === Image.Error)
+                    visible: !root._paneLoading && !root._suppressedPlaceholderCover && (root.detailSuppressed || root._delayedCoverBusy || (!root._coverBusy && (root._coverSource === "" || cover.status === Image.Error)))
                 }
             }
         }
@@ -345,7 +397,7 @@ Item {
         }
 
         LoadingIndicator {
-            visible: root._paneLoading && !root.detailSuppressed
+            visible: root._delayedPaneLoading && !root.detailSuppressed
             x: Sizing.center(parent.width, width)
             y: Sizing.center(parent.height, height)
             text: root.loadingText

--- a/src/ui/screens/HubScreen.qml
+++ b/src/ui/screens/HubScreen.qml
@@ -117,7 +117,7 @@ Item {
     readonly property int _blockHeight: 2 * (categoriesRow.cellHeight + 2 * categoriesRow.verticalPadding) + (categoriesRow.spacing - categoriesRow.verticalPadding - actionsRow.verticalPadding) + Sizing.pctH(3) + Sizing.pctH(7)
     readonly property int _blockY: Math.round((Sizing.headerBottom + hub.height - Sizing.pctH(6) - hub._blockHeight) / 2)
 
-    readonly property bool resumeKnownUnavailable: !Browse.RecentsModel.loading && !Browse.RecentsModel.resume_available && Browse.AppStatus.connection_state === 2
+    readonly property bool resumeKnownUnavailable: !Browse.RecentsModel.resume_loading && !Browse.RecentsModel.resume_available && Browse.AppStatus.connection_state === 2
     readonly property bool resumeActionVisible: !hub.resumeKnownUnavailable
 
     // Action-row data. Resume is visible by default while Core history


### PR DESCRIPTION
## Summary
- fetch the Hub Resume item through `media.history.latest` instead of loading the full Recents page during startup
- lazily load paginated Recents when the Recents screen opens
- display tag labels in detail metadata and delay short-lived detail loading cues to reduce flicker

## Tests
- `just fmt`
- `just lint`
- `just test-qml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lazy-loading of Recents with an explicit resume-loading indicator and an ensure-loaded trigger
  * New “latest media history” support surface (resume entry retrieval)

* **Improvements**
  * Configurable loading delay for detail views (150ms default) for smoother visuals
  * Tag display now prefers descriptive labels over raw tag text
  * More accurate resume availability detection and launch behavior in the Hub/Recents flow
<!-- end of auto-generated comment: release notes by coderabbit.ai -->