### PR TITLE
Polish CRT metadata, settings, and media actions

### DIFF
--- a/cmake/ZaparooRust.cmake
+++ b/cmake/ZaparooRust.cmake
@@ -166,6 +166,7 @@ qt_add_translations(
     "${CMAKE_SOURCE_DIR}/src/ui/translations/frontend_en.ts"
     "${CMAKE_SOURCE_DIR}/src/ui/translations/frontend_it.ts"
     "${CMAKE_SOURCE_DIR}/src/ui/translations/frontend_es.ts"
+    "${CMAKE_SOURCE_DIR}/src/ui/translations/frontend_eu.ts"
     "${CMAKE_SOURCE_DIR}/src/ui/translations/frontend_de.ts"
     "${CMAKE_SOURCE_DIR}/src/ui/translations/frontend_el.ts"
     "${CMAKE_SOURCE_DIR}/src/ui/translations/frontend_ja.ts"

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -156,6 +156,7 @@ other locales fall through to the source strings.
 |---|---|
 | Italian (`it_IT`) | Andrea Bogazzi ([@asturur](https://github.com/asturur)) |
 | Spanish (`es_ES`) | Carlos R. ([@crodriguezdominguez](https://github.com/crodriguezdominguez)) |
+| Basque (`eu`) | devilschile2 |
 
 Translators are added to this table when their `.ts` file is merged. Names
 also appear on the About screen so end users see them.

--- a/rust/frontend/src/models/media_status.rs
+++ b/rust/frontend/src/models/media_status.rs
@@ -113,10 +113,16 @@ pub mod ffi {
         fn start_index(self: Pin<&mut MediaStatus>);
 
         #[qinvokable]
+        fn start_index_for_system(self: Pin<&mut MediaStatus>, system_id: QString);
+
+        #[qinvokable]
         fn cancel_index(self: Pin<&mut MediaStatus>);
 
         #[qinvokable]
         fn start_scrape(self: Pin<&mut MediaStatus>, force: bool);
+
+        #[qinvokable]
+        fn start_scrape_for_system(self: Pin<&mut MediaStatus>, system_id: QString);
 
         #[qinvokable]
         fn cancel_scrape(self: Pin<&mut MediaStatus>);
@@ -229,6 +235,23 @@ impl ffi::MediaStatus {
         });
     }
 
+    fn start_index_for_system(self: Pin<&mut Self>, system_id: QString) {
+        let system_id: String = system_id.into();
+        if system_id.is_empty() {
+            warn!("media_status: start_index_for_system ignored empty system_id");
+            return;
+        }
+        let resource = crate::models::global_store().media_status();
+        crate::models::global_handle().spawn(async move {
+            let params = MediaIndexParams {
+                systems: Some(vec![system_id]),
+            };
+            if let Err(e) = resource.start_index(params).await {
+                warn!("media_status: start_index_for_system failed: {}", e.message);
+            }
+        });
+    }
+
     fn cancel_index(self: Pin<&mut Self>) {
         let resource = crate::models::global_store().media_status();
         crate::models::global_handle().spawn(async move {
@@ -257,6 +280,28 @@ impl ffi::MediaStatus {
             };
             if let Err(e) = resource.start_scrape(params).await {
                 warn!("media_status: start_scrape failed: {}", e.message);
+            }
+        });
+    }
+
+    fn start_scrape_for_system(self: Pin<&mut Self>, system_id: QString) {
+        let system_id: String = system_id.into();
+        if system_id.is_empty() {
+            warn!("media_status: start_scrape_for_system ignored empty system_id");
+            return;
+        }
+        let resource = crate::models::global_store().media_status();
+        crate::models::global_handle().spawn(async move {
+            let params = MediaScrapeParams {
+                scraper_id: "gamelist.xml".into(),
+                systems: vec![system_id],
+                force: false,
+            };
+            if let Err(e) = resource.start_scrape(params).await {
+                warn!(
+                    "media_status: start_scrape_for_system failed: {}",
+                    e.message
+                );
             }
         });
     }

--- a/rust/frontend/src/models/settings.rs
+++ b/rust/frontend/src/models/settings.rs
@@ -87,8 +87,8 @@ const MISTER_RESOLUTIONS: &[&str] = &[
     "2048x1536",
 ];
 const LANGUAGES: &[&str] = &[
-    "auto", "en", "it_IT", "de", "el", "ja", "ko", "nl", "ro", "sk", "uk", "zh_CN", "he", "ar",
-    "hi",
+    "auto", "en", "it_IT", "es", "eu", "de", "el", "ja", "ko", "nl", "ro", "sk", "uk", "zh_CN",
+    "he", "ar", "hi",
 ];
 const DEFAULT_LANGUAGE: &str = "auto";
 const ORIENTATIONS: &[&str] = &["horizontal", "cw", "ccw"];

--- a/rust/frontend/src/models/settings.rs
+++ b/rust/frontend/src/models/settings.rs
@@ -87,8 +87,9 @@ const MISTER_RESOLUTIONS: &[&str] = &[
     "2048x1536",
 ];
 const LANGUAGES: &[&str] = &[
-    "auto", "en", "it_IT", "es", "eu", "de", "el", "ja", "ko", "nl", "ro", "sk", "uk", "zh_CN",
-    "he", "ar", "hi",
+    "auto", "en", "en_US", "en_GB", "it_IT", "es", "es_ES", "eu", "eu_ES", "de", "de_DE", "el",
+    "el_GR", "ja", "ja_JP", "ko", "ko_KR", "nl", "nl_NL", "ro", "ro_RO", "sk", "sk_SK", "uk",
+    "uk_UA", "zh_CN", "zh_TW", "zh_HK", "he", "he_IL", "ar", "ar_SA", "hi", "hi_IN",
 ];
 const DEFAULT_LANGUAGE: &str = "auto";
 const ORIENTATIONS: &[&str] = &["horizontal", "cw", "ccw"];
@@ -729,6 +730,8 @@ mod tests {
         assert_eq!(normalize_language("AUTO"), DEFAULT_LANGUAGE);
         assert_eq!(normalize_language("fr"), DEFAULT_LANGUAGE);
         assert_eq!(normalize_language("it_IT"), "it_IT");
+        assert_eq!(normalize_language("es_ES"), "es_ES");
+        assert_eq!(normalize_language("eu_ES"), "eu_ES");
     }
 
     #[test]

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -1212,6 +1212,16 @@ MainLayout {
                     label: qsTr("Change launcher")
                 });
             }
+            const mediaBusy = Browse.MediaStatus.indexing || Browse.MediaStatus.optimizing || Browse.MediaStatus.scraping;
+            if (!mediaBusy) {
+                entries.push({
+                    id: "index_system",
+                    label: qsTr("Update media database")
+                }, {
+                    id: "scrape_system",
+                    label: qsTr("Scrape metadata")
+                });
+            }
             return entries;
         }
         if (owner === "recents") {
@@ -1414,6 +1424,14 @@ MainLayout {
                 Browse.AlternateVersions.launch_at(altIndex);
         } else if (id === "launch_system") {
             Browse.SystemsModel.launch_at(targetIndex);
+        } else if (id === "index_system") {
+            const systemId = Browse.SystemsModel.system_id_at(targetIndex);
+            if (systemId !== "")
+                Browse.MediaStatus.start_index_for_system(systemId);
+        } else if (id === "scrape_system") {
+            const systemId = Browse.SystemsModel.system_id_at(targetIndex);
+            if (systemId !== "")
+                Browse.MediaStatus.start_scrape_for_system(systemId);
         } else if (id === "launch_game") {
             if (owner === "favorites")
                 Browse.FavoritesModel.launch_at(targetIndex);

--- a/src/ui/app/MainLayout.qml
+++ b/src/ui/app/MainLayout.qml
@@ -702,6 +702,7 @@ ApplicationWindow {
 
             Loader {
                 id: contextMenuLoader
+                anchors.fill: parent
                 active: root.contextMenuRequested
                 sourceComponent: Component {
                     ContextMenu {

--- a/src/ui/components/BrowseDetailPane.qml
+++ b/src/ui/components/BrowseDetailPane.qml
@@ -69,14 +69,16 @@ Item {
     readonly property int _tagRowCount: _detailRows.length
     readonly property int _tagTextSize: Sizing.fontSize(2.2)
     readonly property int _tagLabelGap: Sizing.pctW(1.4)
+    readonly property int _metadataLabelMaxWidth: root._detail && root._detail.metadataLabelMaxWidth !== undefined ? root._detail.metadataLabelMaxWidth : 0
+    readonly property int _labelColumnWidth: root._metadataLabelMaxWidth > 0 ? Math.min(root._labelColumnNaturalWidth, root._metadataLabelMaxWidth) : root._labelColumnNaturalWidth
     readonly property int _metadataNaturalHeight: _tagRowCount <= 0 ? 0 : (_tagRowCount * _tagRowHeight) + ((_tagRowCount - 1) * _tagRowSpacing)
     readonly property int _compactMetadataHeight: Math.min(Sizing.px(content.height * 0.38), _metadataNaturalHeight)
 
-    property int _labelColumnWidth: 0
+    property int _labelColumnNaturalWidth: 0
     property bool _paneLoadingDelayElapsed: false
     property bool _coverLoadingDelayElapsed: false
 
-    onDetailTagsChanged: root._labelColumnWidth = 0
+    onDetailTagsChanged: root._labelColumnNaturalWidth = 0
     onLoadingChanged: root._updatePaneLoadingDelay()
     onLoadingDelayMsChanged: {
         root._updatePaneLoadingDelay();
@@ -124,26 +126,36 @@ Item {
         coverLoadingDelayTimer.restart();
     }
 
-    function _localizedTagLabel(label: string): string {
+    function _tagLabel(fullLabel: string, shortLabel: string): var {
+        return {
+            "label": fullLabel + "\u009C" + shortLabel,
+            "measureLabel": fullLabel
+        };
+    }
+
+    function _localizedTagLabel(label: string): var {
         if (label === "Year")
-            return qsTr("Year");
+            return root._tagLabel(qsTr("Year"), qsTr("Yr", "Short metadata label for Year; keep 2-4 characters if possible"));
         if (label === "Genre")
-            return qsTr("Genre");
+            return root._tagLabel(qsTr("Genre"), qsTr("Gen", "Short metadata label for Genre; keep 2-4 characters if possible"));
         if (label === "Players")
-            return qsTr("Players");
+            return root._tagLabel(qsTr("Players"), qsTr("Plyr", "Short metadata label for Players; keep 2-4 characters if possible"));
         if (label === "Developer")
-            return qsTr("Developer");
+            return root._tagLabel(qsTr("Developer"), qsTr("Dev", "Short metadata label for Developer; keep 2-4 characters if possible"));
         if (label === "Publisher")
-            return qsTr("Publisher");
+            return root._tagLabel(qsTr("Publisher"), qsTr("Pub", "Short metadata label for Publisher; keep 2-4 characters if possible"));
         if (label === "Rating")
-            return qsTr("Rating");
+            return root._tagLabel(qsTr("Rating"), qsTr("Rtg", "Short metadata label for Rating; keep 2-4 characters if possible"));
         if (label === "Category")
-            return qsTr("Category");
+            return root._tagLabel(qsTr("Category"), qsTr("Cat", "Short metadata label for Category; keep 2-4 characters if possible"));
         if (label === "Release date")
-            return qsTr("Release date");
+            return root._tagLabel(qsTr("Release date"), qsTr("Date", "Short metadata label for Release date; keep 2-4 characters if possible"));
         if (label === "Manufacturer")
-            return qsTr("Manufacturer");
-        return label;
+            return root._tagLabel(qsTr("Manufacturer"), qsTr("Mfr", "Short metadata label for Manufacturer; keep 2-4 characters if possible"));
+        return {
+            "label": label,
+            "measureLabel": label
+        };
     }
 
     function _parseDetailTags(tags: string): var {
@@ -152,9 +164,11 @@ Item {
         return tags.split("\n").map(row => {
             const parts = row.split("\t");
             const rawLabel = parts.length > 0 ? parts[0] : "";
+            const label = root._localizedTagLabel(rawLabel);
             return {
                 "rawLabel": rawLabel,
-                "label": root._localizedTagLabel(rawLabel),
+                "label": label.label,
+                "measureLabel": label.measureLabel,
                 "value": parts.length > 1 ? parts[1] : ""
             };
         });
@@ -348,18 +362,19 @@ Item {
                                 height: root._tagRowHeight
 
                                 readonly property string label: modelData.label ?? ""
+                                readonly property string measureLabel: modelData.measureLabel ?? tagRow.label
                                 readonly property string value: modelData.value ?? ""
 
                                 TextMetrics {
                                     id: labelMetrics
 
-                                    text: tagRow.label
+                                    text: tagRow.measureLabel
                                     font.family: Theme.fontUi
                                     font.pixelSize: root._tagTextSize
-                                    onAdvanceWidthChanged: root._labelColumnWidth = Math.max(root._labelColumnWidth, Math.ceil(advanceWidth))
+                                    onAdvanceWidthChanged: root._labelColumnNaturalWidth = Math.max(root._labelColumnNaturalWidth, Math.ceil(advanceWidth))
                                 }
 
-                                Component.onCompleted: root._labelColumnWidth = Math.max(root._labelColumnWidth, Math.ceil(labelMetrics.advanceWidth))
+                                Component.onCompleted: root._labelColumnNaturalWidth = Math.max(root._labelColumnNaturalWidth, Math.ceil(labelMetrics.advanceWidth))
 
                                 Text {
                                     anchors.left: parent.left
@@ -369,6 +384,7 @@ Item {
                                     color: Theme.textLabel
                                     font.family: Theme.fontUi
                                     font.pixelSize: root._tagTextSize
+                                    textFormat: Text.PlainText
                                     elide: Text.ElideRight
                                     horizontalAlignment: Text.AlignRight
                                     renderType: Text.NativeRendering

--- a/src/ui/components/CoreStatusPill.qml
+++ b/src/ui/components/CoreStatusPill.qml
@@ -18,9 +18,10 @@ import QtQuick
 import Zaparoo.Browse as Browse
 import Zaparoo.Theme
 
-// Software-renderer safe: a single Rectangle with two Text children,
-// no animations, no shaders. Counter and step text update via plain
-// property bindings so the dirty rect is bounded to the pill.
+// Software-rendering safe status pill. Connection states keep the compact
+// text-only treatment; active media work switches to a fixed-width progress
+// pill with a tiny local spinner and clipped inverted foreground over the
+// fill. Only this small item repaints while the spinner advances.
 Item {
     id: pill
     property bool mediaActivityEnabled: false
@@ -37,12 +38,10 @@ Item {
     readonly property int _linkReconnecting: 3
     readonly property int _linkUnreachable: 4
     readonly property int _connError: 3
-    // Resolved (priority, label) for the current state. Empty `text`
-    // means "nothing interesting is happening" and the pill hides.
-    readonly property string _label: {
+    readonly property string _connectionLabel: {
         const link = Browse.AppStatus.link_state ?? pill._linkDisconnected;
         const conn = Browse.AppStatus.connection_state ?? pill._linkDisconnected;
-        // Priority 1 — Core link state.
+
         if (link === pill._linkUnreachable)
             return qsTr("Disconnected");
 
@@ -58,75 +57,221 @@ Item {
         if (conn === pill._connError)
             return qsTr("Core error");
 
-        // Priority 2 — media database.
-        if (pill.mediaActivityEnabled) {
-            if (Browse.MediaStatus.optimizing)
-                return qsTr("Optimizing database");
-
-            if (Browse.MediaStatus.indexing) {
-                const cur = Browse.MediaStatus.current_step;
-                const tot = Browse.MediaStatus.total_steps;
-                const display = Browse.MediaStatus.current_step_display;
-                if (Browse.MediaStatus.paused)
-                    return qsTr("Indexing paused");
-
-                if (tot > 0 && display !== "")
-                    return qsTr("Indexing %1/%2 - %3").arg(cur).arg(tot).arg(display);
-
-                if (tot > 0)
-                    return qsTr("Indexing %1/%2").arg(cur).arg(tot);
-
-                return qsTr("Indexing…");
-            }
-            // Priority 3 — scraper.
-            if (Browse.MediaStatus.scraping) {
-                const cur = Browse.MediaStatus.scrape_current_step;
-                const tot = Browse.MediaStatus.scrape_total_steps;
-                const display = Browse.MediaStatus.scrape_current_step_display;
-                if (Browse.MediaStatus.scrape_paused)
-                    return qsTr("Scrape paused");
-
-                if (tot > 0 && display !== "")
-                    return qsTr("Scraping %1/%2 - %3").arg(cur).arg(tot).arg(display);
-
-                if (tot > 0)
-                    return qsTr("Scraping %1/%2").arg(cur).arg(tot);
-
-                return qsTr("Scraping…");
-            }
-        }
         return "";
     }
+    readonly property bool _isMediaActivity: pill.mediaActivityEnabled && pill._connectionLabel === "" && (Browse.MediaStatus.optimizing || Browse.MediaStatus.indexing || Browse.MediaStatus.scraping)
+    readonly property bool _mediaPaused: Browse.MediaStatus.indexing ? Browse.MediaStatus.paused : (Browse.MediaStatus.scraping ? Browse.MediaStatus.scrape_paused : false)
+    readonly property int _progressCurrent: Browse.MediaStatus.indexing ? Browse.MediaStatus.current_step : (Browse.MediaStatus.scraping ? Browse.MediaStatus.scrape_current_step : 0)
+    readonly property int _progressTotal: Browse.MediaStatus.indexing ? Browse.MediaStatus.total_steps : (Browse.MediaStatus.scraping ? Browse.MediaStatus.scrape_total_steps : 0)
+    readonly property real _progressFraction: pill._progressTotal > 0 ? Math.max(0, Math.min(1, pill._progressCurrent / pill._progressTotal)) : 0
+    readonly property bool _spinnerActive: pill._isMediaActivity && !pill._mediaPaused
+    readonly property string _mediaLabel: {
+        const cur = pill._progressCurrent;
+        const tot = pill._progressTotal;
+        const known = tot > 0;
+        const compact = Theme.crtNativePath;
+
+        if (pill._mediaPaused)
+            return known ? qsTr("Paused %1/%2").arg(cur).arg(tot) : qsTr("Paused");
+
+        if (Browse.MediaStatus.optimizing)
+            return compact ? qsTr("Opt…") : qsTr("Optimizing");
+
+        if (Browse.MediaStatus.indexing) {
+            if (known)
+                return compact ? qsTr("Idx %1/%2").arg(cur).arg(tot) : qsTr("Indexing %1/%2").arg(cur).arg(tot);
+            return compact ? qsTr("Idx…") : qsTr("Indexing…");
+        }
+
+        if (Browse.MediaStatus.scraping) {
+            if (known)
+                return compact ? qsTr("Scr %1/%2").arg(cur).arg(tot) : qsTr("Scraping %1/%2").arg(cur).arg(tot);
+            return compact ? qsTr("Scr…") : qsTr("Scraping…");
+        }
+
+        return "";
+    }
+    readonly property string _label: pill._connectionLabel !== "" ? pill._connectionLabel : pill._mediaLabel
     // Border colour leans on the same convention as the old connection
     // strip: warmer accent for error-class link states, muted otherwise.
     readonly property bool _isError: Browse.AppStatus.link_state === pill._linkUnreachable || Browse.AppStatus.connection_state === pill._connError
+    readonly property int _mediaWidth: Theme.crtNativePath ? Sizing.pctH(42) : Math.min(Math.max(Sizing.pctH(28), Sizing.pctW(18)), Sizing.pctH(30))
+    readonly property int _textMargin: Sizing.pctW(1.2)
+    readonly property int _spinnerSize: Math.max(Sizing.pctH(1.8), Sizing.fontSize(2.2))
+    readonly property int _spinnerDotSize: Math.max(Sizing.stroke(2), Sizing.px(pill._spinnerSize / 3))
+    readonly property int _spinnerGap: Sizing.pctW(0.8)
+    property int _spinnerFrame: 0
 
     visible: pill._label !== ""
     height: pill.visible ? Sizing.fontSize(3.4) : 0
-    width: pill.visible ? Sizing.px(labelText.implicitWidth + Sizing.pctW(2.4)) : 0
+    width: pill.visible ? (pill._isMediaActivity ? pill._mediaWidth : Sizing.px(labelMetrics.implicitWidth + Sizing.pctW(2.4))) : 0
+
+    function _spinnerDotX(index: int, size: int): int {
+        if (index === 1)
+            return size - pill._spinnerDotSize;
+        if (index === 3)
+            return 0;
+        return Sizing.center(size, pill._spinnerDotSize);
+    }
+
+    function _spinnerDotY(index: int, size: int): int {
+        if (index === 0)
+            return 0;
+        if (index === 2)
+            return size - pill._spinnerDotSize;
+        return Sizing.center(size, pill._spinnerDotSize);
+    }
+
+    function _spinnerDotColor(index: int, inverted: bool): color {
+        if (index === pill._spinnerFrame)
+            return inverted ? Theme.bgBar : Theme.textPrimary;
+        return inverted ? Theme.accent : Theme.borderMid;
+    }
+
+    Timer {
+        interval: 140
+        running: pill._spinnerActive && pill.visible
+        repeat: true
+        onTriggered: pill._spinnerFrame = (pill._spinnerFrame + 1) % 4
+    }
+
+    Text {
+        id: labelMetrics
+        visible: false
+        text: pill._label
+        font.family: Theme.fontUi
+        font.pixelSize: Sizing.fontSize(2.2)
+    }
 
     Rectangle {
         anchors.fill: parent
         color: Theme.surfaceCard
         radius: Sizing.half(pill.height)
-        border.width: Sizing.stroke(1)
-        border.color: pill._isError ? Theme.accent : Theme.borderMid
+    }
+
+    Item {
+        id: fillClip
+
+        anchors.left: parent.left
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        width: pill._isMediaActivity ? Sizing.px(pill.width * pill._progressFraction) : 0
+        clip: true
+        visible: width > 0
+
+        Rectangle {
+            width: pill.width
+            height: pill.height
+            color: Theme.accent
+            radius: Sizing.half(pill.height)
+        }
+    }
+
+    Item {
+        id: normalForeground
+
+        anchors.fill: parent
+
+        Item {
+            id: normalSpinner
+
+            visible: pill._spinnerActive
+            anchors.left: parent.left
+            anchors.leftMargin: pill._textMargin
+            anchors.verticalCenter: parent.verticalCenter
+            width: pill._spinnerSize
+            height: pill._spinnerSize
+
+            Repeater {
+                model: 4
+                delegate: Rectangle {
+                    required property int modelData
+                    width: pill._spinnerDotSize
+                    height: width
+                    radius: Sizing.half(width)
+                    x: pill._spinnerDotX(modelData, normalSpinner.width)
+                    y: pill._spinnerDotY(modelData, normalSpinner.height)
+                    color: pill._spinnerDotColor(modelData, false)
+                }
+            }
+        }
 
         Text {
-            id: labelText
-
             anchors.verticalCenter: parent.verticalCenter
-            anchors.left: parent.left
-            anchors.leftMargin: Sizing.pctW(1.2)
+            anchors.left: pill._spinnerActive ? normalSpinner.right : parent.left
+            anchors.leftMargin: pill._spinnerActive ? pill._spinnerGap : pill._textMargin
             anchors.right: parent.right
-            anchors.rightMargin: Sizing.pctW(1.2)
+            anchors.rightMargin: pill._textMargin
             elide: Text.ElideRight
-            horizontalAlignment: Text.AlignHCenter
+            horizontalAlignment: pill._spinnerActive ? Text.AlignLeft : Text.AlignHCenter
             text: pill._label
             font.family: Theme.fontUi
             font.pixelSize: Sizing.fontSize(2.2)
             color: Theme.textPrimary
             renderType: Text.NativeRendering
         }
+    }
+
+    Item {
+        id: invertedClip
+
+        anchors.left: parent.left
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        width: fillClip.width
+        clip: true
+        visible: fillClip.visible
+
+        Item {
+            width: pill.width
+            height: pill.height
+
+            Item {
+                id: invertedSpinner
+
+                visible: pill._spinnerActive
+                anchors.left: parent.left
+                anchors.leftMargin: pill._textMargin
+                anchors.verticalCenter: parent.verticalCenter
+                width: pill._spinnerSize
+                height: pill._spinnerSize
+
+                Repeater {
+                    model: 4
+                    delegate: Rectangle {
+                        required property int modelData
+                        width: pill._spinnerDotSize
+                        height: width
+                        radius: Sizing.half(width)
+                        x: pill._spinnerDotX(modelData, invertedSpinner.width)
+                        y: pill._spinnerDotY(modelData, invertedSpinner.height)
+                        color: pill._spinnerDotColor(modelData, true)
+                    }
+                }
+            }
+
+            Text {
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.left: pill._spinnerActive ? invertedSpinner.right : parent.left
+                anchors.leftMargin: pill._spinnerActive ? pill._spinnerGap : pill._textMargin
+                anchors.right: parent.right
+                anchors.rightMargin: pill._textMargin
+                elide: Text.ElideRight
+                horizontalAlignment: pill._spinnerActive ? Text.AlignLeft : Text.AlignHCenter
+                text: pill._label
+                font.family: Theme.fontUi
+                font.pixelSize: Sizing.fontSize(2.2)
+                color: Theme.bgBar
+                renderType: Text.NativeRendering
+            }
+        }
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        color: "transparent"
+        radius: Sizing.half(pill.height)
+        border.width: Sizing.stroke(1)
+        border.color: pill._isError ? Theme.accent : Theme.borderMid
     }
 }

--- a/src/ui/screens/AboutScreen.qml
+++ b/src/ui/screens/AboutScreen.qml
@@ -258,13 +258,13 @@ Item {
                     renderType: Text.NativeRendering
                 }
 
-                // Translator names are not translated, they're proper
-                // names. Native-language labels (Italiano, Español) read
-                // correctly in any UI locale.
+                // Translator names are proper names; the full block stays
+                // one text item so translators can localize language labels
+                // without changing the credits layout.
                 Text {
                     anchors.horizontalCenter: parent.horizontalCenter
                     horizontalAlignment: Text.AlignHCenter
-                    text: "Italiano - Andrea Bogazzi\nEspañol - Carlos R.\nEuskara - devilschile2"
+                    text: qsTr("Italiano - Andrea Bogazzi\nEspañol - Carlos R.\nEuskara - devilschile2")
                     color: Theme.textPrimary
                     font.family: Theme.fontUi
                     font.pixelSize: Sizing.fontSize(2.6)

--- a/src/ui/screens/AboutScreen.qml
+++ b/src/ui/screens/AboutScreen.qml
@@ -264,7 +264,7 @@ Item {
                 Text {
                     anchors.horizontalCenter: parent.horizontalCenter
                     horizontalAlignment: Text.AlignHCenter
-                    text: "Italiano - Andrea Bogazzi\nEspañol - Carlos R."
+                    text: "Italiano - Andrea Bogazzi\nEspañol - Carlos R.\nEuskara - devilschile2"
                     color: Theme.textPrimary
                     font.family: Theme.fontUi
                     font.pixelSize: Sizing.fontSize(2.6)

--- a/src/ui/screens/SettingsScreen.qml
+++ b/src/ui/screens/SettingsScreen.qml
@@ -472,6 +472,10 @@ Item {
             return qsTr("English");
         if (value === "it_IT")
             return qsTr("Italian");
+        if (value === "es")
+            return qsTr("Spanish");
+        if (value === "eu")
+            return qsTr("Basque");
         if (value === "de")
             return qsTr("German");
         if (value === "el")

--- a/src/ui/screens/SettingsScreen.qml
+++ b/src/ui/screens/SettingsScreen.qml
@@ -468,37 +468,39 @@ Item {
     }
 
     function _languageDisplay(value: string): string {
-        if (value === "en")
+        if (value === "en" || value === "en_US" || value === "en_GB")
             return qsTr("English");
         if (value === "it_IT")
             return qsTr("Italian");
-        if (value === "es")
+        if (value === "es" || value === "es_ES")
             return qsTr("Spanish");
-        if (value === "eu")
+        if (value === "eu" || value === "eu_ES")
             return qsTr("Basque");
-        if (value === "de")
+        if (value === "de" || value === "de_DE")
             return qsTr("German");
-        if (value === "el")
+        if (value === "el" || value === "el_GR")
             return qsTr("Greek");
-        if (value === "ja")
+        if (value === "ja" || value === "ja_JP")
             return qsTr("Japanese");
-        if (value === "ko")
+        if (value === "ko" || value === "ko_KR")
             return qsTr("Korean");
-        if (value === "nl")
+        if (value === "nl" || value === "nl_NL")
             return qsTr("Dutch");
-        if (value === "ro")
+        if (value === "ro" || value === "ro_RO")
             return qsTr("Romanian");
-        if (value === "sk")
+        if (value === "sk" || value === "sk_SK")
             return qsTr("Slovak");
-        if (value === "uk")
+        if (value === "uk" || value === "uk_UA")
             return qsTr("Ukrainian");
         if (value === "zh_CN")
             return qsTr("Chinese (Simplified)");
-        if (value === "he")
+        if (value === "zh_TW" || value === "zh_HK")
+            return qsTr("Chinese (Traditional)");
+        if (value === "he" || value === "he_IL")
             return qsTr("Hebrew");
-        if (value === "ar")
+        if (value === "ar" || value === "ar_SA")
             return qsTr("Arabic");
-        if (value === "hi")
+        if (value === "hi" || value === "hi_IN")
             return qsTr("Hindi");
         return qsTr("Auto");
     }

--- a/src/ui/screens/SettingsScreen.qml
+++ b/src/ui/screens/SettingsScreen.qml
@@ -22,8 +22,9 @@ import Zaparoo.Browse as Browse
 // Mouse support is cross-platform and controls cursor visibility plus mouse
 // hit targets.
 //
-// Pure input dispatcher: emits `requestHubScreen()` on Escape; left/
-// right cycle the focused field's value via the model singleton.
+// Pure input dispatcher: root rows open category subpages; subpage
+// rows open pickers, toggle values, or emit router actions. Escape
+// returns from subpage to root, then from root to Hub.
 Item {
     id: settings
 
@@ -47,22 +48,42 @@ Item {
     // matching `Browse.Settings` setter (keyed off `fieldId`).
     signal requestListPicker(title: string, entries: var, initialId: string, fieldId: string)
 
-    // Field registry. Each entry's `kind` is `"header"` (non-focusable
-    // group label) or `"field"` (a navigable row). Field entries also
-    // carry an `id` that handleAction routes to the right model setter.
-    // Keeping this as data (rather than a Repeater of typed children)
-    // makes adding rows a one-line edit and keeps navigation uniform.
-    //
-    // Section grouping mirrors the Settings menus on Switch/Xbox/
-    // Playnite/Pegasus: a single page with non-focusable headers
-    // splitting commonly-used controls (General, Library) from rarer
-    // diagnostics-flavoured ones (Advanced).
-    readonly property var fields: {
+    readonly property string pageRoot: "root"
+    readonly property string pageDisplayInterface: "displayInterface"
+    readonly property string pageControlsInput: "controlsInput"
+    readonly property string pageLibraryData: "libraryData"
+    readonly property string pageSupportAbout: "supportAbout"
+    property string currentPage: settings.pageRoot
+    property var _pageIndexes: ({})
+
+    // Page-aware field registries. The root mirrors console settings
+    // menus: stable domain categories first, short subpages second.
+    // Future Core features should land in these domains rather than a
+    // vague Advanced bucket.
+    readonly property var categoryFields: [
+        {
+            kind: "field",
+            id: "pageDisplayInterface",
+            label: qsTr("Display & Interface")
+        },
+        {
+            kind: "field",
+            id: "pageControlsInput",
+            label: qsTr("Controls & Input")
+        },
+        {
+            kind: "field",
+            id: "pageLibraryData",
+            label: qsTr("Library & Data Management")
+        },
+        {
+            kind: "field",
+            id: "pageSupportAbout",
+            label: qsTr("Support & About")
+        }
+    ]
+    readonly property var displayInterfaceFields: {
         const out = [];
-        out.push({
-            kind: "header",
-            label: qsTr("General")
-        });
         if (Browse.Settings.is_mister) {
             out.push({
                 kind: "field",
@@ -70,11 +91,6 @@ Item {
                 label: qsTr("Resolution")
             });
         }
-        out.push({
-            kind: "field",
-            id: "language",
-            label: qsTr("Language")
-        });
         out.push({
             kind: "field",
             id: "orientation",
@@ -87,8 +103,8 @@ Item {
         });
         out.push({
             kind: "field",
-            id: "buttonLayout",
-            label: qsTr("Button style")
+            id: "mediaImageType",
+            label: qsTr("Preferred artwork")
         });
         out.push({
             kind: "field",
@@ -96,59 +112,84 @@ Item {
             label: qsTr("Screensaver")
         });
         out.push({
-            kind: "header",
-            label: qsTr("Library")
-        });
-        out.push({
             kind: "field",
-            id: "discoverArcadeAlternateVersions",
-            label: qsTr("Discover arcade alternate versions")
+            id: "language",
+            label: qsTr("Language")
         });
-        out.push({
+        return out;
+    }
+    readonly property var controlsInputFields: [
+        {
             kind: "field",
-            id: "mediaImageType",
-            label: qsTr("Preferred artwork")
-        });
-        out.push({
-            kind: "field",
-            id: "updateMediaDb",
-            label: qsTr("Update media database")
-        });
-        out.push({
-            kind: "field",
-            id: "runScraper",
-            label: qsTr("Scrape metadata")
-        });
-        out.push({
-            kind: "field",
-            id: "rescrapeExisting",
-            label: qsTr("Re-scrape existing")
-        });
-        out.push({
-            kind: "header",
-            label: qsTr("Advanced")
-        });
-        out.push({
+            id: "buttonLayout",
+            label: qsTr("Button style")
+        },
+        {
             kind: "field",
             id: "mouseEnabled",
             label: qsTr("Mouse support")
-        });
-        out.push({
+        }
+    ]
+    readonly property var libraryDataFields: [
+        {
             kind: "field",
-            id: "debugLogging",
-            label: qsTr("Debug logging")
-        });
-        out.push({
+            id: "updateMediaDb",
+            label: qsTr("Update media database")
+        },
+        {
             kind: "field",
-            id: "uploadLog",
-            label: qsTr("Upload log file")
-        });
-        out.push({
+            id: "discoverArcadeAlternateVersions",
+            label: qsTr("Discover arcade alternate versions")
+        },
+        {
+            kind: "field",
+            id: "runScraper",
+            label: qsTr("Scrape metadata")
+        },
+        {
+            kind: "field",
+            id: "rescrapeExisting",
+            label: qsTr("Re-scrape existing")
+        }
+    ]
+    readonly property var supportAboutFields: [
+        {
             kind: "field",
             id: "aboutLicense",
             label: qsTr("About / License")
-        });
-        return out;
+        },
+        {
+            kind: "field",
+            id: "debugLogging",
+            label: qsTr("Debug logging")
+        },
+        {
+            kind: "field",
+            id: "uploadLog",
+            label: qsTr("Upload log file")
+        }
+    ]
+    readonly property var fields: {
+        if (settings.currentPage === settings.pageDisplayInterface)
+            return settings.displayInterfaceFields;
+        if (settings.currentPage === settings.pageControlsInput)
+            return settings.controlsInputFields;
+        if (settings.currentPage === settings.pageLibraryData)
+            return settings.libraryDataFields;
+        if (settings.currentPage === settings.pageSupportAbout)
+            return settings.supportAboutFields;
+        return settings.categoryFields;
+    }
+    readonly property string pageTitle: {
+        if (settings.currentPage === settings.pageDisplayInterface)
+            return qsTr("Display & Interface");
+        if (settings.currentPage === settings.pageControlsInput)
+            return qsTr("Controls & Input");
+        if (settings.currentPage === settings.pageLibraryData)
+            return qsTr("Library & Data Management");
+        if (settings.currentPage === settings.pageSupportAbout)
+            return qsTr("Support & About");
+        return qsTr("Settings");
     }
 
     // Live-state caption helpers for the action rows. While the matching
@@ -257,7 +298,7 @@ Item {
     function _fieldControl(id: string): string {
         if (id === "mouseEnabled" || id === "discoverArcadeAlternateVersions" || id === "debugLogging" || id === "rescrapeExisting")
             return "toggle";
-        if (id === "aboutLicense")
+        if (id === "aboutLicense" || id === "pageDisplayInterface" || id === "pageControlsInput" || id === "pageLibraryData" || id === "pageSupportAbout")
             return "navigate";
         if (id === "updateMediaDb" || id === "runScraper" || id === "uploadLog")
             return "action";
@@ -330,14 +371,14 @@ Item {
         const id = settings.fields[settings.currentIndex].id;
         return id === "language" || id === "orientation" || id === "browseLayout" || id === "buttonLayout" || id === "resolution" || id === "screensaverTimeout" || id === "mediaImageType";
     }
-    // True when the focused field is an action button (updateMediaDb,
-    // runScraper, uploadLog, aboutLicense). Drives the help-bar Accept
-    // hint and the SettingsField chevron.
+    // True when focused row accepts A without left/right cycling:
+    // pickers, jobs, modal/navigation rows, and root category rows.
+    // Drives help-bar Accept hint and suppresses left/right Change cue.
     readonly property bool focusedFieldIsAction: {
         if (!settings._isField(settings.currentIndex))
             return false;
         const id = settings.fields[settings.currentIndex].id;
-        return id === "updateMediaDb" || id === "runScraper" || id === "uploadLog" || id === "aboutLicense";
+        return settings.focusedFieldIsPicker || id === "updateMediaDb" || id === "runScraper" || id === "uploadLog" || id === "aboutLicense" || id === "pageDisplayInterface" || id === "pageControlsInput" || id === "pageLibraryData" || id === "pageSupportAbout";
     }
     // Verb shown on the help-bar Accept hint for the focused action
     // row. Index/scrape flip between Start and Cancel because the press
@@ -352,9 +393,7 @@ Item {
             return settings.focusedActionBusy ? qsTr("Cancel") : qsTr("Start");
         if (id === "uploadLog")
             return qsTr("Upload");
-        if (id === "aboutLicense")
-            return qsTr("Open");
-        return "";
+        return qsTr("Open");
     }
     // True when the focused action's matching operation is currently
     // running, so the help bar can label Accept as "Cancel" rather
@@ -677,10 +716,51 @@ Item {
             settings._setRescrapeExisting(direction);
     }
 
+    function _rememberPageFocus(): void {
+        settings._pageIndexes[settings.currentPage] = settings.currentIndex;
+    }
+
+    function _restorePageFocus(): void {
+        const first = settings._firstNavigableIndex();
+        const fallback = first >= 0 ? first : 0;
+        const remembered = settings._pageIndexes[settings.currentPage];
+        const idx = remembered === undefined ? fallback : Math.max(0, Math.min(settings.fieldCount - 1, remembered));
+        settings.currentIndex = settings._isField(idx) ? idx : fallback;
+        flickable.contentY = 0;
+    }
+
+    function _switchPage(page: string): void {
+        settings._rememberPageFocus();
+        settings.currentPage = page;
+        settings._restorePageFocus();
+    }
+
+    function _openPage(id: string): bool {
+        if (id === "pageDisplayInterface")
+            settings._switchPage(settings.pageDisplayInterface);
+        else if (id === "pageControlsInput")
+            settings._switchPage(settings.pageControlsInput);
+        else if (id === "pageLibraryData")
+            settings._switchPage(settings.pageLibraryData);
+        else if (id === "pageSupportAbout")
+            settings._switchPage(settings.pageSupportAbout);
+        else
+            return false;
+        return true;
+    }
+
+    function _goBack(): void {
+        if (settings.currentPage !== settings.pageRoot) {
+            settings._switchPage(settings.pageRoot);
+            return;
+        }
+        settings.requestHubScreen();
+    }
+
     function handleAction(action: string): void {
         if (settings.optimisticLoading) {
             if (action === "cancel")
-                settings.requestHubScreen();
+                settings._goBack();
             return;
         }
         if (action === "up") {
@@ -695,6 +775,8 @@ Item {
             if (!settings._isField(settings.currentIndex))
                 return;
             const id = settings.fields[settings.currentIndex].id;
+            if (settings._openPage(id))
+                return;
             if (id === "mouseEnabled")
                 settings._toggleMouseEnabled();
             else if (id === "discoverArcadeAlternateVersions")
@@ -714,7 +796,7 @@ Item {
             else
                 settings._openPickerForField(id);
         } else if (action === "cancel") {
-            settings.requestHubScreen();
+            settings._goBack();
         }
     }
 
@@ -723,7 +805,7 @@ Item {
     MouseArea {
         anchors.fill: parent
         acceptedButtons: Qt.RightButton
-        onClicked: settings.requestHubScreen()
+        onClicked: settings._goBack()
     }
 
     TopStatusStrip {
@@ -734,7 +816,7 @@ Item {
         anchors.top: parent.top
         anchors.topMargin: Sizing.headerBottom
         height: Sizing.pctH(7)
-        title: qsTr("Settings")
+        title: settings.pageTitle
         currentPage: 0
         totalPages: 0
         totalText: ""
@@ -858,7 +940,7 @@ Item {
                             else if (row.modelData.id === "rescrapeExisting")
                                 settings._toggleRescrapeExisting();
                         }
-                        onRightClicked: settings.requestHubScreen()
+                        onRightClicked: settings._goBack()
                         // Picker, action, and navigate rows route
                         // through `onAccepted` (see SettingsField's
                         // MouseArea), so the focus commit lives here
@@ -866,6 +948,8 @@ Item {
                         // the action.
                         onAccepted: {
                             settings.currentIndex = row.index;
+                            if (settings._openPage(row.modelData.id))
+                                return;
                             if (row.modelData.id === "updateMediaDb")
                                 settings._triggerIndex();
                             else if (row.modelData.id === "runScraper")

--- a/src/ui/theme/BrowseLayouts.qml
+++ b/src/ui/theme/BrowseLayouts.qml
@@ -486,6 +486,7 @@ QtObject {
                         "metadataRightMargin": 1,
                         "metadataHeightAdjustment": 2,
                         "metadataBottomAligned": false,
+                        "metadataLabelMaxWidth": 24,
                         "titleBottomMargin": 2,
                         "tagRowHeight": 9,
                         "tagRowSpacing": 0
@@ -670,6 +671,7 @@ QtObject {
                         "metadataRightMargin": 1,
                         "metadataHeightAdjustment": 2,
                         "metadataBottomAligned": true,
+                        "metadataLabelMaxWidth": 24,
                         "titleBottomMargin": 2,
                         "tagRowHeight": 9,
                         "tagRowSpacing": 0

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -4,57 +4,57 @@
 <context>
     <name>AboutScreen</name>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="71"/>
+        <location filename="../screens/AboutScreen.qml" line="73"/>
         <source>About / License</source>
         <translation>حول / الترخيص</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="153"/>
+        <location filename="../screens/AboutScreen.qml" line="155"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="164"/>
+        <location filename="../screens/AboutScreen.qml" line="166"/>
         <source>Version %1 · %2 · %3</source>
         <translation>الإصدار %1 · %2 · %3</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="174"/>
+        <location filename="../screens/AboutScreen.qml" line="176"/>
         <source>Built %1</source>
         <translation>تم البناء %1</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="185"/>
+        <location filename="../screens/AboutScreen.qml" line="187"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>حقوق النشر 2026 لشركة Wizzo Pty Ltd والمساهمين في مشروع Zaparoo.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="196"/>
+        <location filename="../screens/AboutScreen.qml" line="198"/>
         <source>Source available under the PolyForm Noncommercial License 1.0.0. Free for personal, non-commercial use. Commercial use requires a separate license.</source>
         <translation>المصدر متاح بموجب ترخيص PolyForm Noncommercial 1.0.0. مجاني للاستخدام الشخصي وغير التجاري. يتطلب الاستخدام التجاري أو إعادة التوزيع ترخيصًا منفصلًا.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="207"/>
+        <location filename="../screens/AboutScreen.qml" line="209"/>
         <source>Commercial licensing: legal@zaparoo.org</source>
         <translation>الترخيص التجاري: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="218"/>
+        <location filename="../screens/AboutScreen.qml" line="220"/>
         <source>Project: https://zaparoo.org</source>
         <translation>المشروع: https://zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="228"/>
+        <location filename="../screens/AboutScreen.qml" line="230"/>
         <source>Created by</source>
         <translation>أنشأه</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="252"/>
+        <location filename="../screens/AboutScreen.qml" line="254"/>
         <source>Translations</source>
         <translation>الترجمات</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="276"/>
+        <location filename="../screens/AboutScreen.qml" line="278"/>
         <source>Full license text in COPYING.</source>
         <translation>نص الترخيص الكامل موجود في COPYING.</translation>
     </message>
@@ -90,48 +90,102 @@
         <translation type="unfinished">جارٍ التحميل…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="77"/>
+        <location filename="../components/BrowseDetailPane.qml" line="138"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="79"/>
+        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <source>Yr</source>
+        <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="81"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <source>Gen</source>
+        <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="83"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <source>Plyr</source>
+        <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="85"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <source>Dev</source>
+        <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="87"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <source>Pub</source>
+        <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="89"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <source>Rtg</source>
+        <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="91"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <source>Cat</source>
+        <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="93"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <source>Date</source>
+        <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Manufacturer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <source>Mfr</source>
+        <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -176,68 +230,103 @@
 <context>
     <name>CoreStatusPill</name>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="44"/>
-        <location filename="../components/CoreStatusPill.qml" line="50"/>
+        <location filename="../components/CoreStatusPill.qml" line="46"/>
+        <location filename="../components/CoreStatusPill.qml" line="52"/>
         <source>Disconnected</source>
         <translation>غير متصل</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="47"/>
+        <location filename="../components/CoreStatusPill.qml" line="49"/>
         <source>Reconnecting…</source>
         <translation>جارٍ إعادة الاتصال…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="53"/>
+        <location filename="../components/CoreStatusPill.qml" line="55"/>
         <source>Connecting…</source>
         <translation>جارٍ الاتصال…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="56"/>
+        <location filename="../components/CoreStatusPill.qml" line="58"/>
         <source>Core error</source>
         <translation>خطأ في النواة</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="60"/>
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <source>Paused %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <source>Paused</source>
+        <translation type="unfinished">متوقف مؤقتًا</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="78"/>
+        <source>Opt…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="78"/>
+        <source>Optimizing</source>
+        <translation type="unfinished">جارٍ التحسين</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
+        <source>Idx…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
+        <source>Scr…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Optimizing database</source>
-        <translation>جارٍ تحسين قاعدة البيانات</translation>
+        <translation type="vanished">جارٍ تحسين قاعدة البيانات</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="67"/>
         <source>Indexing paused</source>
-        <translation>تم إيقاف الفهرسة مؤقتًا</translation>
+        <translation type="vanished">تم إيقاف الفهرسة مؤقتًا</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="70"/>
         <source>Indexing %1/%2 - %3</source>
-        <translation>فهرسة %1/%2 - %3</translation>
+        <translation type="vanished">فهرسة %1/%2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="73"/>
+        <location filename="../components/CoreStatusPill.qml" line="82"/>
         <source>Indexing %1/%2</source>
         <translation>فهرسة %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <location filename="../components/CoreStatusPill.qml" line="82"/>
+        <source>Idx %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Indexing…</source>
         <translation>جارٍ الفهرسة…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Scrape paused</source>
-        <translation>تم إيقاف الاستخراج مؤقتًا</translation>
+        <translation type="vanished">تم إيقاف الاستخراج مؤقتًا</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="86"/>
         <source>Scraping %1/%2 - %3</source>
-        <translation>استخراج %1/%2 - %3</translation>
+        <translation type="vanished">استخراج %1/%2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="89"/>
+        <location filename="../components/CoreStatusPill.qml" line="88"/>
         <source>Scraping %1/%2</source>
         <translation>استخراج %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="91"/>
+        <location filename="../components/CoreStatusPill.qml" line="88"/>
+        <source>Scr %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
         <source>Scraping…</source>
         <translation>جارٍ الاستخراج…</translation>
     </message>
@@ -329,34 +418,34 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="117"/>
-        <location filename="../screens/GamesScreen.qml" line="145"/>
+        <location filename="../screens/GamesScreen.qml" line="122"/>
+        <location filename="../screens/GamesScreen.qml" line="157"/>
         <source>%1 files</source>
         <translation>%1 ملفات</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="51"/>
+        <location filename="../screens/GamesScreen.qml" line="55"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="126"/>
-        <location filename="../screens/GamesScreen.qml" line="146"/>
+        <location filename="../screens/GamesScreen.qml" line="131"/>
+        <location filename="../screens/GamesScreen.qml" line="158"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="44"/>
+        <location filename="../screens/GamesScreen.qml" line="48"/>
         <source>No games in this system</source>
         <translation>لا توجد ألعاب في هذا النظام</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="45"/>
+        <location filename="../screens/GamesScreen.qml" line="49"/>
         <source>Loading games…</source>
         <translation>جارٍ تحميل الألعاب…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="122"/>
+        <location filename="../screens/GamesScreen.qml" line="127"/>
         <source>Loading more…</source>
         <translation>جارٍ تحميل المزيد…</translation>
     </message>
@@ -364,32 +453,47 @@
 <context>
     <name>HubScreen</name>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
-        <source>Resume: %1</source>
+        <location filename="../screens/HubScreen.qml" line="56"/>
+        <source>Arcade</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
-        <source>Resume Game</source>
+        <location filename="../screens/HubScreen.qml" line="61"/>
+        <source>Computers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
+        <location filename="../screens/HubScreen.qml" line="66"/>
+        <source>Consoles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="71"/>
+        <source>Handhelds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="134"/>
+        <source>Resume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="140"/>
         <source>Favorites</source>
         <translation>المفضلة</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="96"/>
+        <location filename="../screens/HubScreen.qml" line="145"/>
         <source>Recently Played</source>
         <translation>تم لعبها مؤخرًا</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="101"/>
+        <location filename="../screens/HubScreen.qml" line="150"/>
         <source>Settings</source>
         <translation>الإعدادات</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="537"/>
+        <location filename="../screens/HubScreen.qml" line="644"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>لا توجد أنظمة متاحة. شغّل تحديث قاعدة بيانات الوسائط من الإعدادات.</translation>
     </message>
@@ -438,104 +542,124 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="755"/>
+        <location filename="../app/Main.qml" line="1206"/>
         <source>Launch core</source>
         <translation>تشغيل النواة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="958"/>
+        <location filename="../app/Main.qml" line="1212"/>
+        <location filename="../app/Main.qml" line="1420"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="770"/>
-        <location filename="../app/Main.qml" line="805"/>
+        <location filename="../app/Main.qml" line="1219"/>
+        <source>Update media database</source>
+        <translation type="unfinished">تحديث قاعدة بيانات الوسائط</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1222"/>
+        <source>Scrape metadata</source>
+        <translation type="unfinished">استخراج البيانات الوصفية</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1231"/>
+        <location filename="../app/Main.qml" line="1266"/>
         <source>Launch game</source>
         <translation>تشغيل اللعبة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="786"/>
+        <location filename="../app/Main.qml" line="1247"/>
         <source>Remove from favorites</source>
         <translation>إزالة من المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="786"/>
+        <location filename="../app/Main.qml" line="1247"/>
         <source>Add to favorites</source>
         <translation>أضف إلى المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="791"/>
+        <location filename="../app/Main.qml" line="1252"/>
         <source>Write to NFC token</source>
         <translation>الكتابة إلى رمز NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="795"/>
+        <location filename="../app/Main.qml" line="1256"/>
         <source>QR code</source>
         <translation>رمز QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="954"/>
+        <location filename="../app/Main.qml" line="1416"/>
         <source>Default</source>
         <translation type="unfinished">افتراضي</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="954"/>
+        <location filename="../app/Main.qml" line="1416"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1230"/>
+        <location filename="../app/Main.qml" line="1708"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1234"/>
+        <location filename="../app/Main.qml" line="1712"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1248"/>
+        <location filename="../app/Main.qml" line="1726"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1252"/>
+        <location filename="../app/Main.qml" line="1730"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1256"/>
+        <location filename="../app/Main.qml" line="1734"/>
         <source>Retry</source>
         <translation type="unfinished">إعادة المحاولة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1260"/>
+        <location filename="../app/Main.qml" line="1738"/>
         <source>Cancel</source>
         <translation type="unfinished">إلغاء</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1776"/>
+        <location filename="../app/Main.qml" line="2368"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1778"/>
+        <location filename="../app/Main.qml" line="2370"/>
         <source>Loading games…</source>
         <translation>جارٍ تحميل الألعاب…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1780"/>
+        <location filename="../app/Main.qml" line="2372"/>
+        <source>Loading game…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2374"/>
         <source>Loading favorites…</source>
         <translation>جارٍ تحميل المفضلة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1782"/>
+        <location filename="../app/Main.qml" line="2376"/>
         <source>Loading recently played…</source>
         <translation>جارٍ تحميل آخر ما تم لعبه…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="2378"/>
+        <source>Loading settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2380"/>
         <source>Loading…</source>
         <translation>جارٍ التحميل…</translation>
     </message>
@@ -543,161 +667,161 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="581"/>
+        <location filename="../app/MainLayout.qml" line="680"/>
         <source>Writing failed</source>
         <translation>فشلت الكتابة</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="581"/>
+        <location filename="../app/MainLayout.qml" line="680"/>
         <source>Put a writable card near the reader</source>
         <translation>ضع بطاقة قابلة للكتابة بالقرب من القارئ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="141"/>
+        <location filename="../app/MainLayout.qml" line="170"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="323"/>
+        <location filename="../app/MainLayout.qml" line="364"/>
         <source>Favorites</source>
         <translation type="unfinished">المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="325"/>
+        <location filename="../app/MainLayout.qml" line="366"/>
         <source>Recently Played</source>
         <translation type="unfinished">تم لعبها مؤخرًا</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="592"/>
+        <location filename="../app/MainLayout.qml" line="695"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="593"/>
+        <location filename="../app/MainLayout.qml" line="696"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="668"/>
+        <location filename="../app/MainLayout.qml" line="806"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="669"/>
+        <location filename="../app/MainLayout.qml" line="807"/>
         <source>Are you sure you want to exit?</source>
         <translation>هل أنت متأكد أنك تريد الخروج؟</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="741"/>
-        <location filename="../app/MainLayout.qml" line="813"/>
-        <location filename="../app/MainLayout.qml" line="856"/>
-        <location filename="../app/MainLayout.qml" line="885"/>
-        <location filename="../app/MainLayout.qml" line="932"/>
-        <location filename="../app/MainLayout.qml" line="973"/>
-        <location filename="../app/MainLayout.qml" line="1037"/>
+        <location filename="../app/MainLayout.qml" line="886"/>
+        <location filename="../app/MainLayout.qml" line="960"/>
+        <location filename="../app/MainLayout.qml" line="1003"/>
+        <location filename="../app/MainLayout.qml" line="1034"/>
+        <location filename="../app/MainLayout.qml" line="1084"/>
+        <location filename="../app/MainLayout.qml" line="1127"/>
+        <location filename="../app/MainLayout.qml" line="1195"/>
         <source>Move</source>
         <translation>تحريك</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="745"/>
-        <location filename="../app/MainLayout.qml" line="817"/>
+        <location filename="../app/MainLayout.qml" line="890"/>
+        <location filename="../app/MainLayout.qml" line="964"/>
         <source>Select</source>
         <translation>تحديد</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="749"/>
-        <location filename="../app/MainLayout.qml" line="753"/>
-        <location filename="../app/MainLayout.qml" line="767"/>
-        <location filename="../app/MainLayout.qml" line="780"/>
-        <location filename="../app/MainLayout.qml" line="791"/>
+        <location filename="../app/MainLayout.qml" line="894"/>
+        <location filename="../app/MainLayout.qml" line="898"/>
+        <location filename="../app/MainLayout.qml" line="912"/>
+        <location filename="../app/MainLayout.qml" line="927"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
         <source>Close</source>
         <translation>إغلاق</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="760"/>
-        <location filename="../app/MainLayout.qml" line="798"/>
-        <location filename="../app/MainLayout.qml" line="821"/>
-        <location filename="../app/MainLayout.qml" line="832"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
+        <location filename="../app/MainLayout.qml" line="945"/>
+        <location filename="../app/MainLayout.qml" line="968"/>
+        <location filename="../app/MainLayout.qml" line="979"/>
         <source>Cancel</source>
         <translation>إلغاء</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="776"/>
+        <location filename="../app/MainLayout.qml" line="923"/>
         <source>Done</source>
         <translation>تم</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="787"/>
-        <location filename="../app/MainLayout.qml" line="908"/>
-        <location filename="../app/MainLayout.qml" line="958"/>
-        <location filename="../app/MainLayout.qml" line="1063"/>
+        <location filename="../app/MainLayout.qml" line="934"/>
+        <location filename="../app/MainLayout.qml" line="1057"/>
+        <location filename="../app/MainLayout.qml" line="1110"/>
+        <location filename="../app/MainLayout.qml" line="1221"/>
         <source>Retry</source>
         <translation>إعادة المحاولة</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="806"/>
+        <location filename="../app/MainLayout.qml" line="953"/>
         <source>I understand</source>
         <translation>أفهم</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="840"/>
+        <location filename="../app/MainLayout.qml" line="987"/>
         <source>Start</source>
         <translation>ابدأ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="860"/>
-        <location filename="../app/MainLayout.qml" line="895"/>
-        <location filename="../app/MainLayout.qml" line="942"/>
-        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1007"/>
+        <location filename="../app/MainLayout.qml" line="1044"/>
+        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Open</source>
         <translation>فتح</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="864"/>
+        <location filename="../app/MainLayout.qml" line="1011"/>
         <source>Quit</source>
         <translation>إنهاء</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="873"/>
-        <location filename="../app/MainLayout.qml" line="901"/>
-        <location filename="../app/MainLayout.qml" line="912"/>
-        <location filename="../app/MainLayout.qml" line="924"/>
-        <location filename="../app/MainLayout.qml" line="951"/>
-        <location filename="../app/MainLayout.qml" line="962"/>
-        <location filename="../app/MainLayout.qml" line="997"/>
-        <location filename="../app/MainLayout.qml" line="1013"/>
-        <location filename="../app/MainLayout.qml" line="1022"/>
-        <location filename="../app/MainLayout.qml" line="1056"/>
-        <location filename="../app/MainLayout.qml" line="1067"/>
+        <location filename="../app/MainLayout.qml" line="1020"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1061"/>
+        <location filename="../app/MainLayout.qml" line="1076"/>
+        <location filename="../app/MainLayout.qml" line="1103"/>
+        <location filename="../app/MainLayout.qml" line="1114"/>
+        <location filename="../app/MainLayout.qml" line="1151"/>
+        <location filename="../app/MainLayout.qml" line="1169"/>
+        <location filename="../app/MainLayout.qml" line="1178"/>
+        <location filename="../app/MainLayout.qml" line="1214"/>
+        <location filename="../app/MainLayout.qml" line="1225"/>
         <source>Back</source>
         <translation>رجوع</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="891"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1043"/>
+        <location filename="../app/MainLayout.qml" line="1040"/>
+        <location filename="../app/MainLayout.qml" line="1090"/>
+        <location filename="../app/MainLayout.qml" line="1201"/>
         <source>Page</source>
         <translation>صفحة</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="947"/>
-        <location filename="../app/MainLayout.qml" line="1052"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1210"/>
         <source>Options</source>
         <translation>الخيارات</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="982"/>
+        <location filename="../app/MainLayout.qml" line="1136"/>
         <source>Change</source>
         <translation>تغيير</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="988"/>
+        <location filename="../app/MainLayout.qml" line="1142"/>
         <source>Toggle</source>
         <translation>تبديل</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1009"/>
+        <location filename="../app/MainLayout.qml" line="1165"/>
         <source>Scroll</source>
         <translation>تمرير</translation>
     </message>
@@ -710,12 +834,12 @@
         <translation type="unfinished">جارٍ التحميل…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="306"/>
+        <location filename="../screens/MediaListScreen.qml" line="351"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 عناصر</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="307"/>
+        <location filename="../screens/MediaListScreen.qml" line="352"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -764,17 +888,17 @@
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="26"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
         <source>Nothing here</source>
         <translation>لا يوجد شيء هنا</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="28"/>
         <source>Loading…</source>
         <translation>جارٍ التحميل…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="57"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="58"/>
         <source>Failed to load</source>
         <translation>فشل التحميل</translation>
     </message>
@@ -782,387 +906,423 @@
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="61"/>
         <source>General</source>
-        <translation>عام</translation>
+        <translation type="vanished">عام</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="73"/>
-        <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
         <source>Language</source>
         <translation>اللغة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78"/>
-        <location filename="../screens/SettingsScreen.qml" line="507"/>
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <location filename="../screens/SettingsScreen.qml" line="618"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="516"/>
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Browsing layout</source>
         <translation>تخطيط التصفح</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88"/>
-        <location filename="../screens/SettingsScreen.qml" line="525"/>
+        <location filename="../screens/SettingsScreen.qml" line="125"/>
+        <location filename="../screens/SettingsScreen.qml" line="636"/>
         <source>Button style</source>
         <translation>نمط الأزرار</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="93"/>
-        <location filename="../screens/SettingsScreen.qml" line="534"/>
+        <location filename="../screens/SettingsScreen.qml" line="112"/>
+        <location filename="../screens/SettingsScreen.qml" line="645"/>
         <source>Screensaver</source>
         <translation>شاشة التوقف</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97"/>
         <source>Library</source>
-        <translation>المكتبة</translation>
+        <translation type="vanished">المكتبة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="142"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="543"/>
+        <location filename="../screens/SettingsScreen.qml" line="654"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="112"/>
+        <location filename="../screens/SettingsScreen.qml" line="137"/>
         <source>Update media database</source>
         <translation>تحديث قاعدة بيانات الوسائط</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
         <source>Scrape metadata</source>
         <translation>استخراج البيانات الوصفية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Advanced</source>
-        <translation>متقدم</translation>
+        <translation type="vanished">متقدم</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="130"/>
         <source>Mouse support</source>
         <translation>دعم الفأرة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="136"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
         <source>Debug logging</source>
         <translation>تسجيل التصحيح</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="141"/>
+        <location filename="../screens/SettingsScreen.qml" line="169"/>
         <source>Upload log file</source>
         <translation>رفع ملف السجل</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="146"/>
+        <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>About / License</source>
         <translation>حول / الترخيص</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="162"/>
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
+        <source>Display &amp; Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="72"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <source>Controls &amp; Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="189"/>
+        <source>Library &amp; Data Management</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="82"/>
+        <location filename="../screens/SettingsScreen.qml" line="191"/>
+        <source>Support &amp; About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="206"/>
         <source>Optimizing</source>
         <translation>جارٍ التحسين</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
-        <location filename="../screens/SettingsScreen.qml" line="173"/>
+        <location filename="../screens/SettingsScreen.qml" line="208"/>
+        <location filename="../screens/SettingsScreen.qml" line="217"/>
         <source>Paused</source>
         <translation>متوقف مؤقتًا</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
-        <location filename="../screens/SettingsScreen.qml" line="173"/>
+        <location filename="../screens/SettingsScreen.qml" line="208"/>
+        <location filename="../screens/SettingsScreen.qml" line="217"/>
         <source>In progress</source>
         <translation>قيد التنفيذ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="167"/>
+        <location filename="../screens/SettingsScreen.qml" line="211"/>
         <source>%1 indexed</source>
         <translation>تمت فهرسة %1</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="176"/>
+        <location filename="../screens/SettingsScreen.qml" line="220"/>
         <source>%1 scraped</source>
         <translation>تم استخراج %1</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="284"/>
+        <location filename="../screens/SettingsScreen.qml" line="393"/>
         <source>Cancel</source>
         <translation>إلغاء</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="284"/>
+        <location filename="../screens/SettingsScreen.qml" line="393"/>
         <source>Start</source>
         <translation>ابدأ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="286"/>
+        <location filename="../screens/SettingsScreen.qml" line="395"/>
         <source>Upload</source>
         <translation>رفع</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="288"/>
+        <location filename="../screens/SettingsScreen.qml" line="396"/>
         <source>Open</source>
         <translation>فتح</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="340"/>
+        <location filename="../screens/SettingsScreen.qml" line="447"/>
         <source>Default</source>
         <translation>افتراضي</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="365"/>
+        <location filename="../screens/SettingsScreen.qml" line="472"/>
         <source>English</source>
         <translation>الإنجليزية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="367"/>
+        <location filename="../screens/SettingsScreen.qml" line="474"/>
         <source>Italian</source>
         <translation>الإيطالية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="476"/>
+        <source>Spanish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="478"/>
+        <source>Basque</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="480"/>
         <source>German</source>
         <translation>الألمانية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
+        <location filename="../screens/SettingsScreen.qml" line="482"/>
         <source>Greek</source>
         <translation>اليونانية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="373"/>
+        <location filename="../screens/SettingsScreen.qml" line="484"/>
         <source>Japanese</source>
         <translation>اليابانية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="375"/>
+        <location filename="../screens/SettingsScreen.qml" line="486"/>
         <source>Korean</source>
         <translation>الكورية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Dutch</source>
         <translation>الهولندية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="379"/>
+        <location filename="../screens/SettingsScreen.qml" line="490"/>
         <source>Romanian</source>
         <translation>الرومانية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="381"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Slovak</source>
         <translation>السلوفاكية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="383"/>
+        <location filename="../screens/SettingsScreen.qml" line="494"/>
         <source>Ukrainian</source>
         <translation>الأوكرانية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="385"/>
+        <location filename="../screens/SettingsScreen.qml" line="496"/>
         <source>Chinese (Simplified)</source>
         <translation>الصينية المبسطة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="387"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Hebrew</source>
         <translation>العبرية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="389"/>
+        <location filename="../screens/SettingsScreen.qml" line="500"/>
         <source>Arabic</source>
         <translation>العربية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="391"/>
+        <location filename="../screens/SettingsScreen.qml" line="502"/>
         <source>Hindi</source>
         <translation>الهندية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="392"/>
-        <location filename="../screens/SettingsScreen.qml" line="451"/>
+        <location filename="../screens/SettingsScreen.qml" line="503"/>
+        <location filename="../screens/SettingsScreen.qml" line="562"/>
         <source>Auto</source>
         <translation>تلقائي</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <location filename="../screens/SettingsScreen.qml" line="508"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <location filename="../screens/SettingsScreen.qml" line="510"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="400"/>
+        <location filename="../screens/SettingsScreen.qml" line="511"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405"/>
+        <location filename="../screens/SettingsScreen.qml" line="516"/>
         <source>Detailed list view</source>
         <translation>عرض قائمة مفصلة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="406"/>
+        <location filename="../screens/SettingsScreen.qml" line="517"/>
         <source>Grid view</source>
         <translation>عرض الشبكة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="411"/>
+        <location filename="../screens/SettingsScreen.qml" line="522"/>
         <source>Style B</source>
         <translation>النمط B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="413"/>
+        <location filename="../screens/SettingsScreen.qml" line="524"/>
         <source>Style C</source>
         <translation>النمط C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="415"/>
+        <location filename="../screens/SettingsScreen.qml" line="526"/>
         <source>Style D</source>
         <translation>النمط D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="416"/>
+        <location filename="../screens/SettingsScreen.qml" line="527"/>
         <source>Style A</source>
         <translation>النمط A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="431"/>
+        <location filename="../screens/SettingsScreen.qml" line="542"/>
         <source>Off</source>
         <translation>إيقاف</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="433"/>
+        <location filename="../screens/SettingsScreen.qml" line="544"/>
         <source>1 second (testing)</source>
         <translation>ثانية واحدة (اختبار)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="435"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>1 minute</source>
         <translation>دقيقة واحدة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="437"/>
+        <location filename="../screens/SettingsScreen.qml" line="548"/>
         <source>2 minutes</source>
         <translation>دقيقتان</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="439"/>
+        <location filename="../screens/SettingsScreen.qml" line="550"/>
         <source>5 minutes</source>
         <translation>5 دقائق</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="441"/>
+        <location filename="../screens/SettingsScreen.qml" line="552"/>
         <source>10 minutes</source>
         <translation>10 دقائق</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="443"/>
+        <location filename="../screens/SettingsScreen.qml" line="554"/>
         <source>15 minutes</source>
         <translation>15 دقيقة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="445"/>
+        <location filename="../screens/SettingsScreen.qml" line="556"/>
         <source>30 minutes</source>
         <translation>30 دقيقة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="446"/>
+        <location filename="../screens/SettingsScreen.qml" line="557"/>
         <source>%1 seconds</source>
         <translation>%1 ثوانٍ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="489"/>
+        <location filename="../screens/SettingsScreen.qml" line="1032"/>
+        <source>Loading settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="91"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Resolution</source>
         <translation>الدقة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="453"/>
+        <location filename="../screens/SettingsScreen.qml" line="564"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="455"/>
+        <location filename="../screens/SettingsScreen.qml" line="566"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="457"/>
+        <location filename="../screens/SettingsScreen.qml" line="568"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <location filename="../screens/SettingsScreen.qml" line="570"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="461"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="463"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="465"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="467"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="469"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="471"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="473"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="663"/>
+        <location filename="../screens/SettingsScreen.qml" line="192"/>
         <source>Settings</source>
         <translation>الإعدادات</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="857"/>
+        <location filename="../screens/SettingsScreen.qml" line="1020"/>
         <source>No settings available on this platform</source>
         <translation>لا توجد إعدادات متاحة على هذه المنصة</translation>
     </message>
@@ -1170,24 +1330,24 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="195"/>
-        <location filename="../screens/SystemsScreen.qml" line="292"/>
+        <location filename="../screens/SystemsScreen.qml" line="197"/>
+        <location filename="../screens/SystemsScreen.qml" line="295"/>
         <source>%1 systems</source>
         <translation>%1 أنظمة</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="196"/>
-        <location filename="../screens/SystemsScreen.qml" line="309"/>
+        <location filename="../screens/SystemsScreen.qml" line="198"/>
+        <location filename="../screens/SystemsScreen.qml" line="312"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="324"/>
+        <location filename="../screens/SystemsScreen.qml" line="328"/>
         <source>No systems in this category</source>
         <translation>لا توجد أنظمة في هذه الفئة</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="325"/>
+        <location filename="../screens/SystemsScreen.qml" line="329"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -54,6 +54,13 @@
         <translation>الترجمات</translation>
     </message>
     <message>
+        <location filename="../screens/AboutScreen.qml" line="267"/>
+        <source>Italiano - Andrea Bogazzi
+Español - Carlos R.
+Euskara - devilschile2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/AboutScreen.qml" line="278"/>
         <source>Full license text in COPYING.</source>
         <translation>نص الترخيص الكامل موجود في COPYING.</translation>
@@ -911,31 +918,31 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="611"/>
         <source>Language</source>
         <translation>اللغة</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="97"/>
-        <location filename="../screens/SettingsScreen.qml" line="618"/>
+        <location filename="../screens/SettingsScreen.qml" line="620"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="627"/>
+        <location filename="../screens/SettingsScreen.qml" line="629"/>
         <source>Browsing layout</source>
         <translation>تخطيط التصفح</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="125"/>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="638"/>
         <source>Button style</source>
         <translation>نمط الأزرار</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="112"/>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
+        <location filename="../screens/SettingsScreen.qml" line="647"/>
         <source>Screensaver</source>
         <translation>شاشة التوقف</translation>
     </message>
@@ -950,7 +957,7 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="654"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1136,183 +1143,188 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <source>Chinese (Traditional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="500"/>
         <source>Hebrew</source>
         <translation>العبرية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="500"/>
+        <location filename="../screens/SettingsScreen.qml" line="502"/>
         <source>Arabic</source>
         <translation>العربية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="502"/>
+        <location filename="../screens/SettingsScreen.qml" line="504"/>
         <source>Hindi</source>
         <translation>الهندية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="503"/>
-        <location filename="../screens/SettingsScreen.qml" line="562"/>
+        <location filename="../screens/SettingsScreen.qml" line="505"/>
+        <location filename="../screens/SettingsScreen.qml" line="564"/>
         <source>Auto</source>
         <translation>تلقائي</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="508"/>
+        <location filename="../screens/SettingsScreen.qml" line="510"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="510"/>
+        <location filename="../screens/SettingsScreen.qml" line="512"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="511"/>
+        <location filename="../screens/SettingsScreen.qml" line="513"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="516"/>
+        <location filename="../screens/SettingsScreen.qml" line="518"/>
         <source>Detailed list view</source>
         <translation>عرض قائمة مفصلة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="517"/>
+        <location filename="../screens/SettingsScreen.qml" line="519"/>
         <source>Grid view</source>
         <translation>عرض الشبكة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="522"/>
+        <location filename="../screens/SettingsScreen.qml" line="524"/>
         <source>Style B</source>
         <translation>النمط B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="524"/>
+        <location filename="../screens/SettingsScreen.qml" line="526"/>
         <source>Style C</source>
         <translation>النمط C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="526"/>
+        <location filename="../screens/SettingsScreen.qml" line="528"/>
         <source>Style D</source>
         <translation>النمط D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="527"/>
+        <location filename="../screens/SettingsScreen.qml" line="529"/>
         <source>Style A</source>
         <translation>النمط A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="542"/>
+        <location filename="../screens/SettingsScreen.qml" line="544"/>
         <source>Off</source>
         <translation>إيقاف</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="544"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>1 second (testing)</source>
         <translation>ثانية واحدة (اختبار)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="546"/>
+        <location filename="../screens/SettingsScreen.qml" line="548"/>
         <source>1 minute</source>
         <translation>دقيقة واحدة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="548"/>
+        <location filename="../screens/SettingsScreen.qml" line="550"/>
         <source>2 minutes</source>
         <translation>دقيقتان</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="550"/>
+        <location filename="../screens/SettingsScreen.qml" line="552"/>
         <source>5 minutes</source>
         <translation>5 دقائق</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="552"/>
+        <location filename="../screens/SettingsScreen.qml" line="554"/>
         <source>10 minutes</source>
         <translation>10 دقائق</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="554"/>
+        <location filename="../screens/SettingsScreen.qml" line="556"/>
         <source>15 minutes</source>
         <translation>15 دقيقة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="556"/>
+        <location filename="../screens/SettingsScreen.qml" line="558"/>
         <source>30 minutes</source>
         <translation>30 دقيقة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="557"/>
+        <location filename="../screens/SettingsScreen.qml" line="559"/>
         <source>%1 seconds</source>
         <translation>%1 ثوانٍ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1032"/>
+        <location filename="../screens/SettingsScreen.qml" line="1034"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="91"/>
-        <location filename="../screens/SettingsScreen.qml" line="600"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Resolution</source>
         <translation>الدقة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="564"/>
+        <location filename="../screens/SettingsScreen.qml" line="566"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="566"/>
+        <location filename="../screens/SettingsScreen.qml" line="568"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="568"/>
+        <location filename="../screens/SettingsScreen.qml" line="570"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="570"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1322,7 +1334,7 @@
         <translation>الإعدادات</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1020"/>
+        <location filename="../screens/SettingsScreen.qml" line="1022"/>
         <source>No settings available on this platform</source>
         <translation>لا توجد إعدادات متاحة على هذه المنصة</translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -4,57 +4,57 @@
 <context>
     <name>AboutScreen</name>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="71"/>
+        <location filename="../screens/AboutScreen.qml" line="73"/>
         <source>About / License</source>
         <translation>Über / Lizenz</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="153"/>
+        <location filename="../screens/AboutScreen.qml" line="155"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="164"/>
+        <location filename="../screens/AboutScreen.qml" line="166"/>
         <source>Version %1 · %2 · %3</source>
         <translation>Fassung %1 · %2 · %3</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="174"/>
+        <location filename="../screens/AboutScreen.qml" line="176"/>
         <source>Built %1</source>
         <translation>Erstellt am %1</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="185"/>
+        <location filename="../screens/AboutScreen.qml" line="187"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>Copyright 2026 Wizzo Pty Ltd und die Mitwirkenden des Zaparoo-Projekts.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="196"/>
+        <location filename="../screens/AboutScreen.qml" line="198"/>
         <source>Source available under the PolyForm Noncommercial License 1.0.0. Free for personal, non-commercial use. Commercial use requires a separate license.</source>
         <translation>Quellcode verfügbar unter der PolyForm Noncommercial License 1.0.0. Kostenlos für den persönlichen, nicht kommerziellen Gebrauch. Kommerzielle Nutzung erfordert eine separate Lizenz.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="207"/>
+        <location filename="../screens/AboutScreen.qml" line="209"/>
         <source>Commercial licensing: legal@zaparoo.org</source>
         <translation>Kommerzielle Lizenzierung: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="218"/>
+        <location filename="../screens/AboutScreen.qml" line="220"/>
         <source>Project: https://zaparoo.org</source>
         <translation>Projekt: https://zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="228"/>
+        <location filename="../screens/AboutScreen.qml" line="230"/>
         <source>Created by</source>
         <translation>Erstellt von</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="252"/>
+        <location filename="../screens/AboutScreen.qml" line="254"/>
         <source>Translations</source>
         <translation>Übersetzungen</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="276"/>
+        <location filename="../screens/AboutScreen.qml" line="278"/>
         <source>Full license text in COPYING.</source>
         <translation>Vollständiger Lizenztext in COPYING.</translation>
     </message>
@@ -90,48 +90,102 @@
         <translation type="unfinished">Wird geladen…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="77"/>
+        <location filename="../components/BrowseDetailPane.qml" line="138"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="79"/>
+        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <source>Yr</source>
+        <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="81"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <source>Gen</source>
+        <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="83"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <source>Plyr</source>
+        <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="85"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <source>Dev</source>
+        <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="87"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <source>Pub</source>
+        <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="89"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <source>Rtg</source>
+        <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="91"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <source>Cat</source>
+        <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="93"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <source>Date</source>
+        <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Manufacturer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <source>Mfr</source>
+        <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -176,68 +230,103 @@
 <context>
     <name>CoreStatusPill</name>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="44"/>
-        <location filename="../components/CoreStatusPill.qml" line="50"/>
+        <location filename="../components/CoreStatusPill.qml" line="46"/>
+        <location filename="../components/CoreStatusPill.qml" line="52"/>
         <source>Disconnected</source>
         <translation>Getrennt</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="47"/>
+        <location filename="../components/CoreStatusPill.qml" line="49"/>
         <source>Reconnecting…</source>
         <translation>Verbindung wird wiederhergestellt…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="53"/>
+        <location filename="../components/CoreStatusPill.qml" line="55"/>
         <source>Connecting…</source>
         <translation>Verbindung wird aufgebaut…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="56"/>
+        <location filename="../components/CoreStatusPill.qml" line="58"/>
         <source>Core error</source>
         <translation>Core-Fehler</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="60"/>
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <source>Paused %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <source>Paused</source>
+        <translation type="unfinished">Pausiert</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="78"/>
+        <source>Opt…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="78"/>
+        <source>Optimizing</source>
+        <translation type="unfinished">Wird optimiert</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
+        <source>Idx…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
+        <source>Scr…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Optimizing database</source>
-        <translation>Datenbank wird optimiert</translation>
+        <translation type="vanished">Datenbank wird optimiert</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="67"/>
         <source>Indexing paused</source>
-        <translation>Indizierung pausiert</translation>
+        <translation type="vanished">Indizierung pausiert</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="70"/>
         <source>Indexing %1/%2 - %3</source>
-        <translation>Indizierung %1/%2 – %3</translation>
+        <translation type="vanished">Indizierung %1/%2 – %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="86"/>
         <source>Scraping %1/%2 - %3</source>
-        <translation>Scraping %1/%2 – %3</translation>
+        <translation type="vanished">Scraping %1/%2 – %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="73"/>
+        <location filename="../components/CoreStatusPill.qml" line="82"/>
         <source>Indexing %1/%2</source>
         <translation>Indizierung %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <location filename="../components/CoreStatusPill.qml" line="82"/>
+        <source>Idx %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Indexing…</source>
         <translation>Indizierung…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Scrape paused</source>
-        <translation>Scraping pausiert</translation>
+        <translation type="vanished">Scraping pausiert</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="89"/>
+        <location filename="../components/CoreStatusPill.qml" line="88"/>
         <source>Scraping %1/%2</source>
         <translation>Metadatenabruf %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="91"/>
+        <location filename="../components/CoreStatusPill.qml" line="88"/>
+        <source>Scr %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
         <source>Scraping…</source>
         <translation>Metadaten werden abgerufen…</translation>
     </message>
@@ -329,34 +418,34 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="117"/>
-        <location filename="../screens/GamesScreen.qml" line="145"/>
+        <location filename="../screens/GamesScreen.qml" line="122"/>
+        <location filename="../screens/GamesScreen.qml" line="157"/>
         <source>%1 files</source>
         <translation>%1 Dateien</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="51"/>
+        <location filename="../screens/GamesScreen.qml" line="55"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="126"/>
-        <location filename="../screens/GamesScreen.qml" line="146"/>
+        <location filename="../screens/GamesScreen.qml" line="131"/>
+        <location filename="../screens/GamesScreen.qml" line="158"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="45"/>
+        <location filename="../screens/GamesScreen.qml" line="49"/>
         <source>Loading games…</source>
         <translation>Spiele werden geladen…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="122"/>
+        <location filename="../screens/GamesScreen.qml" line="127"/>
         <source>Loading more…</source>
         <translation>Mehr laden…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="44"/>
+        <location filename="../screens/GamesScreen.qml" line="48"/>
         <source>No games in this system</source>
         <translation>Keine Spiele in diesem System</translation>
     </message>
@@ -364,32 +453,47 @@
 <context>
     <name>HubScreen</name>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
-        <source>Resume: %1</source>
+        <location filename="../screens/HubScreen.qml" line="56"/>
+        <source>Arcade</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
-        <source>Resume Game</source>
+        <location filename="../screens/HubScreen.qml" line="61"/>
+        <source>Computers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
+        <location filename="../screens/HubScreen.qml" line="66"/>
+        <source>Consoles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="71"/>
+        <source>Handhelds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="134"/>
+        <source>Resume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="140"/>
         <source>Favorites</source>
         <translation>Favoriten</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="96"/>
+        <location filename="../screens/HubScreen.qml" line="145"/>
         <source>Recently Played</source>
         <translation>Zuletzt gespielt</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="101"/>
+        <location filename="../screens/HubScreen.qml" line="150"/>
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="537"/>
+        <location filename="../screens/HubScreen.qml" line="644"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Keine Systeme verfügbar. Bitte Mediendatenbank unter Einstellungen aktualisieren.</translation>
     </message>
@@ -438,104 +542,124 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="755"/>
+        <location filename="../app/Main.qml" line="1206"/>
         <source>Launch core</source>
         <translation>Core starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="958"/>
+        <location filename="../app/Main.qml" line="1212"/>
+        <location filename="../app/Main.qml" line="1420"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="786"/>
+        <location filename="../app/Main.qml" line="1247"/>
         <source>Remove from favorites</source>
         <translation>Aus Favoriten entfernen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="786"/>
+        <location filename="../app/Main.qml" line="1247"/>
         <source>Add to favorites</source>
         <translation>Zu Favoriten hinzufügen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="791"/>
+        <location filename="../app/Main.qml" line="1252"/>
         <source>Write to NFC token</source>
         <translation>Auf NFC-Token schreiben</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="795"/>
+        <location filename="../app/Main.qml" line="1256"/>
         <source>QR code</source>
         <translation>QR-Code</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="770"/>
-        <location filename="../app/Main.qml" line="805"/>
+        <location filename="../app/Main.qml" line="1231"/>
+        <location filename="../app/Main.qml" line="1266"/>
         <source>Launch game</source>
         <translation>Spiel starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1776"/>
+        <location filename="../app/Main.qml" line="2368"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1780"/>
+        <location filename="../app/Main.qml" line="2374"/>
         <source>Loading favorites…</source>
         <translation>Favoriten werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1778"/>
+        <location filename="../app/Main.qml" line="2370"/>
         <source>Loading games…</source>
         <translation>Spiele werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="954"/>
+        <location filename="../app/Main.qml" line="1219"/>
+        <source>Update media database</source>
+        <translation type="unfinished">Mediendatenbank aktualisieren</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1222"/>
+        <source>Scrape metadata</source>
+        <translation type="unfinished">Metadaten abrufen</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1416"/>
         <source>Default</source>
         <translation type="unfinished">Standard</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="954"/>
+        <location filename="../app/Main.qml" line="1416"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1230"/>
+        <location filename="../app/Main.qml" line="1708"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1234"/>
+        <location filename="../app/Main.qml" line="1712"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1248"/>
+        <location filename="../app/Main.qml" line="1726"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1252"/>
+        <location filename="../app/Main.qml" line="1730"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1256"/>
+        <location filename="../app/Main.qml" line="1734"/>
         <source>Retry</source>
         <translation type="unfinished">Wiederholen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1260"/>
+        <location filename="../app/Main.qml" line="1738"/>
         <source>Cancel</source>
         <translation type="unfinished">Abbrechen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1782"/>
+        <location filename="../app/Main.qml" line="2372"/>
+        <source>Loading game…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2376"/>
         <source>Loading recently played…</source>
         <translation>Zuletzt gespielte werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="2378"/>
+        <source>Loading settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2380"/>
         <source>Loading…</source>
         <translation>Wird geladen…</translation>
     </message>
@@ -543,161 +667,161 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="581"/>
+        <location filename="../app/MainLayout.qml" line="680"/>
         <source>Writing failed</source>
         <translation>Schreiben fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="581"/>
+        <location filename="../app/MainLayout.qml" line="680"/>
         <source>Put a writable card near the reader</source>
         <translation>Beschreibbare Karte an den Leser halten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="669"/>
+        <location filename="../app/MainLayout.qml" line="807"/>
         <source>Are you sure you want to exit?</source>
         <translation>Wirklich beenden?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="745"/>
-        <location filename="../app/MainLayout.qml" line="817"/>
+        <location filename="../app/MainLayout.qml" line="890"/>
+        <location filename="../app/MainLayout.qml" line="964"/>
         <source>Select</source>
         <translation>Auswählen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="749"/>
-        <location filename="../app/MainLayout.qml" line="753"/>
-        <location filename="../app/MainLayout.qml" line="767"/>
-        <location filename="../app/MainLayout.qml" line="780"/>
-        <location filename="../app/MainLayout.qml" line="791"/>
+        <location filename="../app/MainLayout.qml" line="894"/>
+        <location filename="../app/MainLayout.qml" line="898"/>
+        <location filename="../app/MainLayout.qml" line="912"/>
+        <location filename="../app/MainLayout.qml" line="927"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
         <source>Close</source>
         <translation>Schließen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="760"/>
-        <location filename="../app/MainLayout.qml" line="798"/>
-        <location filename="../app/MainLayout.qml" line="821"/>
-        <location filename="../app/MainLayout.qml" line="832"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
+        <location filename="../app/MainLayout.qml" line="945"/>
+        <location filename="../app/MainLayout.qml" line="968"/>
+        <location filename="../app/MainLayout.qml" line="979"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="776"/>
+        <location filename="../app/MainLayout.qml" line="923"/>
         <source>Done</source>
         <translation>Fertig</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="806"/>
+        <location filename="../app/MainLayout.qml" line="953"/>
         <source>I understand</source>
         <translation>Ich verstehe</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="840"/>
+        <location filename="../app/MainLayout.qml" line="987"/>
         <source>Start</source>
         <translation>Starten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1009"/>
+        <location filename="../app/MainLayout.qml" line="1165"/>
         <source>Scroll</source>
         <translation>Scrollen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="741"/>
-        <location filename="../app/MainLayout.qml" line="813"/>
-        <location filename="../app/MainLayout.qml" line="856"/>
-        <location filename="../app/MainLayout.qml" line="885"/>
-        <location filename="../app/MainLayout.qml" line="932"/>
-        <location filename="../app/MainLayout.qml" line="973"/>
-        <location filename="../app/MainLayout.qml" line="1037"/>
+        <location filename="../app/MainLayout.qml" line="886"/>
+        <location filename="../app/MainLayout.qml" line="960"/>
+        <location filename="../app/MainLayout.qml" line="1003"/>
+        <location filename="../app/MainLayout.qml" line="1034"/>
+        <location filename="../app/MainLayout.qml" line="1084"/>
+        <location filename="../app/MainLayout.qml" line="1127"/>
+        <location filename="../app/MainLayout.qml" line="1195"/>
         <source>Move</source>
         <translation>Bewegen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="141"/>
+        <location filename="../app/MainLayout.qml" line="170"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="323"/>
+        <location filename="../app/MainLayout.qml" line="364"/>
         <source>Favorites</source>
         <translation type="unfinished">Favoriten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="325"/>
+        <location filename="../app/MainLayout.qml" line="366"/>
         <source>Recently Played</source>
         <translation type="unfinished">Zuletzt gespielt</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="592"/>
+        <location filename="../app/MainLayout.qml" line="695"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="593"/>
+        <location filename="../app/MainLayout.qml" line="696"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="668"/>
+        <location filename="../app/MainLayout.qml" line="806"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="860"/>
-        <location filename="../app/MainLayout.qml" line="895"/>
-        <location filename="../app/MainLayout.qml" line="942"/>
-        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1007"/>
+        <location filename="../app/MainLayout.qml" line="1044"/>
+        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Open</source>
         <translation>Öffnen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="864"/>
+        <location filename="../app/MainLayout.qml" line="1011"/>
         <source>Quit</source>
         <translation>Beenden</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="873"/>
-        <location filename="../app/MainLayout.qml" line="901"/>
-        <location filename="../app/MainLayout.qml" line="912"/>
-        <location filename="../app/MainLayout.qml" line="924"/>
-        <location filename="../app/MainLayout.qml" line="951"/>
-        <location filename="../app/MainLayout.qml" line="962"/>
-        <location filename="../app/MainLayout.qml" line="997"/>
-        <location filename="../app/MainLayout.qml" line="1013"/>
-        <location filename="../app/MainLayout.qml" line="1022"/>
-        <location filename="../app/MainLayout.qml" line="1056"/>
-        <location filename="../app/MainLayout.qml" line="1067"/>
+        <location filename="../app/MainLayout.qml" line="1020"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1061"/>
+        <location filename="../app/MainLayout.qml" line="1076"/>
+        <location filename="../app/MainLayout.qml" line="1103"/>
+        <location filename="../app/MainLayout.qml" line="1114"/>
+        <location filename="../app/MainLayout.qml" line="1151"/>
+        <location filename="../app/MainLayout.qml" line="1169"/>
+        <location filename="../app/MainLayout.qml" line="1178"/>
+        <location filename="../app/MainLayout.qml" line="1214"/>
+        <location filename="../app/MainLayout.qml" line="1225"/>
         <source>Back</source>
         <translation>Zurück</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="891"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1043"/>
+        <location filename="../app/MainLayout.qml" line="1040"/>
+        <location filename="../app/MainLayout.qml" line="1090"/>
+        <location filename="../app/MainLayout.qml" line="1201"/>
         <source>Page</source>
         <translation>Seite</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="947"/>
-        <location filename="../app/MainLayout.qml" line="1052"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1210"/>
         <source>Options</source>
         <translation>Optionen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="787"/>
-        <location filename="../app/MainLayout.qml" line="908"/>
-        <location filename="../app/MainLayout.qml" line="958"/>
-        <location filename="../app/MainLayout.qml" line="1063"/>
+        <location filename="../app/MainLayout.qml" line="934"/>
+        <location filename="../app/MainLayout.qml" line="1057"/>
+        <location filename="../app/MainLayout.qml" line="1110"/>
+        <location filename="../app/MainLayout.qml" line="1221"/>
         <source>Retry</source>
         <translation>Wiederholen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="982"/>
+        <location filename="../app/MainLayout.qml" line="1136"/>
         <source>Change</source>
         <translation>Ändern</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="988"/>
+        <location filename="../app/MainLayout.qml" line="1142"/>
         <source>Toggle</source>
         <translation>Umschalten</translation>
     </message>
@@ -710,12 +834,12 @@
         <translation type="unfinished">Wird geladen…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="306"/>
+        <location filename="../screens/MediaListScreen.qml" line="351"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 Einträge</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="307"/>
+        <location filename="../screens/MediaListScreen.qml" line="352"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -764,17 +888,17 @@
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="26"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
         <source>Nothing here</source>
         <translation>Nichts hier</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="28"/>
         <source>Loading…</source>
         <translation>Wird geladen…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="57"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="58"/>
         <source>Failed to load</source>
         <translation>Laden fehlgeschlagen</translation>
     </message>
@@ -782,387 +906,423 @@
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="73"/>
-        <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
         <source>Language</source>
         <translation>Sprache</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="516"/>
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Browsing layout</source>
         <translation>Darstellungsmodus</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="130"/>
         <source>Mouse support</source>
         <translation>Mausunterstützung</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="112"/>
+        <location filename="../screens/SettingsScreen.qml" line="137"/>
         <source>Update media database</source>
         <translation>Mediendatenbank aktualisieren</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="61"/>
         <source>General</source>
-        <translation>Allgemein</translation>
+        <translation type="vanished">Allgemein</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78"/>
-        <location filename="../screens/SettingsScreen.qml" line="507"/>
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <location filename="../screens/SettingsScreen.qml" line="618"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88"/>
-        <location filename="../screens/SettingsScreen.qml" line="525"/>
+        <location filename="../screens/SettingsScreen.qml" line="125"/>
+        <location filename="../screens/SettingsScreen.qml" line="636"/>
         <source>Button style</source>
         <translation>Schaltflächenstil</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="93"/>
-        <location filename="../screens/SettingsScreen.qml" line="534"/>
+        <location filename="../screens/SettingsScreen.qml" line="112"/>
+        <location filename="../screens/SettingsScreen.qml" line="645"/>
         <source>Screensaver</source>
         <translation>Bildschirmschoner</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97"/>
         <source>Library</source>
-        <translation>Bibliothek</translation>
+        <translation type="vanished">Bibliothek</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="142"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="543"/>
+        <location filename="../screens/SettingsScreen.qml" line="654"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
         <source>Scrape metadata</source>
         <translation>Metadaten abrufen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Advanced</source>
-        <translation>Erweitert</translation>
+        <translation type="vanished">Erweitert</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="136"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
         <source>Debug logging</source>
         <translation>Debug-Protokollierung</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="141"/>
+        <location filename="../screens/SettingsScreen.qml" line="169"/>
         <source>Upload log file</source>
         <translation>Protokolldatei hochladen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="146"/>
+        <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>About / License</source>
         <translation>Über / Lizenz</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="162"/>
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
+        <source>Display &amp; Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="72"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <source>Controls &amp; Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="189"/>
+        <source>Library &amp; Data Management</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="82"/>
+        <location filename="../screens/SettingsScreen.qml" line="191"/>
+        <source>Support &amp; About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="206"/>
         <source>Optimizing</source>
         <translation>Wird optimiert</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
-        <location filename="../screens/SettingsScreen.qml" line="173"/>
+        <location filename="../screens/SettingsScreen.qml" line="208"/>
+        <location filename="../screens/SettingsScreen.qml" line="217"/>
         <source>Paused</source>
         <translation>Pausiert</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
-        <location filename="../screens/SettingsScreen.qml" line="173"/>
+        <location filename="../screens/SettingsScreen.qml" line="208"/>
+        <location filename="../screens/SettingsScreen.qml" line="217"/>
         <source>In progress</source>
         <translation>In Bearbeitung</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="167"/>
+        <location filename="../screens/SettingsScreen.qml" line="211"/>
         <source>%1 indexed</source>
         <translation>%1 indiziert</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="176"/>
+        <location filename="../screens/SettingsScreen.qml" line="220"/>
         <source>%1 scraped</source>
         <translation>%1 erfasst</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="284"/>
+        <location filename="../screens/SettingsScreen.qml" line="393"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="284"/>
+        <location filename="../screens/SettingsScreen.qml" line="393"/>
         <source>Start</source>
         <translation>Starten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="286"/>
+        <location filename="../screens/SettingsScreen.qml" line="395"/>
         <source>Upload</source>
         <translation>Hochladen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="288"/>
+        <location filename="../screens/SettingsScreen.qml" line="396"/>
         <source>Open</source>
         <translation>Öffnen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="365"/>
+        <location filename="../screens/SettingsScreen.qml" line="472"/>
         <source>English</source>
         <translation>Englisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="367"/>
+        <location filename="../screens/SettingsScreen.qml" line="474"/>
         <source>Italian</source>
         <translation>Italienisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="476"/>
+        <source>Spanish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="478"/>
+        <source>Basque</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="480"/>
         <source>German</source>
         <translation>Deutsch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
+        <location filename="../screens/SettingsScreen.qml" line="482"/>
         <source>Greek</source>
         <translation>Griechisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="373"/>
+        <location filename="../screens/SettingsScreen.qml" line="484"/>
         <source>Japanese</source>
         <translation>Japanisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="375"/>
+        <location filename="../screens/SettingsScreen.qml" line="486"/>
         <source>Korean</source>
         <translation>Koreanisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Dutch</source>
         <translation>Niederländisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="379"/>
+        <location filename="../screens/SettingsScreen.qml" line="490"/>
         <source>Romanian</source>
         <translation>Rumänisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="381"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Slovak</source>
         <translation>Slowakisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="383"/>
+        <location filename="../screens/SettingsScreen.qml" line="494"/>
         <source>Ukrainian</source>
         <translation>Ukrainisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="385"/>
+        <location filename="../screens/SettingsScreen.qml" line="496"/>
         <source>Chinese (Simplified)</source>
         <translation>Chinesisch (vereinfacht)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="387"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Hebrew</source>
         <translation>Hebräisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="389"/>
+        <location filename="../screens/SettingsScreen.qml" line="500"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="391"/>
+        <location filename="../screens/SettingsScreen.qml" line="502"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="392"/>
-        <location filename="../screens/SettingsScreen.qml" line="451"/>
+        <location filename="../screens/SettingsScreen.qml" line="503"/>
+        <location filename="../screens/SettingsScreen.qml" line="562"/>
         <source>Auto</source>
         <translation>Automatisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <location filename="../screens/SettingsScreen.qml" line="508"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <location filename="../screens/SettingsScreen.qml" line="510"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="400"/>
+        <location filename="../screens/SettingsScreen.qml" line="511"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405"/>
+        <location filename="../screens/SettingsScreen.qml" line="516"/>
         <source>Detailed list view</source>
         <translation>Detaillierte Listenansicht</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="406"/>
+        <location filename="../screens/SettingsScreen.qml" line="517"/>
         <source>Grid view</source>
         <translation>Rasteransicht</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="411"/>
+        <location filename="../screens/SettingsScreen.qml" line="522"/>
         <source>Style B</source>
         <translation>Stil B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="413"/>
+        <location filename="../screens/SettingsScreen.qml" line="524"/>
         <source>Style C</source>
         <translation>Stil C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="415"/>
+        <location filename="../screens/SettingsScreen.qml" line="526"/>
         <source>Style D</source>
         <translation>Stil D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="416"/>
+        <location filename="../screens/SettingsScreen.qml" line="527"/>
         <source>Style A</source>
         <translation>Stil A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="340"/>
+        <location filename="../screens/SettingsScreen.qml" line="1032"/>
+        <source>Loading settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="447"/>
         <source>Default</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="431"/>
+        <location filename="../screens/SettingsScreen.qml" line="542"/>
         <source>Off</source>
         <translation>Aus</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="433"/>
+        <location filename="../screens/SettingsScreen.qml" line="544"/>
         <source>1 second (testing)</source>
         <translation>1 Sekunde (Test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="435"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>1 minute</source>
         <translation>1 Minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="437"/>
+        <location filename="../screens/SettingsScreen.qml" line="548"/>
         <source>2 minutes</source>
         <translation>2 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="439"/>
+        <location filename="../screens/SettingsScreen.qml" line="550"/>
         <source>5 minutes</source>
         <translation>5 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="441"/>
+        <location filename="../screens/SettingsScreen.qml" line="552"/>
         <source>10 minutes</source>
         <translation>10 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="443"/>
+        <location filename="../screens/SettingsScreen.qml" line="554"/>
         <source>15 minutes</source>
         <translation>15 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="445"/>
+        <location filename="../screens/SettingsScreen.qml" line="556"/>
         <source>30 minutes</source>
         <translation>30 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="446"/>
+        <location filename="../screens/SettingsScreen.qml" line="557"/>
         <source>%1 seconds</source>
         <translation>%1 Sekunden</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="489"/>
+        <location filename="../screens/SettingsScreen.qml" line="91"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Resolution</source>
         <translation>Auflösung</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="453"/>
+        <location filename="../screens/SettingsScreen.qml" line="564"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="455"/>
+        <location filename="../screens/SettingsScreen.qml" line="566"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="457"/>
+        <location filename="../screens/SettingsScreen.qml" line="568"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <location filename="../screens/SettingsScreen.qml" line="570"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="461"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="463"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="465"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="467"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="469"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="471"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="473"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="663"/>
+        <location filename="../screens/SettingsScreen.qml" line="192"/>
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="857"/>
+        <location filename="../screens/SettingsScreen.qml" line="1020"/>
         <source>No settings available on this platform</source>
         <translation>Keine Einstellungen für diese Plattform verfügbar</translation>
     </message>
@@ -1170,24 +1330,24 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="195"/>
-        <location filename="../screens/SystemsScreen.qml" line="292"/>
+        <location filename="../screens/SystemsScreen.qml" line="197"/>
+        <location filename="../screens/SystemsScreen.qml" line="295"/>
         <source>%1 systems</source>
         <translation>%1 Systeme</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="196"/>
-        <location filename="../screens/SystemsScreen.qml" line="309"/>
+        <location filename="../screens/SystemsScreen.qml" line="198"/>
+        <location filename="../screens/SystemsScreen.qml" line="312"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="324"/>
+        <location filename="../screens/SystemsScreen.qml" line="328"/>
         <source>No systems in this category</source>
         <translation>Keine Systeme in dieser Kategorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="325"/>
+        <location filename="../screens/SystemsScreen.qml" line="329"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -54,6 +54,13 @@
         <translation>Übersetzungen</translation>
     </message>
     <message>
+        <location filename="../screens/AboutScreen.qml" line="267"/>
+        <source>Italiano - Andrea Bogazzi
+Español - Carlos R.
+Euskara - devilschile2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/AboutScreen.qml" line="278"/>
         <source>Full license text in COPYING.</source>
         <translation>Vollständiger Lizenztext in COPYING.</translation>
@@ -907,13 +914,13 @@
     <name>SettingsScreen</name>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="611"/>
         <source>Language</source>
         <translation>Sprache</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="627"/>
+        <location filename="../screens/SettingsScreen.qml" line="629"/>
         <source>Browsing layout</source>
         <translation>Darstellungsmodus</translation>
     </message>
@@ -933,19 +940,19 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="97"/>
-        <location filename="../screens/SettingsScreen.qml" line="618"/>
+        <location filename="../screens/SettingsScreen.qml" line="620"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="125"/>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="638"/>
         <source>Button style</source>
         <translation>Schaltflächenstil</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="112"/>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
+        <location filename="../screens/SettingsScreen.qml" line="647"/>
         <source>Screensaver</source>
         <translation>Bildschirmschoner</translation>
     </message>
@@ -960,7 +967,7 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="654"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1131,72 +1138,77 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <source>Chinese (Traditional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="500"/>
         <source>Hebrew</source>
         <translation>Hebräisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="500"/>
+        <location filename="../screens/SettingsScreen.qml" line="502"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="502"/>
+        <location filename="../screens/SettingsScreen.qml" line="504"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="503"/>
-        <location filename="../screens/SettingsScreen.qml" line="562"/>
+        <location filename="../screens/SettingsScreen.qml" line="505"/>
+        <location filename="../screens/SettingsScreen.qml" line="564"/>
         <source>Auto</source>
         <translation>Automatisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="508"/>
+        <location filename="../screens/SettingsScreen.qml" line="510"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="510"/>
+        <location filename="../screens/SettingsScreen.qml" line="512"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="511"/>
+        <location filename="../screens/SettingsScreen.qml" line="513"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="516"/>
+        <location filename="../screens/SettingsScreen.qml" line="518"/>
         <source>Detailed list view</source>
         <translation>Detaillierte Listenansicht</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="517"/>
+        <location filename="../screens/SettingsScreen.qml" line="519"/>
         <source>Grid view</source>
         <translation>Rasteransicht</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="522"/>
+        <location filename="../screens/SettingsScreen.qml" line="524"/>
         <source>Style B</source>
         <translation>Stil B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="524"/>
+        <location filename="../screens/SettingsScreen.qml" line="526"/>
         <source>Style C</source>
         <translation>Stil C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="526"/>
+        <location filename="../screens/SettingsScreen.qml" line="528"/>
         <source>Style D</source>
         <translation>Stil D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="527"/>
+        <location filename="../screens/SettingsScreen.qml" line="529"/>
         <source>Style A</source>
         <translation>Stil A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1032"/>
+        <location filename="../screens/SettingsScreen.qml" line="1034"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1206,113 +1218,113 @@
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="542"/>
+        <location filename="../screens/SettingsScreen.qml" line="544"/>
         <source>Off</source>
         <translation>Aus</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="544"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>1 second (testing)</source>
         <translation>1 Sekunde (Test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="546"/>
+        <location filename="../screens/SettingsScreen.qml" line="548"/>
         <source>1 minute</source>
         <translation>1 Minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="548"/>
+        <location filename="../screens/SettingsScreen.qml" line="550"/>
         <source>2 minutes</source>
         <translation>2 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="550"/>
+        <location filename="../screens/SettingsScreen.qml" line="552"/>
         <source>5 minutes</source>
         <translation>5 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="552"/>
+        <location filename="../screens/SettingsScreen.qml" line="554"/>
         <source>10 minutes</source>
         <translation>10 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="554"/>
+        <location filename="../screens/SettingsScreen.qml" line="556"/>
         <source>15 minutes</source>
         <translation>15 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="556"/>
+        <location filename="../screens/SettingsScreen.qml" line="558"/>
         <source>30 minutes</source>
         <translation>30 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="557"/>
+        <location filename="../screens/SettingsScreen.qml" line="559"/>
         <source>%1 seconds</source>
         <translation>%1 Sekunden</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="91"/>
-        <location filename="../screens/SettingsScreen.qml" line="600"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Resolution</source>
         <translation>Auflösung</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="564"/>
+        <location filename="../screens/SettingsScreen.qml" line="566"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="566"/>
+        <location filename="../screens/SettingsScreen.qml" line="568"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="568"/>
+        <location filename="../screens/SettingsScreen.qml" line="570"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="570"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1322,7 +1334,7 @@
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1020"/>
+        <location filename="../screens/SettingsScreen.qml" line="1022"/>
         <source>No settings available on this platform</source>
         <translation>Keine Einstellungen für diese Plattform verfügbar</translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -4,57 +4,57 @@
 <context>
     <name>AboutScreen</name>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="71"/>
+        <location filename="../screens/AboutScreen.qml" line="73"/>
         <source>About / License</source>
         <translation>Σχετικά / Άδεια</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="153"/>
+        <location filename="../screens/AboutScreen.qml" line="155"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="164"/>
+        <location filename="../screens/AboutScreen.qml" line="166"/>
         <source>Version %1 · %2 · %3</source>
         <translation>Έκδοση %1 · %2 · %3</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="174"/>
+        <location filename="../screens/AboutScreen.qml" line="176"/>
         <source>Built %1</source>
         <translation>Κατασκευάστηκε %1</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="185"/>
+        <location filename="../screens/AboutScreen.qml" line="187"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>Πνευματικά δικαιώματα 2026 Wizzo Pty Ltd και οι συντελεστές του έργου Zaparoo.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="196"/>
+        <location filename="../screens/AboutScreen.qml" line="198"/>
         <source>Source available under the PolyForm Noncommercial License 1.0.0. Free for personal, non-commercial use. Commercial use requires a separate license.</source>
         <translation>Ο πηγαίος κώδικας διατίθεται με την άδεια PolyForm Noncommercial License 1.0.0. Δωρεάν για προσωπική, μη εμπορική χρήση. Η εμπορική χρήση ή αναδιανομή απαιτεί ξεχωριστή άδεια.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="207"/>
+        <location filename="../screens/AboutScreen.qml" line="209"/>
         <source>Commercial licensing: legal@zaparoo.org</source>
         <translation>Εμπορική αδειοδότηση: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="218"/>
+        <location filename="../screens/AboutScreen.qml" line="220"/>
         <source>Project: https://zaparoo.org</source>
         <translation>Έργο: https://zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="228"/>
+        <location filename="../screens/AboutScreen.qml" line="230"/>
         <source>Created by</source>
         <translation>Δημιουργήθηκε από</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="252"/>
+        <location filename="../screens/AboutScreen.qml" line="254"/>
         <source>Translations</source>
         <translation>Μεταφράσεις</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="276"/>
+        <location filename="../screens/AboutScreen.qml" line="278"/>
         <source>Full license text in COPYING.</source>
         <translation>Πλήρες κείμενο άδειας στο COPYING.</translation>
     </message>
@@ -90,48 +90,102 @@
         <translation type="unfinished">Φόρτωση…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="77"/>
+        <location filename="../components/BrowseDetailPane.qml" line="138"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="79"/>
+        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <source>Yr</source>
+        <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="81"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <source>Gen</source>
+        <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="83"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <source>Plyr</source>
+        <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="85"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <source>Dev</source>
+        <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="87"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <source>Pub</source>
+        <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="89"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <source>Rtg</source>
+        <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="91"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <source>Cat</source>
+        <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="93"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <source>Date</source>
+        <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Manufacturer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <source>Mfr</source>
+        <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -176,68 +230,103 @@
 <context>
     <name>CoreStatusPill</name>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="44"/>
-        <location filename="../components/CoreStatusPill.qml" line="50"/>
+        <location filename="../components/CoreStatusPill.qml" line="46"/>
+        <location filename="../components/CoreStatusPill.qml" line="52"/>
         <source>Disconnected</source>
         <translation>Αποσυνδεδεμένο</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="47"/>
+        <location filename="../components/CoreStatusPill.qml" line="49"/>
         <source>Reconnecting…</source>
         <translation>Επανασύνδεση…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="53"/>
+        <location filename="../components/CoreStatusPill.qml" line="55"/>
         <source>Connecting…</source>
         <translation>Σύνδεση…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="56"/>
+        <location filename="../components/CoreStatusPill.qml" line="58"/>
         <source>Core error</source>
         <translation>Σφάλμα Core</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="60"/>
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <source>Paused %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <source>Paused</source>
+        <translation type="unfinished">Σε παύση</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="78"/>
+        <source>Opt…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="78"/>
+        <source>Optimizing</source>
+        <translation type="unfinished">Βελτιστοποίηση</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
+        <source>Idx…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
+        <source>Scr…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Optimizing database</source>
-        <translation>Βελτιστοποίηση βάσης δεδομένων</translation>
+        <translation type="vanished">Βελτιστοποίηση βάσης δεδομένων</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="67"/>
         <source>Indexing paused</source>
-        <translation>Ευρετηρίαση σε παύση</translation>
+        <translation type="vanished">Ευρετηρίαση σε παύση</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="70"/>
         <source>Indexing %1/%2 - %3</source>
-        <translation>Ευρετηρίαση %1/%2 – %3</translation>
+        <translation type="vanished">Ευρετηρίαση %1/%2 – %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="86"/>
         <source>Scraping %1/%2 - %3</source>
-        <translation>Scraping %1/%2 – %3</translation>
+        <translation type="vanished">Scraping %1/%2 – %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="73"/>
+        <location filename="../components/CoreStatusPill.qml" line="82"/>
         <source>Indexing %1/%2</source>
         <translation>Ευρετηρίαση %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <location filename="../components/CoreStatusPill.qml" line="82"/>
+        <source>Idx %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Indexing…</source>
         <translation>Ευρετηρίαση…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Scrape paused</source>
-        <translation>Scraping σε παύση</translation>
+        <translation type="vanished">Scraping σε παύση</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="89"/>
+        <location filename="../components/CoreStatusPill.qml" line="88"/>
         <source>Scraping %1/%2</source>
         <translation>Συλλογή %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="91"/>
+        <location filename="../components/CoreStatusPill.qml" line="88"/>
+        <source>Scr %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
         <source>Scraping…</source>
         <translation>Γίνεται συλλογή…</translation>
     </message>
@@ -329,34 +418,34 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="117"/>
-        <location filename="../screens/GamesScreen.qml" line="145"/>
+        <location filename="../screens/GamesScreen.qml" line="122"/>
+        <location filename="../screens/GamesScreen.qml" line="157"/>
         <source>%1 files</source>
         <translation>%1 αρχεία</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="51"/>
+        <location filename="../screens/GamesScreen.qml" line="55"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="126"/>
-        <location filename="../screens/GamesScreen.qml" line="146"/>
+        <location filename="../screens/GamesScreen.qml" line="131"/>
+        <location filename="../screens/GamesScreen.qml" line="158"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="45"/>
+        <location filename="../screens/GamesScreen.qml" line="49"/>
         <source>Loading games…</source>
         <translation>Φόρτωση παιχνιδιών…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="122"/>
+        <location filename="../screens/GamesScreen.qml" line="127"/>
         <source>Loading more…</source>
         <translation>Φόρτωση περισσότερων…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="44"/>
+        <location filename="../screens/GamesScreen.qml" line="48"/>
         <source>No games in this system</source>
         <translation>Δεν υπάρχουν παιχνίδια σε αυτό το σύστημα</translation>
     </message>
@@ -364,32 +453,47 @@
 <context>
     <name>HubScreen</name>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
-        <source>Resume: %1</source>
+        <location filename="../screens/HubScreen.qml" line="56"/>
+        <source>Arcade</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
-        <source>Resume Game</source>
+        <location filename="../screens/HubScreen.qml" line="61"/>
+        <source>Computers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
+        <location filename="../screens/HubScreen.qml" line="66"/>
+        <source>Consoles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="71"/>
+        <source>Handhelds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="134"/>
+        <source>Resume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="140"/>
         <source>Favorites</source>
         <translation>Αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="96"/>
+        <location filename="../screens/HubScreen.qml" line="145"/>
         <source>Recently Played</source>
         <translation>Πρόσφατα Παιγμένα</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="101"/>
+        <location filename="../screens/HubScreen.qml" line="150"/>
         <source>Settings</source>
         <translation>Ρυθμίσεις</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="537"/>
+        <location filename="../screens/HubScreen.qml" line="644"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Δεν υπάρχουν διαθέσιμα συστήματα. Εκτελέστε Ενημέρωση βάσης δεδομένων από τις Ρυθμίσεις.</translation>
     </message>
@@ -438,104 +542,124 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="755"/>
+        <location filename="../app/Main.qml" line="1206"/>
         <source>Launch core</source>
         <translation>Εκκίνηση Core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="958"/>
+        <location filename="../app/Main.qml" line="1212"/>
+        <location filename="../app/Main.qml" line="1420"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="786"/>
+        <location filename="../app/Main.qml" line="1247"/>
         <source>Remove from favorites</source>
         <translation>Αφαίρεση από αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="786"/>
+        <location filename="../app/Main.qml" line="1247"/>
         <source>Add to favorites</source>
         <translation>Προσθήκη στα αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="791"/>
+        <location filename="../app/Main.qml" line="1252"/>
         <source>Write to NFC token</source>
         <translation>Εγγραφή σε NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="795"/>
+        <location filename="../app/Main.qml" line="1256"/>
         <source>QR code</source>
         <translation>Κωδικός QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="770"/>
-        <location filename="../app/Main.qml" line="805"/>
+        <location filename="../app/Main.qml" line="1231"/>
+        <location filename="../app/Main.qml" line="1266"/>
         <source>Launch game</source>
         <translation>Εκκίνηση παιχνιδιού</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1776"/>
+        <location filename="../app/Main.qml" line="2368"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1780"/>
+        <location filename="../app/Main.qml" line="2374"/>
         <source>Loading favorites…</source>
         <translation>Φόρτωση αγαπημένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1778"/>
+        <location filename="../app/Main.qml" line="2370"/>
         <source>Loading games…</source>
         <translation>Φόρτωση παιχνιδιών…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="954"/>
+        <location filename="../app/Main.qml" line="1219"/>
+        <source>Update media database</source>
+        <translation type="unfinished">Ενημέρωση βάσης δεδομένων</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1222"/>
+        <source>Scrape metadata</source>
+        <translation type="unfinished">Ανάκτηση μεταδεδομένων</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1416"/>
         <source>Default</source>
         <translation type="unfinished">Προεπιλογή</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="954"/>
+        <location filename="../app/Main.qml" line="1416"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1230"/>
+        <location filename="../app/Main.qml" line="1708"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1234"/>
+        <location filename="../app/Main.qml" line="1712"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1248"/>
+        <location filename="../app/Main.qml" line="1726"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1252"/>
+        <location filename="../app/Main.qml" line="1730"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1256"/>
+        <location filename="../app/Main.qml" line="1734"/>
         <source>Retry</source>
         <translation type="unfinished">Επανάληψη</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1260"/>
+        <location filename="../app/Main.qml" line="1738"/>
         <source>Cancel</source>
         <translation type="unfinished">Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1782"/>
+        <location filename="../app/Main.qml" line="2372"/>
+        <source>Loading game…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2376"/>
         <source>Loading recently played…</source>
         <translation>Φόρτωση πρόσφατα παιγμένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="2378"/>
+        <source>Loading settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2380"/>
         <source>Loading…</source>
         <translation>Φόρτωση…</translation>
     </message>
@@ -543,161 +667,161 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="581"/>
+        <location filename="../app/MainLayout.qml" line="680"/>
         <source>Writing failed</source>
         <translation>Αποτυχία εγγραφής</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="581"/>
+        <location filename="../app/MainLayout.qml" line="680"/>
         <source>Put a writable card near the reader</source>
         <translation>Τοποθετήστε μια εγγράψιμη κάρτα κοντά στον αναγνώστη</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="669"/>
+        <location filename="../app/MainLayout.qml" line="807"/>
         <source>Are you sure you want to exit?</source>
         <translation>Είστε σίγουροι ότι θέλετε να βγείτε;</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="745"/>
-        <location filename="../app/MainLayout.qml" line="817"/>
+        <location filename="../app/MainLayout.qml" line="890"/>
+        <location filename="../app/MainLayout.qml" line="964"/>
         <source>Select</source>
         <translation>Επιλογή</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="749"/>
-        <location filename="../app/MainLayout.qml" line="753"/>
-        <location filename="../app/MainLayout.qml" line="767"/>
-        <location filename="../app/MainLayout.qml" line="780"/>
-        <location filename="../app/MainLayout.qml" line="791"/>
+        <location filename="../app/MainLayout.qml" line="894"/>
+        <location filename="../app/MainLayout.qml" line="898"/>
+        <location filename="../app/MainLayout.qml" line="912"/>
+        <location filename="../app/MainLayout.qml" line="927"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
         <source>Close</source>
         <translation>Κλείσιμο</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="760"/>
-        <location filename="../app/MainLayout.qml" line="798"/>
-        <location filename="../app/MainLayout.qml" line="821"/>
-        <location filename="../app/MainLayout.qml" line="832"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
+        <location filename="../app/MainLayout.qml" line="945"/>
+        <location filename="../app/MainLayout.qml" line="968"/>
+        <location filename="../app/MainLayout.qml" line="979"/>
         <source>Cancel</source>
         <translation>Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="776"/>
+        <location filename="../app/MainLayout.qml" line="923"/>
         <source>Done</source>
         <translation>Ολοκληρώθηκε</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="806"/>
+        <location filename="../app/MainLayout.qml" line="953"/>
         <source>I understand</source>
         <translation>Κατανοώ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="840"/>
+        <location filename="../app/MainLayout.qml" line="987"/>
         <source>Start</source>
         <translation>Έναρξη</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1009"/>
+        <location filename="../app/MainLayout.qml" line="1165"/>
         <source>Scroll</source>
         <translation>Κύλιση</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="741"/>
-        <location filename="../app/MainLayout.qml" line="813"/>
-        <location filename="../app/MainLayout.qml" line="856"/>
-        <location filename="../app/MainLayout.qml" line="885"/>
-        <location filename="../app/MainLayout.qml" line="932"/>
-        <location filename="../app/MainLayout.qml" line="973"/>
-        <location filename="../app/MainLayout.qml" line="1037"/>
+        <location filename="../app/MainLayout.qml" line="886"/>
+        <location filename="../app/MainLayout.qml" line="960"/>
+        <location filename="../app/MainLayout.qml" line="1003"/>
+        <location filename="../app/MainLayout.qml" line="1034"/>
+        <location filename="../app/MainLayout.qml" line="1084"/>
+        <location filename="../app/MainLayout.qml" line="1127"/>
+        <location filename="../app/MainLayout.qml" line="1195"/>
         <source>Move</source>
         <translation>Μετακίνηση</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="141"/>
+        <location filename="../app/MainLayout.qml" line="170"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="323"/>
+        <location filename="../app/MainLayout.qml" line="364"/>
         <source>Favorites</source>
         <translation type="unfinished">Αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="325"/>
+        <location filename="../app/MainLayout.qml" line="366"/>
         <source>Recently Played</source>
         <translation type="unfinished">Πρόσφατα Παιγμένα</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="592"/>
+        <location filename="../app/MainLayout.qml" line="695"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="593"/>
+        <location filename="../app/MainLayout.qml" line="696"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="668"/>
+        <location filename="../app/MainLayout.qml" line="806"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="860"/>
-        <location filename="../app/MainLayout.qml" line="895"/>
-        <location filename="../app/MainLayout.qml" line="942"/>
-        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1007"/>
+        <location filename="../app/MainLayout.qml" line="1044"/>
+        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Open</source>
         <translation>Άνοιγμα</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="864"/>
+        <location filename="../app/MainLayout.qml" line="1011"/>
         <source>Quit</source>
         <translation>Έξοδος</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="873"/>
-        <location filename="../app/MainLayout.qml" line="901"/>
-        <location filename="../app/MainLayout.qml" line="912"/>
-        <location filename="../app/MainLayout.qml" line="924"/>
-        <location filename="../app/MainLayout.qml" line="951"/>
-        <location filename="../app/MainLayout.qml" line="962"/>
-        <location filename="../app/MainLayout.qml" line="997"/>
-        <location filename="../app/MainLayout.qml" line="1013"/>
-        <location filename="../app/MainLayout.qml" line="1022"/>
-        <location filename="../app/MainLayout.qml" line="1056"/>
-        <location filename="../app/MainLayout.qml" line="1067"/>
+        <location filename="../app/MainLayout.qml" line="1020"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1061"/>
+        <location filename="../app/MainLayout.qml" line="1076"/>
+        <location filename="../app/MainLayout.qml" line="1103"/>
+        <location filename="../app/MainLayout.qml" line="1114"/>
+        <location filename="../app/MainLayout.qml" line="1151"/>
+        <location filename="../app/MainLayout.qml" line="1169"/>
+        <location filename="../app/MainLayout.qml" line="1178"/>
+        <location filename="../app/MainLayout.qml" line="1214"/>
+        <location filename="../app/MainLayout.qml" line="1225"/>
         <source>Back</source>
         <translation>Πίσω</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="891"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1043"/>
+        <location filename="../app/MainLayout.qml" line="1040"/>
+        <location filename="../app/MainLayout.qml" line="1090"/>
+        <location filename="../app/MainLayout.qml" line="1201"/>
         <source>Page</source>
         <translation>Σελίδα</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="947"/>
-        <location filename="../app/MainLayout.qml" line="1052"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1210"/>
         <source>Options</source>
         <translation>Επιλογές</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="787"/>
-        <location filename="../app/MainLayout.qml" line="908"/>
-        <location filename="../app/MainLayout.qml" line="958"/>
-        <location filename="../app/MainLayout.qml" line="1063"/>
+        <location filename="../app/MainLayout.qml" line="934"/>
+        <location filename="../app/MainLayout.qml" line="1057"/>
+        <location filename="../app/MainLayout.qml" line="1110"/>
+        <location filename="../app/MainLayout.qml" line="1221"/>
         <source>Retry</source>
         <translation>Επανάληψη</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="982"/>
+        <location filename="../app/MainLayout.qml" line="1136"/>
         <source>Change</source>
         <translation>Αλλαγή</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="988"/>
+        <location filename="../app/MainLayout.qml" line="1142"/>
         <source>Toggle</source>
         <translation>Εναλλαγή</translation>
     </message>
@@ -710,12 +834,12 @@
         <translation type="unfinished">Φόρτωση…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="306"/>
+        <location filename="../screens/MediaListScreen.qml" line="351"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 εγγραφές</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="307"/>
+        <location filename="../screens/MediaListScreen.qml" line="352"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -764,17 +888,17 @@
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="26"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
         <source>Nothing here</source>
         <translation>Τίποτα εδώ</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="28"/>
         <source>Loading…</source>
         <translation>Φόρτωση…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="57"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="58"/>
         <source>Failed to load</source>
         <translation>Αποτυχία φόρτωσης</translation>
     </message>
@@ -782,387 +906,423 @@
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="73"/>
-        <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
         <source>Language</source>
         <translation>Γλώσσα</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="516"/>
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Browsing layout</source>
         <translation>Διάταξη περιήγησης</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="130"/>
         <source>Mouse support</source>
         <translation>Υποστήριξη ποντικιού</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="112"/>
+        <location filename="../screens/SettingsScreen.qml" line="137"/>
         <source>Update media database</source>
         <translation>Ενημέρωση βάσης δεδομένων</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="61"/>
         <source>General</source>
-        <translation>Γενικά</translation>
+        <translation type="vanished">Γενικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78"/>
-        <location filename="../screens/SettingsScreen.qml" line="507"/>
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <location filename="../screens/SettingsScreen.qml" line="618"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88"/>
-        <location filename="../screens/SettingsScreen.qml" line="525"/>
+        <location filename="../screens/SettingsScreen.qml" line="125"/>
+        <location filename="../screens/SettingsScreen.qml" line="636"/>
         <source>Button style</source>
         <translation>Στυλ κουμπιών</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="93"/>
-        <location filename="../screens/SettingsScreen.qml" line="534"/>
+        <location filename="../screens/SettingsScreen.qml" line="112"/>
+        <location filename="../screens/SettingsScreen.qml" line="645"/>
         <source>Screensaver</source>
         <translation>Προφύλαξη οθόνης</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97"/>
         <source>Library</source>
-        <translation>Βιβλιοθήκη</translation>
+        <translation type="vanished">Βιβλιοθήκη</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="142"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="543"/>
+        <location filename="../screens/SettingsScreen.qml" line="654"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
         <source>Scrape metadata</source>
         <translation>Ανάκτηση μεταδεδομένων</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Advanced</source>
-        <translation>Για προχωρημένους</translation>
+        <translation type="vanished">Για προχωρημένους</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="136"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
         <source>Debug logging</source>
         <translation>Καταγραφή εντοπισμού σφαλμάτων</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="141"/>
+        <location filename="../screens/SettingsScreen.qml" line="169"/>
         <source>Upload log file</source>
         <translation>Αποστολή αρχείου καταγραφής</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="146"/>
+        <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>About / License</source>
         <translation>Σχετικά / Άδεια</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="162"/>
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
+        <source>Display &amp; Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="72"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <source>Controls &amp; Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="189"/>
+        <source>Library &amp; Data Management</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="82"/>
+        <location filename="../screens/SettingsScreen.qml" line="191"/>
+        <source>Support &amp; About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="206"/>
         <source>Optimizing</source>
         <translation>Βελτιστοποίηση</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
-        <location filename="../screens/SettingsScreen.qml" line="173"/>
+        <location filename="../screens/SettingsScreen.qml" line="208"/>
+        <location filename="../screens/SettingsScreen.qml" line="217"/>
         <source>Paused</source>
         <translation>Σε παύση</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
-        <location filename="../screens/SettingsScreen.qml" line="173"/>
+        <location filename="../screens/SettingsScreen.qml" line="208"/>
+        <location filename="../screens/SettingsScreen.qml" line="217"/>
         <source>In progress</source>
         <translation>Σε εξέλιξη</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="167"/>
+        <location filename="../screens/SettingsScreen.qml" line="211"/>
         <source>%1 indexed</source>
         <translation>%1 ευρετηριάστηκαν</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="176"/>
+        <location filename="../screens/SettingsScreen.qml" line="220"/>
         <source>%1 scraped</source>
         <translation>%1 συλλέχθηκαν</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="284"/>
+        <location filename="../screens/SettingsScreen.qml" line="393"/>
         <source>Cancel</source>
         <translation>Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="284"/>
+        <location filename="../screens/SettingsScreen.qml" line="393"/>
         <source>Start</source>
         <translation>Έναρξη</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="286"/>
+        <location filename="../screens/SettingsScreen.qml" line="395"/>
         <source>Upload</source>
         <translation>Μεταφόρτωση</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="288"/>
+        <location filename="../screens/SettingsScreen.qml" line="396"/>
         <source>Open</source>
         <translation>Άνοιγμα</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="365"/>
+        <location filename="../screens/SettingsScreen.qml" line="472"/>
         <source>English</source>
         <translation>Αγγλικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="367"/>
+        <location filename="../screens/SettingsScreen.qml" line="474"/>
         <source>Italian</source>
         <translation>Ιταλικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="476"/>
+        <source>Spanish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="478"/>
+        <source>Basque</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="480"/>
         <source>German</source>
         <translation>Γερμανικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
+        <location filename="../screens/SettingsScreen.qml" line="482"/>
         <source>Greek</source>
         <translation>Ελληνικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="373"/>
+        <location filename="../screens/SettingsScreen.qml" line="484"/>
         <source>Japanese</source>
         <translation>Ιαπωνικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="375"/>
+        <location filename="../screens/SettingsScreen.qml" line="486"/>
         <source>Korean</source>
         <translation>Κορεατικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Dutch</source>
         <translation>Ολλανδικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="379"/>
+        <location filename="../screens/SettingsScreen.qml" line="490"/>
         <source>Romanian</source>
         <translation>Ρουμανικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="381"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Slovak</source>
         <translation>Σλοβακικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="383"/>
+        <location filename="../screens/SettingsScreen.qml" line="494"/>
         <source>Ukrainian</source>
         <translation>Ουκρανικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="385"/>
+        <location filename="../screens/SettingsScreen.qml" line="496"/>
         <source>Chinese (Simplified)</source>
         <translation>Κινεζικά (Απλοποιημένα)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="387"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Hebrew</source>
         <translation>Εβραϊκά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="389"/>
+        <location filename="../screens/SettingsScreen.qml" line="500"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="391"/>
+        <location filename="../screens/SettingsScreen.qml" line="502"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="392"/>
-        <location filename="../screens/SettingsScreen.qml" line="451"/>
+        <location filename="../screens/SettingsScreen.qml" line="503"/>
+        <location filename="../screens/SettingsScreen.qml" line="562"/>
         <source>Auto</source>
         <translation>Αυτόματο</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <location filename="../screens/SettingsScreen.qml" line="508"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <location filename="../screens/SettingsScreen.qml" line="510"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="400"/>
+        <location filename="../screens/SettingsScreen.qml" line="511"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405"/>
+        <location filename="../screens/SettingsScreen.qml" line="516"/>
         <source>Detailed list view</source>
         <translation>Λεπτομερής προβολή λίστας</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="406"/>
+        <location filename="../screens/SettingsScreen.qml" line="517"/>
         <source>Grid view</source>
         <translation>Προβολή πλέγματος</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="411"/>
+        <location filename="../screens/SettingsScreen.qml" line="522"/>
         <source>Style B</source>
         <translation>Στυλ B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="413"/>
+        <location filename="../screens/SettingsScreen.qml" line="524"/>
         <source>Style C</source>
         <translation>Στυλ C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="415"/>
+        <location filename="../screens/SettingsScreen.qml" line="526"/>
         <source>Style D</source>
         <translation>Στυλ D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="416"/>
+        <location filename="../screens/SettingsScreen.qml" line="527"/>
         <source>Style A</source>
         <translation>Στυλ A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="340"/>
+        <location filename="../screens/SettingsScreen.qml" line="1032"/>
+        <source>Loading settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="447"/>
         <source>Default</source>
         <translation>Προεπιλογή</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="431"/>
+        <location filename="../screens/SettingsScreen.qml" line="542"/>
         <source>Off</source>
         <translation>Απενεργοποιημένο</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="433"/>
+        <location filename="../screens/SettingsScreen.qml" line="544"/>
         <source>1 second (testing)</source>
         <translation>1 δευτερόλεπτο (δοκιμή)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="435"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>1 minute</source>
         <translation>1 λεπτό</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="437"/>
+        <location filename="../screens/SettingsScreen.qml" line="548"/>
         <source>2 minutes</source>
         <translation>2 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="439"/>
+        <location filename="../screens/SettingsScreen.qml" line="550"/>
         <source>5 minutes</source>
         <translation>5 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="441"/>
+        <location filename="../screens/SettingsScreen.qml" line="552"/>
         <source>10 minutes</source>
         <translation>10 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="443"/>
+        <location filename="../screens/SettingsScreen.qml" line="554"/>
         <source>15 minutes</source>
         <translation>15 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="445"/>
+        <location filename="../screens/SettingsScreen.qml" line="556"/>
         <source>30 minutes</source>
         <translation>30 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="446"/>
+        <location filename="../screens/SettingsScreen.qml" line="557"/>
         <source>%1 seconds</source>
         <translation>%1 δευτερόλεπτα</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="489"/>
+        <location filename="../screens/SettingsScreen.qml" line="91"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Resolution</source>
         <translation>Ανάλυση</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="453"/>
+        <location filename="../screens/SettingsScreen.qml" line="564"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="455"/>
+        <location filename="../screens/SettingsScreen.qml" line="566"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="457"/>
+        <location filename="../screens/SettingsScreen.qml" line="568"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <location filename="../screens/SettingsScreen.qml" line="570"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="461"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="463"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="465"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="467"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="469"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="471"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="473"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="663"/>
+        <location filename="../screens/SettingsScreen.qml" line="192"/>
         <source>Settings</source>
         <translation>Ρυθμίσεις</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="857"/>
+        <location filename="../screens/SettingsScreen.qml" line="1020"/>
         <source>No settings available on this platform</source>
         <translation>Δεν υπάρχουν διαθέσιμες ρυθμίσεις για αυτή την πλατφόρμα</translation>
     </message>
@@ -1170,24 +1330,24 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="195"/>
-        <location filename="../screens/SystemsScreen.qml" line="292"/>
+        <location filename="../screens/SystemsScreen.qml" line="197"/>
+        <location filename="../screens/SystemsScreen.qml" line="295"/>
         <source>%1 systems</source>
         <translation>%1 συστήματα</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="196"/>
-        <location filename="../screens/SystemsScreen.qml" line="309"/>
+        <location filename="../screens/SystemsScreen.qml" line="198"/>
+        <location filename="../screens/SystemsScreen.qml" line="312"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="324"/>
+        <location filename="../screens/SystemsScreen.qml" line="328"/>
         <source>No systems in this category</source>
         <translation>Δεν υπάρχουν συστήματα σε αυτή την κατηγορία</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="325"/>
+        <location filename="../screens/SystemsScreen.qml" line="329"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -54,6 +54,13 @@
         <translation>Μεταφράσεις</translation>
     </message>
     <message>
+        <location filename="../screens/AboutScreen.qml" line="267"/>
+        <source>Italiano - Andrea Bogazzi
+Español - Carlos R.
+Euskara - devilschile2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/AboutScreen.qml" line="278"/>
         <source>Full license text in COPYING.</source>
         <translation>Πλήρες κείμενο άδειας στο COPYING.</translation>
@@ -907,13 +914,13 @@
     <name>SettingsScreen</name>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="611"/>
         <source>Language</source>
         <translation>Γλώσσα</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="627"/>
+        <location filename="../screens/SettingsScreen.qml" line="629"/>
         <source>Browsing layout</source>
         <translation>Διάταξη περιήγησης</translation>
     </message>
@@ -933,19 +940,19 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="97"/>
-        <location filename="../screens/SettingsScreen.qml" line="618"/>
+        <location filename="../screens/SettingsScreen.qml" line="620"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="125"/>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="638"/>
         <source>Button style</source>
         <translation>Στυλ κουμπιών</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="112"/>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
+        <location filename="../screens/SettingsScreen.qml" line="647"/>
         <source>Screensaver</source>
         <translation>Προφύλαξη οθόνης</translation>
     </message>
@@ -960,7 +967,7 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="654"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1131,72 +1138,77 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <source>Chinese (Traditional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="500"/>
         <source>Hebrew</source>
         <translation>Εβραϊκά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="500"/>
+        <location filename="../screens/SettingsScreen.qml" line="502"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="502"/>
+        <location filename="../screens/SettingsScreen.qml" line="504"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="503"/>
-        <location filename="../screens/SettingsScreen.qml" line="562"/>
+        <location filename="../screens/SettingsScreen.qml" line="505"/>
+        <location filename="../screens/SettingsScreen.qml" line="564"/>
         <source>Auto</source>
         <translation>Αυτόματο</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="508"/>
+        <location filename="../screens/SettingsScreen.qml" line="510"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="510"/>
+        <location filename="../screens/SettingsScreen.qml" line="512"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="511"/>
+        <location filename="../screens/SettingsScreen.qml" line="513"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="516"/>
+        <location filename="../screens/SettingsScreen.qml" line="518"/>
         <source>Detailed list view</source>
         <translation>Λεπτομερής προβολή λίστας</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="517"/>
+        <location filename="../screens/SettingsScreen.qml" line="519"/>
         <source>Grid view</source>
         <translation>Προβολή πλέγματος</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="522"/>
+        <location filename="../screens/SettingsScreen.qml" line="524"/>
         <source>Style B</source>
         <translation>Στυλ B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="524"/>
+        <location filename="../screens/SettingsScreen.qml" line="526"/>
         <source>Style C</source>
         <translation>Στυλ C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="526"/>
+        <location filename="../screens/SettingsScreen.qml" line="528"/>
         <source>Style D</source>
         <translation>Στυλ D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="527"/>
+        <location filename="../screens/SettingsScreen.qml" line="529"/>
         <source>Style A</source>
         <translation>Στυλ A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1032"/>
+        <location filename="../screens/SettingsScreen.qml" line="1034"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1206,113 +1218,113 @@
         <translation>Προεπιλογή</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="542"/>
+        <location filename="../screens/SettingsScreen.qml" line="544"/>
         <source>Off</source>
         <translation>Απενεργοποιημένο</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="544"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>1 second (testing)</source>
         <translation>1 δευτερόλεπτο (δοκιμή)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="546"/>
+        <location filename="../screens/SettingsScreen.qml" line="548"/>
         <source>1 minute</source>
         <translation>1 λεπτό</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="548"/>
+        <location filename="../screens/SettingsScreen.qml" line="550"/>
         <source>2 minutes</source>
         <translation>2 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="550"/>
+        <location filename="../screens/SettingsScreen.qml" line="552"/>
         <source>5 minutes</source>
         <translation>5 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="552"/>
+        <location filename="../screens/SettingsScreen.qml" line="554"/>
         <source>10 minutes</source>
         <translation>10 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="554"/>
+        <location filename="../screens/SettingsScreen.qml" line="556"/>
         <source>15 minutes</source>
         <translation>15 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="556"/>
+        <location filename="../screens/SettingsScreen.qml" line="558"/>
         <source>30 minutes</source>
         <translation>30 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="557"/>
+        <location filename="../screens/SettingsScreen.qml" line="559"/>
         <source>%1 seconds</source>
         <translation>%1 δευτερόλεπτα</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="91"/>
-        <location filename="../screens/SettingsScreen.qml" line="600"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Resolution</source>
         <translation>Ανάλυση</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="564"/>
+        <location filename="../screens/SettingsScreen.qml" line="566"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="566"/>
+        <location filename="../screens/SettingsScreen.qml" line="568"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="568"/>
+        <location filename="../screens/SettingsScreen.qml" line="570"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="570"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1322,7 +1334,7 @@
         <translation>Ρυθμίσεις</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1020"/>
+        <location filename="../screens/SettingsScreen.qml" line="1022"/>
         <source>No settings available on this platform</source>
         <translation>Δεν υπάρχουν διαθέσιμες ρυθμίσεις για αυτή την πλατφόρμα</translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -54,6 +54,13 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../screens/AboutScreen.qml" line="267"/>
+        <source>Italiano - Andrea Bogazzi
+Español - Carlos R.
+Euskara - devilschile2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/AboutScreen.qml" line="278"/>
         <source>Full license text in COPYING.</source>
         <translation type="unfinished"></translation>
@@ -895,13 +902,13 @@
     <name>SettingsScreen</name>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="611"/>
         <source>Language</source>
         <translation>Language</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="627"/>
+        <location filename="../screens/SettingsScreen.qml" line="629"/>
         <source>Browsing layout</source>
         <translation>Browsing layout</translation>
     </message>
@@ -917,19 +924,19 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="97"/>
-        <location filename="../screens/SettingsScreen.qml" line="618"/>
+        <location filename="../screens/SettingsScreen.qml" line="620"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="125"/>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="638"/>
         <source>Button style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="112"/>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
+        <location filename="../screens/SettingsScreen.qml" line="647"/>
         <source>Screensaver</source>
         <translation type="unfinished"></translation>
     </message>
@@ -940,7 +947,7 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="654"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1107,72 +1114,77 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="498"/>
-        <source>Hebrew</source>
+        <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="500"/>
-        <source>Arabic</source>
+        <source>Hebrew</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="502"/>
+        <source>Arabic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="504"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="503"/>
-        <location filename="../screens/SettingsScreen.qml" line="562"/>
+        <location filename="../screens/SettingsScreen.qml" line="505"/>
+        <location filename="../screens/SettingsScreen.qml" line="564"/>
         <source>Auto</source>
         <translation>Auto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="508"/>
+        <location filename="../screens/SettingsScreen.qml" line="510"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="510"/>
+        <location filename="../screens/SettingsScreen.qml" line="512"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="511"/>
+        <location filename="../screens/SettingsScreen.qml" line="513"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="516"/>
+        <location filename="../screens/SettingsScreen.qml" line="518"/>
         <source>Detailed list view</source>
         <translation>Detailed list view</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="517"/>
+        <location filename="../screens/SettingsScreen.qml" line="519"/>
         <source>Grid view</source>
         <translation>Grid view</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="522"/>
+        <location filename="../screens/SettingsScreen.qml" line="524"/>
         <source>Style B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="524"/>
+        <location filename="../screens/SettingsScreen.qml" line="526"/>
         <source>Style C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="526"/>
+        <location filename="../screens/SettingsScreen.qml" line="528"/>
         <source>Style D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="527"/>
+        <location filename="../screens/SettingsScreen.qml" line="529"/>
         <source>Style A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1032"/>
+        <location filename="../screens/SettingsScreen.qml" line="1034"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1182,113 +1194,113 @@
         <translation>Default</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="542"/>
+        <location filename="../screens/SettingsScreen.qml" line="544"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="544"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>1 second (testing)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="546"/>
+        <location filename="../screens/SettingsScreen.qml" line="548"/>
         <source>1 minute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="548"/>
+        <location filename="../screens/SettingsScreen.qml" line="550"/>
         <source>2 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="550"/>
+        <location filename="../screens/SettingsScreen.qml" line="552"/>
         <source>5 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="552"/>
+        <location filename="../screens/SettingsScreen.qml" line="554"/>
         <source>10 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="554"/>
+        <location filename="../screens/SettingsScreen.qml" line="556"/>
         <source>15 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="556"/>
+        <location filename="../screens/SettingsScreen.qml" line="558"/>
         <source>30 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="557"/>
+        <location filename="../screens/SettingsScreen.qml" line="559"/>
         <source>%1 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="91"/>
-        <location filename="../screens/SettingsScreen.qml" line="600"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="564"/>
+        <location filename="../screens/SettingsScreen.qml" line="566"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="566"/>
+        <location filename="../screens/SettingsScreen.qml" line="568"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="568"/>
+        <location filename="../screens/SettingsScreen.qml" line="570"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="570"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1298,7 +1310,7 @@
         <translation>Settings</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1020"/>
+        <location filename="../screens/SettingsScreen.qml" line="1022"/>
         <source>No settings available on this platform</source>
         <translation>No settings available on this platform</translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -4,57 +4,57 @@
 <context>
     <name>AboutScreen</name>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="71"/>
+        <location filename="../screens/AboutScreen.qml" line="73"/>
         <source>About / License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="153"/>
+        <location filename="../screens/AboutScreen.qml" line="155"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="164"/>
+        <location filename="../screens/AboutScreen.qml" line="166"/>
         <source>Version %1 · %2 · %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="174"/>
+        <location filename="../screens/AboutScreen.qml" line="176"/>
         <source>Built %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="185"/>
+        <location filename="../screens/AboutScreen.qml" line="187"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="196"/>
+        <location filename="../screens/AboutScreen.qml" line="198"/>
         <source>Source available under the PolyForm Noncommercial License 1.0.0. Free for personal, non-commercial use. Commercial use requires a separate license.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="207"/>
+        <location filename="../screens/AboutScreen.qml" line="209"/>
         <source>Commercial licensing: legal@zaparoo.org</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="218"/>
+        <location filename="../screens/AboutScreen.qml" line="220"/>
         <source>Project: https://zaparoo.org</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="228"/>
+        <location filename="../screens/AboutScreen.qml" line="230"/>
         <source>Created by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="252"/>
+        <location filename="../screens/AboutScreen.qml" line="254"/>
         <source>Translations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="276"/>
+        <location filename="../screens/AboutScreen.qml" line="278"/>
         <source>Full license text in COPYING.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -90,48 +90,102 @@
         <translation type="unfinished">Loading…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="77"/>
+        <location filename="../components/BrowseDetailPane.qml" line="138"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="79"/>
+        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <source>Yr</source>
+        <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="81"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <source>Gen</source>
+        <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="83"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <source>Plyr</source>
+        <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="85"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <source>Dev</source>
+        <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="87"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <source>Pub</source>
+        <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="89"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <source>Rtg</source>
+        <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="91"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <source>Cat</source>
+        <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="93"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <source>Date</source>
+        <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Manufacturer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <source>Mfr</source>
+        <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -176,68 +230,83 @@
 <context>
     <name>CoreStatusPill</name>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="44"/>
-        <location filename="../components/CoreStatusPill.qml" line="50"/>
+        <location filename="../components/CoreStatusPill.qml" line="46"/>
+        <location filename="../components/CoreStatusPill.qml" line="52"/>
         <source>Disconnected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="47"/>
+        <location filename="../components/CoreStatusPill.qml" line="49"/>
         <source>Reconnecting…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="53"/>
+        <location filename="../components/CoreStatusPill.qml" line="55"/>
         <source>Connecting…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="56"/>
+        <location filename="../components/CoreStatusPill.qml" line="58"/>
         <source>Core error</source>
         <translation type="unfinished">Core error</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="60"/>
-        <source>Optimizing database</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/CoreStatusPill.qml" line="67"/>
-        <source>Indexing paused</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/CoreStatusPill.qml" line="70"/>
-        <source>Indexing %1/%2 - %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/CoreStatusPill.qml" line="86"/>
-        <source>Scraping %1/%2 - %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/CoreStatusPill.qml" line="73"/>
-        <source>Indexing %1/%2</source>
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <source>Paused %1/%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/CoreStatusPill.qml" line="75"/>
-        <source>Indexing…</source>
+        <source>Paused</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="78"/>
+        <source>Opt…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="78"/>
+        <source>Optimizing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/CoreStatusPill.qml" line="83"/>
-        <source>Scrape paused</source>
+        <source>Idx…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/CoreStatusPill.qml" line="89"/>
+        <source>Scr…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="82"/>
+        <source>Indexing %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="82"/>
+        <source>Idx %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
+        <source>Indexing…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="88"/>
         <source>Scraping %1/%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="91"/>
+        <location filename="../components/CoreStatusPill.qml" line="88"/>
+        <source>Scr %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
         <source>Scraping…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -329,34 +398,34 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="117"/>
-        <location filename="../screens/GamesScreen.qml" line="145"/>
+        <location filename="../screens/GamesScreen.qml" line="122"/>
+        <location filename="../screens/GamesScreen.qml" line="157"/>
         <source>%1 files</source>
         <translation>%1 files</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="51"/>
+        <location filename="../screens/GamesScreen.qml" line="55"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="126"/>
-        <location filename="../screens/GamesScreen.qml" line="146"/>
+        <location filename="../screens/GamesScreen.qml" line="131"/>
+        <location filename="../screens/GamesScreen.qml" line="158"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="45"/>
+        <location filename="../screens/GamesScreen.qml" line="49"/>
         <source>Loading games…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="122"/>
+        <location filename="../screens/GamesScreen.qml" line="127"/>
         <source>Loading more…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="44"/>
+        <location filename="../screens/GamesScreen.qml" line="48"/>
         <source>No games in this system</source>
         <translation>No games in this system</translation>
     </message>
@@ -364,32 +433,55 @@
 <context>
     <name>HubScreen</name>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
         <source>Resume: %1</source>
-        <translation>Resume: %1</translation>
+        <translation type="vanished">Resume: %1</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
         <source>Resume Game</source>
-        <translation>Resume Game</translation>
+        <translation type="vanished">Resume Game</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
+        <location filename="../screens/HubScreen.qml" line="56"/>
+        <source>Arcade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="61"/>
+        <source>Computers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="66"/>
+        <source>Consoles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="71"/>
+        <source>Handhelds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="134"/>
+        <source>Resume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="140"/>
         <source>Favorites</source>
         <translation>Favorites</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="96"/>
+        <location filename="../screens/HubScreen.qml" line="145"/>
         <source>Recently Played</source>
         <translation>Recently Played</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="101"/>
+        <location filename="../screens/HubScreen.qml" line="150"/>
         <source>Settings</source>
         <translation>Settings</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="537"/>
+        <location filename="../screens/HubScreen.qml" line="644"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -438,104 +530,124 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="755"/>
+        <location filename="../app/Main.qml" line="1206"/>
         <source>Launch core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="958"/>
+        <location filename="../app/Main.qml" line="1212"/>
+        <location filename="../app/Main.qml" line="1420"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="786"/>
+        <location filename="../app/Main.qml" line="1247"/>
         <source>Remove from favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="786"/>
+        <location filename="../app/Main.qml" line="1247"/>
         <source>Add to favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="791"/>
+        <location filename="../app/Main.qml" line="1252"/>
         <source>Write to NFC token</source>
         <translation type="unfinished">Write to NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="795"/>
+        <location filename="../app/Main.qml" line="1256"/>
         <source>QR code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="770"/>
-        <location filename="../app/Main.qml" line="805"/>
+        <location filename="../app/Main.qml" line="1231"/>
+        <location filename="../app/Main.qml" line="1266"/>
         <source>Launch game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1776"/>
+        <location filename="../app/Main.qml" line="2368"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1780"/>
+        <location filename="../app/Main.qml" line="2374"/>
         <source>Loading favorites…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1778"/>
+        <location filename="../app/Main.qml" line="2370"/>
         <source>Loading games…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="954"/>
+        <location filename="../app/Main.qml" line="1219"/>
+        <source>Update media database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1222"/>
+        <source>Scrape metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1416"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="954"/>
+        <location filename="../app/Main.qml" line="1416"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1230"/>
+        <location filename="../app/Main.qml" line="1708"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1234"/>
+        <location filename="../app/Main.qml" line="1712"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1248"/>
+        <location filename="../app/Main.qml" line="1726"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1252"/>
+        <location filename="../app/Main.qml" line="1730"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1256"/>
+        <location filename="../app/Main.qml" line="1734"/>
         <source>Retry</source>
         <translation type="unfinished">Retry</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1260"/>
+        <location filename="../app/Main.qml" line="1738"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1782"/>
+        <location filename="../app/Main.qml" line="2372"/>
+        <source>Loading game…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2376"/>
         <source>Loading recently played…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="2378"/>
+        <source>Loading settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2380"/>
         <source>Loading…</source>
         <translation type="unfinished">Loading…</translation>
     </message>
@@ -543,161 +655,161 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="581"/>
+        <location filename="../app/MainLayout.qml" line="680"/>
         <source>Writing failed</source>
         <translation>Writing failed</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="581"/>
+        <location filename="../app/MainLayout.qml" line="680"/>
         <source>Put a writable card near the reader</source>
         <translation>Put a writable card near the reader</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="669"/>
+        <location filename="../app/MainLayout.qml" line="807"/>
         <source>Are you sure you want to exit?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="745"/>
-        <location filename="../app/MainLayout.qml" line="817"/>
+        <location filename="../app/MainLayout.qml" line="890"/>
+        <location filename="../app/MainLayout.qml" line="964"/>
         <source>Select</source>
         <translation>Select</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="749"/>
-        <location filename="../app/MainLayout.qml" line="753"/>
-        <location filename="../app/MainLayout.qml" line="767"/>
-        <location filename="../app/MainLayout.qml" line="780"/>
-        <location filename="../app/MainLayout.qml" line="791"/>
+        <location filename="../app/MainLayout.qml" line="894"/>
+        <location filename="../app/MainLayout.qml" line="898"/>
+        <location filename="../app/MainLayout.qml" line="912"/>
+        <location filename="../app/MainLayout.qml" line="927"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
         <source>Close</source>
         <translation>Close</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="760"/>
-        <location filename="../app/MainLayout.qml" line="798"/>
-        <location filename="../app/MainLayout.qml" line="821"/>
-        <location filename="../app/MainLayout.qml" line="832"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
+        <location filename="../app/MainLayout.qml" line="945"/>
+        <location filename="../app/MainLayout.qml" line="968"/>
+        <location filename="../app/MainLayout.qml" line="979"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="776"/>
+        <location filename="../app/MainLayout.qml" line="923"/>
         <source>Done</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="806"/>
+        <location filename="../app/MainLayout.qml" line="953"/>
         <source>I understand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="840"/>
+        <location filename="../app/MainLayout.qml" line="987"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1009"/>
+        <location filename="../app/MainLayout.qml" line="1165"/>
         <source>Scroll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="741"/>
-        <location filename="../app/MainLayout.qml" line="813"/>
-        <location filename="../app/MainLayout.qml" line="856"/>
-        <location filename="../app/MainLayout.qml" line="885"/>
-        <location filename="../app/MainLayout.qml" line="932"/>
-        <location filename="../app/MainLayout.qml" line="973"/>
-        <location filename="../app/MainLayout.qml" line="1037"/>
+        <location filename="../app/MainLayout.qml" line="886"/>
+        <location filename="../app/MainLayout.qml" line="960"/>
+        <location filename="../app/MainLayout.qml" line="1003"/>
+        <location filename="../app/MainLayout.qml" line="1034"/>
+        <location filename="../app/MainLayout.qml" line="1084"/>
+        <location filename="../app/MainLayout.qml" line="1127"/>
+        <location filename="../app/MainLayout.qml" line="1195"/>
         <source>Move</source>
         <translation>Move</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="141"/>
+        <location filename="../app/MainLayout.qml" line="170"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="323"/>
+        <location filename="../app/MainLayout.qml" line="364"/>
         <source>Favorites</source>
         <translation type="unfinished">Favorites</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="325"/>
+        <location filename="../app/MainLayout.qml" line="366"/>
         <source>Recently Played</source>
         <translation type="unfinished">Recently Played</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="592"/>
+        <location filename="../app/MainLayout.qml" line="695"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="593"/>
+        <location filename="../app/MainLayout.qml" line="696"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="668"/>
+        <location filename="../app/MainLayout.qml" line="806"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="860"/>
-        <location filename="../app/MainLayout.qml" line="895"/>
-        <location filename="../app/MainLayout.qml" line="942"/>
-        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1007"/>
+        <location filename="../app/MainLayout.qml" line="1044"/>
+        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Open</source>
         <translation>Open</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="864"/>
+        <location filename="../app/MainLayout.qml" line="1011"/>
         <source>Quit</source>
         <translation>Quit</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="873"/>
-        <location filename="../app/MainLayout.qml" line="901"/>
-        <location filename="../app/MainLayout.qml" line="912"/>
-        <location filename="../app/MainLayout.qml" line="924"/>
-        <location filename="../app/MainLayout.qml" line="951"/>
-        <location filename="../app/MainLayout.qml" line="962"/>
-        <location filename="../app/MainLayout.qml" line="997"/>
-        <location filename="../app/MainLayout.qml" line="1013"/>
-        <location filename="../app/MainLayout.qml" line="1022"/>
-        <location filename="../app/MainLayout.qml" line="1056"/>
-        <location filename="../app/MainLayout.qml" line="1067"/>
+        <location filename="../app/MainLayout.qml" line="1020"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1061"/>
+        <location filename="../app/MainLayout.qml" line="1076"/>
+        <location filename="../app/MainLayout.qml" line="1103"/>
+        <location filename="../app/MainLayout.qml" line="1114"/>
+        <location filename="../app/MainLayout.qml" line="1151"/>
+        <location filename="../app/MainLayout.qml" line="1169"/>
+        <location filename="../app/MainLayout.qml" line="1178"/>
+        <location filename="../app/MainLayout.qml" line="1214"/>
+        <location filename="../app/MainLayout.qml" line="1225"/>
         <source>Back</source>
         <translation>Back</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="891"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1043"/>
+        <location filename="../app/MainLayout.qml" line="1040"/>
+        <location filename="../app/MainLayout.qml" line="1090"/>
+        <location filename="../app/MainLayout.qml" line="1201"/>
         <source>Page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="947"/>
-        <location filename="../app/MainLayout.qml" line="1052"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1210"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="787"/>
-        <location filename="../app/MainLayout.qml" line="908"/>
-        <location filename="../app/MainLayout.qml" line="958"/>
-        <location filename="../app/MainLayout.qml" line="1063"/>
+        <location filename="../app/MainLayout.qml" line="934"/>
+        <location filename="../app/MainLayout.qml" line="1057"/>
+        <location filename="../app/MainLayout.qml" line="1110"/>
+        <location filename="../app/MainLayout.qml" line="1221"/>
         <source>Retry</source>
         <translation>Retry</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="982"/>
+        <location filename="../app/MainLayout.qml" line="1136"/>
         <source>Change</source>
         <translation>Change</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="988"/>
+        <location filename="../app/MainLayout.qml" line="1142"/>
         <source>Toggle</source>
         <translation>Toggle</translation>
     </message>
@@ -710,12 +822,12 @@
         <translation type="unfinished">Loading…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="306"/>
+        <location filename="../screens/MediaListScreen.qml" line="351"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 entries</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="307"/>
+        <location filename="../screens/MediaListScreen.qml" line="352"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -764,17 +876,17 @@
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="26"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
         <source>Nothing here</source>
         <translation>Nothing here</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="28"/>
         <source>Loading…</source>
         <translation type="unfinished">Loading…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="57"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="58"/>
         <source>Failed to load</source>
         <translation>Failed to load</translation>
     </message>
@@ -782,387 +894,411 @@
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="73"/>
-        <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
         <source>Language</source>
         <translation>Language</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="516"/>
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Browsing layout</source>
         <translation>Browsing layout</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="130"/>
         <source>Mouse support</source>
         <translation>Mouse support</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="112"/>
+        <location filename="../screens/SettingsScreen.qml" line="137"/>
         <source>Update media database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="61"/>
-        <source>General</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="78"/>
-        <location filename="../screens/SettingsScreen.qml" line="507"/>
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <location filename="../screens/SettingsScreen.qml" line="618"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88"/>
-        <location filename="../screens/SettingsScreen.qml" line="525"/>
+        <location filename="../screens/SettingsScreen.qml" line="125"/>
+        <location filename="../screens/SettingsScreen.qml" line="636"/>
         <source>Button style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="93"/>
-        <location filename="../screens/SettingsScreen.qml" line="534"/>
+        <location filename="../screens/SettingsScreen.qml" line="112"/>
+        <location filename="../screens/SettingsScreen.qml" line="645"/>
         <source>Screensaver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97"/>
-        <source>Library</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="142"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="543"/>
+        <location filename="../screens/SettingsScreen.qml" line="654"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
         <source>Scrape metadata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
-        <source>Advanced</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="136"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
         <source>Debug logging</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="141"/>
+        <location filename="../screens/SettingsScreen.qml" line="169"/>
         <source>Upload log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="146"/>
+        <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>About / License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="162"/>
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
+        <source>Display &amp; Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="72"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <source>Controls &amp; Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="189"/>
+        <source>Library &amp; Data Management</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="82"/>
+        <location filename="../screens/SettingsScreen.qml" line="191"/>
+        <source>Support &amp; About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="206"/>
         <source>Optimizing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
-        <location filename="../screens/SettingsScreen.qml" line="173"/>
+        <location filename="../screens/SettingsScreen.qml" line="208"/>
+        <location filename="../screens/SettingsScreen.qml" line="217"/>
         <source>Paused</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
-        <location filename="../screens/SettingsScreen.qml" line="173"/>
+        <location filename="../screens/SettingsScreen.qml" line="208"/>
+        <location filename="../screens/SettingsScreen.qml" line="217"/>
         <source>In progress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="167"/>
+        <location filename="../screens/SettingsScreen.qml" line="211"/>
         <source>%1 indexed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="176"/>
+        <location filename="../screens/SettingsScreen.qml" line="220"/>
         <source>%1 scraped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="284"/>
+        <location filename="../screens/SettingsScreen.qml" line="393"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="284"/>
+        <location filename="../screens/SettingsScreen.qml" line="393"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="286"/>
+        <location filename="../screens/SettingsScreen.qml" line="395"/>
         <source>Upload</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="288"/>
+        <location filename="../screens/SettingsScreen.qml" line="396"/>
         <source>Open</source>
         <translation type="unfinished">Open</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="365"/>
+        <location filename="../screens/SettingsScreen.qml" line="472"/>
         <source>English</source>
         <translation>English</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="367"/>
+        <location filename="../screens/SettingsScreen.qml" line="474"/>
         <source>Italian</source>
         <translation>Italian</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="476"/>
+        <source>Spanish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="478"/>
+        <source>Basque</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="480"/>
         <source>German</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
+        <location filename="../screens/SettingsScreen.qml" line="482"/>
         <source>Greek</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="373"/>
+        <location filename="../screens/SettingsScreen.qml" line="484"/>
         <source>Japanese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="375"/>
+        <location filename="../screens/SettingsScreen.qml" line="486"/>
         <source>Korean</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Dutch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="379"/>
+        <location filename="../screens/SettingsScreen.qml" line="490"/>
         <source>Romanian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="381"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Slovak</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="383"/>
+        <location filename="../screens/SettingsScreen.qml" line="494"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="385"/>
+        <location filename="../screens/SettingsScreen.qml" line="496"/>
         <source>Chinese (Simplified)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="387"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Hebrew</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="389"/>
+        <location filename="../screens/SettingsScreen.qml" line="500"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="391"/>
+        <location filename="../screens/SettingsScreen.qml" line="502"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="392"/>
-        <location filename="../screens/SettingsScreen.qml" line="451"/>
+        <location filename="../screens/SettingsScreen.qml" line="503"/>
+        <location filename="../screens/SettingsScreen.qml" line="562"/>
         <source>Auto</source>
         <translation>Auto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <location filename="../screens/SettingsScreen.qml" line="508"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <location filename="../screens/SettingsScreen.qml" line="510"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="400"/>
+        <location filename="../screens/SettingsScreen.qml" line="511"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405"/>
+        <location filename="../screens/SettingsScreen.qml" line="516"/>
         <source>Detailed list view</source>
         <translation>Detailed list view</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="406"/>
+        <location filename="../screens/SettingsScreen.qml" line="517"/>
         <source>Grid view</source>
         <translation>Grid view</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="411"/>
+        <location filename="../screens/SettingsScreen.qml" line="522"/>
         <source>Style B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="413"/>
+        <location filename="../screens/SettingsScreen.qml" line="524"/>
         <source>Style C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="415"/>
+        <location filename="../screens/SettingsScreen.qml" line="526"/>
         <source>Style D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="416"/>
+        <location filename="../screens/SettingsScreen.qml" line="527"/>
         <source>Style A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="340"/>
+        <location filename="../screens/SettingsScreen.qml" line="1032"/>
+        <source>Loading settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="447"/>
         <source>Default</source>
         <translation>Default</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="431"/>
+        <location filename="../screens/SettingsScreen.qml" line="542"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="433"/>
+        <location filename="../screens/SettingsScreen.qml" line="544"/>
         <source>1 second (testing)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="435"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>1 minute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="437"/>
+        <location filename="../screens/SettingsScreen.qml" line="548"/>
         <source>2 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="439"/>
+        <location filename="../screens/SettingsScreen.qml" line="550"/>
         <source>5 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="441"/>
+        <location filename="../screens/SettingsScreen.qml" line="552"/>
         <source>10 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="443"/>
+        <location filename="../screens/SettingsScreen.qml" line="554"/>
         <source>15 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="445"/>
+        <location filename="../screens/SettingsScreen.qml" line="556"/>
         <source>30 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="446"/>
+        <location filename="../screens/SettingsScreen.qml" line="557"/>
         <source>%1 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="489"/>
+        <location filename="../screens/SettingsScreen.qml" line="91"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="453"/>
+        <location filename="../screens/SettingsScreen.qml" line="564"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="455"/>
+        <location filename="../screens/SettingsScreen.qml" line="566"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="457"/>
+        <location filename="../screens/SettingsScreen.qml" line="568"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <location filename="../screens/SettingsScreen.qml" line="570"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="461"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="463"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="465"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="467"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="469"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="471"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="473"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="663"/>
+        <location filename="../screens/SettingsScreen.qml" line="192"/>
         <source>Settings</source>
         <translation>Settings</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="857"/>
+        <location filename="../screens/SettingsScreen.qml" line="1020"/>
         <source>No settings available on this platform</source>
         <translation>No settings available on this platform</translation>
     </message>
@@ -1170,24 +1306,24 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="195"/>
-        <location filename="../screens/SystemsScreen.qml" line="292"/>
+        <location filename="../screens/SystemsScreen.qml" line="197"/>
+        <location filename="../screens/SystemsScreen.qml" line="295"/>
         <source>%1 systems</source>
         <translation>%1 systems</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="196"/>
-        <location filename="../screens/SystemsScreen.qml" line="309"/>
+        <location filename="../screens/SystemsScreen.qml" line="198"/>
+        <location filename="../screens/SystemsScreen.qml" line="312"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="324"/>
+        <location filename="../screens/SystemsScreen.qml" line="328"/>
         <source>No systems in this category</source>
         <translation>No systems in this category</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="325"/>
+        <location filename="../screens/SystemsScreen.qml" line="329"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -4,57 +4,57 @@
 <context>
     <name>AboutScreen</name>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="71"/>
+        <location filename="../screens/AboutScreen.qml" line="73"/>
         <source>About / License</source>
         <translation>Acerca de / Licencia</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="153"/>
+        <location filename="../screens/AboutScreen.qml" line="155"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="164"/>
+        <location filename="../screens/AboutScreen.qml" line="166"/>
         <source>Version %1 · %2 · %3</source>
         <translation>Versión %1 · %2 · %3</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="174"/>
+        <location filename="../screens/AboutScreen.qml" line="176"/>
         <source>Built %1</source>
         <translation>Compilado %1</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="185"/>
+        <location filename="../screens/AboutScreen.qml" line="187"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>Copyright 2026 Wizzo Pty Ltd y los colaboradores del proyecto Zaparoo.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="196"/>
+        <location filename="../screens/AboutScreen.qml" line="198"/>
         <source>Source available under the PolyForm Noncommercial License 1.0.0. Free for personal, non-commercial use. Commercial use requires a separate license.</source>
         <translation>Código fuente disponible bajo la Licencia PolyForm Noncommercial 1.0.0. Gratis para uso personal y no comercial. El uso comercial requiere una licencia independiente.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="207"/>
+        <location filename="../screens/AboutScreen.qml" line="209"/>
         <source>Commercial licensing: legal@zaparoo.org</source>
         <translation>Licencia comercial: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="218"/>
+        <location filename="../screens/AboutScreen.qml" line="220"/>
         <source>Project: https://zaparoo.org</source>
         <translation>Proyecto: https://zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="228"/>
+        <location filename="../screens/AboutScreen.qml" line="230"/>
         <source>Created by</source>
         <translation>Creado por</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="252"/>
+        <location filename="../screens/AboutScreen.qml" line="254"/>
         <source>Translations</source>
         <translation>Traducciones</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="276"/>
+        <location filename="../screens/AboutScreen.qml" line="278"/>
         <source>Full license text in COPYING.</source>
         <translation>Texto completo de la licencia en COPYING.</translation>
     </message>
@@ -90,48 +90,102 @@
         <translation type="unfinished">Cargando…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="77"/>
+        <location filename="../components/BrowseDetailPane.qml" line="138"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="79"/>
+        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <source>Yr</source>
+        <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="81"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <source>Gen</source>
+        <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="83"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <source>Plyr</source>
+        <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="85"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <source>Dev</source>
+        <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="87"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <source>Pub</source>
+        <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="89"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <source>Rtg</source>
+        <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="91"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <source>Cat</source>
+        <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="93"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <source>Date</source>
+        <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Manufacturer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <source>Mfr</source>
+        <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -176,68 +230,103 @@
 <context>
     <name>CoreStatusPill</name>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="44"/>
-        <location filename="../components/CoreStatusPill.qml" line="50"/>
+        <location filename="../components/CoreStatusPill.qml" line="46"/>
+        <location filename="../components/CoreStatusPill.qml" line="52"/>
         <source>Disconnected</source>
         <translation>Desconectado</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="47"/>
+        <location filename="../components/CoreStatusPill.qml" line="49"/>
         <source>Reconnecting…</source>
         <translation>Reconectando…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="53"/>
+        <location filename="../components/CoreStatusPill.qml" line="55"/>
         <source>Connecting…</source>
         <translation>Conectando…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="56"/>
+        <location filename="../components/CoreStatusPill.qml" line="58"/>
         <source>Core error</source>
         <translation>Error del Core</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="60"/>
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <source>Paused %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <source>Paused</source>
+        <translation type="unfinished">Pausado</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="78"/>
+        <source>Opt…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="78"/>
+        <source>Optimizing</source>
+        <translation type="unfinished">Optimizando</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
+        <source>Idx…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
+        <source>Scr…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Optimizing database</source>
-        <translation>Optimizando base de datos</translation>
+        <translation type="vanished">Optimizando base de datos</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="67"/>
         <source>Indexing paused</source>
-        <translation>Indexación en pausa</translation>
+        <translation type="vanished">Indexación en pausa</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="70"/>
         <source>Indexing %1/%2 - %3</source>
-        <translation>Indexando %1/%2 - %3</translation>
+        <translation type="vanished">Indexando %1/%2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="86"/>
         <source>Scraping %1/%2 - %3</source>
-        <translation>Extrayendo %1/%2 - %3</translation>
+        <translation type="vanished">Extrayendo %1/%2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="73"/>
+        <location filename="../components/CoreStatusPill.qml" line="82"/>
         <source>Indexing %1/%2</source>
         <translation>Indexando %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <location filename="../components/CoreStatusPill.qml" line="82"/>
+        <source>Idx %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Indexing…</source>
         <translation>Indexando…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Scrape paused</source>
-        <translation>Scraping en pausa</translation>
+        <translation type="vanished">Scraping en pausa</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="89"/>
+        <location filename="../components/CoreStatusPill.qml" line="88"/>
         <source>Scraping %1/%2</source>
         <translation>Extrayendo %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="91"/>
+        <location filename="../components/CoreStatusPill.qml" line="88"/>
+        <source>Scr %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
         <source>Scraping…</source>
         <translation>Extrayendo…</translation>
     </message>
@@ -329,34 +418,34 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="117"/>
-        <location filename="../screens/GamesScreen.qml" line="145"/>
+        <location filename="../screens/GamesScreen.qml" line="122"/>
+        <location filename="../screens/GamesScreen.qml" line="157"/>
         <source>%1 files</source>
         <translation>%1 archivos</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="51"/>
+        <location filename="../screens/GamesScreen.qml" line="55"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="126"/>
-        <location filename="../screens/GamesScreen.qml" line="146"/>
+        <location filename="../screens/GamesScreen.qml" line="131"/>
+        <location filename="../screens/GamesScreen.qml" line="158"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="45"/>
+        <location filename="../screens/GamesScreen.qml" line="49"/>
         <source>Loading games…</source>
         <translation>Cargando juegos…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="122"/>
+        <location filename="../screens/GamesScreen.qml" line="127"/>
         <source>Loading more…</source>
         <translation>Cargando más…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="44"/>
+        <location filename="../screens/GamesScreen.qml" line="48"/>
         <source>No games in this system</source>
         <translation>No hay juegos en este sistema</translation>
     </message>
@@ -364,32 +453,47 @@
 <context>
     <name>HubScreen</name>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
-        <source>Resume: %1</source>
+        <location filename="../screens/HubScreen.qml" line="56"/>
+        <source>Arcade</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
-        <source>Resume Game</source>
+        <location filename="../screens/HubScreen.qml" line="61"/>
+        <source>Computers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
+        <location filename="../screens/HubScreen.qml" line="66"/>
+        <source>Consoles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="71"/>
+        <source>Handhelds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="134"/>
+        <source>Resume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="140"/>
         <source>Favorites</source>
         <translation>Favoritos</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="96"/>
+        <location filename="../screens/HubScreen.qml" line="145"/>
         <source>Recently Played</source>
         <translation>Recientemente Jugados</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="101"/>
+        <location filename="../screens/HubScreen.qml" line="150"/>
         <source>Settings</source>
         <translation>Ajustes</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="537"/>
+        <location filename="../screens/HubScreen.qml" line="644"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>No hay sistemas disponibles. Ejecuta Actualizar la base de datos de medios desde Ajustes.</translation>
     </message>
@@ -438,104 +542,124 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="755"/>
+        <location filename="../app/Main.qml" line="1206"/>
         <source>Launch core</source>
         <translation>Lanzar core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="958"/>
+        <location filename="../app/Main.qml" line="1212"/>
+        <location filename="../app/Main.qml" line="1420"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="786"/>
+        <location filename="../app/Main.qml" line="1247"/>
         <source>Remove from favorites</source>
         <translation>Eliminar de favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="786"/>
+        <location filename="../app/Main.qml" line="1247"/>
         <source>Add to favorites</source>
         <translation>Agregar a favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="791"/>
+        <location filename="../app/Main.qml" line="1252"/>
         <source>Write to NFC token</source>
         <translation>Escribir en token NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="795"/>
+        <location filename="../app/Main.qml" line="1256"/>
         <source>QR code</source>
         <translation>Código QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="770"/>
-        <location filename="../app/Main.qml" line="805"/>
+        <location filename="../app/Main.qml" line="1231"/>
+        <location filename="../app/Main.qml" line="1266"/>
         <source>Launch game</source>
         <translation>Iniciar juego</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1776"/>
+        <location filename="../app/Main.qml" line="2368"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1780"/>
+        <location filename="../app/Main.qml" line="2374"/>
         <source>Loading favorites…</source>
         <translation>Cargando favoritos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1778"/>
+        <location filename="../app/Main.qml" line="2370"/>
         <source>Loading games…</source>
         <translation>Cargando juegos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="954"/>
+        <location filename="../app/Main.qml" line="1219"/>
+        <source>Update media database</source>
+        <translation type="unfinished">Actualizar base de datos de medios</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1222"/>
+        <source>Scrape metadata</source>
+        <translation type="unfinished">Extraer metadatos</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1416"/>
         <source>Default</source>
         <translation type="unfinished">Por defecto</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="954"/>
+        <location filename="../app/Main.qml" line="1416"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1230"/>
+        <location filename="../app/Main.qml" line="1708"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1234"/>
+        <location filename="../app/Main.qml" line="1712"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1248"/>
+        <location filename="../app/Main.qml" line="1726"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1252"/>
+        <location filename="../app/Main.qml" line="1730"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1256"/>
+        <location filename="../app/Main.qml" line="1734"/>
         <source>Retry</source>
         <translation type="unfinished">Reintentar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1260"/>
+        <location filename="../app/Main.qml" line="1738"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1782"/>
+        <location filename="../app/Main.qml" line="2372"/>
+        <source>Loading game…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2376"/>
         <source>Loading recently played…</source>
         <translation>Cargando jugados recientemente…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="2378"/>
+        <source>Loading settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2380"/>
         <source>Loading…</source>
         <translation>Cargando…</translation>
     </message>
@@ -543,161 +667,161 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="581"/>
+        <location filename="../app/MainLayout.qml" line="680"/>
         <source>Writing failed</source>
         <translation>Error de escritura</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="581"/>
+        <location filename="../app/MainLayout.qml" line="680"/>
         <source>Put a writable card near the reader</source>
         <translation>Pon una tarjeta escribible junto al lector</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="669"/>
+        <location filename="../app/MainLayout.qml" line="807"/>
         <source>Are you sure you want to exit?</source>
         <translation>¿Seguro que quieres salir?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="745"/>
-        <location filename="../app/MainLayout.qml" line="817"/>
+        <location filename="../app/MainLayout.qml" line="890"/>
+        <location filename="../app/MainLayout.qml" line="964"/>
         <source>Select</source>
         <translation>Seleccionar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="749"/>
-        <location filename="../app/MainLayout.qml" line="753"/>
-        <location filename="../app/MainLayout.qml" line="767"/>
-        <location filename="../app/MainLayout.qml" line="780"/>
-        <location filename="../app/MainLayout.qml" line="791"/>
+        <location filename="../app/MainLayout.qml" line="894"/>
+        <location filename="../app/MainLayout.qml" line="898"/>
+        <location filename="../app/MainLayout.qml" line="912"/>
+        <location filename="../app/MainLayout.qml" line="927"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="760"/>
-        <location filename="../app/MainLayout.qml" line="798"/>
-        <location filename="../app/MainLayout.qml" line="821"/>
-        <location filename="../app/MainLayout.qml" line="832"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
+        <location filename="../app/MainLayout.qml" line="945"/>
+        <location filename="../app/MainLayout.qml" line="968"/>
+        <location filename="../app/MainLayout.qml" line="979"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="776"/>
+        <location filename="../app/MainLayout.qml" line="923"/>
         <source>Done</source>
         <translation>Hecho</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="806"/>
+        <location filename="../app/MainLayout.qml" line="953"/>
         <source>I understand</source>
         <translation>Entendido</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="840"/>
+        <location filename="../app/MainLayout.qml" line="987"/>
         <source>Start</source>
         <translation>Iniciar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1009"/>
+        <location filename="../app/MainLayout.qml" line="1165"/>
         <source>Scroll</source>
         <translation>Desplazar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="741"/>
-        <location filename="../app/MainLayout.qml" line="813"/>
-        <location filename="../app/MainLayout.qml" line="856"/>
-        <location filename="../app/MainLayout.qml" line="885"/>
-        <location filename="../app/MainLayout.qml" line="932"/>
-        <location filename="../app/MainLayout.qml" line="973"/>
-        <location filename="../app/MainLayout.qml" line="1037"/>
+        <location filename="../app/MainLayout.qml" line="886"/>
+        <location filename="../app/MainLayout.qml" line="960"/>
+        <location filename="../app/MainLayout.qml" line="1003"/>
+        <location filename="../app/MainLayout.qml" line="1034"/>
+        <location filename="../app/MainLayout.qml" line="1084"/>
+        <location filename="../app/MainLayout.qml" line="1127"/>
+        <location filename="../app/MainLayout.qml" line="1195"/>
         <source>Move</source>
         <translation>Mover</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="141"/>
+        <location filename="../app/MainLayout.qml" line="170"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="323"/>
+        <location filename="../app/MainLayout.qml" line="364"/>
         <source>Favorites</source>
         <translation type="unfinished">Favoritos</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="325"/>
+        <location filename="../app/MainLayout.qml" line="366"/>
         <source>Recently Played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="592"/>
+        <location filename="../app/MainLayout.qml" line="695"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="593"/>
+        <location filename="../app/MainLayout.qml" line="696"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="668"/>
+        <location filename="../app/MainLayout.qml" line="806"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="860"/>
-        <location filename="../app/MainLayout.qml" line="895"/>
-        <location filename="../app/MainLayout.qml" line="942"/>
-        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1007"/>
+        <location filename="../app/MainLayout.qml" line="1044"/>
+        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="864"/>
+        <location filename="../app/MainLayout.qml" line="1011"/>
         <source>Quit</source>
         <translation>Salir</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="873"/>
-        <location filename="../app/MainLayout.qml" line="901"/>
-        <location filename="../app/MainLayout.qml" line="912"/>
-        <location filename="../app/MainLayout.qml" line="924"/>
-        <location filename="../app/MainLayout.qml" line="951"/>
-        <location filename="../app/MainLayout.qml" line="962"/>
-        <location filename="../app/MainLayout.qml" line="997"/>
-        <location filename="../app/MainLayout.qml" line="1013"/>
-        <location filename="../app/MainLayout.qml" line="1022"/>
-        <location filename="../app/MainLayout.qml" line="1056"/>
-        <location filename="../app/MainLayout.qml" line="1067"/>
+        <location filename="../app/MainLayout.qml" line="1020"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1061"/>
+        <location filename="../app/MainLayout.qml" line="1076"/>
+        <location filename="../app/MainLayout.qml" line="1103"/>
+        <location filename="../app/MainLayout.qml" line="1114"/>
+        <location filename="../app/MainLayout.qml" line="1151"/>
+        <location filename="../app/MainLayout.qml" line="1169"/>
+        <location filename="../app/MainLayout.qml" line="1178"/>
+        <location filename="../app/MainLayout.qml" line="1214"/>
+        <location filename="../app/MainLayout.qml" line="1225"/>
         <source>Back</source>
         <translation>Atrás</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="891"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1043"/>
+        <location filename="../app/MainLayout.qml" line="1040"/>
+        <location filename="../app/MainLayout.qml" line="1090"/>
+        <location filename="../app/MainLayout.qml" line="1201"/>
         <source>Page</source>
         <translation>Página</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="947"/>
-        <location filename="../app/MainLayout.qml" line="1052"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1210"/>
         <source>Options</source>
         <translation>Opciones</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="787"/>
-        <location filename="../app/MainLayout.qml" line="908"/>
-        <location filename="../app/MainLayout.qml" line="958"/>
-        <location filename="../app/MainLayout.qml" line="1063"/>
+        <location filename="../app/MainLayout.qml" line="934"/>
+        <location filename="../app/MainLayout.qml" line="1057"/>
+        <location filename="../app/MainLayout.qml" line="1110"/>
+        <location filename="../app/MainLayout.qml" line="1221"/>
         <source>Retry</source>
         <translation>Reintentar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="982"/>
+        <location filename="../app/MainLayout.qml" line="1136"/>
         <source>Change</source>
         <translation>Cambiar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="988"/>
+        <location filename="../app/MainLayout.qml" line="1142"/>
         <source>Toggle</source>
         <translation>Alternar</translation>
     </message>
@@ -710,12 +834,12 @@
         <translation type="unfinished">Cargando…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="306"/>
+        <location filename="../screens/MediaListScreen.qml" line="351"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 entradas</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="307"/>
+        <location filename="../screens/MediaListScreen.qml" line="352"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -764,17 +888,17 @@
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="26"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
         <source>Nothing here</source>
         <translation>Nada aquí</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="28"/>
         <source>Loading…</source>
         <translation>Cargando…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="57"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="58"/>
         <source>Failed to load</source>
         <translation>Fallo al cargar</translation>
     </message>
@@ -782,387 +906,423 @@
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="73"/>
-        <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
         <source>Language</source>
         <translation>Idioma</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="130"/>
         <source>Mouse support</source>
         <translation>Soporte a ratón</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="112"/>
+        <location filename="../screens/SettingsScreen.qml" line="137"/>
         <source>Update media database</source>
         <translation>Actualizar base de datos de medios</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="61"/>
         <source>General</source>
-        <translation>Ajustes generales</translation>
+        <translation type="vanished">Ajustes generales</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78"/>
-        <location filename="../screens/SettingsScreen.qml" line="507"/>
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <location filename="../screens/SettingsScreen.qml" line="618"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="516"/>
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Browsing layout</source>
         <translation>Diseño de exploración</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88"/>
-        <location filename="../screens/SettingsScreen.qml" line="525"/>
+        <location filename="../screens/SettingsScreen.qml" line="125"/>
+        <location filename="../screens/SettingsScreen.qml" line="636"/>
         <source>Button style</source>
         <translation>Estilo de botón</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="93"/>
-        <location filename="../screens/SettingsScreen.qml" line="534"/>
+        <location filename="../screens/SettingsScreen.qml" line="112"/>
+        <location filename="../screens/SettingsScreen.qml" line="645"/>
         <source>Screensaver</source>
         <translation>Salvapantallas</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97"/>
         <source>Library</source>
-        <translation>Biblioteca</translation>
+        <translation type="vanished">Biblioteca</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="142"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="543"/>
+        <location filename="../screens/SettingsScreen.qml" line="654"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
         <source>Scrape metadata</source>
         <translation>Extraer metadatos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Advanced</source>
-        <translation>Avanzado</translation>
+        <translation type="vanished">Avanzado</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="136"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
         <source>Debug logging</source>
         <translation>Registro de depuración</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="141"/>
+        <location filename="../screens/SettingsScreen.qml" line="169"/>
         <source>Upload log file</source>
         <translation>Subir archivo de registro</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="146"/>
+        <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>About / License</source>
         <translation>Acerca de / Licencia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="162"/>
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
+        <source>Display &amp; Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="72"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <source>Controls &amp; Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="189"/>
+        <source>Library &amp; Data Management</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="82"/>
+        <location filename="../screens/SettingsScreen.qml" line="191"/>
+        <source>Support &amp; About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="206"/>
         <source>Optimizing</source>
         <translation>Optimizando</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
-        <location filename="../screens/SettingsScreen.qml" line="173"/>
+        <location filename="../screens/SettingsScreen.qml" line="208"/>
+        <location filename="../screens/SettingsScreen.qml" line="217"/>
         <source>Paused</source>
         <translation>Pausado</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
-        <location filename="../screens/SettingsScreen.qml" line="173"/>
+        <location filename="../screens/SettingsScreen.qml" line="208"/>
+        <location filename="../screens/SettingsScreen.qml" line="217"/>
         <source>In progress</source>
         <translation>En progreso</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="167"/>
+        <location filename="../screens/SettingsScreen.qml" line="211"/>
         <source>%1 indexed</source>
         <translation>%1 indexados</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="176"/>
+        <location filename="../screens/SettingsScreen.qml" line="220"/>
         <source>%1 scraped</source>
         <translation>%1 extraídos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="284"/>
+        <location filename="../screens/SettingsScreen.qml" line="393"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="284"/>
+        <location filename="../screens/SettingsScreen.qml" line="393"/>
         <source>Start</source>
         <translation>Iniciar</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="286"/>
+        <location filename="../screens/SettingsScreen.qml" line="395"/>
         <source>Upload</source>
         <translation>Subir</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="288"/>
+        <location filename="../screens/SettingsScreen.qml" line="396"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="365"/>
+        <location filename="../screens/SettingsScreen.qml" line="472"/>
         <source>English</source>
         <translation>Inglés</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="367"/>
+        <location filename="../screens/SettingsScreen.qml" line="474"/>
         <source>Italian</source>
         <translation>Italiano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="476"/>
+        <source>Spanish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="478"/>
+        <source>Basque</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="480"/>
         <source>German</source>
         <translation>Alemán</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
+        <location filename="../screens/SettingsScreen.qml" line="482"/>
         <source>Greek</source>
         <translation>Griego</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="373"/>
+        <location filename="../screens/SettingsScreen.qml" line="484"/>
         <source>Japanese</source>
         <translation>Japonés</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="375"/>
+        <location filename="../screens/SettingsScreen.qml" line="486"/>
         <source>Korean</source>
         <translation>Coreano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Dutch</source>
         <translation>Neerlandés</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="379"/>
+        <location filename="../screens/SettingsScreen.qml" line="490"/>
         <source>Romanian</source>
         <translation>Rumano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="381"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Slovak</source>
         <translation>Eslovaco</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="383"/>
+        <location filename="../screens/SettingsScreen.qml" line="494"/>
         <source>Ukrainian</source>
         <translation>Ucraniano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="385"/>
+        <location filename="../screens/SettingsScreen.qml" line="496"/>
         <source>Chinese (Simplified)</source>
         <translation>Chino (simplificado)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="387"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Hebrew</source>
         <translation>Hebreo</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="389"/>
+        <location filename="../screens/SettingsScreen.qml" line="500"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="391"/>
+        <location filename="../screens/SettingsScreen.qml" line="502"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="392"/>
-        <location filename="../screens/SettingsScreen.qml" line="451"/>
+        <location filename="../screens/SettingsScreen.qml" line="503"/>
+        <location filename="../screens/SettingsScreen.qml" line="562"/>
         <source>Auto</source>
         <translation>Automático</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <location filename="../screens/SettingsScreen.qml" line="508"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <location filename="../screens/SettingsScreen.qml" line="510"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="400"/>
+        <location filename="../screens/SettingsScreen.qml" line="511"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405"/>
+        <location filename="../screens/SettingsScreen.qml" line="516"/>
         <source>Detailed list view</source>
         <translation>Vista de lista detallada</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="406"/>
+        <location filename="../screens/SettingsScreen.qml" line="517"/>
         <source>Grid view</source>
         <translation>Vista de cuadrícula</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="411"/>
+        <location filename="../screens/SettingsScreen.qml" line="522"/>
         <source>Style B</source>
         <translation>Estilo B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="413"/>
+        <location filename="../screens/SettingsScreen.qml" line="524"/>
         <source>Style C</source>
         <translation>Estilo C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="415"/>
+        <location filename="../screens/SettingsScreen.qml" line="526"/>
         <source>Style D</source>
         <translation>Estilo D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="416"/>
+        <location filename="../screens/SettingsScreen.qml" line="527"/>
         <source>Style A</source>
         <translation>Estilo A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="340"/>
+        <location filename="../screens/SettingsScreen.qml" line="1032"/>
+        <source>Loading settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="447"/>
         <source>Default</source>
         <translation>Por defecto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="431"/>
+        <location filename="../screens/SettingsScreen.qml" line="542"/>
         <source>Off</source>
         <translation>Desactivado</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="433"/>
+        <location filename="../screens/SettingsScreen.qml" line="544"/>
         <source>1 second (testing)</source>
         <translation>1 segundo (prueba)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="435"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>1 minute</source>
         <translation>1 minuto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="437"/>
+        <location filename="../screens/SettingsScreen.qml" line="548"/>
         <source>2 minutes</source>
         <translation>2 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="439"/>
+        <location filename="../screens/SettingsScreen.qml" line="550"/>
         <source>5 minutes</source>
         <translation>5 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="441"/>
+        <location filename="../screens/SettingsScreen.qml" line="552"/>
         <source>10 minutes</source>
         <translation>10 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="443"/>
+        <location filename="../screens/SettingsScreen.qml" line="554"/>
         <source>15 minutes</source>
         <translation>15 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="445"/>
+        <location filename="../screens/SettingsScreen.qml" line="556"/>
         <source>30 minutes</source>
         <translation>30 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="446"/>
+        <location filename="../screens/SettingsScreen.qml" line="557"/>
         <source>%1 seconds</source>
         <translation>%1 segundos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="489"/>
+        <location filename="../screens/SettingsScreen.qml" line="91"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Resolution</source>
         <translation>Resolución</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="453"/>
+        <location filename="../screens/SettingsScreen.qml" line="564"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="455"/>
+        <location filename="../screens/SettingsScreen.qml" line="566"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="457"/>
+        <location filename="../screens/SettingsScreen.qml" line="568"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <location filename="../screens/SettingsScreen.qml" line="570"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="461"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="463"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="465"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="467"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="469"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="471"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="473"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="663"/>
+        <location filename="../screens/SettingsScreen.qml" line="192"/>
         <source>Settings</source>
         <translation>Ajustes</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="857"/>
+        <location filename="../screens/SettingsScreen.qml" line="1020"/>
         <source>No settings available on this platform</source>
         <translation>No hay ajustes en esta plataforma</translation>
     </message>
@@ -1170,24 +1330,24 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="195"/>
-        <location filename="../screens/SystemsScreen.qml" line="292"/>
+        <location filename="../screens/SystemsScreen.qml" line="197"/>
+        <location filename="../screens/SystemsScreen.qml" line="295"/>
         <source>%1 systems</source>
         <translation>%1 sistemas</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="196"/>
-        <location filename="../screens/SystemsScreen.qml" line="309"/>
+        <location filename="../screens/SystemsScreen.qml" line="198"/>
+        <location filename="../screens/SystemsScreen.qml" line="312"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="324"/>
+        <location filename="../screens/SystemsScreen.qml" line="328"/>
         <source>No systems in this category</source>
         <translation>No hay sistemas en esta categoría</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="325"/>
+        <location filename="../screens/SystemsScreen.qml" line="329"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -54,6 +54,13 @@
         <translation>Traducciones</translation>
     </message>
     <message>
+        <location filename="../screens/AboutScreen.qml" line="267"/>
+        <source>Italiano - Andrea Bogazzi
+Español - Carlos R.
+Euskara - devilschile2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/AboutScreen.qml" line="278"/>
         <source>Full license text in COPYING.</source>
         <translation>Texto completo de la licencia en COPYING.</translation>
@@ -907,7 +914,7 @@
     <name>SettingsScreen</name>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="611"/>
         <source>Language</source>
         <translation>Idioma</translation>
     </message>
@@ -927,25 +934,25 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="97"/>
-        <location filename="../screens/SettingsScreen.qml" line="618"/>
+        <location filename="../screens/SettingsScreen.qml" line="620"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="627"/>
+        <location filename="../screens/SettingsScreen.qml" line="629"/>
         <source>Browsing layout</source>
         <translation>Diseño de exploración</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="125"/>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="638"/>
         <source>Button style</source>
         <translation>Estilo de botón</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="112"/>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
+        <location filename="../screens/SettingsScreen.qml" line="647"/>
         <source>Screensaver</source>
         <translation>Salvapantallas</translation>
     </message>
@@ -960,7 +967,7 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="654"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1131,72 +1138,77 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <source>Chinese (Traditional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="500"/>
         <source>Hebrew</source>
         <translation>Hebreo</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="500"/>
+        <location filename="../screens/SettingsScreen.qml" line="502"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="502"/>
+        <location filename="../screens/SettingsScreen.qml" line="504"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="503"/>
-        <location filename="../screens/SettingsScreen.qml" line="562"/>
+        <location filename="../screens/SettingsScreen.qml" line="505"/>
+        <location filename="../screens/SettingsScreen.qml" line="564"/>
         <source>Auto</source>
         <translation>Automático</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="508"/>
+        <location filename="../screens/SettingsScreen.qml" line="510"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="510"/>
+        <location filename="../screens/SettingsScreen.qml" line="512"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="511"/>
+        <location filename="../screens/SettingsScreen.qml" line="513"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="516"/>
+        <location filename="../screens/SettingsScreen.qml" line="518"/>
         <source>Detailed list view</source>
         <translation>Vista de lista detallada</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="517"/>
+        <location filename="../screens/SettingsScreen.qml" line="519"/>
         <source>Grid view</source>
         <translation>Vista de cuadrícula</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="522"/>
+        <location filename="../screens/SettingsScreen.qml" line="524"/>
         <source>Style B</source>
         <translation>Estilo B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="524"/>
+        <location filename="../screens/SettingsScreen.qml" line="526"/>
         <source>Style C</source>
         <translation>Estilo C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="526"/>
+        <location filename="../screens/SettingsScreen.qml" line="528"/>
         <source>Style D</source>
         <translation>Estilo D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="527"/>
+        <location filename="../screens/SettingsScreen.qml" line="529"/>
         <source>Style A</source>
         <translation>Estilo A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1032"/>
+        <location filename="../screens/SettingsScreen.qml" line="1034"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1206,113 +1218,113 @@
         <translation>Por defecto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="542"/>
+        <location filename="../screens/SettingsScreen.qml" line="544"/>
         <source>Off</source>
         <translation>Desactivado</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="544"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>1 second (testing)</source>
         <translation>1 segundo (prueba)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="546"/>
+        <location filename="../screens/SettingsScreen.qml" line="548"/>
         <source>1 minute</source>
         <translation>1 minuto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="548"/>
+        <location filename="../screens/SettingsScreen.qml" line="550"/>
         <source>2 minutes</source>
         <translation>2 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="550"/>
+        <location filename="../screens/SettingsScreen.qml" line="552"/>
         <source>5 minutes</source>
         <translation>5 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="552"/>
+        <location filename="../screens/SettingsScreen.qml" line="554"/>
         <source>10 minutes</source>
         <translation>10 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="554"/>
+        <location filename="../screens/SettingsScreen.qml" line="556"/>
         <source>15 minutes</source>
         <translation>15 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="556"/>
+        <location filename="../screens/SettingsScreen.qml" line="558"/>
         <source>30 minutes</source>
         <translation>30 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="557"/>
+        <location filename="../screens/SettingsScreen.qml" line="559"/>
         <source>%1 seconds</source>
         <translation>%1 segundos</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="91"/>
-        <location filename="../screens/SettingsScreen.qml" line="600"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Resolution</source>
         <translation>Resolución</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="564"/>
+        <location filename="../screens/SettingsScreen.qml" line="566"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="566"/>
+        <location filename="../screens/SettingsScreen.qml" line="568"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="568"/>
+        <location filename="../screens/SettingsScreen.qml" line="570"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="570"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1322,7 +1334,7 @@
         <translation>Ajustes</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1020"/>
+        <location filename="../screens/SettingsScreen.qml" line="1022"/>
         <source>No settings available on this platform</source>
         <translation>No hay ajustes en esta plataforma</translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -54,6 +54,13 @@
         <translation type="unfinished">Itzulpenak</translation>
     </message>
     <message>
+        <location filename="../screens/AboutScreen.qml" line="267"/>
+        <source>Italiano - Andrea Bogazzi
+Español - Carlos R.
+Euskara - devilschile2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/AboutScreen.qml" line="278"/>
         <source>Full license text in COPYING.</source>
         <translation type="unfinished">Lizentziaren testu osoa KOPIAn</translation>
@@ -915,13 +922,13 @@
     <name>SettingsScreen</name>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="611"/>
         <source>Language</source>
         <translation>Hizkuntza</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="627"/>
+        <location filename="../screens/SettingsScreen.qml" line="629"/>
         <source>Browsing layout</source>
         <translation>Nabigazio diseinua</translation>
     </message>
@@ -941,19 +948,19 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="97"/>
-        <location filename="../screens/SettingsScreen.qml" line="618"/>
+        <location filename="../screens/SettingsScreen.qml" line="620"/>
         <source>Orientation</source>
         <translation type="unfinished">Orientazioa</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="125"/>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="638"/>
         <source>Button style</source>
         <translation type="unfinished">Botoi estiloa</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="112"/>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
+        <location filename="../screens/SettingsScreen.qml" line="647"/>
         <source>Screensaver</source>
         <translation type="unfinished">Pantaila babeslea</translation>
     </message>
@@ -968,7 +975,7 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="654"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Preferred artwork</source>
         <translation type="unfinished">Hobetsitako artelana</translation>
     </message>
@@ -1139,72 +1146,77 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="498"/>
-        <source>Hebrew</source>
+        <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="500"/>
+        <source>Hebrew</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="502"/>
         <source>Arabic</source>
         <translation type="unfinished">Arabiera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="502"/>
+        <location filename="../screens/SettingsScreen.qml" line="504"/>
         <source>Hindi</source>
         <translation type="unfinished">HIndia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="503"/>
-        <location filename="../screens/SettingsScreen.qml" line="562"/>
+        <location filename="../screens/SettingsScreen.qml" line="505"/>
+        <location filename="../screens/SettingsScreen.qml" line="564"/>
         <source>Auto</source>
         <translation>Auto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="508"/>
+        <location filename="../screens/SettingsScreen.qml" line="510"/>
         <source>Rotated CW</source>
         <translation type="unfinished">CW biratua</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="510"/>
+        <location filename="../screens/SettingsScreen.qml" line="512"/>
         <source>Rotated CCW</source>
         <translation type="unfinished">CCW biratua</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="511"/>
+        <location filename="../screens/SettingsScreen.qml" line="513"/>
         <source>Horizontal</source>
         <translation type="unfinished">Horizontala</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="516"/>
+        <location filename="../screens/SettingsScreen.qml" line="518"/>
         <source>Detailed list view</source>
         <translation>Xehetasun listaren ikuspegia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="517"/>
+        <location filename="../screens/SettingsScreen.qml" line="519"/>
         <source>Grid view</source>
         <translation>Sarearen ikuspegia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="522"/>
+        <location filename="../screens/SettingsScreen.qml" line="524"/>
         <source>Style B</source>
         <translation type="unfinished">B estiloa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="524"/>
+        <location filename="../screens/SettingsScreen.qml" line="526"/>
         <source>Style C</source>
         <translation type="unfinished">C estiloa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="526"/>
+        <location filename="../screens/SettingsScreen.qml" line="528"/>
         <source>Style D</source>
         <translation type="unfinished">D estiloa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="527"/>
+        <location filename="../screens/SettingsScreen.qml" line="529"/>
         <source>Style A</source>
         <translation type="unfinished">A estiloa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1032"/>
+        <location filename="../screens/SettingsScreen.qml" line="1034"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1214,113 +1226,113 @@
         <translation>Lehenetsia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="542"/>
+        <location filename="../screens/SettingsScreen.qml" line="544"/>
         <source>Off</source>
         <translation type="unfinished">Desaktibatuta</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="544"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>1 second (testing)</source>
         <translation type="unfinished">segundu 1 (frogatzen)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="546"/>
+        <location filename="../screens/SettingsScreen.qml" line="548"/>
         <source>1 minute</source>
         <translation type="unfinished">minutu 1</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="548"/>
+        <location filename="../screens/SettingsScreen.qml" line="550"/>
         <source>2 minutes</source>
         <translation type="unfinished">2 minutu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="550"/>
+        <location filename="../screens/SettingsScreen.qml" line="552"/>
         <source>5 minutes</source>
         <translation type="unfinished">5 minutu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="552"/>
+        <location filename="../screens/SettingsScreen.qml" line="554"/>
         <source>10 minutes</source>
         <translation type="unfinished">10 minutu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="554"/>
+        <location filename="../screens/SettingsScreen.qml" line="556"/>
         <source>15 minutes</source>
         <translation type="unfinished">15 minutu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="556"/>
+        <location filename="../screens/SettingsScreen.qml" line="558"/>
         <source>30 minutes</source>
         <translation type="unfinished">30 minutu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="557"/>
+        <location filename="../screens/SettingsScreen.qml" line="559"/>
         <source>%1 seconds</source>
         <translation type="unfinished">%1 segundu</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="91"/>
-        <location filename="../screens/SettingsScreen.qml" line="600"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Resolution</source>
         <translation type="unfinished">Bereizmena</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="564"/>
+        <location filename="../screens/SettingsScreen.qml" line="566"/>
         <source>Image</source>
         <translation type="unfinished">Irudia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="566"/>
+        <location filename="../screens/SettingsScreen.qml" line="568"/>
         <source>Thumbnail</source>
         <translation type="unfinished">Miniatura</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="568"/>
+        <location filename="../screens/SettingsScreen.qml" line="570"/>
         <source>Box art</source>
         <translation type="unfinished">Kaxaren artelana</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="570"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>3D box art</source>
         <translation type="unfinished">Kaxaren 3D artelana</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Screenshot</source>
         <translation type="unfinished">Pantaila argazkoa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Wheel</source>
         <translation type="unfinished">Gurpila</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Title screen</source>
         <translation type="unfinished">Izenburu pantaila</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Map</source>
         <translation type="unfinished">Mapa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Marquee</source>
         <translation type="unfinished">Karpa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Fan art</source>
         <translation type="unfinished">Fan artelana</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Box side</source>
         <translation type="unfinished">Kaxa alboa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Box back</source>
         <translation type="unfinished">Kaxa atzekaldea</translation>
     </message>
@@ -1330,7 +1342,7 @@
         <translation>Ezarpenak</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1020"/>
+        <location filename="../screens/SettingsScreen.qml" line="1022"/>
         <source>No settings available on this platform</source>
         <translation>Ez dago ezarpenik plataforma honetan</translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -4,57 +4,57 @@
 <context>
     <name>AboutScreen</name>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="71"/>
+        <location filename="../screens/AboutScreen.qml" line="73"/>
         <source>About / License</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Buruz / Lizentzia</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="153"/>
+        <location filename="../screens/AboutScreen.qml" line="155"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished">Zaparoo Frontend-a</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="164"/>
+        <location filename="../screens/AboutScreen.qml" line="166"/>
         <source>Version %1 · %2 · %3</source>
         <translation type="unfinished">%1 · %2 · %3 Bertsioa</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="174"/>
+        <location filename="../screens/AboutScreen.qml" line="176"/>
         <source>Built %1</source>
         <translation type="unfinished">%1 Eraikuntza</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="185"/>
+        <location filename="../screens/AboutScreen.qml" line="187"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation type="unfinished">Copyright 2026 Wizzo Pty Ltd eta Zaparoo Project-eko laguntzaileak</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="196"/>
+        <location filename="../screens/AboutScreen.qml" line="198"/>
         <source>Source available under the PolyForm Noncommercial License 1.0.0. Free for personal, non-commercial use. Commercial use requires a separate license.</source>
         <translation type="unfinished">Kodea PolyForm Noncommercial License 1.0.0. lizentziapean eskuragai dago. Doan erabilera pertsonal, ez komertzialerako. Erabilera komertzialak aparteko lizentzia eskatzen du.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="207"/>
+        <location filename="../screens/AboutScreen.qml" line="209"/>
         <source>Commercial licensing: legal@zaparoo.org</source>
         <translation type="unfinished">Lizentziazio komertizala: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="218"/>
+        <location filename="../screens/AboutScreen.qml" line="220"/>
         <source>Project: https://zaparoo.org</source>
         <translation type="unfinished">Proiektua: https://zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="228"/>
+        <location filename="../screens/AboutScreen.qml" line="230"/>
         <source>Created by</source>
         <translation type="unfinished">Honek sortua</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="252"/>
+        <location filename="../screens/AboutScreen.qml" line="254"/>
         <source>Translations</source>
         <translation type="unfinished">Itzulpenak</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="276"/>
+        <location filename="../screens/AboutScreen.qml" line="278"/>
         <source>Full license text in COPYING.</source>
         <translation type="unfinished">Lizentziaren testu osoa KOPIAn</translation>
     </message>
@@ -90,49 +90,103 @@
         <translation type="unfinished">Kargatzen…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="77"/>
+        <location filename="../components/BrowseDetailPane.qml" line="138"/>
         <source>Year</source>
         <translation type="unfinished">Urtea</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="79"/>
+        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <source>Yr</source>
+        <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Genre</source>
         <translation type="unfinished">Mota</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="81"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <source>Gen</source>
+        <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Players</source>
         <translation type="unfinished">Jokalariak</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="83"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <source>Plyr</source>
+        <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Developer</source>
         <translation type="unfinished">Garatzailea</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="85"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <source>Dev</source>
+        <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Publisher</source>
         <translation type="unfinished">Argitaratzailea</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="87"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <source>Pub</source>
+        <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Rating</source>
         <translation type="unfinished">Balorazioa</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="89"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <source>Rtg</source>
+        <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Category</source>
         <translation type="unfinished">Kategoria</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="91"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <source>Cat</source>
+        <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Release date</source>
         <translation type="unfinished">Argitaratze data</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="93"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <source>Date</source>
+        <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Manufacturer</source>
         <translation type="unfinished">Fabrikatzailea</translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <source>Mfr</source>
+        <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -176,68 +230,103 @@
 <context>
     <name>CoreStatusPill</name>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="44"/>
-        <location filename="../components/CoreStatusPill.qml" line="50"/>
+        <location filename="../components/CoreStatusPill.qml" line="46"/>
+        <location filename="../components/CoreStatusPill.qml" line="52"/>
         <source>Disconnected</source>
         <translation type="unfinished">Deskonektatuta</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="47"/>
+        <location filename="../components/CoreStatusPill.qml" line="49"/>
         <source>Reconnecting…</source>
         <translation type="unfinished">Berkonektatzen...</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="53"/>
+        <location filename="../components/CoreStatusPill.qml" line="55"/>
         <source>Connecting…</source>
         <translation type="unfinished">Konektatzen...</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="56"/>
+        <location filename="../components/CoreStatusPill.qml" line="58"/>
         <source>Core error</source>
         <translation type="unfinished">Nukleo errorea</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="60"/>
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <source>Paused %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <source>Paused</source>
+        <translation type="unfinished">Geldituta</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="78"/>
+        <source>Opt…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="78"/>
+        <source>Optimizing</source>
+        <translation type="unfinished">Optimizatzen</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
+        <source>Idx…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
+        <source>Scr…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Optimizing database</source>
-        <translation type="unfinished">Datu basea optimizatzen</translation>
+        <translation type="obsolete">Datu basea optimizatzen</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="67"/>
         <source>Indexing paused</source>
-        <translation type="unfinished">Indexatzea pausatuta</translation>
+        <translation type="obsolete">Indexatzea pausatuta</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="70"/>
         <source>Indexing %1/%2 - %3</source>
-        <translation type="unfinished">Indexatzen %1/%2 - %3</translation>
+        <translation type="obsolete">Indexatzen %1/%2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="86"/>
         <source>Scraping %1/%2 - %3</source>
-        <translation type="unfinished">Scrapeatzen %1/%2 - %3</translation>
+        <translation type="obsolete">Scrapeatzen %1/%2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="73"/>
+        <location filename="../components/CoreStatusPill.qml" line="82"/>
         <source>Indexing %1/%2</source>
         <translation type="unfinished">Indexatzen %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <location filename="../components/CoreStatusPill.qml" line="82"/>
+        <source>Idx %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Indexing…</source>
         <translation type="unfinished">Indexatzen...</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Scrape paused</source>
-        <translation type="unfinished">Scrapeatzea pausatuta</translation>
+        <translation type="obsolete">Scrapeatzea pausatuta</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="89"/>
+        <location filename="../components/CoreStatusPill.qml" line="88"/>
         <source>Scraping %1/%2</source>
         <translation type="unfinished">Scrapeatzen %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="91"/>
+        <location filename="../components/CoreStatusPill.qml" line="88"/>
+        <source>Scr %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
         <source>Scraping…</source>
         <translation type="unfinished">Scrapeatzen...</translation>
     </message>
@@ -329,34 +418,34 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="117"/>
-        <location filename="../screens/GamesScreen.qml" line="145"/>
+        <location filename="../screens/GamesScreen.qml" line="122"/>
+        <location filename="../screens/GamesScreen.qml" line="157"/>
         <source>%1 files</source>
         <translation>%1 fitxategi</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="51"/>
+        <location filename="../screens/GamesScreen.qml" line="55"/>
         <source>Loading game…</source>
         <translation type="unfinished">Jokua kargatzen...</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="126"/>
-        <location filename="../screens/GamesScreen.qml" line="146"/>
+        <location filename="../screens/GamesScreen.qml" line="131"/>
+        <location filename="../screens/GamesScreen.qml" line="158"/>
         <source>%1 / %2</source>
         <translation type="unfinished">%1 / %2</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="45"/>
+        <location filename="../screens/GamesScreen.qml" line="49"/>
         <source>Loading games…</source>
         <translation type="unfinished">Jokuak kargatzen</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="122"/>
+        <location filename="../screens/GamesScreen.qml" line="127"/>
         <source>Loading more…</source>
         <translation type="unfinished">Gehiago kargatzen...</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="44"/>
+        <location filename="../screens/GamesScreen.qml" line="48"/>
         <source>No games in this system</source>
         <translation>Sistema honek ez du jokurik</translation>
     </message>
@@ -364,32 +453,55 @@
 <context>
     <name>HubScreen</name>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
         <source>Resume: %1</source>
-        <translation>Berrekin: %1</translation>
+        <translation type="vanished">Berrekin: %1</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
         <source>Resume Game</source>
-        <translation>Jokua berrekin</translation>
+        <translation type="vanished">Jokua berrekin</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
+        <location filename="../screens/HubScreen.qml" line="56"/>
+        <source>Arcade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="61"/>
+        <source>Computers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="66"/>
+        <source>Consoles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="71"/>
+        <source>Handhelds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="134"/>
+        <source>Resume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="140"/>
         <source>Favorites</source>
         <translation>Gogokoak</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="96"/>
+        <location filename="../screens/HubScreen.qml" line="145"/>
         <source>Recently Played</source>
         <translation>Duela gutxi jolastuta</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="101"/>
+        <location filename="../screens/HubScreen.qml" line="150"/>
         <source>Settings</source>
         <translation>Ezarpenak</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="537"/>
+        <location filename="../screens/HubScreen.qml" line="644"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation type="unfinished">Ez dago sistemarik eskuragarri. Exekutatu Eguneratu baliabide datubasea Aukeretatik</translation>
     </message>
@@ -438,104 +550,124 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="755"/>
+        <location filename="../app/Main.qml" line="1206"/>
         <source>Launch core</source>
         <translation type="unfinished">Exekutatu nukleoa</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="958"/>
+        <location filename="../app/Main.qml" line="1212"/>
+        <location filename="../app/Main.qml" line="1420"/>
         <source>Change launcher</source>
         <translation type="unfinished">Aldatu abiarazlea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="786"/>
+        <location filename="../app/Main.qml" line="1247"/>
         <source>Remove from favorites</source>
         <translation type="unfinished">Kendu gogokoetatik</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="786"/>
+        <location filename="../app/Main.qml" line="1247"/>
         <source>Add to favorites</source>
         <translation type="unfinished">Gehitu gogokoetan</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="791"/>
+        <location filename="../app/Main.qml" line="1252"/>
         <source>Write to NFC token</source>
         <translation type="unfinished">Idatzi NFC token-a</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="795"/>
+        <location filename="../app/Main.qml" line="1256"/>
         <source>QR code</source>
         <translation type="unfinished">QR kodea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="770"/>
-        <location filename="../app/Main.qml" line="805"/>
+        <location filename="../app/Main.qml" line="1231"/>
+        <location filename="../app/Main.qml" line="1266"/>
         <source>Launch game</source>
         <translation type="unfinished">Abiarazi jokua</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1776"/>
+        <location filename="../app/Main.qml" line="2368"/>
         <source>Loading systems…</source>
         <translation type="unfinished">Sistemak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1780"/>
+        <location filename="../app/Main.qml" line="2374"/>
         <source>Loading favorites…</source>
         <translation type="unfinished">Gogokoak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1778"/>
+        <location filename="../app/Main.qml" line="2370"/>
         <source>Loading games…</source>
         <translation type="unfinished">Jokoak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="954"/>
+        <location filename="../app/Main.qml" line="1219"/>
+        <source>Update media database</source>
+        <translation type="unfinished">Eguneratu multimedia datu-basea</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1222"/>
+        <source>Scrape metadata</source>
+        <translation type="unfinished">Metadatuak scrapeatu</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1416"/>
         <source>Default</source>
         <translation type="unfinished">Lehenetsia</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="954"/>
+        <location filename="../app/Main.qml" line="1416"/>
         <source>Current: %1</source>
         <translation type="unfinished">Unekoa: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1230"/>
+        <location filename="../app/Main.qml" line="1708"/>
         <source>Saving launcher</source>
         <translation type="unfinished">Abiarazlea gordetzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1234"/>
+        <location filename="../app/Main.qml" line="1712"/>
         <source>Saving…</source>
         <translation type="unfinished">Gordetzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1248"/>
+        <location filename="../app/Main.qml" line="1726"/>
         <source>Launcher update failed</source>
         <translation type="unfinished">Abiarazle egukeraketak huts egin du</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1252"/>
+        <location filename="../app/Main.qml" line="1730"/>
         <source>Error: %1</source>
         <translation type="unfinished">Errorea: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1256"/>
+        <location filename="../app/Main.qml" line="1734"/>
         <source>Retry</source>
         <translation type="unfinished">Berriro saiatu</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1260"/>
+        <location filename="../app/Main.qml" line="1738"/>
         <source>Cancel</source>
         <translation type="unfinished">Utzi</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1782"/>
+        <location filename="../app/Main.qml" line="2372"/>
+        <source>Loading game…</source>
+        <translation type="unfinished">Jokua kargatzen...</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2376"/>
         <source>Loading recently played…</source>
         <translation type="unfinished">Duela gutxi jokatutakoak kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="2378"/>
+        <source>Loading settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2380"/>
         <source>Loading…</source>
         <translation type="unfinished">Kargatzen…</translation>
     </message>
@@ -543,161 +675,161 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="581"/>
+        <location filename="../app/MainLayout.qml" line="680"/>
         <source>Writing failed</source>
         <translation>Idazketak huts egin du</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="581"/>
+        <location filename="../app/MainLayout.qml" line="680"/>
         <source>Put a writable card near the reader</source>
         <translation>Jarri idatzi daitekeen txartel bat irakurlearen ondoan</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="669"/>
+        <location filename="../app/MainLayout.qml" line="807"/>
         <source>Are you sure you want to exit?</source>
         <translation type="unfinished">Ziur zaude irten nahi duzula?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="745"/>
-        <location filename="../app/MainLayout.qml" line="817"/>
+        <location filename="../app/MainLayout.qml" line="890"/>
+        <location filename="../app/MainLayout.qml" line="964"/>
         <source>Select</source>
         <translation>Aukeratu</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="749"/>
-        <location filename="../app/MainLayout.qml" line="753"/>
-        <location filename="../app/MainLayout.qml" line="767"/>
-        <location filename="../app/MainLayout.qml" line="780"/>
-        <location filename="../app/MainLayout.qml" line="791"/>
+        <location filename="../app/MainLayout.qml" line="894"/>
+        <location filename="../app/MainLayout.qml" line="898"/>
+        <location filename="../app/MainLayout.qml" line="912"/>
+        <location filename="../app/MainLayout.qml" line="927"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
         <source>Close</source>
         <translation>Itxi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="760"/>
-        <location filename="../app/MainLayout.qml" line="798"/>
-        <location filename="../app/MainLayout.qml" line="821"/>
-        <location filename="../app/MainLayout.qml" line="832"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
+        <location filename="../app/MainLayout.qml" line="945"/>
+        <location filename="../app/MainLayout.qml" line="968"/>
+        <location filename="../app/MainLayout.qml" line="979"/>
         <source>Cancel</source>
         <translation>Utzi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="776"/>
+        <location filename="../app/MainLayout.qml" line="923"/>
         <source>Done</source>
         <translation type="unfinished">Eginda</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="806"/>
+        <location filename="../app/MainLayout.qml" line="953"/>
         <source>I understand</source>
         <translation type="unfinished">Ulertzen dut</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="840"/>
+        <location filename="../app/MainLayout.qml" line="987"/>
         <source>Start</source>
         <translation type="unfinished">Hasi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1009"/>
+        <location filename="../app/MainLayout.qml" line="1165"/>
         <source>Scroll</source>
         <translation type="unfinished">Scroll-a egin</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="741"/>
-        <location filename="../app/MainLayout.qml" line="813"/>
-        <location filename="../app/MainLayout.qml" line="856"/>
-        <location filename="../app/MainLayout.qml" line="885"/>
-        <location filename="../app/MainLayout.qml" line="932"/>
-        <location filename="../app/MainLayout.qml" line="973"/>
-        <location filename="../app/MainLayout.qml" line="1037"/>
+        <location filename="../app/MainLayout.qml" line="886"/>
+        <location filename="../app/MainLayout.qml" line="960"/>
+        <location filename="../app/MainLayout.qml" line="1003"/>
+        <location filename="../app/MainLayout.qml" line="1034"/>
+        <location filename="../app/MainLayout.qml" line="1084"/>
+        <location filename="../app/MainLayout.qml" line="1127"/>
+        <location filename="../app/MainLayout.qml" line="1195"/>
         <source>Move</source>
         <translation>Mugitu</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="141"/>
+        <location filename="../app/MainLayout.qml" line="170"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished">Zaparoo Frontend</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="323"/>
+        <location filename="../app/MainLayout.qml" line="364"/>
         <source>Favorites</source>
         <translation type="unfinished">Gogokoak</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="325"/>
+        <location filename="../app/MainLayout.qml" line="366"/>
         <source>Recently Played</source>
         <translation type="unfinished">Duela gutxi jokatuak</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="592"/>
+        <location filename="../app/MainLayout.qml" line="695"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished">Itxi eta Zaparoo Frontend berabiarazi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="593"/>
+        <location filename="../app/MainLayout.qml" line="696"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished">Ezarpenak indarrean jartzeko frontend-a berrabiarazi behar dugu</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="668"/>
+        <location filename="../app/MainLayout.qml" line="806"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished">Itxi Zaparoo Frontend?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="860"/>
-        <location filename="../app/MainLayout.qml" line="895"/>
-        <location filename="../app/MainLayout.qml" line="942"/>
-        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1007"/>
+        <location filename="../app/MainLayout.qml" line="1044"/>
+        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Open</source>
         <translation>Ireki</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="864"/>
+        <location filename="../app/MainLayout.qml" line="1011"/>
         <source>Quit</source>
         <translation>Irten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="873"/>
-        <location filename="../app/MainLayout.qml" line="901"/>
-        <location filename="../app/MainLayout.qml" line="912"/>
-        <location filename="../app/MainLayout.qml" line="924"/>
-        <location filename="../app/MainLayout.qml" line="951"/>
-        <location filename="../app/MainLayout.qml" line="962"/>
-        <location filename="../app/MainLayout.qml" line="997"/>
-        <location filename="../app/MainLayout.qml" line="1013"/>
-        <location filename="../app/MainLayout.qml" line="1022"/>
-        <location filename="../app/MainLayout.qml" line="1056"/>
-        <location filename="../app/MainLayout.qml" line="1067"/>
+        <location filename="../app/MainLayout.qml" line="1020"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1061"/>
+        <location filename="../app/MainLayout.qml" line="1076"/>
+        <location filename="../app/MainLayout.qml" line="1103"/>
+        <location filename="../app/MainLayout.qml" line="1114"/>
+        <location filename="../app/MainLayout.qml" line="1151"/>
+        <location filename="../app/MainLayout.qml" line="1169"/>
+        <location filename="../app/MainLayout.qml" line="1178"/>
+        <location filename="../app/MainLayout.qml" line="1214"/>
+        <location filename="../app/MainLayout.qml" line="1225"/>
         <source>Back</source>
         <translation>Atzera</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="891"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1043"/>
+        <location filename="../app/MainLayout.qml" line="1040"/>
+        <location filename="../app/MainLayout.qml" line="1090"/>
+        <location filename="../app/MainLayout.qml" line="1201"/>
         <source>Page</source>
         <translation type="unfinished">Orria</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="947"/>
-        <location filename="../app/MainLayout.qml" line="1052"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1210"/>
         <source>Options</source>
         <translation type="unfinished">Aukerak</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="787"/>
-        <location filename="../app/MainLayout.qml" line="908"/>
-        <location filename="../app/MainLayout.qml" line="958"/>
-        <location filename="../app/MainLayout.qml" line="1063"/>
+        <location filename="../app/MainLayout.qml" line="934"/>
+        <location filename="../app/MainLayout.qml" line="1057"/>
+        <location filename="../app/MainLayout.qml" line="1110"/>
+        <location filename="../app/MainLayout.qml" line="1221"/>
         <source>Retry</source>
         <translation>Berriro saiatu</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="982"/>
+        <location filename="../app/MainLayout.qml" line="1136"/>
         <source>Change</source>
         <translation>Aldatu</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="988"/>
+        <location filename="../app/MainLayout.qml" line="1142"/>
         <source>Toggle</source>
         <translation>Txandakatu</translation>
     </message>
@@ -710,14 +842,14 @@
         <translation type="unfinished">Kargatzen…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="306"/>
+        <location filename="../screens/MediaListScreen.qml" line="351"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 sarrera</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="307"/>
+        <location filename="../screens/MediaListScreen.qml" line="352"/>
         <source>%1 / %2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1 / %2</translation>
     </message>
 </context>
 <context>
@@ -764,17 +896,17 @@
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="26"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
         <source>Nothing here</source>
         <translation>Ez dago ezer hemen</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="28"/>
         <source>Loading…</source>
         <translation type="unfinished">Kargatzen…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="57"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="58"/>
         <source>Failed to load</source>
         <translation>Ezin izan da kargatu</translation>
     </message>
@@ -782,387 +914,423 @@
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="73"/>
-        <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
         <source>Language</source>
         <translation>Hizkuntza</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="516"/>
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Browsing layout</source>
         <translation>Nabigazio diseinua</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="130"/>
         <source>Mouse support</source>
         <translation>Saguaren euskarria</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="112"/>
+        <location filename="../screens/SettingsScreen.qml" line="137"/>
         <source>Update media database</source>
         <translation type="unfinished">Eguneratu multimedia datu-basea</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="61"/>
         <source>General</source>
-        <translation type="unfinished">Orokorra</translation>
+        <translation type="obsolete">Orokorra</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78"/>
-        <location filename="../screens/SettingsScreen.qml" line="507"/>
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <location filename="../screens/SettingsScreen.qml" line="618"/>
         <source>Orientation</source>
         <translation type="unfinished">Orientazioa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88"/>
-        <location filename="../screens/SettingsScreen.qml" line="525"/>
+        <location filename="../screens/SettingsScreen.qml" line="125"/>
+        <location filename="../screens/SettingsScreen.qml" line="636"/>
         <source>Button style</source>
         <translation type="unfinished">Botoi estiloa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="93"/>
-        <location filename="../screens/SettingsScreen.qml" line="534"/>
+        <location filename="../screens/SettingsScreen.qml" line="112"/>
+        <location filename="../screens/SettingsScreen.qml" line="645"/>
         <source>Screensaver</source>
         <translation type="unfinished">Pantaila babeslea</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97"/>
         <source>Library</source>
-        <translation type="unfinished">Liburutegia</translation>
+        <translation type="obsolete">Liburutegia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="142"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished">Aurkitu arcade bertsio alternatiboak</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="543"/>
+        <location filename="../screens/SettingsScreen.qml" line="654"/>
         <source>Preferred artwork</source>
         <translation type="unfinished">Hobetsitako artelana</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadatuak scrapeatu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished">Berriro scrapeatzea existitzen da</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Advanced</source>
-        <translation type="unfinished">Aurreratua</translation>
+        <translation type="obsolete">Aurreratua</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="136"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
         <source>Debug logging</source>
         <translation type="unfinished">Arazte erregistroa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="141"/>
+        <location filename="../screens/SettingsScreen.qml" line="169"/>
         <source>Upload log file</source>
         <translation type="unfinished">Igo erregistro fitxategia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="146"/>
+        <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>About / License</source>
         <translation type="unfinished">Buruz / Lizentzia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="162"/>
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
+        <source>Display &amp; Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="72"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <source>Controls &amp; Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="189"/>
+        <source>Library &amp; Data Management</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="82"/>
+        <location filename="../screens/SettingsScreen.qml" line="191"/>
+        <source>Support &amp; About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="206"/>
         <source>Optimizing</source>
         <translation type="unfinished">Optimizatzen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
-        <location filename="../screens/SettingsScreen.qml" line="173"/>
+        <location filename="../screens/SettingsScreen.qml" line="208"/>
+        <location filename="../screens/SettingsScreen.qml" line="217"/>
         <source>Paused</source>
         <translation type="unfinished">Geldituta</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
-        <location filename="../screens/SettingsScreen.qml" line="173"/>
+        <location filename="../screens/SettingsScreen.qml" line="208"/>
+        <location filename="../screens/SettingsScreen.qml" line="217"/>
         <source>In progress</source>
         <translation type="unfinished">Abian</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="167"/>
+        <location filename="../screens/SettingsScreen.qml" line="211"/>
         <source>%1 indexed</source>
         <translation type="unfinished">%1 indexatuta</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="176"/>
+        <location filename="../screens/SettingsScreen.qml" line="220"/>
         <source>%1 scraped</source>
         <translation type="unfinished">%1 scrapetatuta</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="284"/>
+        <location filename="../screens/SettingsScreen.qml" line="393"/>
         <source>Cancel</source>
         <translation type="unfinished">Utzi</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="284"/>
+        <location filename="../screens/SettingsScreen.qml" line="393"/>
         <source>Start</source>
         <translation type="unfinished">Hasi</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="286"/>
+        <location filename="../screens/SettingsScreen.qml" line="395"/>
         <source>Upload</source>
         <translation type="unfinished">Igo</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="288"/>
+        <location filename="../screens/SettingsScreen.qml" line="396"/>
         <source>Open</source>
         <translation type="unfinished">Ireki</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="365"/>
+        <location filename="../screens/SettingsScreen.qml" line="472"/>
         <source>English</source>
         <translation>Ingelera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="367"/>
+        <location filename="../screens/SettingsScreen.qml" line="474"/>
         <source>Italian</source>
         <translation>Italiera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="476"/>
+        <source>Spanish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="478"/>
+        <source>Basque</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="480"/>
         <source>German</source>
         <translation type="unfinished">Alemaniera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
+        <location filename="../screens/SettingsScreen.qml" line="482"/>
         <source>Greek</source>
         <translation type="unfinished">Grekoa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="373"/>
+        <location filename="../screens/SettingsScreen.qml" line="484"/>
         <source>Japanese</source>
         <translation type="unfinished">Japoniera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="375"/>
+        <location filename="../screens/SettingsScreen.qml" line="486"/>
         <source>Korean</source>
         <translation type="unfinished">Koreera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Dutch</source>
         <translation type="unfinished">Holandera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="379"/>
+        <location filename="../screens/SettingsScreen.qml" line="490"/>
         <source>Romanian</source>
         <translation type="unfinished">Errumaniera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="381"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Slovak</source>
         <translation type="unfinished">eslovakiera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="383"/>
+        <location filename="../screens/SettingsScreen.qml" line="494"/>
         <source>Ukrainian</source>
         <translation type="unfinished">Ukraniera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="385"/>
+        <location filename="../screens/SettingsScreen.qml" line="496"/>
         <source>Chinese (Simplified)</source>
         <translation type="unfinished">Txinera (sinplifikatua)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="387"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Hebrew</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="389"/>
+        <location filename="../screens/SettingsScreen.qml" line="500"/>
         <source>Arabic</source>
         <translation type="unfinished">Arabiera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="391"/>
+        <location filename="../screens/SettingsScreen.qml" line="502"/>
         <source>Hindi</source>
         <translation type="unfinished">HIndia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="392"/>
-        <location filename="../screens/SettingsScreen.qml" line="451"/>
+        <location filename="../screens/SettingsScreen.qml" line="503"/>
+        <location filename="../screens/SettingsScreen.qml" line="562"/>
         <source>Auto</source>
         <translation>Auto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <location filename="../screens/SettingsScreen.qml" line="508"/>
         <source>Rotated CW</source>
         <translation type="unfinished">CW biratua</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <location filename="../screens/SettingsScreen.qml" line="510"/>
         <source>Rotated CCW</source>
         <translation type="unfinished">CCW biratua</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="400"/>
+        <location filename="../screens/SettingsScreen.qml" line="511"/>
         <source>Horizontal</source>
         <translation type="unfinished">Horizontala</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405"/>
+        <location filename="../screens/SettingsScreen.qml" line="516"/>
         <source>Detailed list view</source>
         <translation>Xehetasun listaren ikuspegia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="406"/>
+        <location filename="../screens/SettingsScreen.qml" line="517"/>
         <source>Grid view</source>
         <translation>Sarearen ikuspegia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="411"/>
+        <location filename="../screens/SettingsScreen.qml" line="522"/>
         <source>Style B</source>
         <translation type="unfinished">B estiloa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="413"/>
+        <location filename="../screens/SettingsScreen.qml" line="524"/>
         <source>Style C</source>
         <translation type="unfinished">C estiloa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="415"/>
+        <location filename="../screens/SettingsScreen.qml" line="526"/>
         <source>Style D</source>
         <translation type="unfinished">D estiloa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="416"/>
+        <location filename="../screens/SettingsScreen.qml" line="527"/>
         <source>Style A</source>
         <translation type="unfinished">A estiloa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="340"/>
+        <location filename="../screens/SettingsScreen.qml" line="1032"/>
+        <source>Loading settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="447"/>
         <source>Default</source>
         <translation>Lehenetsia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="431"/>
+        <location filename="../screens/SettingsScreen.qml" line="542"/>
         <source>Off</source>
         <translation type="unfinished">Desaktibatuta</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="433"/>
+        <location filename="../screens/SettingsScreen.qml" line="544"/>
         <source>1 second (testing)</source>
         <translation type="unfinished">segundu 1 (frogatzen)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="435"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>1 minute</source>
         <translation type="unfinished">minutu 1</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="437"/>
+        <location filename="../screens/SettingsScreen.qml" line="548"/>
         <source>2 minutes</source>
         <translation type="unfinished">2 minutu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="439"/>
+        <location filename="../screens/SettingsScreen.qml" line="550"/>
         <source>5 minutes</source>
         <translation type="unfinished">5 minutu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="441"/>
+        <location filename="../screens/SettingsScreen.qml" line="552"/>
         <source>10 minutes</source>
         <translation type="unfinished">10 minutu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="443"/>
+        <location filename="../screens/SettingsScreen.qml" line="554"/>
         <source>15 minutes</source>
         <translation type="unfinished">15 minutu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="445"/>
+        <location filename="../screens/SettingsScreen.qml" line="556"/>
         <source>30 minutes</source>
         <translation type="unfinished">30 minutu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="446"/>
+        <location filename="../screens/SettingsScreen.qml" line="557"/>
         <source>%1 seconds</source>
         <translation type="unfinished">%1 segundu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="489"/>
+        <location filename="../screens/SettingsScreen.qml" line="91"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Resolution</source>
         <translation type="unfinished">Bereizmena</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="453"/>
+        <location filename="../screens/SettingsScreen.qml" line="564"/>
         <source>Image</source>
         <translation type="unfinished">Irudia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="455"/>
+        <location filename="../screens/SettingsScreen.qml" line="566"/>
         <source>Thumbnail</source>
         <translation type="unfinished">Miniatura</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="457"/>
+        <location filename="../screens/SettingsScreen.qml" line="568"/>
         <source>Box art</source>
         <translation type="unfinished">Kaxaren artelana</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <location filename="../screens/SettingsScreen.qml" line="570"/>
         <source>3D box art</source>
         <translation type="unfinished">Kaxaren 3D artelana</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="461"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>Screenshot</source>
         <translation type="unfinished">Pantaila argazkoa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="463"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Wheel</source>
         <translation type="unfinished">Gurpila</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="465"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Title screen</source>
         <translation type="unfinished">Izenburu pantaila</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="467"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Map</source>
         <translation type="unfinished">Mapa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="469"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Marquee</source>
         <translation type="unfinished">Karpa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="471"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Fan art</source>
         <translation type="unfinished">Fan artelana</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="473"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Box side</source>
         <translation type="unfinished">Kaxa alboa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Box back</source>
         <translation type="unfinished">Kaxa atzekaldea</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="663"/>
+        <location filename="../screens/SettingsScreen.qml" line="192"/>
         <source>Settings</source>
         <translation>Ezarpenak</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="857"/>
+        <location filename="../screens/SettingsScreen.qml" line="1020"/>
         <source>No settings available on this platform</source>
         <translation>Ez dago ezarpenik plataforma honetan</translation>
     </message>
@@ -1170,24 +1338,24 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="195"/>
-        <location filename="../screens/SystemsScreen.qml" line="292"/>
+        <location filename="../screens/SystemsScreen.qml" line="197"/>
+        <location filename="../screens/SystemsScreen.qml" line="295"/>
         <source>%1 systems</source>
         <translation>%1 sistema</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="196"/>
-        <location filename="../screens/SystemsScreen.qml" line="309"/>
+        <location filename="../screens/SystemsScreen.qml" line="198"/>
+        <location filename="../screens/SystemsScreen.qml" line="312"/>
         <source>%1 / %2</source>
         <translation type="unfinished">%1 / %2</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="324"/>
+        <location filename="../screens/SystemsScreen.qml" line="328"/>
         <source>No systems in this category</source>
         <translation>Ez dago sistemarik kategoria honetan</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="325"/>
+        <location filename="../screens/SystemsScreen.qml" line="329"/>
         <source>Loading systems…</source>
         <translation type="unfinished">Sistemak kargatzen</translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -4,57 +4,57 @@
 <context>
     <name>AboutScreen</name>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="71"/>
+        <location filename="../screens/AboutScreen.qml" line="73"/>
         <source>About / License</source>
         <translation>אודות / רישיון</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="153"/>
+        <location filename="../screens/AboutScreen.qml" line="155"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="164"/>
+        <location filename="../screens/AboutScreen.qml" line="166"/>
         <source>Version %1 · %2 · %3</source>
         <translation>גרסה %1 · %2 · %3</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="174"/>
+        <location filename="../screens/AboutScreen.qml" line="176"/>
         <source>Built %1</source>
         <translation>נבנה %1</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="185"/>
+        <location filename="../screens/AboutScreen.qml" line="187"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>כל הזכויות שמורות 2026 ל-Wizzo Pty Ltd ולתורמי פרויקט Zaparoo.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="196"/>
+        <location filename="../screens/AboutScreen.qml" line="198"/>
         <source>Source available under the PolyForm Noncommercial License 1.0.0. Free for personal, non-commercial use. Commercial use requires a separate license.</source>
         <translation>קוד המקור זמין תחת רישיון PolyForm Noncommercial 1.0.0. חינם לשימוש אישי ולא מסחרי. שימוש מסחרי או הפצה מחדש דורשים רישיון נפרד.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="207"/>
+        <location filename="../screens/AboutScreen.qml" line="209"/>
         <source>Commercial licensing: legal@zaparoo.org</source>
         <translation>רישוי מסחרי: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="218"/>
+        <location filename="../screens/AboutScreen.qml" line="220"/>
         <source>Project: https://zaparoo.org</source>
         <translation>פרויקט: https://zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="228"/>
+        <location filename="../screens/AboutScreen.qml" line="230"/>
         <source>Created by</source>
         <translation>נוצר על ידי</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="252"/>
+        <location filename="../screens/AboutScreen.qml" line="254"/>
         <source>Translations</source>
         <translation>תרגומים</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="276"/>
+        <location filename="../screens/AboutScreen.qml" line="278"/>
         <source>Full license text in COPYING.</source>
         <translation>נוסח הרישיון המלא נמצא ב-COPYING.</translation>
     </message>
@@ -90,48 +90,102 @@
         <translation type="unfinished">טוען…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="77"/>
+        <location filename="../components/BrowseDetailPane.qml" line="138"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="79"/>
+        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <source>Yr</source>
+        <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="81"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <source>Gen</source>
+        <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="83"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <source>Plyr</source>
+        <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="85"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <source>Dev</source>
+        <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="87"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <source>Pub</source>
+        <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="89"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <source>Rtg</source>
+        <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="91"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <source>Cat</source>
+        <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="93"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <source>Date</source>
+        <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Manufacturer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <source>Mfr</source>
+        <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -176,68 +230,103 @@
 <context>
     <name>CoreStatusPill</name>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="44"/>
-        <location filename="../components/CoreStatusPill.qml" line="50"/>
+        <location filename="../components/CoreStatusPill.qml" line="46"/>
+        <location filename="../components/CoreStatusPill.qml" line="52"/>
         <source>Disconnected</source>
         <translation>מנותק</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="47"/>
+        <location filename="../components/CoreStatusPill.qml" line="49"/>
         <source>Reconnecting…</source>
         <translation>מתחבר מחדש…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="53"/>
+        <location filename="../components/CoreStatusPill.qml" line="55"/>
         <source>Connecting…</source>
         <translation>מתחבר…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="56"/>
+        <location filename="../components/CoreStatusPill.qml" line="58"/>
         <source>Core error</source>
         <translation>שגיאת Core</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="60"/>
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <source>Paused %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <source>Paused</source>
+        <translation type="unfinished">מושהה</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="78"/>
+        <source>Opt…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="78"/>
+        <source>Optimizing</source>
+        <translation type="unfinished">מבצע אופטימיזציה</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
+        <source>Idx…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
+        <source>Scr…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Optimizing database</source>
-        <translation>מבצע אופטימיזציה למסד הנתונים</translation>
+        <translation type="vanished">מבצע אופטימיזציה למסד הנתונים</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="67"/>
         <source>Indexing paused</source>
-        <translation>יצירת האינדקס הושהתה</translation>
+        <translation type="vanished">יצירת האינדקס הושהתה</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="70"/>
         <source>Indexing %1/%2 - %3</source>
-        <translation>מאנדקס %1/%2 - %3</translation>
+        <translation type="vanished">מאנדקס %1/%2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="73"/>
+        <location filename="../components/CoreStatusPill.qml" line="82"/>
         <source>Indexing %1/%2</source>
         <translation>מאנדקס %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <location filename="../components/CoreStatusPill.qml" line="82"/>
+        <source>Idx %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Indexing…</source>
         <translation>מאנדקס…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Scrape paused</source>
-        <translation>איסוף הנתונים הושהה</translation>
+        <translation type="vanished">איסוף הנתונים הושהה</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="86"/>
         <source>Scraping %1/%2 - %3</source>
-        <translation>אוסף נתונים %1/%2 - %3</translation>
+        <translation type="vanished">אוסף נתונים %1/%2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="89"/>
+        <location filename="../components/CoreStatusPill.qml" line="88"/>
         <source>Scraping %1/%2</source>
         <translation>אוסף נתונים %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="91"/>
+        <location filename="../components/CoreStatusPill.qml" line="88"/>
+        <source>Scr %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
         <source>Scraping…</source>
         <translation>אוסף נתונים…</translation>
     </message>
@@ -329,34 +418,34 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="117"/>
-        <location filename="../screens/GamesScreen.qml" line="145"/>
+        <location filename="../screens/GamesScreen.qml" line="122"/>
+        <location filename="../screens/GamesScreen.qml" line="157"/>
         <source>%1 files</source>
         <translation>%1 קבצים</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="51"/>
+        <location filename="../screens/GamesScreen.qml" line="55"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="126"/>
-        <location filename="../screens/GamesScreen.qml" line="146"/>
+        <location filename="../screens/GamesScreen.qml" line="131"/>
+        <location filename="../screens/GamesScreen.qml" line="158"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="44"/>
+        <location filename="../screens/GamesScreen.qml" line="48"/>
         <source>No games in this system</source>
         <translation>אין משחקים במערכת זו</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="45"/>
+        <location filename="../screens/GamesScreen.qml" line="49"/>
         <source>Loading games…</source>
         <translation>טוען משחקים…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="122"/>
+        <location filename="../screens/GamesScreen.qml" line="127"/>
         <source>Loading more…</source>
         <translation>טוען עוד…</translation>
     </message>
@@ -364,32 +453,47 @@
 <context>
     <name>HubScreen</name>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
-        <source>Resume: %1</source>
+        <location filename="../screens/HubScreen.qml" line="56"/>
+        <source>Arcade</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
-        <source>Resume Game</source>
+        <location filename="../screens/HubScreen.qml" line="61"/>
+        <source>Computers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
+        <location filename="../screens/HubScreen.qml" line="66"/>
+        <source>Consoles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="71"/>
+        <source>Handhelds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="134"/>
+        <source>Resume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="140"/>
         <source>Favorites</source>
         <translation>מועדפים</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="96"/>
+        <location filename="../screens/HubScreen.qml" line="145"/>
         <source>Recently Played</source>
         <translation>שוחקו לאחרונה</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="101"/>
+        <location filename="../screens/HubScreen.qml" line="150"/>
         <source>Settings</source>
         <translation>הגדרות</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="537"/>
+        <location filename="../screens/HubScreen.qml" line="644"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>אין מערכות זמינות. הפעילו &quot;עדכון מסד נתוני מדיה&quot; מההגדרות.</translation>
     </message>
@@ -438,104 +542,124 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="755"/>
+        <location filename="../app/Main.qml" line="1206"/>
         <source>Launch core</source>
         <translation>הפעל את הליבה</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="958"/>
+        <location filename="../app/Main.qml" line="1212"/>
+        <location filename="../app/Main.qml" line="1420"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="770"/>
-        <location filename="../app/Main.qml" line="805"/>
+        <location filename="../app/Main.qml" line="1219"/>
+        <source>Update media database</source>
+        <translation type="unfinished">עדכון מסד נתוני המדיה</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1222"/>
+        <source>Scrape metadata</source>
+        <translation type="unfinished">איסוף מטא-נתונים</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1231"/>
+        <location filename="../app/Main.qml" line="1266"/>
         <source>Launch game</source>
         <translation>הפעל משחק</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="786"/>
+        <location filename="../app/Main.qml" line="1247"/>
         <source>Remove from favorites</source>
         <translation>הסר מהמועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="786"/>
+        <location filename="../app/Main.qml" line="1247"/>
         <source>Add to favorites</source>
         <translation>הוסף למועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="791"/>
+        <location filename="../app/Main.qml" line="1252"/>
         <source>Write to NFC token</source>
         <translation>כתוב לטוקן NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="795"/>
+        <location filename="../app/Main.qml" line="1256"/>
         <source>QR code</source>
         <translation>קוד QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="954"/>
+        <location filename="../app/Main.qml" line="1416"/>
         <source>Default</source>
         <translation type="unfinished">ברירת מחדל</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="954"/>
+        <location filename="../app/Main.qml" line="1416"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1230"/>
+        <location filename="../app/Main.qml" line="1708"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1234"/>
+        <location filename="../app/Main.qml" line="1712"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1248"/>
+        <location filename="../app/Main.qml" line="1726"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1252"/>
+        <location filename="../app/Main.qml" line="1730"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1256"/>
+        <location filename="../app/Main.qml" line="1734"/>
         <source>Retry</source>
         <translation type="unfinished">נסה שוב</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1260"/>
+        <location filename="../app/Main.qml" line="1738"/>
         <source>Cancel</source>
         <translation type="unfinished">ביטול</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1776"/>
+        <location filename="../app/Main.qml" line="2368"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1778"/>
+        <location filename="../app/Main.qml" line="2370"/>
         <source>Loading games…</source>
         <translation>טוען משחקים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1780"/>
+        <location filename="../app/Main.qml" line="2372"/>
+        <source>Loading game…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2374"/>
         <source>Loading favorites…</source>
         <translation>טוען מועדפים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1782"/>
+        <location filename="../app/Main.qml" line="2376"/>
         <source>Loading recently played…</source>
         <translation>טוען את הפריטים ששוחקו לאחרונה…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="2378"/>
+        <source>Loading settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2380"/>
         <source>Loading…</source>
         <translation>טוען…</translation>
     </message>
@@ -543,161 +667,161 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="581"/>
+        <location filename="../app/MainLayout.qml" line="680"/>
         <source>Writing failed</source>
         <translation>הכתיבה נכשלה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="581"/>
+        <location filename="../app/MainLayout.qml" line="680"/>
         <source>Put a writable card near the reader</source>
         <translation>הניחו כרטיס הניתן לכתיבה ליד הקורא</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="141"/>
+        <location filename="../app/MainLayout.qml" line="170"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="323"/>
+        <location filename="../app/MainLayout.qml" line="364"/>
         <source>Favorites</source>
         <translation type="unfinished">מועדפים</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="325"/>
+        <location filename="../app/MainLayout.qml" line="366"/>
         <source>Recently Played</source>
         <translation type="unfinished">שוחקו לאחרונה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="592"/>
+        <location filename="../app/MainLayout.qml" line="695"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="593"/>
+        <location filename="../app/MainLayout.qml" line="696"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="668"/>
+        <location filename="../app/MainLayout.qml" line="806"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="669"/>
+        <location filename="../app/MainLayout.qml" line="807"/>
         <source>Are you sure you want to exit?</source>
         <translation>האם אתה בטוח שברצונך לצאת?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="741"/>
-        <location filename="../app/MainLayout.qml" line="813"/>
-        <location filename="../app/MainLayout.qml" line="856"/>
-        <location filename="../app/MainLayout.qml" line="885"/>
-        <location filename="../app/MainLayout.qml" line="932"/>
-        <location filename="../app/MainLayout.qml" line="973"/>
-        <location filename="../app/MainLayout.qml" line="1037"/>
+        <location filename="../app/MainLayout.qml" line="886"/>
+        <location filename="../app/MainLayout.qml" line="960"/>
+        <location filename="../app/MainLayout.qml" line="1003"/>
+        <location filename="../app/MainLayout.qml" line="1034"/>
+        <location filename="../app/MainLayout.qml" line="1084"/>
+        <location filename="../app/MainLayout.qml" line="1127"/>
+        <location filename="../app/MainLayout.qml" line="1195"/>
         <source>Move</source>
         <translation>הזזה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="745"/>
-        <location filename="../app/MainLayout.qml" line="817"/>
+        <location filename="../app/MainLayout.qml" line="890"/>
+        <location filename="../app/MainLayout.qml" line="964"/>
         <source>Select</source>
         <translation>בחירה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="749"/>
-        <location filename="../app/MainLayout.qml" line="753"/>
-        <location filename="../app/MainLayout.qml" line="767"/>
-        <location filename="../app/MainLayout.qml" line="780"/>
-        <location filename="../app/MainLayout.qml" line="791"/>
+        <location filename="../app/MainLayout.qml" line="894"/>
+        <location filename="../app/MainLayout.qml" line="898"/>
+        <location filename="../app/MainLayout.qml" line="912"/>
+        <location filename="../app/MainLayout.qml" line="927"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
         <source>Close</source>
         <translation>סגור</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="760"/>
-        <location filename="../app/MainLayout.qml" line="798"/>
-        <location filename="../app/MainLayout.qml" line="821"/>
-        <location filename="../app/MainLayout.qml" line="832"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
+        <location filename="../app/MainLayout.qml" line="945"/>
+        <location filename="../app/MainLayout.qml" line="968"/>
+        <location filename="../app/MainLayout.qml" line="979"/>
         <source>Cancel</source>
         <translation>ביטול</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="776"/>
+        <location filename="../app/MainLayout.qml" line="923"/>
         <source>Done</source>
         <translation>הושלם</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="787"/>
-        <location filename="../app/MainLayout.qml" line="908"/>
-        <location filename="../app/MainLayout.qml" line="958"/>
-        <location filename="../app/MainLayout.qml" line="1063"/>
+        <location filename="../app/MainLayout.qml" line="934"/>
+        <location filename="../app/MainLayout.qml" line="1057"/>
+        <location filename="../app/MainLayout.qml" line="1110"/>
+        <location filename="../app/MainLayout.qml" line="1221"/>
         <source>Retry</source>
         <translation>נסה שוב</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="806"/>
+        <location filename="../app/MainLayout.qml" line="953"/>
         <source>I understand</source>
         <translation>הבנתי</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="840"/>
+        <location filename="../app/MainLayout.qml" line="987"/>
         <source>Start</source>
         <translation>התחל</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="860"/>
-        <location filename="../app/MainLayout.qml" line="895"/>
-        <location filename="../app/MainLayout.qml" line="942"/>
-        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1007"/>
+        <location filename="../app/MainLayout.qml" line="1044"/>
+        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Open</source>
         <translation>פתח</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="864"/>
+        <location filename="../app/MainLayout.qml" line="1011"/>
         <source>Quit</source>
         <translation>יציאה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="873"/>
-        <location filename="../app/MainLayout.qml" line="901"/>
-        <location filename="../app/MainLayout.qml" line="912"/>
-        <location filename="../app/MainLayout.qml" line="924"/>
-        <location filename="../app/MainLayout.qml" line="951"/>
-        <location filename="../app/MainLayout.qml" line="962"/>
-        <location filename="../app/MainLayout.qml" line="997"/>
-        <location filename="../app/MainLayout.qml" line="1013"/>
-        <location filename="../app/MainLayout.qml" line="1022"/>
-        <location filename="../app/MainLayout.qml" line="1056"/>
-        <location filename="../app/MainLayout.qml" line="1067"/>
+        <location filename="../app/MainLayout.qml" line="1020"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1061"/>
+        <location filename="../app/MainLayout.qml" line="1076"/>
+        <location filename="../app/MainLayout.qml" line="1103"/>
+        <location filename="../app/MainLayout.qml" line="1114"/>
+        <location filename="../app/MainLayout.qml" line="1151"/>
+        <location filename="../app/MainLayout.qml" line="1169"/>
+        <location filename="../app/MainLayout.qml" line="1178"/>
+        <location filename="../app/MainLayout.qml" line="1214"/>
+        <location filename="../app/MainLayout.qml" line="1225"/>
         <source>Back</source>
         <translation>חזרה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="891"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1043"/>
+        <location filename="../app/MainLayout.qml" line="1040"/>
+        <location filename="../app/MainLayout.qml" line="1090"/>
+        <location filename="../app/MainLayout.qml" line="1201"/>
         <source>Page</source>
         <translation>עמוד</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="947"/>
-        <location filename="../app/MainLayout.qml" line="1052"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1210"/>
         <source>Options</source>
         <translation>אפשרויות</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="982"/>
+        <location filename="../app/MainLayout.qml" line="1136"/>
         <source>Change</source>
         <translation>שינוי</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="988"/>
+        <location filename="../app/MainLayout.qml" line="1142"/>
         <source>Toggle</source>
         <translation>החלף</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1009"/>
+        <location filename="../app/MainLayout.qml" line="1165"/>
         <source>Scroll</source>
         <translation>גלילה</translation>
     </message>
@@ -710,12 +834,12 @@
         <translation type="unfinished">טוען…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="306"/>
+        <location filename="../screens/MediaListScreen.qml" line="351"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 פריטים</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="307"/>
+        <location filename="../screens/MediaListScreen.qml" line="352"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -764,17 +888,17 @@
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="26"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
         <source>Nothing here</source>
         <translation>אין כאן כלום</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="28"/>
         <source>Loading…</source>
         <translation>טוען…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="57"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="58"/>
         <source>Failed to load</source>
         <translation>הטעינה נכשלה</translation>
     </message>
@@ -782,387 +906,423 @@
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="61"/>
         <source>General</source>
-        <translation>כללי</translation>
+        <translation type="vanished">כללי</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="73"/>
-        <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
         <source>Language</source>
         <translation>שפה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78"/>
-        <location filename="../screens/SettingsScreen.qml" line="507"/>
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <location filename="../screens/SettingsScreen.qml" line="618"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="516"/>
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Browsing layout</source>
         <translation>פריסת עיון</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88"/>
-        <location filename="../screens/SettingsScreen.qml" line="525"/>
+        <location filename="../screens/SettingsScreen.qml" line="125"/>
+        <location filename="../screens/SettingsScreen.qml" line="636"/>
         <source>Button style</source>
         <translation>סגנון כפתורים</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="93"/>
-        <location filename="../screens/SettingsScreen.qml" line="534"/>
+        <location filename="../screens/SettingsScreen.qml" line="112"/>
+        <location filename="../screens/SettingsScreen.qml" line="645"/>
         <source>Screensaver</source>
         <translation>שומר מסך</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97"/>
         <source>Library</source>
-        <translation>ספרייה</translation>
+        <translation type="vanished">ספרייה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="142"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="543"/>
+        <location filename="../screens/SettingsScreen.qml" line="654"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="112"/>
+        <location filename="../screens/SettingsScreen.qml" line="137"/>
         <source>Update media database</source>
         <translation>עדכון מסד נתוני המדיה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
         <source>Scrape metadata</source>
         <translation>איסוף מטא-נתונים</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Advanced</source>
-        <translation>מתקדם</translation>
+        <translation type="vanished">מתקדם</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="130"/>
         <source>Mouse support</source>
         <translation>תמיכת עכבר</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="136"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
         <source>Debug logging</source>
         <translation>רישום ניפוי שגיאות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="141"/>
+        <location filename="../screens/SettingsScreen.qml" line="169"/>
         <source>Upload log file</source>
         <translation>העלאת קובץ יומן</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="146"/>
+        <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>About / License</source>
         <translation>אודות / רישיון</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="162"/>
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
+        <source>Display &amp; Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="72"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <source>Controls &amp; Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="189"/>
+        <source>Library &amp; Data Management</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="82"/>
+        <location filename="../screens/SettingsScreen.qml" line="191"/>
+        <source>Support &amp; About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="206"/>
         <source>Optimizing</source>
         <translation>מבצע אופטימיזציה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
-        <location filename="../screens/SettingsScreen.qml" line="173"/>
+        <location filename="../screens/SettingsScreen.qml" line="208"/>
+        <location filename="../screens/SettingsScreen.qml" line="217"/>
         <source>Paused</source>
         <translation>מושהה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
-        <location filename="../screens/SettingsScreen.qml" line="173"/>
+        <location filename="../screens/SettingsScreen.qml" line="208"/>
+        <location filename="../screens/SettingsScreen.qml" line="217"/>
         <source>In progress</source>
         <translation>בתהליך</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="167"/>
+        <location filename="../screens/SettingsScreen.qml" line="211"/>
         <source>%1 indexed</source>
         <translation>%1 אונדקסו</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="176"/>
+        <location filename="../screens/SettingsScreen.qml" line="220"/>
         <source>%1 scraped</source>
         <translation>%1 נאספו</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="284"/>
+        <location filename="../screens/SettingsScreen.qml" line="393"/>
         <source>Cancel</source>
         <translation>ביטול</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="284"/>
+        <location filename="../screens/SettingsScreen.qml" line="393"/>
         <source>Start</source>
         <translation>התחל</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="286"/>
+        <location filename="../screens/SettingsScreen.qml" line="395"/>
         <source>Upload</source>
         <translation>העלאה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="288"/>
+        <location filename="../screens/SettingsScreen.qml" line="396"/>
         <source>Open</source>
         <translation>פתח</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="340"/>
+        <location filename="../screens/SettingsScreen.qml" line="447"/>
         <source>Default</source>
         <translation>ברירת מחדל</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="365"/>
+        <location filename="../screens/SettingsScreen.qml" line="472"/>
         <source>English</source>
         <translation>אנגלית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="367"/>
+        <location filename="../screens/SettingsScreen.qml" line="474"/>
         <source>Italian</source>
         <translation>איטלקית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="476"/>
+        <source>Spanish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="478"/>
+        <source>Basque</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="480"/>
         <source>German</source>
         <translation>גרמנית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
+        <location filename="../screens/SettingsScreen.qml" line="482"/>
         <source>Greek</source>
         <translation>יוונית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="373"/>
+        <location filename="../screens/SettingsScreen.qml" line="484"/>
         <source>Japanese</source>
         <translation>יפנית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="375"/>
+        <location filename="../screens/SettingsScreen.qml" line="486"/>
         <source>Korean</source>
         <translation>קוריאנית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Dutch</source>
         <translation>הולנדית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="379"/>
+        <location filename="../screens/SettingsScreen.qml" line="490"/>
         <source>Romanian</source>
         <translation>רומנית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="381"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Slovak</source>
         <translation>סלובקית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="383"/>
+        <location filename="../screens/SettingsScreen.qml" line="494"/>
         <source>Ukrainian</source>
         <translation>אוקראינית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="385"/>
+        <location filename="../screens/SettingsScreen.qml" line="496"/>
         <source>Chinese (Simplified)</source>
         <translation>סינית (מפושטת)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="387"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Hebrew</source>
         <translation>עברית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="389"/>
+        <location filename="../screens/SettingsScreen.qml" line="500"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="391"/>
+        <location filename="../screens/SettingsScreen.qml" line="502"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="392"/>
-        <location filename="../screens/SettingsScreen.qml" line="451"/>
+        <location filename="../screens/SettingsScreen.qml" line="503"/>
+        <location filename="../screens/SettingsScreen.qml" line="562"/>
         <source>Auto</source>
         <translation>אוטומטי</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <location filename="../screens/SettingsScreen.qml" line="508"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <location filename="../screens/SettingsScreen.qml" line="510"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="400"/>
+        <location filename="../screens/SettingsScreen.qml" line="511"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405"/>
+        <location filename="../screens/SettingsScreen.qml" line="516"/>
         <source>Detailed list view</source>
         <translation>תצוגת רשימה מפורטת</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="406"/>
+        <location filename="../screens/SettingsScreen.qml" line="517"/>
         <source>Grid view</source>
         <translation>תצוגת רשת</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="411"/>
+        <location filename="../screens/SettingsScreen.qml" line="522"/>
         <source>Style B</source>
         <translation>סגנון B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="413"/>
+        <location filename="../screens/SettingsScreen.qml" line="524"/>
         <source>Style C</source>
         <translation>סגנון C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="415"/>
+        <location filename="../screens/SettingsScreen.qml" line="526"/>
         <source>Style D</source>
         <translation>סגנון D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="416"/>
+        <location filename="../screens/SettingsScreen.qml" line="527"/>
         <source>Style A</source>
         <translation>סגנון A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="431"/>
+        <location filename="../screens/SettingsScreen.qml" line="542"/>
         <source>Off</source>
         <translation>כבוי</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="433"/>
+        <location filename="../screens/SettingsScreen.qml" line="544"/>
         <source>1 second (testing)</source>
         <translation>שנייה אחת (לבדיקה)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="435"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>1 minute</source>
         <translation>דקה אחת</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="437"/>
+        <location filename="../screens/SettingsScreen.qml" line="548"/>
         <source>2 minutes</source>
         <translation>2 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="439"/>
+        <location filename="../screens/SettingsScreen.qml" line="550"/>
         <source>5 minutes</source>
         <translation>5 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="441"/>
+        <location filename="../screens/SettingsScreen.qml" line="552"/>
         <source>10 minutes</source>
         <translation>10 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="443"/>
+        <location filename="../screens/SettingsScreen.qml" line="554"/>
         <source>15 minutes</source>
         <translation>15 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="445"/>
+        <location filename="../screens/SettingsScreen.qml" line="556"/>
         <source>30 minutes</source>
         <translation>30 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="446"/>
+        <location filename="../screens/SettingsScreen.qml" line="557"/>
         <source>%1 seconds</source>
         <translation>%1 שניות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="489"/>
+        <location filename="../screens/SettingsScreen.qml" line="1032"/>
+        <source>Loading settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="91"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Resolution</source>
         <translation>רזולוציה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="453"/>
+        <location filename="../screens/SettingsScreen.qml" line="564"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="455"/>
+        <location filename="../screens/SettingsScreen.qml" line="566"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="457"/>
+        <location filename="../screens/SettingsScreen.qml" line="568"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <location filename="../screens/SettingsScreen.qml" line="570"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="461"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="463"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="465"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="467"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="469"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="471"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="473"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="663"/>
+        <location filename="../screens/SettingsScreen.qml" line="192"/>
         <source>Settings</source>
         <translation>הגדרות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="857"/>
+        <location filename="../screens/SettingsScreen.qml" line="1020"/>
         <source>No settings available on this platform</source>
         <translation>אין הגדרות זמינות בפלטפורמה זו</translation>
     </message>
@@ -1170,24 +1330,24 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="195"/>
-        <location filename="../screens/SystemsScreen.qml" line="292"/>
+        <location filename="../screens/SystemsScreen.qml" line="197"/>
+        <location filename="../screens/SystemsScreen.qml" line="295"/>
         <source>%1 systems</source>
         <translation>%1 מערכות</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="196"/>
-        <location filename="../screens/SystemsScreen.qml" line="309"/>
+        <location filename="../screens/SystemsScreen.qml" line="198"/>
+        <location filename="../screens/SystemsScreen.qml" line="312"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="324"/>
+        <location filename="../screens/SystemsScreen.qml" line="328"/>
         <source>No systems in this category</source>
         <translation>אין מערכות בקטגוריה זו</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="325"/>
+        <location filename="../screens/SystemsScreen.qml" line="329"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -54,6 +54,13 @@
         <translation>תרגומים</translation>
     </message>
     <message>
+        <location filename="../screens/AboutScreen.qml" line="267"/>
+        <source>Italiano - Andrea Bogazzi
+Español - Carlos R.
+Euskara - devilschile2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/AboutScreen.qml" line="278"/>
         <source>Full license text in COPYING.</source>
         <translation>נוסח הרישיון המלא נמצא ב-COPYING.</translation>
@@ -911,31 +918,31 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="611"/>
         <source>Language</source>
         <translation>שפה</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="97"/>
-        <location filename="../screens/SettingsScreen.qml" line="618"/>
+        <location filename="../screens/SettingsScreen.qml" line="620"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="627"/>
+        <location filename="../screens/SettingsScreen.qml" line="629"/>
         <source>Browsing layout</source>
         <translation>פריסת עיון</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="125"/>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="638"/>
         <source>Button style</source>
         <translation>סגנון כפתורים</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="112"/>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
+        <location filename="../screens/SettingsScreen.qml" line="647"/>
         <source>Screensaver</source>
         <translation>שומר מסך</translation>
     </message>
@@ -950,7 +957,7 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="654"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1136,183 +1143,188 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <source>Chinese (Traditional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="500"/>
         <source>Hebrew</source>
         <translation>עברית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="500"/>
+        <location filename="../screens/SettingsScreen.qml" line="502"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="502"/>
+        <location filename="../screens/SettingsScreen.qml" line="504"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="503"/>
-        <location filename="../screens/SettingsScreen.qml" line="562"/>
+        <location filename="../screens/SettingsScreen.qml" line="505"/>
+        <location filename="../screens/SettingsScreen.qml" line="564"/>
         <source>Auto</source>
         <translation>אוטומטי</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="508"/>
+        <location filename="../screens/SettingsScreen.qml" line="510"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="510"/>
+        <location filename="../screens/SettingsScreen.qml" line="512"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="511"/>
+        <location filename="../screens/SettingsScreen.qml" line="513"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="516"/>
+        <location filename="../screens/SettingsScreen.qml" line="518"/>
         <source>Detailed list view</source>
         <translation>תצוגת רשימה מפורטת</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="517"/>
+        <location filename="../screens/SettingsScreen.qml" line="519"/>
         <source>Grid view</source>
         <translation>תצוגת רשת</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="522"/>
+        <location filename="../screens/SettingsScreen.qml" line="524"/>
         <source>Style B</source>
         <translation>סגנון B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="524"/>
+        <location filename="../screens/SettingsScreen.qml" line="526"/>
         <source>Style C</source>
         <translation>סגנון C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="526"/>
+        <location filename="../screens/SettingsScreen.qml" line="528"/>
         <source>Style D</source>
         <translation>סגנון D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="527"/>
+        <location filename="../screens/SettingsScreen.qml" line="529"/>
         <source>Style A</source>
         <translation>סגנון A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="542"/>
+        <location filename="../screens/SettingsScreen.qml" line="544"/>
         <source>Off</source>
         <translation>כבוי</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="544"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>1 second (testing)</source>
         <translation>שנייה אחת (לבדיקה)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="546"/>
+        <location filename="../screens/SettingsScreen.qml" line="548"/>
         <source>1 minute</source>
         <translation>דקה אחת</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="548"/>
+        <location filename="../screens/SettingsScreen.qml" line="550"/>
         <source>2 minutes</source>
         <translation>2 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="550"/>
+        <location filename="../screens/SettingsScreen.qml" line="552"/>
         <source>5 minutes</source>
         <translation>5 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="552"/>
+        <location filename="../screens/SettingsScreen.qml" line="554"/>
         <source>10 minutes</source>
         <translation>10 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="554"/>
+        <location filename="../screens/SettingsScreen.qml" line="556"/>
         <source>15 minutes</source>
         <translation>15 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="556"/>
+        <location filename="../screens/SettingsScreen.qml" line="558"/>
         <source>30 minutes</source>
         <translation>30 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="557"/>
+        <location filename="../screens/SettingsScreen.qml" line="559"/>
         <source>%1 seconds</source>
         <translation>%1 שניות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1032"/>
+        <location filename="../screens/SettingsScreen.qml" line="1034"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="91"/>
-        <location filename="../screens/SettingsScreen.qml" line="600"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Resolution</source>
         <translation>רזולוציה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="564"/>
+        <location filename="../screens/SettingsScreen.qml" line="566"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="566"/>
+        <location filename="../screens/SettingsScreen.qml" line="568"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="568"/>
+        <location filename="../screens/SettingsScreen.qml" line="570"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="570"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1322,7 +1334,7 @@
         <translation>הגדרות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1020"/>
+        <location filename="../screens/SettingsScreen.qml" line="1022"/>
         <source>No settings available on this platform</source>
         <translation>אין הגדרות זמינות בפלטפורמה זו</translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -4,57 +4,57 @@
 <context>
     <name>AboutScreen</name>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="71"/>
+        <location filename="../screens/AboutScreen.qml" line="73"/>
         <source>About / License</source>
         <translation>परिचय / लाइसेंस</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="153"/>
+        <location filename="../screens/AboutScreen.qml" line="155"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="164"/>
+        <location filename="../screens/AboutScreen.qml" line="166"/>
         <source>Version %1 · %2 · %3</source>
         <translation>संस्करण %1 · %2 · %3</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="174"/>
+        <location filename="../screens/AboutScreen.qml" line="176"/>
         <source>Built %1</source>
         <translation>%1 को निर्मित</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="185"/>
+        <location filename="../screens/AboutScreen.qml" line="187"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>कॉपीराइट 2026 Wizzo Pty Ltd और Zaparoo परियोजना के योगदानकर्ता।</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="196"/>
+        <location filename="../screens/AboutScreen.qml" line="198"/>
         <source>Source available under the PolyForm Noncommercial License 1.0.0. Free for personal, non-commercial use. Commercial use requires a separate license.</source>
         <translation>स्रोत PolyForm Noncommercial License 1.0.0 के अंतर्गत उपलब्ध है। व्यक्तिगत, गैर-व्यावसायिक उपयोग के लिए निःशुल्क। व्यावसायिक उपयोग या पुनर्वितरण के लिए अलग लाइसेंस आवश्यक है।</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="207"/>
+        <location filename="../screens/AboutScreen.qml" line="209"/>
         <source>Commercial licensing: legal@zaparoo.org</source>
         <translation>व्यावसायिक लाइसेंसिंग: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="218"/>
+        <location filename="../screens/AboutScreen.qml" line="220"/>
         <source>Project: https://zaparoo.org</source>
         <translation>परियोजना: https://zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="228"/>
+        <location filename="../screens/AboutScreen.qml" line="230"/>
         <source>Created by</source>
         <translation>निर्माता</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="252"/>
+        <location filename="../screens/AboutScreen.qml" line="254"/>
         <source>Translations</source>
         <translation>अनुवाद</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="276"/>
+        <location filename="../screens/AboutScreen.qml" line="278"/>
         <source>Full license text in COPYING.</source>
         <translation>पूरा लाइसेंस पाठ COPYING में है।</translation>
     </message>
@@ -90,48 +90,102 @@
         <translation type="unfinished">लोड हो रहा है…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="77"/>
+        <location filename="../components/BrowseDetailPane.qml" line="138"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="79"/>
+        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <source>Yr</source>
+        <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="81"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <source>Gen</source>
+        <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="83"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <source>Plyr</source>
+        <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="85"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <source>Dev</source>
+        <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="87"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <source>Pub</source>
+        <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="89"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <source>Rtg</source>
+        <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="91"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <source>Cat</source>
+        <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="93"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <source>Date</source>
+        <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Manufacturer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <source>Mfr</source>
+        <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -176,68 +230,103 @@
 <context>
     <name>CoreStatusPill</name>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="44"/>
-        <location filename="../components/CoreStatusPill.qml" line="50"/>
+        <location filename="../components/CoreStatusPill.qml" line="46"/>
+        <location filename="../components/CoreStatusPill.qml" line="52"/>
         <source>Disconnected</source>
         <translation>डिस्कनेक्टेड</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="47"/>
+        <location filename="../components/CoreStatusPill.qml" line="49"/>
         <source>Reconnecting…</source>
         <translation>फिर से कनेक्ट किया जा रहा है…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="53"/>
+        <location filename="../components/CoreStatusPill.qml" line="55"/>
         <source>Connecting…</source>
         <translation>कनेक्ट किया जा रहा है…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="56"/>
+        <location filename="../components/CoreStatusPill.qml" line="58"/>
         <source>Core error</source>
         <translation>कोर त्रुटि</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="60"/>
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <source>Paused %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <source>Paused</source>
+        <translation type="unfinished">रोक दिया गया</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="78"/>
+        <source>Opt…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="78"/>
+        <source>Optimizing</source>
+        <translation type="unfinished">अनुकूलित किया जा रहा है</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
+        <source>Idx…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
+        <source>Scr…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Optimizing database</source>
-        <translation>डेटाबेस अनुकूलित किया जा रहा है</translation>
+        <translation type="vanished">डेटाबेस अनुकूलित किया जा रहा है</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="67"/>
         <source>Indexing paused</source>
-        <translation>इंडेक्सिंग रोकी गई</translation>
+        <translation type="vanished">इंडेक्सिंग रोकी गई</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="70"/>
         <source>Indexing %1/%2 - %3</source>
-        <translation>इंडेक्सिंग %1/%2 - %3</translation>
+        <translation type="vanished">इंडेक्सिंग %1/%2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="73"/>
+        <location filename="../components/CoreStatusPill.qml" line="82"/>
         <source>Indexing %1/%2</source>
         <translation>इंडेक्सिंग %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <location filename="../components/CoreStatusPill.qml" line="82"/>
+        <source>Idx %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Indexing…</source>
         <translation>इंडेक्सिंग…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Scrape paused</source>
-        <translation>स्क्रैप रोका गया</translation>
+        <translation type="vanished">स्क्रैप रोका गया</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="86"/>
         <source>Scraping %1/%2 - %3</source>
-        <translation>स्क्रैपिंग %1/%2 - %3</translation>
+        <translation type="vanished">स्क्रैपिंग %1/%2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="89"/>
+        <location filename="../components/CoreStatusPill.qml" line="88"/>
         <source>Scraping %1/%2</source>
         <translation>स्क्रैपिंग %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="91"/>
+        <location filename="../components/CoreStatusPill.qml" line="88"/>
+        <source>Scr %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
         <source>Scraping…</source>
         <translation>स्क्रैपिंग…</translation>
     </message>
@@ -329,34 +418,34 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="117"/>
-        <location filename="../screens/GamesScreen.qml" line="145"/>
+        <location filename="../screens/GamesScreen.qml" line="122"/>
+        <location filename="../screens/GamesScreen.qml" line="157"/>
         <source>%1 files</source>
         <translation>%1 फ़ाइलें</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="51"/>
+        <location filename="../screens/GamesScreen.qml" line="55"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="126"/>
-        <location filename="../screens/GamesScreen.qml" line="146"/>
+        <location filename="../screens/GamesScreen.qml" line="131"/>
+        <location filename="../screens/GamesScreen.qml" line="158"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="44"/>
+        <location filename="../screens/GamesScreen.qml" line="48"/>
         <source>No games in this system</source>
         <translation>इस सिस्टम में कोई गेम नहीं है</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="45"/>
+        <location filename="../screens/GamesScreen.qml" line="49"/>
         <source>Loading games…</source>
         <translation>गेम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="122"/>
+        <location filename="../screens/GamesScreen.qml" line="127"/>
         <source>Loading more…</source>
         <translation>और लोड हो रहा है…</translation>
     </message>
@@ -364,32 +453,47 @@
 <context>
     <name>HubScreen</name>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
-        <source>Resume: %1</source>
+        <location filename="../screens/HubScreen.qml" line="56"/>
+        <source>Arcade</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
-        <source>Resume Game</source>
+        <location filename="../screens/HubScreen.qml" line="61"/>
+        <source>Computers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
+        <location filename="../screens/HubScreen.qml" line="66"/>
+        <source>Consoles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="71"/>
+        <source>Handhelds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="134"/>
+        <source>Resume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="140"/>
         <source>Favorites</source>
         <translation>पसंदीदा</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="96"/>
+        <location filename="../screens/HubScreen.qml" line="145"/>
         <source>Recently Played</source>
         <translation>हाल ही में खेले गए</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="101"/>
+        <location filename="../screens/HubScreen.qml" line="150"/>
         <source>Settings</source>
         <translation>सेटिंग्स</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="537"/>
+        <location filename="../screens/HubScreen.qml" line="644"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>कोई सिस्टम उपलब्ध नहीं है। सेटिंग्स से मीडिया डेटाबेस अपडेट चलाएँ।</translation>
     </message>
@@ -438,104 +542,124 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="755"/>
+        <location filename="../app/Main.qml" line="1206"/>
         <source>Launch core</source>
         <translation>कोर चलाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="958"/>
+        <location filename="../app/Main.qml" line="1212"/>
+        <location filename="../app/Main.qml" line="1420"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="770"/>
-        <location filename="../app/Main.qml" line="805"/>
+        <location filename="../app/Main.qml" line="1219"/>
+        <source>Update media database</source>
+        <translation type="unfinished">मीडिया डेटाबेस अपडेट करें</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1222"/>
+        <source>Scrape metadata</source>
+        <translation type="unfinished">मेटाडेटा स्क्रैप करें</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1231"/>
+        <location filename="../app/Main.qml" line="1266"/>
         <source>Launch game</source>
         <translation>गेम चलाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="786"/>
+        <location filename="../app/Main.qml" line="1247"/>
         <source>Remove from favorites</source>
         <translation>पसंदीदा से हटाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="786"/>
+        <location filename="../app/Main.qml" line="1247"/>
         <source>Add to favorites</source>
         <translation>पसंदीदा में जोड़ें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="791"/>
+        <location filename="../app/Main.qml" line="1252"/>
         <source>Write to NFC token</source>
         <translation>NFC टोकन पर लिखें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="795"/>
+        <location filename="../app/Main.qml" line="1256"/>
         <source>QR code</source>
         <translation>QR कोड</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="954"/>
+        <location filename="../app/Main.qml" line="1416"/>
         <source>Default</source>
         <translation type="unfinished">डिफ़ॉल्ट</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="954"/>
+        <location filename="../app/Main.qml" line="1416"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1230"/>
+        <location filename="../app/Main.qml" line="1708"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1234"/>
+        <location filename="../app/Main.qml" line="1712"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1248"/>
+        <location filename="../app/Main.qml" line="1726"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1252"/>
+        <location filename="../app/Main.qml" line="1730"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1256"/>
+        <location filename="../app/Main.qml" line="1734"/>
         <source>Retry</source>
         <translation type="unfinished">फिर से प्रयास करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1260"/>
+        <location filename="../app/Main.qml" line="1738"/>
         <source>Cancel</source>
         <translation type="unfinished">रद्द करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1776"/>
+        <location filename="../app/Main.qml" line="2368"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1778"/>
+        <location filename="../app/Main.qml" line="2370"/>
         <source>Loading games…</source>
         <translation>गेम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1780"/>
+        <location filename="../app/Main.qml" line="2372"/>
+        <source>Loading game…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2374"/>
         <source>Loading favorites…</source>
         <translation>पसंदीदा लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1782"/>
+        <location filename="../app/Main.qml" line="2376"/>
         <source>Loading recently played…</source>
         <translation>हाल ही में खेले गए लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="2378"/>
+        <source>Loading settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2380"/>
         <source>Loading…</source>
         <translation>लोड हो रहा है…</translation>
     </message>
@@ -543,161 +667,161 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="581"/>
+        <location filename="../app/MainLayout.qml" line="680"/>
         <source>Writing failed</source>
         <translation>लिखना विफल हुआ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="581"/>
+        <location filename="../app/MainLayout.qml" line="680"/>
         <source>Put a writable card near the reader</source>
         <translation>रीडर के पास लिखने योग्य कार्ड रखें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="141"/>
+        <location filename="../app/MainLayout.qml" line="170"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="323"/>
+        <location filename="../app/MainLayout.qml" line="364"/>
         <source>Favorites</source>
         <translation type="unfinished">पसंदीदा</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="325"/>
+        <location filename="../app/MainLayout.qml" line="366"/>
         <source>Recently Played</source>
         <translation type="unfinished">हाल ही में खेले गए</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="592"/>
+        <location filename="../app/MainLayout.qml" line="695"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="593"/>
+        <location filename="../app/MainLayout.qml" line="696"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="668"/>
+        <location filename="../app/MainLayout.qml" line="806"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="669"/>
+        <location filename="../app/MainLayout.qml" line="807"/>
         <source>Are you sure you want to exit?</source>
         <translation>क्या आप वाकई बाहर निकलना चाहते हैं?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="741"/>
-        <location filename="../app/MainLayout.qml" line="813"/>
-        <location filename="../app/MainLayout.qml" line="856"/>
-        <location filename="../app/MainLayout.qml" line="885"/>
-        <location filename="../app/MainLayout.qml" line="932"/>
-        <location filename="../app/MainLayout.qml" line="973"/>
-        <location filename="../app/MainLayout.qml" line="1037"/>
+        <location filename="../app/MainLayout.qml" line="886"/>
+        <location filename="../app/MainLayout.qml" line="960"/>
+        <location filename="../app/MainLayout.qml" line="1003"/>
+        <location filename="../app/MainLayout.qml" line="1034"/>
+        <location filename="../app/MainLayout.qml" line="1084"/>
+        <location filename="../app/MainLayout.qml" line="1127"/>
+        <location filename="../app/MainLayout.qml" line="1195"/>
         <source>Move</source>
         <translation>स्थानांतरित करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="745"/>
-        <location filename="../app/MainLayout.qml" line="817"/>
+        <location filename="../app/MainLayout.qml" line="890"/>
+        <location filename="../app/MainLayout.qml" line="964"/>
         <source>Select</source>
         <translation>चुनें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="749"/>
-        <location filename="../app/MainLayout.qml" line="753"/>
-        <location filename="../app/MainLayout.qml" line="767"/>
-        <location filename="../app/MainLayout.qml" line="780"/>
-        <location filename="../app/MainLayout.qml" line="791"/>
+        <location filename="../app/MainLayout.qml" line="894"/>
+        <location filename="../app/MainLayout.qml" line="898"/>
+        <location filename="../app/MainLayout.qml" line="912"/>
+        <location filename="../app/MainLayout.qml" line="927"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
         <source>Close</source>
         <translation>बंद करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="760"/>
-        <location filename="../app/MainLayout.qml" line="798"/>
-        <location filename="../app/MainLayout.qml" line="821"/>
-        <location filename="../app/MainLayout.qml" line="832"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
+        <location filename="../app/MainLayout.qml" line="945"/>
+        <location filename="../app/MainLayout.qml" line="968"/>
+        <location filename="../app/MainLayout.qml" line="979"/>
         <source>Cancel</source>
         <translation>रद्द करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="776"/>
+        <location filename="../app/MainLayout.qml" line="923"/>
         <source>Done</source>
         <translation>पूरा</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="787"/>
-        <location filename="../app/MainLayout.qml" line="908"/>
-        <location filename="../app/MainLayout.qml" line="958"/>
-        <location filename="../app/MainLayout.qml" line="1063"/>
+        <location filename="../app/MainLayout.qml" line="934"/>
+        <location filename="../app/MainLayout.qml" line="1057"/>
+        <location filename="../app/MainLayout.qml" line="1110"/>
+        <location filename="../app/MainLayout.qml" line="1221"/>
         <source>Retry</source>
         <translation>फिर से प्रयास करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="806"/>
+        <location filename="../app/MainLayout.qml" line="953"/>
         <source>I understand</source>
         <translation>मैं समझ गया</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="840"/>
+        <location filename="../app/MainLayout.qml" line="987"/>
         <source>Start</source>
         <translation>शुरू करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="860"/>
-        <location filename="../app/MainLayout.qml" line="895"/>
-        <location filename="../app/MainLayout.qml" line="942"/>
-        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1007"/>
+        <location filename="../app/MainLayout.qml" line="1044"/>
+        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Open</source>
         <translation>खोलें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="864"/>
+        <location filename="../app/MainLayout.qml" line="1011"/>
         <source>Quit</source>
         <translation>बंद करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="873"/>
-        <location filename="../app/MainLayout.qml" line="901"/>
-        <location filename="../app/MainLayout.qml" line="912"/>
-        <location filename="../app/MainLayout.qml" line="924"/>
-        <location filename="../app/MainLayout.qml" line="951"/>
-        <location filename="../app/MainLayout.qml" line="962"/>
-        <location filename="../app/MainLayout.qml" line="997"/>
-        <location filename="../app/MainLayout.qml" line="1013"/>
-        <location filename="../app/MainLayout.qml" line="1022"/>
-        <location filename="../app/MainLayout.qml" line="1056"/>
-        <location filename="../app/MainLayout.qml" line="1067"/>
+        <location filename="../app/MainLayout.qml" line="1020"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1061"/>
+        <location filename="../app/MainLayout.qml" line="1076"/>
+        <location filename="../app/MainLayout.qml" line="1103"/>
+        <location filename="../app/MainLayout.qml" line="1114"/>
+        <location filename="../app/MainLayout.qml" line="1151"/>
+        <location filename="../app/MainLayout.qml" line="1169"/>
+        <location filename="../app/MainLayout.qml" line="1178"/>
+        <location filename="../app/MainLayout.qml" line="1214"/>
+        <location filename="../app/MainLayout.qml" line="1225"/>
         <source>Back</source>
         <translation>वापस</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="891"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1043"/>
+        <location filename="../app/MainLayout.qml" line="1040"/>
+        <location filename="../app/MainLayout.qml" line="1090"/>
+        <location filename="../app/MainLayout.qml" line="1201"/>
         <source>Page</source>
         <translation>पृष्ठ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="947"/>
-        <location filename="../app/MainLayout.qml" line="1052"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1210"/>
         <source>Options</source>
         <translation>विकल्प</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="982"/>
+        <location filename="../app/MainLayout.qml" line="1136"/>
         <source>Change</source>
         <translation>बदलें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="988"/>
+        <location filename="../app/MainLayout.qml" line="1142"/>
         <source>Toggle</source>
         <translation>टॉगल</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1009"/>
+        <location filename="../app/MainLayout.qml" line="1165"/>
         <source>Scroll</source>
         <translation>स्क्रॉल</translation>
     </message>
@@ -710,12 +834,12 @@
         <translation type="unfinished">लोड हो रहा है…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="306"/>
+        <location filename="../screens/MediaListScreen.qml" line="351"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 प्रविष्टियाँ</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="307"/>
+        <location filename="../screens/MediaListScreen.qml" line="352"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -764,17 +888,17 @@
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="26"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
         <source>Nothing here</source>
         <translation>यहाँ कुछ नहीं है</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="28"/>
         <source>Loading…</source>
         <translation>लोड हो रहा है…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="57"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="58"/>
         <source>Failed to load</source>
         <translation>लोड करने में विफल</translation>
     </message>
@@ -782,387 +906,423 @@
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="61"/>
         <source>General</source>
-        <translation>सामान्य</translation>
+        <translation type="vanished">सामान्य</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="73"/>
-        <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
         <source>Language</source>
         <translation>भाषा</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78"/>
-        <location filename="../screens/SettingsScreen.qml" line="507"/>
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <location filename="../screens/SettingsScreen.qml" line="618"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="516"/>
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Browsing layout</source>
         <translation>ब्राउज़िंग लेआउट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88"/>
-        <location filename="../screens/SettingsScreen.qml" line="525"/>
+        <location filename="../screens/SettingsScreen.qml" line="125"/>
+        <location filename="../screens/SettingsScreen.qml" line="636"/>
         <source>Button style</source>
         <translation>बटन शैली</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="93"/>
-        <location filename="../screens/SettingsScreen.qml" line="534"/>
+        <location filename="../screens/SettingsScreen.qml" line="112"/>
+        <location filename="../screens/SettingsScreen.qml" line="645"/>
         <source>Screensaver</source>
         <translation>स्क्रीनसेवर</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97"/>
         <source>Library</source>
-        <translation>लाइब्रेरी</translation>
+        <translation type="vanished">लाइब्रेरी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="142"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="543"/>
+        <location filename="../screens/SettingsScreen.qml" line="654"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="112"/>
+        <location filename="../screens/SettingsScreen.qml" line="137"/>
         <source>Update media database</source>
         <translation>मीडिया डेटाबेस अपडेट करें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
         <source>Scrape metadata</source>
         <translation>मेटाडेटा स्क्रैप करें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Advanced</source>
-        <translation>उन्नत</translation>
+        <translation type="vanished">उन्नत</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="130"/>
         <source>Mouse support</source>
         <translation>माउस समर्थन</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="136"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
         <source>Debug logging</source>
         <translation>डीबग लॉगिंग</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="141"/>
+        <location filename="../screens/SettingsScreen.qml" line="169"/>
         <source>Upload log file</source>
         <translation>लॉग फ़ाइल अपलोड करें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="146"/>
+        <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>About / License</source>
         <translation>परिचय / लाइसेंस</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="162"/>
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
+        <source>Display &amp; Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="72"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <source>Controls &amp; Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="189"/>
+        <source>Library &amp; Data Management</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="82"/>
+        <location filename="../screens/SettingsScreen.qml" line="191"/>
+        <source>Support &amp; About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="206"/>
         <source>Optimizing</source>
         <translation>अनुकूलित किया जा रहा है</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
-        <location filename="../screens/SettingsScreen.qml" line="173"/>
+        <location filename="../screens/SettingsScreen.qml" line="208"/>
+        <location filename="../screens/SettingsScreen.qml" line="217"/>
         <source>Paused</source>
         <translation>रोक दिया गया</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
-        <location filename="../screens/SettingsScreen.qml" line="173"/>
+        <location filename="../screens/SettingsScreen.qml" line="208"/>
+        <location filename="../screens/SettingsScreen.qml" line="217"/>
         <source>In progress</source>
         <translation>प्रगति पर</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="167"/>
+        <location filename="../screens/SettingsScreen.qml" line="211"/>
         <source>%1 indexed</source>
         <translation>%1 इंडेक्स किए गए</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="176"/>
+        <location filename="../screens/SettingsScreen.qml" line="220"/>
         <source>%1 scraped</source>
         <translation>%1 स्क्रैप किए गए</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="284"/>
+        <location filename="../screens/SettingsScreen.qml" line="393"/>
         <source>Cancel</source>
         <translation>रद्द करें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="284"/>
+        <location filename="../screens/SettingsScreen.qml" line="393"/>
         <source>Start</source>
         <translation>शुरू करें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="286"/>
+        <location filename="../screens/SettingsScreen.qml" line="395"/>
         <source>Upload</source>
         <translation>अपलोड</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="288"/>
+        <location filename="../screens/SettingsScreen.qml" line="396"/>
         <source>Open</source>
         <translation>खोलें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="340"/>
+        <location filename="../screens/SettingsScreen.qml" line="447"/>
         <source>Default</source>
         <translation>डिफ़ॉल्ट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="365"/>
+        <location filename="../screens/SettingsScreen.qml" line="472"/>
         <source>English</source>
         <translation>अंग्रेज़ी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="367"/>
+        <location filename="../screens/SettingsScreen.qml" line="474"/>
         <source>Italian</source>
         <translation>इतालवी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="476"/>
+        <source>Spanish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="478"/>
+        <source>Basque</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="480"/>
         <source>German</source>
         <translation>जर्मन</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
+        <location filename="../screens/SettingsScreen.qml" line="482"/>
         <source>Greek</source>
         <translation>ग्रीक</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="373"/>
+        <location filename="../screens/SettingsScreen.qml" line="484"/>
         <source>Japanese</source>
         <translation>जापानी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="375"/>
+        <location filename="../screens/SettingsScreen.qml" line="486"/>
         <source>Korean</source>
         <translation>कोरियाई</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Dutch</source>
         <translation>डच</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="379"/>
+        <location filename="../screens/SettingsScreen.qml" line="490"/>
         <source>Romanian</source>
         <translation>रोमानियाई</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="381"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Slovak</source>
         <translation>स्लोवाक</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="383"/>
+        <location filename="../screens/SettingsScreen.qml" line="494"/>
         <source>Ukrainian</source>
         <translation>यूक्रेनी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="385"/>
+        <location filename="../screens/SettingsScreen.qml" line="496"/>
         <source>Chinese (Simplified)</source>
         <translation>चीनी (सरलीकृत)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="387"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Hebrew</source>
         <translation>हिब्रू</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="389"/>
+        <location filename="../screens/SettingsScreen.qml" line="500"/>
         <source>Arabic</source>
         <translation>अरबी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="391"/>
+        <location filename="../screens/SettingsScreen.qml" line="502"/>
         <source>Hindi</source>
         <translation>हिंदी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="392"/>
-        <location filename="../screens/SettingsScreen.qml" line="451"/>
+        <location filename="../screens/SettingsScreen.qml" line="503"/>
+        <location filename="../screens/SettingsScreen.qml" line="562"/>
         <source>Auto</source>
         <translation>स्वचालित</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <location filename="../screens/SettingsScreen.qml" line="508"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <location filename="../screens/SettingsScreen.qml" line="510"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="400"/>
+        <location filename="../screens/SettingsScreen.qml" line="511"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405"/>
+        <location filename="../screens/SettingsScreen.qml" line="516"/>
         <source>Detailed list view</source>
         <translation>विस्तृत सूची दृश्य</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="406"/>
+        <location filename="../screens/SettingsScreen.qml" line="517"/>
         <source>Grid view</source>
         <translation>ग्रिड दृश्य</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="411"/>
+        <location filename="../screens/SettingsScreen.qml" line="522"/>
         <source>Style B</source>
         <translation>शैली B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="413"/>
+        <location filename="../screens/SettingsScreen.qml" line="524"/>
         <source>Style C</source>
         <translation>शैली C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="415"/>
+        <location filename="../screens/SettingsScreen.qml" line="526"/>
         <source>Style D</source>
         <translation>शैली D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="416"/>
+        <location filename="../screens/SettingsScreen.qml" line="527"/>
         <source>Style A</source>
         <translation>शैली A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="431"/>
+        <location filename="../screens/SettingsScreen.qml" line="542"/>
         <source>Off</source>
         <translation>बंद</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="433"/>
+        <location filename="../screens/SettingsScreen.qml" line="544"/>
         <source>1 second (testing)</source>
         <translation>1 सेकंड (परीक्षण)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="435"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>1 minute</source>
         <translation>1 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="437"/>
+        <location filename="../screens/SettingsScreen.qml" line="548"/>
         <source>2 minutes</source>
         <translation>2 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="439"/>
+        <location filename="../screens/SettingsScreen.qml" line="550"/>
         <source>5 minutes</source>
         <translation>5 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="441"/>
+        <location filename="../screens/SettingsScreen.qml" line="552"/>
         <source>10 minutes</source>
         <translation>10 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="443"/>
+        <location filename="../screens/SettingsScreen.qml" line="554"/>
         <source>15 minutes</source>
         <translation>15 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="445"/>
+        <location filename="../screens/SettingsScreen.qml" line="556"/>
         <source>30 minutes</source>
         <translation>30 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="446"/>
+        <location filename="../screens/SettingsScreen.qml" line="557"/>
         <source>%1 seconds</source>
         <translation>%1 सेकंड</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="489"/>
+        <location filename="../screens/SettingsScreen.qml" line="1032"/>
+        <source>Loading settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="91"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Resolution</source>
         <translation>रिज़ॉल्यूशन</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="453"/>
+        <location filename="../screens/SettingsScreen.qml" line="564"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="455"/>
+        <location filename="../screens/SettingsScreen.qml" line="566"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="457"/>
+        <location filename="../screens/SettingsScreen.qml" line="568"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <location filename="../screens/SettingsScreen.qml" line="570"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="461"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="463"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="465"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="467"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="469"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="471"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="473"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="663"/>
+        <location filename="../screens/SettingsScreen.qml" line="192"/>
         <source>Settings</source>
         <translation>सेटिंग्स</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="857"/>
+        <location filename="../screens/SettingsScreen.qml" line="1020"/>
         <source>No settings available on this platform</source>
         <translation>इस प्लेटफ़ॉर्म पर कोई सेटिंग उपलब्ध नहीं है</translation>
     </message>
@@ -1170,24 +1330,24 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="195"/>
-        <location filename="../screens/SystemsScreen.qml" line="292"/>
+        <location filename="../screens/SystemsScreen.qml" line="197"/>
+        <location filename="../screens/SystemsScreen.qml" line="295"/>
         <source>%1 systems</source>
         <translation>%1 सिस्टम</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="196"/>
-        <location filename="../screens/SystemsScreen.qml" line="309"/>
+        <location filename="../screens/SystemsScreen.qml" line="198"/>
+        <location filename="../screens/SystemsScreen.qml" line="312"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="324"/>
+        <location filename="../screens/SystemsScreen.qml" line="328"/>
         <source>No systems in this category</source>
         <translation>इस श्रेणी में कोई सिस्टम नहीं है</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="325"/>
+        <location filename="../screens/SystemsScreen.qml" line="329"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -54,6 +54,13 @@
         <translation>अनुवाद</translation>
     </message>
     <message>
+        <location filename="../screens/AboutScreen.qml" line="267"/>
+        <source>Italiano - Andrea Bogazzi
+Español - Carlos R.
+Euskara - devilschile2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/AboutScreen.qml" line="278"/>
         <source>Full license text in COPYING.</source>
         <translation>पूरा लाइसेंस पाठ COPYING में है।</translation>
@@ -911,31 +918,31 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="611"/>
         <source>Language</source>
         <translation>भाषा</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="97"/>
-        <location filename="../screens/SettingsScreen.qml" line="618"/>
+        <location filename="../screens/SettingsScreen.qml" line="620"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="627"/>
+        <location filename="../screens/SettingsScreen.qml" line="629"/>
         <source>Browsing layout</source>
         <translation>ब्राउज़िंग लेआउट</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="125"/>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="638"/>
         <source>Button style</source>
         <translation>बटन शैली</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="112"/>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
+        <location filename="../screens/SettingsScreen.qml" line="647"/>
         <source>Screensaver</source>
         <translation>स्क्रीनसेवर</translation>
     </message>
@@ -950,7 +957,7 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="654"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1136,183 +1143,188 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <source>Chinese (Traditional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="500"/>
         <source>Hebrew</source>
         <translation>हिब्रू</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="500"/>
+        <location filename="../screens/SettingsScreen.qml" line="502"/>
         <source>Arabic</source>
         <translation>अरबी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="502"/>
+        <location filename="../screens/SettingsScreen.qml" line="504"/>
         <source>Hindi</source>
         <translation>हिंदी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="503"/>
-        <location filename="../screens/SettingsScreen.qml" line="562"/>
+        <location filename="../screens/SettingsScreen.qml" line="505"/>
+        <location filename="../screens/SettingsScreen.qml" line="564"/>
         <source>Auto</source>
         <translation>स्वचालित</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="508"/>
+        <location filename="../screens/SettingsScreen.qml" line="510"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="510"/>
+        <location filename="../screens/SettingsScreen.qml" line="512"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="511"/>
+        <location filename="../screens/SettingsScreen.qml" line="513"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="516"/>
+        <location filename="../screens/SettingsScreen.qml" line="518"/>
         <source>Detailed list view</source>
         <translation>विस्तृत सूची दृश्य</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="517"/>
+        <location filename="../screens/SettingsScreen.qml" line="519"/>
         <source>Grid view</source>
         <translation>ग्रिड दृश्य</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="522"/>
+        <location filename="../screens/SettingsScreen.qml" line="524"/>
         <source>Style B</source>
         <translation>शैली B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="524"/>
+        <location filename="../screens/SettingsScreen.qml" line="526"/>
         <source>Style C</source>
         <translation>शैली C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="526"/>
+        <location filename="../screens/SettingsScreen.qml" line="528"/>
         <source>Style D</source>
         <translation>शैली D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="527"/>
+        <location filename="../screens/SettingsScreen.qml" line="529"/>
         <source>Style A</source>
         <translation>शैली A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="542"/>
+        <location filename="../screens/SettingsScreen.qml" line="544"/>
         <source>Off</source>
         <translation>बंद</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="544"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>1 second (testing)</source>
         <translation>1 सेकंड (परीक्षण)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="546"/>
+        <location filename="../screens/SettingsScreen.qml" line="548"/>
         <source>1 minute</source>
         <translation>1 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="548"/>
+        <location filename="../screens/SettingsScreen.qml" line="550"/>
         <source>2 minutes</source>
         <translation>2 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="550"/>
+        <location filename="../screens/SettingsScreen.qml" line="552"/>
         <source>5 minutes</source>
         <translation>5 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="552"/>
+        <location filename="../screens/SettingsScreen.qml" line="554"/>
         <source>10 minutes</source>
         <translation>10 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="554"/>
+        <location filename="../screens/SettingsScreen.qml" line="556"/>
         <source>15 minutes</source>
         <translation>15 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="556"/>
+        <location filename="../screens/SettingsScreen.qml" line="558"/>
         <source>30 minutes</source>
         <translation>30 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="557"/>
+        <location filename="../screens/SettingsScreen.qml" line="559"/>
         <source>%1 seconds</source>
         <translation>%1 सेकंड</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1032"/>
+        <location filename="../screens/SettingsScreen.qml" line="1034"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="91"/>
-        <location filename="../screens/SettingsScreen.qml" line="600"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Resolution</source>
         <translation>रिज़ॉल्यूशन</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="564"/>
+        <location filename="../screens/SettingsScreen.qml" line="566"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="566"/>
+        <location filename="../screens/SettingsScreen.qml" line="568"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="568"/>
+        <location filename="../screens/SettingsScreen.qml" line="570"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="570"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1322,7 +1334,7 @@
         <translation>सेटिंग्स</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1020"/>
+        <location filename="../screens/SettingsScreen.qml" line="1022"/>
         <source>No settings available on this platform</source>
         <translation>इस प्लेटफ़ॉर्म पर कोई सेटिंग उपलब्ध नहीं है</translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -4,57 +4,57 @@
 <context>
     <name>AboutScreen</name>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="71"/>
+        <location filename="../screens/AboutScreen.qml" line="73"/>
         <source>About / License</source>
         <translation>Informazioni / Licenza</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="153"/>
+        <location filename="../screens/AboutScreen.qml" line="155"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="164"/>
+        <location filename="../screens/AboutScreen.qml" line="166"/>
         <source>Version %1 · %2 · %3</source>
         <translation>Versione %1 · %2 · %3</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="174"/>
+        <location filename="../screens/AboutScreen.qml" line="176"/>
         <source>Built %1</source>
         <translation>Compilato %1</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="185"/>
+        <location filename="../screens/AboutScreen.qml" line="187"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>Copyright 2026 Wizzo Pty Ltd e i collaboratori del progetto Zaparoo.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="196"/>
+        <location filename="../screens/AboutScreen.qml" line="198"/>
         <source>Source available under the PolyForm Noncommercial License 1.0.0. Free for personal, non-commercial use. Commercial use requires a separate license.</source>
         <translation>Codice sorgente disponibile sotto la licenza PolyForm Noncommercial 1.0.0. Gratuito per uso personale e non commerciale. L&apos;uso commerciale richiede una licenza separata.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="207"/>
+        <location filename="../screens/AboutScreen.qml" line="209"/>
         <source>Commercial licensing: legal@zaparoo.org</source>
         <translation>Licenze commerciali: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="218"/>
+        <location filename="../screens/AboutScreen.qml" line="220"/>
         <source>Project: https://zaparoo.org</source>
         <translation>Progetto: https://zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="228"/>
+        <location filename="../screens/AboutScreen.qml" line="230"/>
         <source>Created by</source>
         <translation>Creato da</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="252"/>
+        <location filename="../screens/AboutScreen.qml" line="254"/>
         <source>Translations</source>
         <translation>Traduzioni</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="276"/>
+        <location filename="../screens/AboutScreen.qml" line="278"/>
         <source>Full license text in COPYING.</source>
         <translation>Testo completo della licenza in COPYING.</translation>
     </message>
@@ -90,48 +90,102 @@
         <translation type="unfinished">Caricamento…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="77"/>
+        <location filename="../components/BrowseDetailPane.qml" line="138"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="79"/>
+        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <source>Yr</source>
+        <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="81"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <source>Gen</source>
+        <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="83"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <source>Plyr</source>
+        <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="85"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <source>Dev</source>
+        <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="87"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <source>Pub</source>
+        <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="89"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <source>Rtg</source>
+        <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="91"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <source>Cat</source>
+        <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="93"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <source>Date</source>
+        <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Manufacturer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <source>Mfr</source>
+        <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -176,68 +230,103 @@
 <context>
     <name>CoreStatusPill</name>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="44"/>
-        <location filename="../components/CoreStatusPill.qml" line="50"/>
+        <location filename="../components/CoreStatusPill.qml" line="46"/>
+        <location filename="../components/CoreStatusPill.qml" line="52"/>
         <source>Disconnected</source>
         <translation>Disconnesso</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="47"/>
+        <location filename="../components/CoreStatusPill.qml" line="49"/>
         <source>Reconnecting…</source>
         <translation>Riconnessione…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="53"/>
+        <location filename="../components/CoreStatusPill.qml" line="55"/>
         <source>Connecting…</source>
         <translation>Connessione…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="56"/>
+        <location filename="../components/CoreStatusPill.qml" line="58"/>
         <source>Core error</source>
         <translation>Errore del Core</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="60"/>
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <source>Paused %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <source>Paused</source>
+        <translation type="unfinished">In pausa</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="78"/>
+        <source>Opt…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="78"/>
+        <source>Optimizing</source>
+        <translation type="unfinished">Ottimizzazione</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
+        <source>Idx…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
+        <source>Scr…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Optimizing database</source>
-        <translation>Ottimizzazione database</translation>
+        <translation type="vanished">Ottimizzazione database</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="67"/>
         <source>Indexing paused</source>
-        <translation>Indicizzazione in pausa</translation>
+        <translation type="vanished">Indicizzazione in pausa</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="70"/>
         <source>Indexing %1/%2 - %3</source>
-        <translation>Indicizzazione %1/%2 - %3</translation>
+        <translation type="vanished">Indicizzazione %1/%2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="86"/>
         <source>Scraping %1/%2 - %3</source>
-        <translation>Recupero %1/%2 - %3</translation>
+        <translation type="vanished">Recupero %1/%2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="73"/>
+        <location filename="../components/CoreStatusPill.qml" line="82"/>
         <source>Indexing %1/%2</source>
         <translation>Indicizzazione %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <location filename="../components/CoreStatusPill.qml" line="82"/>
+        <source>Idx %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Indexing…</source>
         <translation>Indicizzazione…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Scrape paused</source>
-        <translation>Recupero in pausa</translation>
+        <translation type="vanished">Recupero in pausa</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="89"/>
+        <location filename="../components/CoreStatusPill.qml" line="88"/>
         <source>Scraping %1/%2</source>
         <translation>Recupero %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="91"/>
+        <location filename="../components/CoreStatusPill.qml" line="88"/>
+        <source>Scr %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
         <source>Scraping…</source>
         <translation>Recupero metadati…</translation>
     </message>
@@ -329,34 +418,34 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="117"/>
-        <location filename="../screens/GamesScreen.qml" line="145"/>
+        <location filename="../screens/GamesScreen.qml" line="122"/>
+        <location filename="../screens/GamesScreen.qml" line="157"/>
         <source>%1 files</source>
         <translation>%1 file</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="51"/>
+        <location filename="../screens/GamesScreen.qml" line="55"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="126"/>
-        <location filename="../screens/GamesScreen.qml" line="146"/>
+        <location filename="../screens/GamesScreen.qml" line="131"/>
+        <location filename="../screens/GamesScreen.qml" line="158"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="45"/>
+        <location filename="../screens/GamesScreen.qml" line="49"/>
         <source>Loading games…</source>
         <translation>Caricamento giochi…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="122"/>
+        <location filename="../screens/GamesScreen.qml" line="127"/>
         <source>Loading more…</source>
         <translation>Caricamento altro…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="44"/>
+        <location filename="../screens/GamesScreen.qml" line="48"/>
         <source>No games in this system</source>
         <translation>Nessun gioco in questo sistema</translation>
     </message>
@@ -364,32 +453,47 @@
 <context>
     <name>HubScreen</name>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
-        <source>Resume: %1</source>
+        <location filename="../screens/HubScreen.qml" line="56"/>
+        <source>Arcade</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
-        <source>Resume Game</source>
+        <location filename="../screens/HubScreen.qml" line="61"/>
+        <source>Computers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
+        <location filename="../screens/HubScreen.qml" line="66"/>
+        <source>Consoles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="71"/>
+        <source>Handhelds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="134"/>
+        <source>Resume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="140"/>
         <source>Favorites</source>
         <translation>Preferiti</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="96"/>
+        <location filename="../screens/HubScreen.qml" line="145"/>
         <source>Recently Played</source>
         <translation>Giocati di recente</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="101"/>
+        <location filename="../screens/HubScreen.qml" line="150"/>
         <source>Settings</source>
         <translation>Impostazioni</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="537"/>
+        <location filename="../screens/HubScreen.qml" line="644"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Nessun sistema disponibile. Esegui Aggiorna database multimediale dalle Impostazioni.</translation>
     </message>
@@ -438,104 +542,124 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="755"/>
+        <location filename="../app/Main.qml" line="1206"/>
         <source>Launch core</source>
         <translation>Avvia core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="958"/>
+        <location filename="../app/Main.qml" line="1212"/>
+        <location filename="../app/Main.qml" line="1420"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="786"/>
+        <location filename="../app/Main.qml" line="1247"/>
         <source>Remove from favorites</source>
         <translation>Rimuovi dai preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="786"/>
+        <location filename="../app/Main.qml" line="1247"/>
         <source>Add to favorites</source>
         <translation>Aggiungi ai preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="791"/>
+        <location filename="../app/Main.qml" line="1252"/>
         <source>Write to NFC token</source>
         <translation>Scrivi sul token NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="795"/>
+        <location filename="../app/Main.qml" line="1256"/>
         <source>QR code</source>
         <translation>Codice QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="770"/>
-        <location filename="../app/Main.qml" line="805"/>
+        <location filename="../app/Main.qml" line="1231"/>
+        <location filename="../app/Main.qml" line="1266"/>
         <source>Launch game</source>
         <translation>Avvia gioco</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1776"/>
+        <location filename="../app/Main.qml" line="2368"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1780"/>
+        <location filename="../app/Main.qml" line="2374"/>
         <source>Loading favorites…</source>
         <translation>Caricamento preferiti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1778"/>
+        <location filename="../app/Main.qml" line="2370"/>
         <source>Loading games…</source>
         <translation>Caricamento giochi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="954"/>
+        <location filename="../app/Main.qml" line="1219"/>
+        <source>Update media database</source>
+        <translation type="unfinished">Aggiorna database multimediale</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1222"/>
+        <source>Scrape metadata</source>
+        <translation type="unfinished">Recupera metadati</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1416"/>
         <source>Default</source>
         <translation type="unfinished">Predefinito</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="954"/>
+        <location filename="../app/Main.qml" line="1416"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1230"/>
+        <location filename="../app/Main.qml" line="1708"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1234"/>
+        <location filename="../app/Main.qml" line="1712"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1248"/>
+        <location filename="../app/Main.qml" line="1726"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1252"/>
+        <location filename="../app/Main.qml" line="1730"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1256"/>
+        <location filename="../app/Main.qml" line="1734"/>
         <source>Retry</source>
         <translation type="unfinished">Riprova</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1260"/>
+        <location filename="../app/Main.qml" line="1738"/>
         <source>Cancel</source>
         <translation type="unfinished">Annulla</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1782"/>
+        <location filename="../app/Main.qml" line="2372"/>
+        <source>Loading game…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2376"/>
         <source>Loading recently played…</source>
         <translation>Caricamento recenti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="2378"/>
+        <source>Loading settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2380"/>
         <source>Loading…</source>
         <translation>Caricamento…</translation>
     </message>
@@ -543,161 +667,161 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="581"/>
+        <location filename="../app/MainLayout.qml" line="680"/>
         <source>Writing failed</source>
         <translation>Scrittura non riuscita</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="581"/>
+        <location filename="../app/MainLayout.qml" line="680"/>
         <source>Put a writable card near the reader</source>
         <translation>Avvicina una scheda scrivibile al lettore</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="669"/>
+        <location filename="../app/MainLayout.qml" line="807"/>
         <source>Are you sure you want to exit?</source>
         <translation>Sei sicuro di voler uscire?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="745"/>
-        <location filename="../app/MainLayout.qml" line="817"/>
+        <location filename="../app/MainLayout.qml" line="890"/>
+        <location filename="../app/MainLayout.qml" line="964"/>
         <source>Select</source>
         <translation>Seleziona</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="749"/>
-        <location filename="../app/MainLayout.qml" line="753"/>
-        <location filename="../app/MainLayout.qml" line="767"/>
-        <location filename="../app/MainLayout.qml" line="780"/>
-        <location filename="../app/MainLayout.qml" line="791"/>
+        <location filename="../app/MainLayout.qml" line="894"/>
+        <location filename="../app/MainLayout.qml" line="898"/>
+        <location filename="../app/MainLayout.qml" line="912"/>
+        <location filename="../app/MainLayout.qml" line="927"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
         <source>Close</source>
         <translation>Chiudi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="760"/>
-        <location filename="../app/MainLayout.qml" line="798"/>
-        <location filename="../app/MainLayout.qml" line="821"/>
-        <location filename="../app/MainLayout.qml" line="832"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
+        <location filename="../app/MainLayout.qml" line="945"/>
+        <location filename="../app/MainLayout.qml" line="968"/>
+        <location filename="../app/MainLayout.qml" line="979"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="776"/>
+        <location filename="../app/MainLayout.qml" line="923"/>
         <source>Done</source>
         <translation>Fatto</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="806"/>
+        <location filename="../app/MainLayout.qml" line="953"/>
         <source>I understand</source>
         <translation>Ho capito</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="840"/>
+        <location filename="../app/MainLayout.qml" line="987"/>
         <source>Start</source>
         <translation>Avvia</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1009"/>
+        <location filename="../app/MainLayout.qml" line="1165"/>
         <source>Scroll</source>
         <translation>Scorri</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="741"/>
-        <location filename="../app/MainLayout.qml" line="813"/>
-        <location filename="../app/MainLayout.qml" line="856"/>
-        <location filename="../app/MainLayout.qml" line="885"/>
-        <location filename="../app/MainLayout.qml" line="932"/>
-        <location filename="../app/MainLayout.qml" line="973"/>
-        <location filename="../app/MainLayout.qml" line="1037"/>
+        <location filename="../app/MainLayout.qml" line="886"/>
+        <location filename="../app/MainLayout.qml" line="960"/>
+        <location filename="../app/MainLayout.qml" line="1003"/>
+        <location filename="../app/MainLayout.qml" line="1034"/>
+        <location filename="../app/MainLayout.qml" line="1084"/>
+        <location filename="../app/MainLayout.qml" line="1127"/>
+        <location filename="../app/MainLayout.qml" line="1195"/>
         <source>Move</source>
         <translation>Muovi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="141"/>
+        <location filename="../app/MainLayout.qml" line="170"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="323"/>
+        <location filename="../app/MainLayout.qml" line="364"/>
         <source>Favorites</source>
         <translation type="unfinished">Preferiti</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="325"/>
+        <location filename="../app/MainLayout.qml" line="366"/>
         <source>Recently Played</source>
         <translation type="unfinished">Giocati di recente</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="592"/>
+        <location filename="../app/MainLayout.qml" line="695"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="593"/>
+        <location filename="../app/MainLayout.qml" line="696"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="668"/>
+        <location filename="../app/MainLayout.qml" line="806"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="860"/>
-        <location filename="../app/MainLayout.qml" line="895"/>
-        <location filename="../app/MainLayout.qml" line="942"/>
-        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1007"/>
+        <location filename="../app/MainLayout.qml" line="1044"/>
+        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Open</source>
         <translation>Apri</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="864"/>
+        <location filename="../app/MainLayout.qml" line="1011"/>
         <source>Quit</source>
         <translation>Esci</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="873"/>
-        <location filename="../app/MainLayout.qml" line="901"/>
-        <location filename="../app/MainLayout.qml" line="912"/>
-        <location filename="../app/MainLayout.qml" line="924"/>
-        <location filename="../app/MainLayout.qml" line="951"/>
-        <location filename="../app/MainLayout.qml" line="962"/>
-        <location filename="../app/MainLayout.qml" line="997"/>
-        <location filename="../app/MainLayout.qml" line="1013"/>
-        <location filename="../app/MainLayout.qml" line="1022"/>
-        <location filename="../app/MainLayout.qml" line="1056"/>
-        <location filename="../app/MainLayout.qml" line="1067"/>
+        <location filename="../app/MainLayout.qml" line="1020"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1061"/>
+        <location filename="../app/MainLayout.qml" line="1076"/>
+        <location filename="../app/MainLayout.qml" line="1103"/>
+        <location filename="../app/MainLayout.qml" line="1114"/>
+        <location filename="../app/MainLayout.qml" line="1151"/>
+        <location filename="../app/MainLayout.qml" line="1169"/>
+        <location filename="../app/MainLayout.qml" line="1178"/>
+        <location filename="../app/MainLayout.qml" line="1214"/>
+        <location filename="../app/MainLayout.qml" line="1225"/>
         <source>Back</source>
         <translation>Indietro</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="891"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1043"/>
+        <location filename="../app/MainLayout.qml" line="1040"/>
+        <location filename="../app/MainLayout.qml" line="1090"/>
+        <location filename="../app/MainLayout.qml" line="1201"/>
         <source>Page</source>
         <translation>Pagina</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="947"/>
-        <location filename="../app/MainLayout.qml" line="1052"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1210"/>
         <source>Options</source>
         <translation>Opzioni</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="787"/>
-        <location filename="../app/MainLayout.qml" line="908"/>
-        <location filename="../app/MainLayout.qml" line="958"/>
-        <location filename="../app/MainLayout.qml" line="1063"/>
+        <location filename="../app/MainLayout.qml" line="934"/>
+        <location filename="../app/MainLayout.qml" line="1057"/>
+        <location filename="../app/MainLayout.qml" line="1110"/>
+        <location filename="../app/MainLayout.qml" line="1221"/>
         <source>Retry</source>
         <translation>Riprova</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="982"/>
+        <location filename="../app/MainLayout.qml" line="1136"/>
         <source>Change</source>
         <translation>Cambia</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="988"/>
+        <location filename="../app/MainLayout.qml" line="1142"/>
         <source>Toggle</source>
         <translation>Alterna</translation>
     </message>
@@ -710,12 +834,12 @@
         <translation type="unfinished">Caricamento…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="306"/>
+        <location filename="../screens/MediaListScreen.qml" line="351"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 elementi</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="307"/>
+        <location filename="../screens/MediaListScreen.qml" line="352"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -764,17 +888,17 @@
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="26"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
         <source>Nothing here</source>
         <translation>Niente qui</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="28"/>
         <source>Loading…</source>
         <translation>Caricamento…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="57"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="58"/>
         <source>Failed to load</source>
         <translation>Caricamento non riuscito</translation>
     </message>
@@ -782,387 +906,423 @@
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="73"/>
-        <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
         <source>Language</source>
         <translation>Lingua</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="516"/>
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Browsing layout</source>
         <translation>Layout navigazione</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="130"/>
         <source>Mouse support</source>
         <translation>Supporto mouse</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="112"/>
+        <location filename="../screens/SettingsScreen.qml" line="137"/>
         <source>Update media database</source>
         <translation>Aggiorna database multimediale</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="61"/>
         <source>General</source>
-        <translation>Generale</translation>
+        <translation type="vanished">Generale</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78"/>
-        <location filename="../screens/SettingsScreen.qml" line="507"/>
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <location filename="../screens/SettingsScreen.qml" line="618"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88"/>
-        <location filename="../screens/SettingsScreen.qml" line="525"/>
+        <location filename="../screens/SettingsScreen.qml" line="125"/>
+        <location filename="../screens/SettingsScreen.qml" line="636"/>
         <source>Button style</source>
         <translation>Stile pulsanti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="93"/>
-        <location filename="../screens/SettingsScreen.qml" line="534"/>
+        <location filename="../screens/SettingsScreen.qml" line="112"/>
+        <location filename="../screens/SettingsScreen.qml" line="645"/>
         <source>Screensaver</source>
         <translation>Salvaschermo</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97"/>
         <source>Library</source>
-        <translation>Libreria</translation>
+        <translation type="vanished">Libreria</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="142"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="543"/>
+        <location filename="../screens/SettingsScreen.qml" line="654"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
         <source>Scrape metadata</source>
         <translation>Recupera metadati</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Advanced</source>
-        <translation>Avanzate</translation>
+        <translation type="vanished">Avanzate</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="136"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
         <source>Debug logging</source>
         <translation>Log di debug</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="141"/>
+        <location filename="../screens/SettingsScreen.qml" line="169"/>
         <source>Upload log file</source>
         <translation>Carica file di log</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="146"/>
+        <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>About / License</source>
         <translation>Informazioni / Licenza</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="162"/>
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
+        <source>Display &amp; Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="72"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <source>Controls &amp; Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="189"/>
+        <source>Library &amp; Data Management</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="82"/>
+        <location filename="../screens/SettingsScreen.qml" line="191"/>
+        <source>Support &amp; About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="206"/>
         <source>Optimizing</source>
         <translation>Ottimizzazione</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
-        <location filename="../screens/SettingsScreen.qml" line="173"/>
+        <location filename="../screens/SettingsScreen.qml" line="208"/>
+        <location filename="../screens/SettingsScreen.qml" line="217"/>
         <source>Paused</source>
         <translation>In pausa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
-        <location filename="../screens/SettingsScreen.qml" line="173"/>
+        <location filename="../screens/SettingsScreen.qml" line="208"/>
+        <location filename="../screens/SettingsScreen.qml" line="217"/>
         <source>In progress</source>
         <translation>In corso</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="167"/>
+        <location filename="../screens/SettingsScreen.qml" line="211"/>
         <source>%1 indexed</source>
         <translation>%1 indicizzati</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="176"/>
+        <location filename="../screens/SettingsScreen.qml" line="220"/>
         <source>%1 scraped</source>
         <translation>%1 recuperati</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="284"/>
+        <location filename="../screens/SettingsScreen.qml" line="393"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="284"/>
+        <location filename="../screens/SettingsScreen.qml" line="393"/>
         <source>Start</source>
         <translation>Avvia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="286"/>
+        <location filename="../screens/SettingsScreen.qml" line="395"/>
         <source>Upload</source>
         <translation>Carica</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="288"/>
+        <location filename="../screens/SettingsScreen.qml" line="396"/>
         <source>Open</source>
         <translation>Apri</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="365"/>
+        <location filename="../screens/SettingsScreen.qml" line="472"/>
         <source>English</source>
         <translation>Inglese</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="367"/>
+        <location filename="../screens/SettingsScreen.qml" line="474"/>
         <source>Italian</source>
         <translation>Italiano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="476"/>
+        <source>Spanish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="478"/>
+        <source>Basque</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="480"/>
         <source>German</source>
         <translation>Tedesco</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
+        <location filename="../screens/SettingsScreen.qml" line="482"/>
         <source>Greek</source>
         <translation>Greco</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="373"/>
+        <location filename="../screens/SettingsScreen.qml" line="484"/>
         <source>Japanese</source>
         <translation>Giapponese</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="375"/>
+        <location filename="../screens/SettingsScreen.qml" line="486"/>
         <source>Korean</source>
         <translation>Coreano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Dutch</source>
         <translation>Olandese</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="379"/>
+        <location filename="../screens/SettingsScreen.qml" line="490"/>
         <source>Romanian</source>
         <translation>Rumeno</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="381"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Slovak</source>
         <translation>Slovacco</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="383"/>
+        <location filename="../screens/SettingsScreen.qml" line="494"/>
         <source>Ukrainian</source>
         <translation>Ucraino</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="385"/>
+        <location filename="../screens/SettingsScreen.qml" line="496"/>
         <source>Chinese (Simplified)</source>
         <translation>Cinese (semplificato)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="387"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Hebrew</source>
         <translation>Ebraico</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="389"/>
+        <location filename="../screens/SettingsScreen.qml" line="500"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="391"/>
+        <location filename="../screens/SettingsScreen.qml" line="502"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="392"/>
-        <location filename="../screens/SettingsScreen.qml" line="451"/>
+        <location filename="../screens/SettingsScreen.qml" line="503"/>
+        <location filename="../screens/SettingsScreen.qml" line="562"/>
         <source>Auto</source>
         <translation>Automatico</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <location filename="../screens/SettingsScreen.qml" line="508"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <location filename="../screens/SettingsScreen.qml" line="510"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="400"/>
+        <location filename="../screens/SettingsScreen.qml" line="511"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405"/>
+        <location filename="../screens/SettingsScreen.qml" line="516"/>
         <source>Detailed list view</source>
         <translation>Vista elenco dettagliata</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="406"/>
+        <location filename="../screens/SettingsScreen.qml" line="517"/>
         <source>Grid view</source>
         <translation>Vista griglia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="411"/>
+        <location filename="../screens/SettingsScreen.qml" line="522"/>
         <source>Style B</source>
         <translation>Stile B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="413"/>
+        <location filename="../screens/SettingsScreen.qml" line="524"/>
         <source>Style C</source>
         <translation>Stile C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="415"/>
+        <location filename="../screens/SettingsScreen.qml" line="526"/>
         <source>Style D</source>
         <translation>Stile D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="416"/>
+        <location filename="../screens/SettingsScreen.qml" line="527"/>
         <source>Style A</source>
         <translation>Stile A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="340"/>
+        <location filename="../screens/SettingsScreen.qml" line="1032"/>
+        <source>Loading settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="447"/>
         <source>Default</source>
         <translation>Predefinito</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="431"/>
+        <location filename="../screens/SettingsScreen.qml" line="542"/>
         <source>Off</source>
         <translation>Disattivato</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="433"/>
+        <location filename="../screens/SettingsScreen.qml" line="544"/>
         <source>1 second (testing)</source>
         <translation>1 secondo (test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="435"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>1 minute</source>
         <translation>1 minuto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="437"/>
+        <location filename="../screens/SettingsScreen.qml" line="548"/>
         <source>2 minutes</source>
         <translation>2 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="439"/>
+        <location filename="../screens/SettingsScreen.qml" line="550"/>
         <source>5 minutes</source>
         <translation>5 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="441"/>
+        <location filename="../screens/SettingsScreen.qml" line="552"/>
         <source>10 minutes</source>
         <translation>10 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="443"/>
+        <location filename="../screens/SettingsScreen.qml" line="554"/>
         <source>15 minutes</source>
         <translation>15 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="445"/>
+        <location filename="../screens/SettingsScreen.qml" line="556"/>
         <source>30 minutes</source>
         <translation>30 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="446"/>
+        <location filename="../screens/SettingsScreen.qml" line="557"/>
         <source>%1 seconds</source>
         <translation>%1 secondi</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="489"/>
+        <location filename="../screens/SettingsScreen.qml" line="91"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Resolution</source>
         <translation>Risoluzione</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="453"/>
+        <location filename="../screens/SettingsScreen.qml" line="564"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="455"/>
+        <location filename="../screens/SettingsScreen.qml" line="566"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="457"/>
+        <location filename="../screens/SettingsScreen.qml" line="568"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <location filename="../screens/SettingsScreen.qml" line="570"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="461"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="463"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="465"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="467"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="469"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="471"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="473"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="663"/>
+        <location filename="../screens/SettingsScreen.qml" line="192"/>
         <source>Settings</source>
         <translation>Impostazioni</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="857"/>
+        <location filename="../screens/SettingsScreen.qml" line="1020"/>
         <source>No settings available on this platform</source>
         <translation>Nessuna impostazione disponibile su questa piattaforma</translation>
     </message>
@@ -1170,24 +1330,24 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="195"/>
-        <location filename="../screens/SystemsScreen.qml" line="292"/>
+        <location filename="../screens/SystemsScreen.qml" line="197"/>
+        <location filename="../screens/SystemsScreen.qml" line="295"/>
         <source>%1 systems</source>
         <translation>%1 sistemi</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="196"/>
-        <location filename="../screens/SystemsScreen.qml" line="309"/>
+        <location filename="../screens/SystemsScreen.qml" line="198"/>
+        <location filename="../screens/SystemsScreen.qml" line="312"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="324"/>
+        <location filename="../screens/SystemsScreen.qml" line="328"/>
         <source>No systems in this category</source>
         <translation>Nessun sistema in questa categoria</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="325"/>
+        <location filename="../screens/SystemsScreen.qml" line="329"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -54,6 +54,13 @@
         <translation>Traduzioni</translation>
     </message>
     <message>
+        <location filename="../screens/AboutScreen.qml" line="267"/>
+        <source>Italiano - Andrea Bogazzi
+Español - Carlos R.
+Euskara - devilschile2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/AboutScreen.qml" line="278"/>
         <source>Full license text in COPYING.</source>
         <translation>Testo completo della licenza in COPYING.</translation>
@@ -907,13 +914,13 @@
     <name>SettingsScreen</name>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="611"/>
         <source>Language</source>
         <translation>Lingua</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="627"/>
+        <location filename="../screens/SettingsScreen.qml" line="629"/>
         <source>Browsing layout</source>
         <translation>Layout navigazione</translation>
     </message>
@@ -933,19 +940,19 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="97"/>
-        <location filename="../screens/SettingsScreen.qml" line="618"/>
+        <location filename="../screens/SettingsScreen.qml" line="620"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="125"/>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="638"/>
         <source>Button style</source>
         <translation>Stile pulsanti</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="112"/>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
+        <location filename="../screens/SettingsScreen.qml" line="647"/>
         <source>Screensaver</source>
         <translation>Salvaschermo</translation>
     </message>
@@ -960,7 +967,7 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="654"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1131,72 +1138,77 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <source>Chinese (Traditional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="500"/>
         <source>Hebrew</source>
         <translation>Ebraico</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="500"/>
+        <location filename="../screens/SettingsScreen.qml" line="502"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="502"/>
+        <location filename="../screens/SettingsScreen.qml" line="504"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="503"/>
-        <location filename="../screens/SettingsScreen.qml" line="562"/>
+        <location filename="../screens/SettingsScreen.qml" line="505"/>
+        <location filename="../screens/SettingsScreen.qml" line="564"/>
         <source>Auto</source>
         <translation>Automatico</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="508"/>
+        <location filename="../screens/SettingsScreen.qml" line="510"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="510"/>
+        <location filename="../screens/SettingsScreen.qml" line="512"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="511"/>
+        <location filename="../screens/SettingsScreen.qml" line="513"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="516"/>
+        <location filename="../screens/SettingsScreen.qml" line="518"/>
         <source>Detailed list view</source>
         <translation>Vista elenco dettagliata</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="517"/>
+        <location filename="../screens/SettingsScreen.qml" line="519"/>
         <source>Grid view</source>
         <translation>Vista griglia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="522"/>
+        <location filename="../screens/SettingsScreen.qml" line="524"/>
         <source>Style B</source>
         <translation>Stile B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="524"/>
+        <location filename="../screens/SettingsScreen.qml" line="526"/>
         <source>Style C</source>
         <translation>Stile C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="526"/>
+        <location filename="../screens/SettingsScreen.qml" line="528"/>
         <source>Style D</source>
         <translation>Stile D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="527"/>
+        <location filename="../screens/SettingsScreen.qml" line="529"/>
         <source>Style A</source>
         <translation>Stile A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1032"/>
+        <location filename="../screens/SettingsScreen.qml" line="1034"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1206,113 +1218,113 @@
         <translation>Predefinito</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="542"/>
+        <location filename="../screens/SettingsScreen.qml" line="544"/>
         <source>Off</source>
         <translation>Disattivato</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="544"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>1 second (testing)</source>
         <translation>1 secondo (test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="546"/>
+        <location filename="../screens/SettingsScreen.qml" line="548"/>
         <source>1 minute</source>
         <translation>1 minuto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="548"/>
+        <location filename="../screens/SettingsScreen.qml" line="550"/>
         <source>2 minutes</source>
         <translation>2 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="550"/>
+        <location filename="../screens/SettingsScreen.qml" line="552"/>
         <source>5 minutes</source>
         <translation>5 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="552"/>
+        <location filename="../screens/SettingsScreen.qml" line="554"/>
         <source>10 minutes</source>
         <translation>10 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="554"/>
+        <location filename="../screens/SettingsScreen.qml" line="556"/>
         <source>15 minutes</source>
         <translation>15 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="556"/>
+        <location filename="../screens/SettingsScreen.qml" line="558"/>
         <source>30 minutes</source>
         <translation>30 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="557"/>
+        <location filename="../screens/SettingsScreen.qml" line="559"/>
         <source>%1 seconds</source>
         <translation>%1 secondi</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="91"/>
-        <location filename="../screens/SettingsScreen.qml" line="600"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Resolution</source>
         <translation>Risoluzione</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="564"/>
+        <location filename="../screens/SettingsScreen.qml" line="566"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="566"/>
+        <location filename="../screens/SettingsScreen.qml" line="568"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="568"/>
+        <location filename="../screens/SettingsScreen.qml" line="570"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="570"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1322,7 +1334,7 @@
         <translation>Impostazioni</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1020"/>
+        <location filename="../screens/SettingsScreen.qml" line="1022"/>
         <source>No settings available on this platform</source>
         <translation>Nessuna impostazione disponibile su questa piattaforma</translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -4,57 +4,57 @@
 <context>
     <name>AboutScreen</name>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="71"/>
+        <location filename="../screens/AboutScreen.qml" line="73"/>
         <source>About / License</source>
         <translation>情報 / ライセンス</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="153"/>
+        <location filename="../screens/AboutScreen.qml" line="155"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="164"/>
+        <location filename="../screens/AboutScreen.qml" line="166"/>
         <source>Version %1 · %2 · %3</source>
         <translation>バージョン %1 · %2 · %3</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="174"/>
+        <location filename="../screens/AboutScreen.qml" line="176"/>
         <source>Built %1</source>
         <translation>ビルド日 %1</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="185"/>
+        <location filename="../screens/AboutScreen.qml" line="187"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>Copyright 2026 Wizzo Pty Ltd および Zaparoo Project contributors.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="196"/>
+        <location filename="../screens/AboutScreen.qml" line="198"/>
         <source>Source available under the PolyForm Noncommercial License 1.0.0. Free for personal, non-commercial use. Commercial use requires a separate license.</source>
         <translation>PolyForm Noncommercial License 1.0.0 のもとでソースを公開しています。個人・非商用利用は無料です。商用利用または再配布には別途ライセンスが必要です。</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="207"/>
+        <location filename="../screens/AboutScreen.qml" line="209"/>
         <source>Commercial licensing: legal@zaparoo.org</source>
         <translation>商用ライセンス: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="218"/>
+        <location filename="../screens/AboutScreen.qml" line="220"/>
         <source>Project: https://zaparoo.org</source>
         <translation>プロジェクト: https://zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="228"/>
+        <location filename="../screens/AboutScreen.qml" line="230"/>
         <source>Created by</source>
         <translation>制作</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="252"/>
+        <location filename="../screens/AboutScreen.qml" line="254"/>
         <source>Translations</source>
         <translation>翻訳</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="276"/>
+        <location filename="../screens/AboutScreen.qml" line="278"/>
         <source>Full license text in COPYING.</source>
         <translation>ライセンス全文は COPYING をご覧ください。</translation>
     </message>
@@ -90,48 +90,102 @@
         <translation type="unfinished">読み込み中…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="77"/>
+        <location filename="../components/BrowseDetailPane.qml" line="138"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="79"/>
+        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <source>Yr</source>
+        <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="81"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <source>Gen</source>
+        <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="83"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <source>Plyr</source>
+        <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="85"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <source>Dev</source>
+        <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="87"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <source>Pub</source>
+        <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="89"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <source>Rtg</source>
+        <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="91"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <source>Cat</source>
+        <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="93"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <source>Date</source>
+        <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Manufacturer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <source>Mfr</source>
+        <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -176,68 +230,103 @@
 <context>
     <name>CoreStatusPill</name>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="44"/>
-        <location filename="../components/CoreStatusPill.qml" line="50"/>
+        <location filename="../components/CoreStatusPill.qml" line="46"/>
+        <location filename="../components/CoreStatusPill.qml" line="52"/>
         <source>Disconnected</source>
         <translation>切断済み</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="47"/>
+        <location filename="../components/CoreStatusPill.qml" line="49"/>
         <source>Reconnecting…</source>
         <translation>再接続中…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="53"/>
+        <location filename="../components/CoreStatusPill.qml" line="55"/>
         <source>Connecting…</source>
         <translation>接続中…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="56"/>
+        <location filename="../components/CoreStatusPill.qml" line="58"/>
         <source>Core error</source>
         <translation>Core エラー</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="60"/>
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <source>Paused %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <source>Paused</source>
+        <translation type="unfinished">一時停止中</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="78"/>
+        <source>Opt…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="78"/>
+        <source>Optimizing</source>
+        <translation type="unfinished">最適化中</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
+        <source>Idx…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
+        <source>Scr…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Optimizing database</source>
-        <translation>データベースを最適化中</translation>
+        <translation type="vanished">データベースを最適化中</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="67"/>
         <source>Indexing paused</source>
-        <translation>インデックス作成を一時停止</translation>
+        <translation type="vanished">インデックス作成を一時停止</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="70"/>
         <source>Indexing %1/%2 - %3</source>
-        <translation>インデックス作成中 %1/%2 - %3</translation>
+        <translation type="vanished">インデックス作成中 %1/%2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="86"/>
         <source>Scraping %1/%2 - %3</source>
-        <translation>スクレイピング中 %1/%2 - %3</translation>
+        <translation type="vanished">スクレイピング中 %1/%2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="73"/>
+        <location filename="../components/CoreStatusPill.qml" line="82"/>
         <source>Indexing %1/%2</source>
         <translation>インデックス作成中 %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <location filename="../components/CoreStatusPill.qml" line="82"/>
+        <source>Idx %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Indexing…</source>
         <translation>インデックス作成中…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Scrape paused</source>
-        <translation>スクレイピングを一時停止</translation>
+        <translation type="vanished">スクレイピングを一時停止</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="89"/>
+        <location filename="../components/CoreStatusPill.qml" line="88"/>
         <source>Scraping %1/%2</source>
         <translation>スクレイピング中 %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="91"/>
+        <location filename="../components/CoreStatusPill.qml" line="88"/>
+        <source>Scr %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
         <source>Scraping…</source>
         <translation>スクレイピング中…</translation>
     </message>
@@ -329,34 +418,34 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="117"/>
-        <location filename="../screens/GamesScreen.qml" line="145"/>
+        <location filename="../screens/GamesScreen.qml" line="122"/>
+        <location filename="../screens/GamesScreen.qml" line="157"/>
         <source>%1 files</source>
         <translation>%1 ファイル</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="51"/>
+        <location filename="../screens/GamesScreen.qml" line="55"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="126"/>
-        <location filename="../screens/GamesScreen.qml" line="146"/>
+        <location filename="../screens/GamesScreen.qml" line="131"/>
+        <location filename="../screens/GamesScreen.qml" line="158"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="45"/>
+        <location filename="../screens/GamesScreen.qml" line="49"/>
         <source>Loading games…</source>
         <translation>ゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="122"/>
+        <location filename="../screens/GamesScreen.qml" line="127"/>
         <source>Loading more…</source>
         <translation>さらに読み込み中…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="44"/>
+        <location filename="../screens/GamesScreen.qml" line="48"/>
         <source>No games in this system</source>
         <translation>このシステムにゲームはありません</translation>
     </message>
@@ -364,32 +453,47 @@
 <context>
     <name>HubScreen</name>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
-        <source>Resume: %1</source>
+        <location filename="../screens/HubScreen.qml" line="56"/>
+        <source>Arcade</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
-        <source>Resume Game</source>
+        <location filename="../screens/HubScreen.qml" line="61"/>
+        <source>Computers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
+        <location filename="../screens/HubScreen.qml" line="66"/>
+        <source>Consoles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="71"/>
+        <source>Handhelds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="134"/>
+        <source>Resume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="140"/>
         <source>Favorites</source>
         <translation>お気に入り</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="96"/>
+        <location filename="../screens/HubScreen.qml" line="145"/>
         <source>Recently Played</source>
         <translation>最近プレイしたゲーム</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="101"/>
+        <location filename="../screens/HubScreen.qml" line="150"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="537"/>
+        <location filename="../screens/HubScreen.qml" line="644"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>利用可能なシステムがありません。設定からメディアデータベースの更新を実行してください。</translation>
     </message>
@@ -438,104 +542,124 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="755"/>
+        <location filename="../app/Main.qml" line="1206"/>
         <source>Launch core</source>
         <translation>コアを起動</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="958"/>
+        <location filename="../app/Main.qml" line="1212"/>
+        <location filename="../app/Main.qml" line="1420"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="786"/>
+        <location filename="../app/Main.qml" line="1247"/>
         <source>Remove from favorites</source>
         <translation>お気に入りから削除</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="786"/>
+        <location filename="../app/Main.qml" line="1247"/>
         <source>Add to favorites</source>
         <translation>お気に入りに追加</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="791"/>
+        <location filename="../app/Main.qml" line="1252"/>
         <source>Write to NFC token</source>
         <translation>NFC トークンに書き込む</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="795"/>
+        <location filename="../app/Main.qml" line="1256"/>
         <source>QR code</source>
         <translation>QR コード</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="770"/>
-        <location filename="../app/Main.qml" line="805"/>
+        <location filename="../app/Main.qml" line="1231"/>
+        <location filename="../app/Main.qml" line="1266"/>
         <source>Launch game</source>
         <translation>ゲームを起動</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1776"/>
+        <location filename="../app/Main.qml" line="2368"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1780"/>
+        <location filename="../app/Main.qml" line="2374"/>
         <source>Loading favorites…</source>
         <translation>お気に入りを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1778"/>
+        <location filename="../app/Main.qml" line="2370"/>
         <source>Loading games…</source>
         <translation>ゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="954"/>
+        <location filename="../app/Main.qml" line="1219"/>
+        <source>Update media database</source>
+        <translation type="unfinished">メディアデータベースを更新</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1222"/>
+        <source>Scrape metadata</source>
+        <translation type="unfinished">メタデータをスクレイピング</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1416"/>
         <source>Default</source>
         <translation type="unfinished">デフォルト</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="954"/>
+        <location filename="../app/Main.qml" line="1416"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1230"/>
+        <location filename="../app/Main.qml" line="1708"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1234"/>
+        <location filename="../app/Main.qml" line="1712"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1248"/>
+        <location filename="../app/Main.qml" line="1726"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1252"/>
+        <location filename="../app/Main.qml" line="1730"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1256"/>
+        <location filename="../app/Main.qml" line="1734"/>
         <source>Retry</source>
         <translation type="unfinished">再試行</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1260"/>
+        <location filename="../app/Main.qml" line="1738"/>
         <source>Cancel</source>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1782"/>
+        <location filename="../app/Main.qml" line="2372"/>
+        <source>Loading game…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2376"/>
         <source>Loading recently played…</source>
         <translation>最近プレイしたゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="2378"/>
+        <source>Loading settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2380"/>
         <source>Loading…</source>
         <translation>読み込み中…</translation>
     </message>
@@ -543,161 +667,161 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="581"/>
+        <location filename="../app/MainLayout.qml" line="680"/>
         <source>Writing failed</source>
         <translation>書き込み失敗</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="581"/>
+        <location filename="../app/MainLayout.qml" line="680"/>
         <source>Put a writable card near the reader</source>
         <translation>書き込み可能なカードをリーダーに近づけてください</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="669"/>
+        <location filename="../app/MainLayout.qml" line="807"/>
         <source>Are you sure you want to exit?</source>
         <translation>本当に終了しますか？</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="745"/>
-        <location filename="../app/MainLayout.qml" line="817"/>
+        <location filename="../app/MainLayout.qml" line="890"/>
+        <location filename="../app/MainLayout.qml" line="964"/>
         <source>Select</source>
         <translation>選択</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="749"/>
-        <location filename="../app/MainLayout.qml" line="753"/>
-        <location filename="../app/MainLayout.qml" line="767"/>
-        <location filename="../app/MainLayout.qml" line="780"/>
-        <location filename="../app/MainLayout.qml" line="791"/>
+        <location filename="../app/MainLayout.qml" line="894"/>
+        <location filename="../app/MainLayout.qml" line="898"/>
+        <location filename="../app/MainLayout.qml" line="912"/>
+        <location filename="../app/MainLayout.qml" line="927"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
         <source>Close</source>
         <translation>閉じる</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="760"/>
-        <location filename="../app/MainLayout.qml" line="798"/>
-        <location filename="../app/MainLayout.qml" line="821"/>
-        <location filename="../app/MainLayout.qml" line="832"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
+        <location filename="../app/MainLayout.qml" line="945"/>
+        <location filename="../app/MainLayout.qml" line="968"/>
+        <location filename="../app/MainLayout.qml" line="979"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="776"/>
+        <location filename="../app/MainLayout.qml" line="923"/>
         <source>Done</source>
         <translation>完了</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="806"/>
+        <location filename="../app/MainLayout.qml" line="953"/>
         <source>I understand</source>
         <translation>了解しました</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="840"/>
+        <location filename="../app/MainLayout.qml" line="987"/>
         <source>Start</source>
         <translation>開始</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1009"/>
+        <location filename="../app/MainLayout.qml" line="1165"/>
         <source>Scroll</source>
         <translation>スクロール</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="741"/>
-        <location filename="../app/MainLayout.qml" line="813"/>
-        <location filename="../app/MainLayout.qml" line="856"/>
-        <location filename="../app/MainLayout.qml" line="885"/>
-        <location filename="../app/MainLayout.qml" line="932"/>
-        <location filename="../app/MainLayout.qml" line="973"/>
-        <location filename="../app/MainLayout.qml" line="1037"/>
+        <location filename="../app/MainLayout.qml" line="886"/>
+        <location filename="../app/MainLayout.qml" line="960"/>
+        <location filename="../app/MainLayout.qml" line="1003"/>
+        <location filename="../app/MainLayout.qml" line="1034"/>
+        <location filename="../app/MainLayout.qml" line="1084"/>
+        <location filename="../app/MainLayout.qml" line="1127"/>
+        <location filename="../app/MainLayout.qml" line="1195"/>
         <source>Move</source>
         <translation>移動</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="141"/>
+        <location filename="../app/MainLayout.qml" line="170"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="323"/>
+        <location filename="../app/MainLayout.qml" line="364"/>
         <source>Favorites</source>
         <translation type="unfinished">お気に入り</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="325"/>
+        <location filename="../app/MainLayout.qml" line="366"/>
         <source>Recently Played</source>
         <translation type="unfinished">最近プレイしたゲーム</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="592"/>
+        <location filename="../app/MainLayout.qml" line="695"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="593"/>
+        <location filename="../app/MainLayout.qml" line="696"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="668"/>
+        <location filename="../app/MainLayout.qml" line="806"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="860"/>
-        <location filename="../app/MainLayout.qml" line="895"/>
-        <location filename="../app/MainLayout.qml" line="942"/>
-        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1007"/>
+        <location filename="../app/MainLayout.qml" line="1044"/>
+        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Open</source>
         <translation>開く</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="864"/>
+        <location filename="../app/MainLayout.qml" line="1011"/>
         <source>Quit</source>
         <translation>終了</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="873"/>
-        <location filename="../app/MainLayout.qml" line="901"/>
-        <location filename="../app/MainLayout.qml" line="912"/>
-        <location filename="../app/MainLayout.qml" line="924"/>
-        <location filename="../app/MainLayout.qml" line="951"/>
-        <location filename="../app/MainLayout.qml" line="962"/>
-        <location filename="../app/MainLayout.qml" line="997"/>
-        <location filename="../app/MainLayout.qml" line="1013"/>
-        <location filename="../app/MainLayout.qml" line="1022"/>
-        <location filename="../app/MainLayout.qml" line="1056"/>
-        <location filename="../app/MainLayout.qml" line="1067"/>
+        <location filename="../app/MainLayout.qml" line="1020"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1061"/>
+        <location filename="../app/MainLayout.qml" line="1076"/>
+        <location filename="../app/MainLayout.qml" line="1103"/>
+        <location filename="../app/MainLayout.qml" line="1114"/>
+        <location filename="../app/MainLayout.qml" line="1151"/>
+        <location filename="../app/MainLayout.qml" line="1169"/>
+        <location filename="../app/MainLayout.qml" line="1178"/>
+        <location filename="../app/MainLayout.qml" line="1214"/>
+        <location filename="../app/MainLayout.qml" line="1225"/>
         <source>Back</source>
         <translation>戻る</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="891"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1043"/>
+        <location filename="../app/MainLayout.qml" line="1040"/>
+        <location filename="../app/MainLayout.qml" line="1090"/>
+        <location filename="../app/MainLayout.qml" line="1201"/>
         <source>Page</source>
         <translation>ページ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="947"/>
-        <location filename="../app/MainLayout.qml" line="1052"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1210"/>
         <source>Options</source>
         <translation>オプション</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="787"/>
-        <location filename="../app/MainLayout.qml" line="908"/>
-        <location filename="../app/MainLayout.qml" line="958"/>
-        <location filename="../app/MainLayout.qml" line="1063"/>
+        <location filename="../app/MainLayout.qml" line="934"/>
+        <location filename="../app/MainLayout.qml" line="1057"/>
+        <location filename="../app/MainLayout.qml" line="1110"/>
+        <location filename="../app/MainLayout.qml" line="1221"/>
         <source>Retry</source>
         <translation>再試行</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="982"/>
+        <location filename="../app/MainLayout.qml" line="1136"/>
         <source>Change</source>
         <translation>変更</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="988"/>
+        <location filename="../app/MainLayout.qml" line="1142"/>
         <source>Toggle</source>
         <translation>切り替え</translation>
     </message>
@@ -710,12 +834,12 @@
         <translation type="unfinished">読み込み中…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="306"/>
+        <location filename="../screens/MediaListScreen.qml" line="351"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 件</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="307"/>
+        <location filename="../screens/MediaListScreen.qml" line="352"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -764,17 +888,17 @@
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="26"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
         <source>Nothing here</source>
         <translation>ここには何もありません</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="28"/>
         <source>Loading…</source>
         <translation>読み込み中…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="57"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="58"/>
         <source>Failed to load</source>
         <translation>読み込みに失敗しました</translation>
     </message>
@@ -782,387 +906,423 @@
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="73"/>
-        <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
         <source>Language</source>
         <translation>言語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="516"/>
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Browsing layout</source>
         <translation>ブラウジングレイアウト</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="130"/>
         <source>Mouse support</source>
         <translation>マウスサポート</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="112"/>
+        <location filename="../screens/SettingsScreen.qml" line="137"/>
         <source>Update media database</source>
         <translation>メディアデータベースを更新</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="61"/>
         <source>General</source>
-        <translation>一般</translation>
+        <translation type="vanished">一般</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78"/>
-        <location filename="../screens/SettingsScreen.qml" line="507"/>
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <location filename="../screens/SettingsScreen.qml" line="618"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88"/>
-        <location filename="../screens/SettingsScreen.qml" line="525"/>
+        <location filename="../screens/SettingsScreen.qml" line="125"/>
+        <location filename="../screens/SettingsScreen.qml" line="636"/>
         <source>Button style</source>
         <translation>ボタンスタイル</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="93"/>
-        <location filename="../screens/SettingsScreen.qml" line="534"/>
+        <location filename="../screens/SettingsScreen.qml" line="112"/>
+        <location filename="../screens/SettingsScreen.qml" line="645"/>
         <source>Screensaver</source>
         <translation>スクリーンセーバー</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97"/>
         <source>Library</source>
-        <translation>ライブラリ</translation>
+        <translation type="vanished">ライブラリ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="142"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="543"/>
+        <location filename="../screens/SettingsScreen.qml" line="654"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
         <source>Scrape metadata</source>
         <translation>メタデータをスクレイピング</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Advanced</source>
-        <translation>詳細設定</translation>
+        <translation type="vanished">詳細設定</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="136"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
         <source>Debug logging</source>
         <translation>デバッグログ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="141"/>
+        <location filename="../screens/SettingsScreen.qml" line="169"/>
         <source>Upload log file</source>
         <translation>ログファイルをアップロード</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="146"/>
+        <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>About / License</source>
         <translation>情報 / ライセンス</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="162"/>
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
+        <source>Display &amp; Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="72"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <source>Controls &amp; Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="189"/>
+        <source>Library &amp; Data Management</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="82"/>
+        <location filename="../screens/SettingsScreen.qml" line="191"/>
+        <source>Support &amp; About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="206"/>
         <source>Optimizing</source>
         <translation>最適化中</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
-        <location filename="../screens/SettingsScreen.qml" line="173"/>
+        <location filename="../screens/SettingsScreen.qml" line="208"/>
+        <location filename="../screens/SettingsScreen.qml" line="217"/>
         <source>Paused</source>
         <translation>一時停止中</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
-        <location filename="../screens/SettingsScreen.qml" line="173"/>
+        <location filename="../screens/SettingsScreen.qml" line="208"/>
+        <location filename="../screens/SettingsScreen.qml" line="217"/>
         <source>In progress</source>
         <translation>実行中</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="167"/>
+        <location filename="../screens/SettingsScreen.qml" line="211"/>
         <source>%1 indexed</source>
         <translation>%1 件を索引化</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="176"/>
+        <location filename="../screens/SettingsScreen.qml" line="220"/>
         <source>%1 scraped</source>
         <translation>%1 件取得済み</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="284"/>
+        <location filename="../screens/SettingsScreen.qml" line="393"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="284"/>
+        <location filename="../screens/SettingsScreen.qml" line="393"/>
         <source>Start</source>
         <translation>開始</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="286"/>
+        <location filename="../screens/SettingsScreen.qml" line="395"/>
         <source>Upload</source>
         <translation>アップロード</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="288"/>
+        <location filename="../screens/SettingsScreen.qml" line="396"/>
         <source>Open</source>
         <translation>開く</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="365"/>
+        <location filename="../screens/SettingsScreen.qml" line="472"/>
         <source>English</source>
         <translation>英語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="367"/>
+        <location filename="../screens/SettingsScreen.qml" line="474"/>
         <source>Italian</source>
         <translation>イタリア語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="476"/>
+        <source>Spanish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="478"/>
+        <source>Basque</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="480"/>
         <source>German</source>
         <translation>ドイツ語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
+        <location filename="../screens/SettingsScreen.qml" line="482"/>
         <source>Greek</source>
         <translation>ギリシャ語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="373"/>
+        <location filename="../screens/SettingsScreen.qml" line="484"/>
         <source>Japanese</source>
         <translation>日本語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="375"/>
+        <location filename="../screens/SettingsScreen.qml" line="486"/>
         <source>Korean</source>
         <translation>韓国語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Dutch</source>
         <translation>オランダ語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="379"/>
+        <location filename="../screens/SettingsScreen.qml" line="490"/>
         <source>Romanian</source>
         <translation>ルーマニア語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="381"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Slovak</source>
         <translation>スロバキア語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="383"/>
+        <location filename="../screens/SettingsScreen.qml" line="494"/>
         <source>Ukrainian</source>
         <translation>ウクライナ語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="385"/>
+        <location filename="../screens/SettingsScreen.qml" line="496"/>
         <source>Chinese (Simplified)</source>
         <translation>中国語（簡体字）</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="387"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Hebrew</source>
         <translation>ヘブライ語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="389"/>
+        <location filename="../screens/SettingsScreen.qml" line="500"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="391"/>
+        <location filename="../screens/SettingsScreen.qml" line="502"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="392"/>
-        <location filename="../screens/SettingsScreen.qml" line="451"/>
+        <location filename="../screens/SettingsScreen.qml" line="503"/>
+        <location filename="../screens/SettingsScreen.qml" line="562"/>
         <source>Auto</source>
         <translation>自動</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <location filename="../screens/SettingsScreen.qml" line="508"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <location filename="../screens/SettingsScreen.qml" line="510"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="400"/>
+        <location filename="../screens/SettingsScreen.qml" line="511"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405"/>
+        <location filename="../screens/SettingsScreen.qml" line="516"/>
         <source>Detailed list view</source>
         <translation>詳細リスト表示</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="406"/>
+        <location filename="../screens/SettingsScreen.qml" line="517"/>
         <source>Grid view</source>
         <translation>グリッド表示</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="411"/>
+        <location filename="../screens/SettingsScreen.qml" line="522"/>
         <source>Style B</source>
         <translation>スタイル B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="413"/>
+        <location filename="../screens/SettingsScreen.qml" line="524"/>
         <source>Style C</source>
         <translation>スタイル C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="415"/>
+        <location filename="../screens/SettingsScreen.qml" line="526"/>
         <source>Style D</source>
         <translation>スタイル D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="416"/>
+        <location filename="../screens/SettingsScreen.qml" line="527"/>
         <source>Style A</source>
         <translation>スタイル A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="340"/>
+        <location filename="../screens/SettingsScreen.qml" line="1032"/>
+        <source>Loading settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="447"/>
         <source>Default</source>
         <translation>デフォルト</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="431"/>
+        <location filename="../screens/SettingsScreen.qml" line="542"/>
         <source>Off</source>
         <translation>オフ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="433"/>
+        <location filename="../screens/SettingsScreen.qml" line="544"/>
         <source>1 second (testing)</source>
         <translation>1秒（テスト）</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="435"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>1 minute</source>
         <translation>1分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="437"/>
+        <location filename="../screens/SettingsScreen.qml" line="548"/>
         <source>2 minutes</source>
         <translation>2分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="439"/>
+        <location filename="../screens/SettingsScreen.qml" line="550"/>
         <source>5 minutes</source>
         <translation>5分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="441"/>
+        <location filename="../screens/SettingsScreen.qml" line="552"/>
         <source>10 minutes</source>
         <translation>10分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="443"/>
+        <location filename="../screens/SettingsScreen.qml" line="554"/>
         <source>15 minutes</source>
         <translation>15分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="445"/>
+        <location filename="../screens/SettingsScreen.qml" line="556"/>
         <source>30 minutes</source>
         <translation>30分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="446"/>
+        <location filename="../screens/SettingsScreen.qml" line="557"/>
         <source>%1 seconds</source>
         <translation>%1秒</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="489"/>
+        <location filename="../screens/SettingsScreen.qml" line="91"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Resolution</source>
         <translation>解像度</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="453"/>
+        <location filename="../screens/SettingsScreen.qml" line="564"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="455"/>
+        <location filename="../screens/SettingsScreen.qml" line="566"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="457"/>
+        <location filename="../screens/SettingsScreen.qml" line="568"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <location filename="../screens/SettingsScreen.qml" line="570"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="461"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="463"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="465"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="467"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="469"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="471"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="473"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="663"/>
+        <location filename="../screens/SettingsScreen.qml" line="192"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="857"/>
+        <location filename="../screens/SettingsScreen.qml" line="1020"/>
         <source>No settings available on this platform</source>
         <translation>このプラットフォームでは設定項目がありません</translation>
     </message>
@@ -1170,24 +1330,24 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="195"/>
-        <location filename="../screens/SystemsScreen.qml" line="292"/>
+        <location filename="../screens/SystemsScreen.qml" line="197"/>
+        <location filename="../screens/SystemsScreen.qml" line="295"/>
         <source>%1 systems</source>
         <translation>%1 システム</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="196"/>
-        <location filename="../screens/SystemsScreen.qml" line="309"/>
+        <location filename="../screens/SystemsScreen.qml" line="198"/>
+        <location filename="../screens/SystemsScreen.qml" line="312"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="324"/>
+        <location filename="../screens/SystemsScreen.qml" line="328"/>
         <source>No systems in this category</source>
         <translation>このカテゴリにシステムはありません</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="325"/>
+        <location filename="../screens/SystemsScreen.qml" line="329"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -54,6 +54,13 @@
         <translation>翻訳</translation>
     </message>
     <message>
+        <location filename="../screens/AboutScreen.qml" line="267"/>
+        <source>Italiano - Andrea Bogazzi
+Español - Carlos R.
+Euskara - devilschile2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/AboutScreen.qml" line="278"/>
         <source>Full license text in COPYING.</source>
         <translation>ライセンス全文は COPYING をご覧ください。</translation>
@@ -907,13 +914,13 @@
     <name>SettingsScreen</name>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="611"/>
         <source>Language</source>
         <translation>言語</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="627"/>
+        <location filename="../screens/SettingsScreen.qml" line="629"/>
         <source>Browsing layout</source>
         <translation>ブラウジングレイアウト</translation>
     </message>
@@ -933,19 +940,19 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="97"/>
-        <location filename="../screens/SettingsScreen.qml" line="618"/>
+        <location filename="../screens/SettingsScreen.qml" line="620"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="125"/>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="638"/>
         <source>Button style</source>
         <translation>ボタンスタイル</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="112"/>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
+        <location filename="../screens/SettingsScreen.qml" line="647"/>
         <source>Screensaver</source>
         <translation>スクリーンセーバー</translation>
     </message>
@@ -960,7 +967,7 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="654"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1131,72 +1138,77 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <source>Chinese (Traditional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="500"/>
         <source>Hebrew</source>
         <translation>ヘブライ語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="500"/>
+        <location filename="../screens/SettingsScreen.qml" line="502"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="502"/>
+        <location filename="../screens/SettingsScreen.qml" line="504"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="503"/>
-        <location filename="../screens/SettingsScreen.qml" line="562"/>
+        <location filename="../screens/SettingsScreen.qml" line="505"/>
+        <location filename="../screens/SettingsScreen.qml" line="564"/>
         <source>Auto</source>
         <translation>自動</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="508"/>
+        <location filename="../screens/SettingsScreen.qml" line="510"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="510"/>
+        <location filename="../screens/SettingsScreen.qml" line="512"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="511"/>
+        <location filename="../screens/SettingsScreen.qml" line="513"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="516"/>
+        <location filename="../screens/SettingsScreen.qml" line="518"/>
         <source>Detailed list view</source>
         <translation>詳細リスト表示</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="517"/>
+        <location filename="../screens/SettingsScreen.qml" line="519"/>
         <source>Grid view</source>
         <translation>グリッド表示</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="522"/>
+        <location filename="../screens/SettingsScreen.qml" line="524"/>
         <source>Style B</source>
         <translation>スタイル B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="524"/>
+        <location filename="../screens/SettingsScreen.qml" line="526"/>
         <source>Style C</source>
         <translation>スタイル C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="526"/>
+        <location filename="../screens/SettingsScreen.qml" line="528"/>
         <source>Style D</source>
         <translation>スタイル D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="527"/>
+        <location filename="../screens/SettingsScreen.qml" line="529"/>
         <source>Style A</source>
         <translation>スタイル A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1032"/>
+        <location filename="../screens/SettingsScreen.qml" line="1034"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1206,113 +1218,113 @@
         <translation>デフォルト</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="542"/>
+        <location filename="../screens/SettingsScreen.qml" line="544"/>
         <source>Off</source>
         <translation>オフ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="544"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>1 second (testing)</source>
         <translation>1秒（テスト）</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="546"/>
+        <location filename="../screens/SettingsScreen.qml" line="548"/>
         <source>1 minute</source>
         <translation>1分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="548"/>
+        <location filename="../screens/SettingsScreen.qml" line="550"/>
         <source>2 minutes</source>
         <translation>2分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="550"/>
+        <location filename="../screens/SettingsScreen.qml" line="552"/>
         <source>5 minutes</source>
         <translation>5分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="552"/>
+        <location filename="../screens/SettingsScreen.qml" line="554"/>
         <source>10 minutes</source>
         <translation>10分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="554"/>
+        <location filename="../screens/SettingsScreen.qml" line="556"/>
         <source>15 minutes</source>
         <translation>15分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="556"/>
+        <location filename="../screens/SettingsScreen.qml" line="558"/>
         <source>30 minutes</source>
         <translation>30分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="557"/>
+        <location filename="../screens/SettingsScreen.qml" line="559"/>
         <source>%1 seconds</source>
         <translation>%1秒</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="91"/>
-        <location filename="../screens/SettingsScreen.qml" line="600"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Resolution</source>
         <translation>解像度</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="564"/>
+        <location filename="../screens/SettingsScreen.qml" line="566"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="566"/>
+        <location filename="../screens/SettingsScreen.qml" line="568"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="568"/>
+        <location filename="../screens/SettingsScreen.qml" line="570"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="570"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1322,7 +1334,7 @@
         <translation>設定</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1020"/>
+        <location filename="../screens/SettingsScreen.qml" line="1022"/>
         <source>No settings available on this platform</source>
         <translation>このプラットフォームでは設定項目がありません</translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -54,6 +54,13 @@
         <translation>번역</translation>
     </message>
     <message>
+        <location filename="../screens/AboutScreen.qml" line="267"/>
+        <source>Italiano - Andrea Bogazzi
+Español - Carlos R.
+Euskara - devilschile2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/AboutScreen.qml" line="278"/>
         <source>Full license text in COPYING.</source>
         <translation>전체 라이선스 텍스트는 COPYING에 있습니다.</translation>
@@ -911,31 +918,31 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="611"/>
         <source>Language</source>
         <translation>언어</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="97"/>
-        <location filename="../screens/SettingsScreen.qml" line="618"/>
+        <location filename="../screens/SettingsScreen.qml" line="620"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="627"/>
+        <location filename="../screens/SettingsScreen.qml" line="629"/>
         <source>Browsing layout</source>
         <translation>탐색 레이아웃</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="125"/>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="638"/>
         <source>Button style</source>
         <translation>버튼 스타일</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="112"/>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
+        <location filename="../screens/SettingsScreen.qml" line="647"/>
         <source>Screensaver</source>
         <translation>화면 보호기</translation>
     </message>
@@ -950,7 +957,7 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="654"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1136,183 +1143,188 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <source>Chinese (Traditional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="500"/>
         <source>Hebrew</source>
         <translation>히브리어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="500"/>
+        <location filename="../screens/SettingsScreen.qml" line="502"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="502"/>
+        <location filename="../screens/SettingsScreen.qml" line="504"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="503"/>
-        <location filename="../screens/SettingsScreen.qml" line="562"/>
+        <location filename="../screens/SettingsScreen.qml" line="505"/>
+        <location filename="../screens/SettingsScreen.qml" line="564"/>
         <source>Auto</source>
         <translation>자동</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="508"/>
+        <location filename="../screens/SettingsScreen.qml" line="510"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="510"/>
+        <location filename="../screens/SettingsScreen.qml" line="512"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="511"/>
+        <location filename="../screens/SettingsScreen.qml" line="513"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="516"/>
+        <location filename="../screens/SettingsScreen.qml" line="518"/>
         <source>Detailed list view</source>
         <translation>자세한 목록 보기</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="517"/>
+        <location filename="../screens/SettingsScreen.qml" line="519"/>
         <source>Grid view</source>
         <translation>그리드 보기</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="522"/>
+        <location filename="../screens/SettingsScreen.qml" line="524"/>
         <source>Style B</source>
         <translation>스타일 B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="524"/>
+        <location filename="../screens/SettingsScreen.qml" line="526"/>
         <source>Style C</source>
         <translation>스타일 C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="526"/>
+        <location filename="../screens/SettingsScreen.qml" line="528"/>
         <source>Style D</source>
         <translation>스타일 D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="527"/>
+        <location filename="../screens/SettingsScreen.qml" line="529"/>
         <source>Style A</source>
         <translation>스타일 A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="542"/>
+        <location filename="../screens/SettingsScreen.qml" line="544"/>
         <source>Off</source>
         <translation>끔</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="544"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>1 second (testing)</source>
         <translation>1초 (테스트용)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="546"/>
+        <location filename="../screens/SettingsScreen.qml" line="548"/>
         <source>1 minute</source>
         <translation>1분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="548"/>
+        <location filename="../screens/SettingsScreen.qml" line="550"/>
         <source>2 minutes</source>
         <translation>2분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="550"/>
+        <location filename="../screens/SettingsScreen.qml" line="552"/>
         <source>5 minutes</source>
         <translation>5분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="552"/>
+        <location filename="../screens/SettingsScreen.qml" line="554"/>
         <source>10 minutes</source>
         <translation>10분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="554"/>
+        <location filename="../screens/SettingsScreen.qml" line="556"/>
         <source>15 minutes</source>
         <translation>15분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="556"/>
+        <location filename="../screens/SettingsScreen.qml" line="558"/>
         <source>30 minutes</source>
         <translation>30분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="557"/>
+        <location filename="../screens/SettingsScreen.qml" line="559"/>
         <source>%1 seconds</source>
         <translation>%1초</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1032"/>
+        <location filename="../screens/SettingsScreen.qml" line="1034"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="91"/>
-        <location filename="../screens/SettingsScreen.qml" line="600"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Resolution</source>
         <translation>해상도</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="564"/>
+        <location filename="../screens/SettingsScreen.qml" line="566"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="566"/>
+        <location filename="../screens/SettingsScreen.qml" line="568"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="568"/>
+        <location filename="../screens/SettingsScreen.qml" line="570"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="570"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1322,7 +1334,7 @@
         <translation>설정</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1020"/>
+        <location filename="../screens/SettingsScreen.qml" line="1022"/>
         <source>No settings available on this platform</source>
         <translation>이 플랫폼에서는 설정을 사용할 수 없습니다</translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -4,57 +4,57 @@
 <context>
     <name>AboutScreen</name>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="71"/>
+        <location filename="../screens/AboutScreen.qml" line="73"/>
         <source>About / License</source>
         <translation>정보 / 라이선스</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="153"/>
+        <location filename="../screens/AboutScreen.qml" line="155"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="164"/>
+        <location filename="../screens/AboutScreen.qml" line="166"/>
         <source>Version %1 · %2 · %3</source>
         <translation>버전 %1 · %2 · %3</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="174"/>
+        <location filename="../screens/AboutScreen.qml" line="176"/>
         <source>Built %1</source>
         <translation>빌드 %1</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="185"/>
+        <location filename="../screens/AboutScreen.qml" line="187"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>Copyright 2026 Wizzo Pty Ltd 및 Zaparoo Project 기여자.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="196"/>
+        <location filename="../screens/AboutScreen.qml" line="198"/>
         <source>Source available under the PolyForm Noncommercial License 1.0.0. Free for personal, non-commercial use. Commercial use requires a separate license.</source>
         <translation>소스는 PolyForm Noncommercial License 1.0.0에 따라 제공됩니다. 개인적이고 비상업적인 용도로 무료로 사용할 수 있습니다. 상업적 사용 또는 재배포에는 별도 라이선스가 필요합니다.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="207"/>
+        <location filename="../screens/AboutScreen.qml" line="209"/>
         <source>Commercial licensing: legal@zaparoo.org</source>
         <translation>상업용 라이선스: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="218"/>
+        <location filename="../screens/AboutScreen.qml" line="220"/>
         <source>Project: https://zaparoo.org</source>
         <translation>프로젝트: https://zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="228"/>
+        <location filename="../screens/AboutScreen.qml" line="230"/>
         <source>Created by</source>
         <translation>만든 사람</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="252"/>
+        <location filename="../screens/AboutScreen.qml" line="254"/>
         <source>Translations</source>
         <translation>번역</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="276"/>
+        <location filename="../screens/AboutScreen.qml" line="278"/>
         <source>Full license text in COPYING.</source>
         <translation>전체 라이선스 텍스트는 COPYING에 있습니다.</translation>
     </message>
@@ -90,48 +90,102 @@
         <translation type="unfinished">불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="77"/>
+        <location filename="../components/BrowseDetailPane.qml" line="138"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="79"/>
+        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <source>Yr</source>
+        <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="81"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <source>Gen</source>
+        <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="83"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <source>Plyr</source>
+        <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="85"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <source>Dev</source>
+        <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="87"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <source>Pub</source>
+        <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="89"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <source>Rtg</source>
+        <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="91"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <source>Cat</source>
+        <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="93"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <source>Date</source>
+        <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Manufacturer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <source>Mfr</source>
+        <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -176,68 +230,103 @@
 <context>
     <name>CoreStatusPill</name>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="44"/>
-        <location filename="../components/CoreStatusPill.qml" line="50"/>
+        <location filename="../components/CoreStatusPill.qml" line="46"/>
+        <location filename="../components/CoreStatusPill.qml" line="52"/>
         <source>Disconnected</source>
         <translation>연결 끊김</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="47"/>
+        <location filename="../components/CoreStatusPill.qml" line="49"/>
         <source>Reconnecting…</source>
         <translation>재연결 중…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="53"/>
+        <location filename="../components/CoreStatusPill.qml" line="55"/>
         <source>Connecting…</source>
         <translation>연결 중…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="56"/>
+        <location filename="../components/CoreStatusPill.qml" line="58"/>
         <source>Core error</source>
         <translation>코어 오류</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="60"/>
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <source>Paused %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <source>Paused</source>
+        <translation type="unfinished">일시중지됨</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="78"/>
+        <source>Opt…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="78"/>
+        <source>Optimizing</source>
+        <translation type="unfinished">최적화 중</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
+        <source>Idx…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
+        <source>Scr…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Optimizing database</source>
-        <translation>데이터베이스 최적화 중</translation>
+        <translation type="vanished">데이터베이스 최적화 중</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="67"/>
         <source>Indexing paused</source>
-        <translation>인덱싱 일시중지됨</translation>
+        <translation type="vanished">인덱싱 일시중지됨</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="70"/>
         <source>Indexing %1/%2 - %3</source>
-        <translation>인덱싱 %1/%2 - %3</translation>
+        <translation type="vanished">인덱싱 %1/%2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="73"/>
+        <location filename="../components/CoreStatusPill.qml" line="82"/>
         <source>Indexing %1/%2</source>
         <translation>인덱싱 %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <location filename="../components/CoreStatusPill.qml" line="82"/>
+        <source>Idx %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Indexing…</source>
         <translation>인덱싱 중…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Scrape paused</source>
-        <translation>수집 일시중지됨</translation>
+        <translation type="vanished">수집 일시중지됨</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="86"/>
         <source>Scraping %1/%2 - %3</source>
-        <translation>메타데이터 수집 %1/%2 - %3</translation>
+        <translation type="vanished">메타데이터 수집 %1/%2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="89"/>
+        <location filename="../components/CoreStatusPill.qml" line="88"/>
         <source>Scraping %1/%2</source>
         <translation>메타데이터 수집 %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="91"/>
+        <location filename="../components/CoreStatusPill.qml" line="88"/>
+        <source>Scr %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
         <source>Scraping…</source>
         <translation>메타데이터 수집 중…</translation>
     </message>
@@ -329,34 +418,34 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="117"/>
-        <location filename="../screens/GamesScreen.qml" line="145"/>
+        <location filename="../screens/GamesScreen.qml" line="122"/>
+        <location filename="../screens/GamesScreen.qml" line="157"/>
         <source>%1 files</source>
         <translation>파일 %1개</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="51"/>
+        <location filename="../screens/GamesScreen.qml" line="55"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="126"/>
-        <location filename="../screens/GamesScreen.qml" line="146"/>
+        <location filename="../screens/GamesScreen.qml" line="131"/>
+        <location filename="../screens/GamesScreen.qml" line="158"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="44"/>
+        <location filename="../screens/GamesScreen.qml" line="48"/>
         <source>No games in this system</source>
         <translation>이 시스템에는 게임이 없습니다</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="45"/>
+        <location filename="../screens/GamesScreen.qml" line="49"/>
         <source>Loading games…</source>
         <translation>게임 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="122"/>
+        <location filename="../screens/GamesScreen.qml" line="127"/>
         <source>Loading more…</source>
         <translation>더 불러오는 중…</translation>
     </message>
@@ -364,32 +453,47 @@
 <context>
     <name>HubScreen</name>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
-        <source>Resume: %1</source>
+        <location filename="../screens/HubScreen.qml" line="56"/>
+        <source>Arcade</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
-        <source>Resume Game</source>
+        <location filename="../screens/HubScreen.qml" line="61"/>
+        <source>Computers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
+        <location filename="../screens/HubScreen.qml" line="66"/>
+        <source>Consoles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="71"/>
+        <source>Handhelds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="134"/>
+        <source>Resume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="140"/>
         <source>Favorites</source>
         <translation>즐겨찾기</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="96"/>
+        <location filename="../screens/HubScreen.qml" line="145"/>
         <source>Recently Played</source>
         <translation>최근 플레이</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="101"/>
+        <location filename="../screens/HubScreen.qml" line="150"/>
         <source>Settings</source>
         <translation>설정</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="537"/>
+        <location filename="../screens/HubScreen.qml" line="644"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>사용 가능한 시스템이 없습니다. 설정에서 미디어 데이터베이스 업데이트를 실행하세요.</translation>
     </message>
@@ -438,104 +542,124 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="755"/>
+        <location filename="../app/Main.qml" line="1206"/>
         <source>Launch core</source>
         <translation>코어 실행</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="958"/>
+        <location filename="../app/Main.qml" line="1212"/>
+        <location filename="../app/Main.qml" line="1420"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="770"/>
-        <location filename="../app/Main.qml" line="805"/>
+        <location filename="../app/Main.qml" line="1219"/>
+        <source>Update media database</source>
+        <translation type="unfinished">미디어 데이터베이스 업데이트</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1222"/>
+        <source>Scrape metadata</source>
+        <translation type="unfinished">메타데이터 수집</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1231"/>
+        <location filename="../app/Main.qml" line="1266"/>
         <source>Launch game</source>
         <translation>게임 실행</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="786"/>
+        <location filename="../app/Main.qml" line="1247"/>
         <source>Remove from favorites</source>
         <translation>즐겨찾기에서 제거</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="786"/>
+        <location filename="../app/Main.qml" line="1247"/>
         <source>Add to favorites</source>
         <translation>즐겨찾기에 추가</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="791"/>
+        <location filename="../app/Main.qml" line="1252"/>
         <source>Write to NFC token</source>
         <translation>NFC 토큰에 쓰기</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="795"/>
+        <location filename="../app/Main.qml" line="1256"/>
         <source>QR code</source>
         <translation>QR 코드</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="954"/>
+        <location filename="../app/Main.qml" line="1416"/>
         <source>Default</source>
         <translation type="unfinished">기본값</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="954"/>
+        <location filename="../app/Main.qml" line="1416"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1230"/>
+        <location filename="../app/Main.qml" line="1708"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1234"/>
+        <location filename="../app/Main.qml" line="1712"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1248"/>
+        <location filename="../app/Main.qml" line="1726"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1252"/>
+        <location filename="../app/Main.qml" line="1730"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1256"/>
+        <location filename="../app/Main.qml" line="1734"/>
         <source>Retry</source>
         <translation type="unfinished">다시 시도</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1260"/>
+        <location filename="../app/Main.qml" line="1738"/>
         <source>Cancel</source>
         <translation type="unfinished">취소</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1776"/>
+        <location filename="../app/Main.qml" line="2368"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1778"/>
+        <location filename="../app/Main.qml" line="2370"/>
         <source>Loading games…</source>
         <translation>게임 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1780"/>
+        <location filename="../app/Main.qml" line="2372"/>
+        <source>Loading game…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2374"/>
         <source>Loading favorites…</source>
         <translation>즐겨찾기 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1782"/>
+        <location filename="../app/Main.qml" line="2376"/>
         <source>Loading recently played…</source>
         <translation>최근 플레이 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="2378"/>
+        <source>Loading settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2380"/>
         <source>Loading…</source>
         <translation>불러오는 중…</translation>
     </message>
@@ -543,161 +667,161 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="581"/>
+        <location filename="../app/MainLayout.qml" line="680"/>
         <source>Writing failed</source>
         <translation>쓰기 실패</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="581"/>
+        <location filename="../app/MainLayout.qml" line="680"/>
         <source>Put a writable card near the reader</source>
         <translation>기록 가능한 카드를 리더 근처에 놓으세요</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="141"/>
+        <location filename="../app/MainLayout.qml" line="170"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="323"/>
+        <location filename="../app/MainLayout.qml" line="364"/>
         <source>Favorites</source>
         <translation type="unfinished">즐겨찾기</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="325"/>
+        <location filename="../app/MainLayout.qml" line="366"/>
         <source>Recently Played</source>
         <translation type="unfinished">최근 플레이</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="592"/>
+        <location filename="../app/MainLayout.qml" line="695"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="593"/>
+        <location filename="../app/MainLayout.qml" line="696"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="668"/>
+        <location filename="../app/MainLayout.qml" line="806"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="669"/>
+        <location filename="../app/MainLayout.qml" line="807"/>
         <source>Are you sure you want to exit?</source>
         <translation>정말 종료하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="741"/>
-        <location filename="../app/MainLayout.qml" line="813"/>
-        <location filename="../app/MainLayout.qml" line="856"/>
-        <location filename="../app/MainLayout.qml" line="885"/>
-        <location filename="../app/MainLayout.qml" line="932"/>
-        <location filename="../app/MainLayout.qml" line="973"/>
-        <location filename="../app/MainLayout.qml" line="1037"/>
+        <location filename="../app/MainLayout.qml" line="886"/>
+        <location filename="../app/MainLayout.qml" line="960"/>
+        <location filename="../app/MainLayout.qml" line="1003"/>
+        <location filename="../app/MainLayout.qml" line="1034"/>
+        <location filename="../app/MainLayout.qml" line="1084"/>
+        <location filename="../app/MainLayout.qml" line="1127"/>
+        <location filename="../app/MainLayout.qml" line="1195"/>
         <source>Move</source>
         <translation>이동</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="745"/>
-        <location filename="../app/MainLayout.qml" line="817"/>
+        <location filename="../app/MainLayout.qml" line="890"/>
+        <location filename="../app/MainLayout.qml" line="964"/>
         <source>Select</source>
         <translation>선택</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="749"/>
-        <location filename="../app/MainLayout.qml" line="753"/>
-        <location filename="../app/MainLayout.qml" line="767"/>
-        <location filename="../app/MainLayout.qml" line="780"/>
-        <location filename="../app/MainLayout.qml" line="791"/>
+        <location filename="../app/MainLayout.qml" line="894"/>
+        <location filename="../app/MainLayout.qml" line="898"/>
+        <location filename="../app/MainLayout.qml" line="912"/>
+        <location filename="../app/MainLayout.qml" line="927"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
         <source>Close</source>
         <translation>닫기</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="760"/>
-        <location filename="../app/MainLayout.qml" line="798"/>
-        <location filename="../app/MainLayout.qml" line="821"/>
-        <location filename="../app/MainLayout.qml" line="832"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
+        <location filename="../app/MainLayout.qml" line="945"/>
+        <location filename="../app/MainLayout.qml" line="968"/>
+        <location filename="../app/MainLayout.qml" line="979"/>
         <source>Cancel</source>
         <translation>취소</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="776"/>
+        <location filename="../app/MainLayout.qml" line="923"/>
         <source>Done</source>
         <translation>완료</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="787"/>
-        <location filename="../app/MainLayout.qml" line="908"/>
-        <location filename="../app/MainLayout.qml" line="958"/>
-        <location filename="../app/MainLayout.qml" line="1063"/>
+        <location filename="../app/MainLayout.qml" line="934"/>
+        <location filename="../app/MainLayout.qml" line="1057"/>
+        <location filename="../app/MainLayout.qml" line="1110"/>
+        <location filename="../app/MainLayout.qml" line="1221"/>
         <source>Retry</source>
         <translation>다시 시도</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="806"/>
+        <location filename="../app/MainLayout.qml" line="953"/>
         <source>I understand</source>
         <translation>이해했습니다</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="840"/>
+        <location filename="../app/MainLayout.qml" line="987"/>
         <source>Start</source>
         <translation>시작</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="860"/>
-        <location filename="../app/MainLayout.qml" line="895"/>
-        <location filename="../app/MainLayout.qml" line="942"/>
-        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1007"/>
+        <location filename="../app/MainLayout.qml" line="1044"/>
+        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Open</source>
         <translation>열기</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="864"/>
+        <location filename="../app/MainLayout.qml" line="1011"/>
         <source>Quit</source>
         <translation>종료</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="873"/>
-        <location filename="../app/MainLayout.qml" line="901"/>
-        <location filename="../app/MainLayout.qml" line="912"/>
-        <location filename="../app/MainLayout.qml" line="924"/>
-        <location filename="../app/MainLayout.qml" line="951"/>
-        <location filename="../app/MainLayout.qml" line="962"/>
-        <location filename="../app/MainLayout.qml" line="997"/>
-        <location filename="../app/MainLayout.qml" line="1013"/>
-        <location filename="../app/MainLayout.qml" line="1022"/>
-        <location filename="../app/MainLayout.qml" line="1056"/>
-        <location filename="../app/MainLayout.qml" line="1067"/>
+        <location filename="../app/MainLayout.qml" line="1020"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1061"/>
+        <location filename="../app/MainLayout.qml" line="1076"/>
+        <location filename="../app/MainLayout.qml" line="1103"/>
+        <location filename="../app/MainLayout.qml" line="1114"/>
+        <location filename="../app/MainLayout.qml" line="1151"/>
+        <location filename="../app/MainLayout.qml" line="1169"/>
+        <location filename="../app/MainLayout.qml" line="1178"/>
+        <location filename="../app/MainLayout.qml" line="1214"/>
+        <location filename="../app/MainLayout.qml" line="1225"/>
         <source>Back</source>
         <translation>뒤로</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="891"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1043"/>
+        <location filename="../app/MainLayout.qml" line="1040"/>
+        <location filename="../app/MainLayout.qml" line="1090"/>
+        <location filename="../app/MainLayout.qml" line="1201"/>
         <source>Page</source>
         <translation>페이지</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="947"/>
-        <location filename="../app/MainLayout.qml" line="1052"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1210"/>
         <source>Options</source>
         <translation>옵션</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="982"/>
+        <location filename="../app/MainLayout.qml" line="1136"/>
         <source>Change</source>
         <translation>변경</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="988"/>
+        <location filename="../app/MainLayout.qml" line="1142"/>
         <source>Toggle</source>
         <translation>전환</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1009"/>
+        <location filename="../app/MainLayout.qml" line="1165"/>
         <source>Scroll</source>
         <translation>스크롤</translation>
     </message>
@@ -710,12 +834,12 @@
         <translation type="unfinished">불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="306"/>
+        <location filename="../screens/MediaListScreen.qml" line="351"/>
         <source>%1 entries</source>
         <translation type="unfinished">항목 %1개</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="307"/>
+        <location filename="../screens/MediaListScreen.qml" line="352"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -764,17 +888,17 @@
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="26"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
         <source>Nothing here</source>
         <translation>여기에 아무것도 없습니다</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="28"/>
         <source>Loading…</source>
         <translation>불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="57"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="58"/>
         <source>Failed to load</source>
         <translation>불러오지 못했습니다</translation>
     </message>
@@ -782,387 +906,423 @@
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="61"/>
         <source>General</source>
-        <translation>일반</translation>
+        <translation type="vanished">일반</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="73"/>
-        <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
         <source>Language</source>
         <translation>언어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78"/>
-        <location filename="../screens/SettingsScreen.qml" line="507"/>
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <location filename="../screens/SettingsScreen.qml" line="618"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="516"/>
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Browsing layout</source>
         <translation>탐색 레이아웃</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88"/>
-        <location filename="../screens/SettingsScreen.qml" line="525"/>
+        <location filename="../screens/SettingsScreen.qml" line="125"/>
+        <location filename="../screens/SettingsScreen.qml" line="636"/>
         <source>Button style</source>
         <translation>버튼 스타일</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="93"/>
-        <location filename="../screens/SettingsScreen.qml" line="534"/>
+        <location filename="../screens/SettingsScreen.qml" line="112"/>
+        <location filename="../screens/SettingsScreen.qml" line="645"/>
         <source>Screensaver</source>
         <translation>화면 보호기</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97"/>
         <source>Library</source>
-        <translation>라이브러리</translation>
+        <translation type="vanished">라이브러리</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="142"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="543"/>
+        <location filename="../screens/SettingsScreen.qml" line="654"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="112"/>
+        <location filename="../screens/SettingsScreen.qml" line="137"/>
         <source>Update media database</source>
         <translation>미디어 데이터베이스 업데이트</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
         <source>Scrape metadata</source>
         <translation>메타데이터 수집</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Advanced</source>
-        <translation>고급</translation>
+        <translation type="vanished">고급</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="130"/>
         <source>Mouse support</source>
         <translation>마우스 지원</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="136"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
         <source>Debug logging</source>
         <translation>디버그 로깅</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="141"/>
+        <location filename="../screens/SettingsScreen.qml" line="169"/>
         <source>Upload log file</source>
         <translation>로그 파일 업로드</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="146"/>
+        <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>About / License</source>
         <translation>정보 / 라이선스</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="162"/>
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
+        <source>Display &amp; Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="72"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <source>Controls &amp; Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="189"/>
+        <source>Library &amp; Data Management</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="82"/>
+        <location filename="../screens/SettingsScreen.qml" line="191"/>
+        <source>Support &amp; About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="206"/>
         <source>Optimizing</source>
         <translation>최적화 중</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
-        <location filename="../screens/SettingsScreen.qml" line="173"/>
+        <location filename="../screens/SettingsScreen.qml" line="208"/>
+        <location filename="../screens/SettingsScreen.qml" line="217"/>
         <source>Paused</source>
         <translation>일시중지됨</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
-        <location filename="../screens/SettingsScreen.qml" line="173"/>
+        <location filename="../screens/SettingsScreen.qml" line="208"/>
+        <location filename="../screens/SettingsScreen.qml" line="217"/>
         <source>In progress</source>
         <translation>진행 중</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="167"/>
+        <location filename="../screens/SettingsScreen.qml" line="211"/>
         <source>%1 indexed</source>
         <translation>%1개 인덱싱됨</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="176"/>
+        <location filename="../screens/SettingsScreen.qml" line="220"/>
         <source>%1 scraped</source>
         <translation>%1개 수집됨</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="284"/>
+        <location filename="../screens/SettingsScreen.qml" line="393"/>
         <source>Cancel</source>
         <translation>취소</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="284"/>
+        <location filename="../screens/SettingsScreen.qml" line="393"/>
         <source>Start</source>
         <translation>시작</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="286"/>
+        <location filename="../screens/SettingsScreen.qml" line="395"/>
         <source>Upload</source>
         <translation>업로드</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="288"/>
+        <location filename="../screens/SettingsScreen.qml" line="396"/>
         <source>Open</source>
         <translation>열기</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="340"/>
+        <location filename="../screens/SettingsScreen.qml" line="447"/>
         <source>Default</source>
         <translation>기본값</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="365"/>
+        <location filename="../screens/SettingsScreen.qml" line="472"/>
         <source>English</source>
         <translation>영어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="367"/>
+        <location filename="../screens/SettingsScreen.qml" line="474"/>
         <source>Italian</source>
         <translation>이탈리아어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="476"/>
+        <source>Spanish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="478"/>
+        <source>Basque</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="480"/>
         <source>German</source>
         <translation>독일어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
+        <location filename="../screens/SettingsScreen.qml" line="482"/>
         <source>Greek</source>
         <translation>그리스어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="373"/>
+        <location filename="../screens/SettingsScreen.qml" line="484"/>
         <source>Japanese</source>
         <translation>일본어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="375"/>
+        <location filename="../screens/SettingsScreen.qml" line="486"/>
         <source>Korean</source>
         <translation>한국어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Dutch</source>
         <translation>네덜란드어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="379"/>
+        <location filename="../screens/SettingsScreen.qml" line="490"/>
         <source>Romanian</source>
         <translation>루마니아어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="381"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Slovak</source>
         <translation>슬로바키아어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="383"/>
+        <location filename="../screens/SettingsScreen.qml" line="494"/>
         <source>Ukrainian</source>
         <translation>우크라이나어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="385"/>
+        <location filename="../screens/SettingsScreen.qml" line="496"/>
         <source>Chinese (Simplified)</source>
         <translation>중국어(간체)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="387"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Hebrew</source>
         <translation>히브리어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="389"/>
+        <location filename="../screens/SettingsScreen.qml" line="500"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="391"/>
+        <location filename="../screens/SettingsScreen.qml" line="502"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="392"/>
-        <location filename="../screens/SettingsScreen.qml" line="451"/>
+        <location filename="../screens/SettingsScreen.qml" line="503"/>
+        <location filename="../screens/SettingsScreen.qml" line="562"/>
         <source>Auto</source>
         <translation>자동</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <location filename="../screens/SettingsScreen.qml" line="508"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <location filename="../screens/SettingsScreen.qml" line="510"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="400"/>
+        <location filename="../screens/SettingsScreen.qml" line="511"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405"/>
+        <location filename="../screens/SettingsScreen.qml" line="516"/>
         <source>Detailed list view</source>
         <translation>자세한 목록 보기</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="406"/>
+        <location filename="../screens/SettingsScreen.qml" line="517"/>
         <source>Grid view</source>
         <translation>그리드 보기</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="411"/>
+        <location filename="../screens/SettingsScreen.qml" line="522"/>
         <source>Style B</source>
         <translation>스타일 B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="413"/>
+        <location filename="../screens/SettingsScreen.qml" line="524"/>
         <source>Style C</source>
         <translation>스타일 C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="415"/>
+        <location filename="../screens/SettingsScreen.qml" line="526"/>
         <source>Style D</source>
         <translation>스타일 D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="416"/>
+        <location filename="../screens/SettingsScreen.qml" line="527"/>
         <source>Style A</source>
         <translation>스타일 A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="431"/>
+        <location filename="../screens/SettingsScreen.qml" line="542"/>
         <source>Off</source>
         <translation>끔</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="433"/>
+        <location filename="../screens/SettingsScreen.qml" line="544"/>
         <source>1 second (testing)</source>
         <translation>1초 (테스트용)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="435"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>1 minute</source>
         <translation>1분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="437"/>
+        <location filename="../screens/SettingsScreen.qml" line="548"/>
         <source>2 minutes</source>
         <translation>2분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="439"/>
+        <location filename="../screens/SettingsScreen.qml" line="550"/>
         <source>5 minutes</source>
         <translation>5분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="441"/>
+        <location filename="../screens/SettingsScreen.qml" line="552"/>
         <source>10 minutes</source>
         <translation>10분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="443"/>
+        <location filename="../screens/SettingsScreen.qml" line="554"/>
         <source>15 minutes</source>
         <translation>15분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="445"/>
+        <location filename="../screens/SettingsScreen.qml" line="556"/>
         <source>30 minutes</source>
         <translation>30분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="446"/>
+        <location filename="../screens/SettingsScreen.qml" line="557"/>
         <source>%1 seconds</source>
         <translation>%1초</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="489"/>
+        <location filename="../screens/SettingsScreen.qml" line="1032"/>
+        <source>Loading settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="91"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Resolution</source>
         <translation>해상도</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="453"/>
+        <location filename="../screens/SettingsScreen.qml" line="564"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="455"/>
+        <location filename="../screens/SettingsScreen.qml" line="566"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="457"/>
+        <location filename="../screens/SettingsScreen.qml" line="568"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <location filename="../screens/SettingsScreen.qml" line="570"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="461"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="463"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="465"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="467"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="469"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="471"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="473"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="663"/>
+        <location filename="../screens/SettingsScreen.qml" line="192"/>
         <source>Settings</source>
         <translation>설정</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="857"/>
+        <location filename="../screens/SettingsScreen.qml" line="1020"/>
         <source>No settings available on this platform</source>
         <translation>이 플랫폼에서는 설정을 사용할 수 없습니다</translation>
     </message>
@@ -1170,24 +1330,24 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="195"/>
-        <location filename="../screens/SystemsScreen.qml" line="292"/>
+        <location filename="../screens/SystemsScreen.qml" line="197"/>
+        <location filename="../screens/SystemsScreen.qml" line="295"/>
         <source>%1 systems</source>
         <translation>시스템 %1개</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="196"/>
-        <location filename="../screens/SystemsScreen.qml" line="309"/>
+        <location filename="../screens/SystemsScreen.qml" line="198"/>
+        <location filename="../screens/SystemsScreen.qml" line="312"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="324"/>
+        <location filename="../screens/SystemsScreen.qml" line="328"/>
         <source>No systems in this category</source>
         <translation>이 카테고리에는 시스템이 없습니다</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="325"/>
+        <location filename="../screens/SystemsScreen.qml" line="329"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -54,6 +54,13 @@
         <translation>Vertalingen</translation>
     </message>
     <message>
+        <location filename="../screens/AboutScreen.qml" line="267"/>
+        <source>Italiano - Andrea Bogazzi
+Español - Carlos R.
+Euskara - devilschile2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/AboutScreen.qml" line="278"/>
         <source>Full license text in COPYING.</source>
         <translation>Volledige licentietekst in COPYING.</translation>
@@ -907,13 +914,13 @@
     <name>SettingsScreen</name>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="611"/>
         <source>Language</source>
         <translation>Taal</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="627"/>
+        <location filename="../screens/SettingsScreen.qml" line="629"/>
         <source>Browsing layout</source>
         <translation>Bladerlayout</translation>
     </message>
@@ -933,19 +940,19 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="97"/>
-        <location filename="../screens/SettingsScreen.qml" line="618"/>
+        <location filename="../screens/SettingsScreen.qml" line="620"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="125"/>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="638"/>
         <source>Button style</source>
         <translation>Knopstijl</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="112"/>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
+        <location filename="../screens/SettingsScreen.qml" line="647"/>
         <source>Screensaver</source>
         <translation>Schermbeveiliging</translation>
     </message>
@@ -960,7 +967,7 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="654"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1131,72 +1138,77 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <source>Chinese (Traditional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="500"/>
         <source>Hebrew</source>
         <translation>Hebreeuws</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="500"/>
+        <location filename="../screens/SettingsScreen.qml" line="502"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="502"/>
+        <location filename="../screens/SettingsScreen.qml" line="504"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="503"/>
-        <location filename="../screens/SettingsScreen.qml" line="562"/>
+        <location filename="../screens/SettingsScreen.qml" line="505"/>
+        <location filename="../screens/SettingsScreen.qml" line="564"/>
         <source>Auto</source>
         <translation>Automatisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="508"/>
+        <location filename="../screens/SettingsScreen.qml" line="510"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="510"/>
+        <location filename="../screens/SettingsScreen.qml" line="512"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="511"/>
+        <location filename="../screens/SettingsScreen.qml" line="513"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="516"/>
+        <location filename="../screens/SettingsScreen.qml" line="518"/>
         <source>Detailed list view</source>
         <translation>Gedetailleerde lijstweergave</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="517"/>
+        <location filename="../screens/SettingsScreen.qml" line="519"/>
         <source>Grid view</source>
         <translation>Rasterweergave</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="522"/>
+        <location filename="../screens/SettingsScreen.qml" line="524"/>
         <source>Style B</source>
         <translation>Stijl B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="524"/>
+        <location filename="../screens/SettingsScreen.qml" line="526"/>
         <source>Style C</source>
         <translation>Stijl C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="526"/>
+        <location filename="../screens/SettingsScreen.qml" line="528"/>
         <source>Style D</source>
         <translation>Stijl D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="527"/>
+        <location filename="../screens/SettingsScreen.qml" line="529"/>
         <source>Style A</source>
         <translation>Stijl A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1032"/>
+        <location filename="../screens/SettingsScreen.qml" line="1034"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1206,113 +1218,113 @@
         <translation>Standaard</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="542"/>
+        <location filename="../screens/SettingsScreen.qml" line="544"/>
         <source>Off</source>
         <translation>Uit</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="544"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>1 second (testing)</source>
         <translation>1 seconde (test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="546"/>
+        <location filename="../screens/SettingsScreen.qml" line="548"/>
         <source>1 minute</source>
         <translation>1 minuut</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="548"/>
+        <location filename="../screens/SettingsScreen.qml" line="550"/>
         <source>2 minutes</source>
         <translation>2 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="550"/>
+        <location filename="../screens/SettingsScreen.qml" line="552"/>
         <source>5 minutes</source>
         <translation>5 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="552"/>
+        <location filename="../screens/SettingsScreen.qml" line="554"/>
         <source>10 minutes</source>
         <translation>10 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="554"/>
+        <location filename="../screens/SettingsScreen.qml" line="556"/>
         <source>15 minutes</source>
         <translation>15 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="556"/>
+        <location filename="../screens/SettingsScreen.qml" line="558"/>
         <source>30 minutes</source>
         <translation>30 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="557"/>
+        <location filename="../screens/SettingsScreen.qml" line="559"/>
         <source>%1 seconds</source>
         <translation>%1 seconden</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="91"/>
-        <location filename="../screens/SettingsScreen.qml" line="600"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Resolution</source>
         <translation>Resolutie</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="564"/>
+        <location filename="../screens/SettingsScreen.qml" line="566"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="566"/>
+        <location filename="../screens/SettingsScreen.qml" line="568"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="568"/>
+        <location filename="../screens/SettingsScreen.qml" line="570"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="570"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1322,7 +1334,7 @@
         <translation>Instellingen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1020"/>
+        <location filename="../screens/SettingsScreen.qml" line="1022"/>
         <source>No settings available on this platform</source>
         <translation>Geen instellingen beschikbaar op dit platform</translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -4,57 +4,57 @@
 <context>
     <name>AboutScreen</name>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="71"/>
+        <location filename="../screens/AboutScreen.qml" line="73"/>
         <source>About / License</source>
         <translation>Over / Licentie</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="153"/>
+        <location filename="../screens/AboutScreen.qml" line="155"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="164"/>
+        <location filename="../screens/AboutScreen.qml" line="166"/>
         <source>Version %1 · %2 · %3</source>
         <translation>Versie %1 · %2 · %3</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="174"/>
+        <location filename="../screens/AboutScreen.qml" line="176"/>
         <source>Built %1</source>
         <translation>Gebouwd op %1</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="185"/>
+        <location filename="../screens/AboutScreen.qml" line="187"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>Copyright 2026 Wizzo Pty Ltd en de bijdragers aan het Zaparoo-project.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="196"/>
+        <location filename="../screens/AboutScreen.qml" line="198"/>
         <source>Source available under the PolyForm Noncommercial License 1.0.0. Free for personal, non-commercial use. Commercial use requires a separate license.</source>
         <translation>Broncode beschikbaar onder de PolyForm Noncommercial License 1.0.0. Gratis voor persoonlijk, niet-commercieel gebruik. Commercieel gebruik of herdistributie vereist een aparte licentie.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="207"/>
+        <location filename="../screens/AboutScreen.qml" line="209"/>
         <source>Commercial licensing: legal@zaparoo.org</source>
         <translation>Commerciële licenties: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="218"/>
+        <location filename="../screens/AboutScreen.qml" line="220"/>
         <source>Project: https://zaparoo.org</source>
         <translation>Projectwebsite: https://zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="228"/>
+        <location filename="../screens/AboutScreen.qml" line="230"/>
         <source>Created by</source>
         <translation>Gemaakt door</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="252"/>
+        <location filename="../screens/AboutScreen.qml" line="254"/>
         <source>Translations</source>
         <translation>Vertalingen</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="276"/>
+        <location filename="../screens/AboutScreen.qml" line="278"/>
         <source>Full license text in COPYING.</source>
         <translation>Volledige licentietekst in COPYING.</translation>
     </message>
@@ -90,48 +90,102 @@
         <translation type="unfinished">Laden…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="77"/>
+        <location filename="../components/BrowseDetailPane.qml" line="138"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="79"/>
+        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <source>Yr</source>
+        <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="81"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <source>Gen</source>
+        <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="83"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <source>Plyr</source>
+        <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="85"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <source>Dev</source>
+        <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="87"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <source>Pub</source>
+        <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="89"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <source>Rtg</source>
+        <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="91"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <source>Cat</source>
+        <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="93"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <source>Date</source>
+        <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Manufacturer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <source>Mfr</source>
+        <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -176,68 +230,103 @@
 <context>
     <name>CoreStatusPill</name>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="44"/>
-        <location filename="../components/CoreStatusPill.qml" line="50"/>
+        <location filename="../components/CoreStatusPill.qml" line="46"/>
+        <location filename="../components/CoreStatusPill.qml" line="52"/>
         <source>Disconnected</source>
         <translation>Verbroken</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="47"/>
+        <location filename="../components/CoreStatusPill.qml" line="49"/>
         <source>Reconnecting…</source>
         <translation>Opnieuw verbinden…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="53"/>
+        <location filename="../components/CoreStatusPill.qml" line="55"/>
         <source>Connecting…</source>
         <translation>Verbinden…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="56"/>
+        <location filename="../components/CoreStatusPill.qml" line="58"/>
         <source>Core error</source>
         <translation>Core-fout</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="60"/>
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <source>Paused %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <source>Paused</source>
+        <translation type="unfinished">Gepauzeerd</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="78"/>
+        <source>Opt…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="78"/>
+        <source>Optimizing</source>
+        <translation type="unfinished">Optimaliseren</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
+        <source>Idx…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
+        <source>Scr…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Optimizing database</source>
-        <translation>Database optimaliseren</translation>
+        <translation type="vanished">Database optimaliseren</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="67"/>
         <source>Indexing paused</source>
-        <translation>Indexering gepauzeerd</translation>
+        <translation type="vanished">Indexering gepauzeerd</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="70"/>
         <source>Indexing %1/%2 - %3</source>
-        <translation>Indexering %1/%2 – %3</translation>
+        <translation type="vanished">Indexering %1/%2 – %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="86"/>
         <source>Scraping %1/%2 - %3</source>
-        <translation>Scraping %1/%2 – %3</translation>
+        <translation type="vanished">Scraping %1/%2 – %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="73"/>
+        <location filename="../components/CoreStatusPill.qml" line="82"/>
         <source>Indexing %1/%2</source>
         <translation>Indexering %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <location filename="../components/CoreStatusPill.qml" line="82"/>
+        <source>Idx %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Indexing…</source>
         <translation>Indexering…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Scrape paused</source>
-        <translation>Scraping gepauzeerd</translation>
+        <translation type="vanished">Scraping gepauzeerd</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="89"/>
+        <location filename="../components/CoreStatusPill.qml" line="88"/>
         <source>Scraping %1/%2</source>
         <translation>Scrapen %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="91"/>
+        <location filename="../components/CoreStatusPill.qml" line="88"/>
+        <source>Scr %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
         <source>Scraping…</source>
         <translation>Bezig met scrapen…</translation>
     </message>
@@ -329,34 +418,34 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="117"/>
-        <location filename="../screens/GamesScreen.qml" line="145"/>
+        <location filename="../screens/GamesScreen.qml" line="122"/>
+        <location filename="../screens/GamesScreen.qml" line="157"/>
         <source>%1 files</source>
         <translation>%1 bestanden</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="51"/>
+        <location filename="../screens/GamesScreen.qml" line="55"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="126"/>
-        <location filename="../screens/GamesScreen.qml" line="146"/>
+        <location filename="../screens/GamesScreen.qml" line="131"/>
+        <location filename="../screens/GamesScreen.qml" line="158"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="45"/>
+        <location filename="../screens/GamesScreen.qml" line="49"/>
         <source>Loading games…</source>
         <translation>Games laden…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="122"/>
+        <location filename="../screens/GamesScreen.qml" line="127"/>
         <source>Loading more…</source>
         <translation>Meer laden…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="44"/>
+        <location filename="../screens/GamesScreen.qml" line="48"/>
         <source>No games in this system</source>
         <translation>Geen games in dit systeem</translation>
     </message>
@@ -364,32 +453,47 @@
 <context>
     <name>HubScreen</name>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
-        <source>Resume: %1</source>
+        <location filename="../screens/HubScreen.qml" line="56"/>
+        <source>Arcade</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
-        <source>Resume Game</source>
+        <location filename="../screens/HubScreen.qml" line="61"/>
+        <source>Computers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
+        <location filename="../screens/HubScreen.qml" line="66"/>
+        <source>Consoles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="71"/>
+        <source>Handhelds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="134"/>
+        <source>Resume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="140"/>
         <source>Favorites</source>
         <translation>Favorieten</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="96"/>
+        <location filename="../screens/HubScreen.qml" line="145"/>
         <source>Recently Played</source>
         <translation>Recent gespeeld</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="101"/>
+        <location filename="../screens/HubScreen.qml" line="150"/>
         <source>Settings</source>
         <translation>Instellingen</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="537"/>
+        <location filename="../screens/HubScreen.qml" line="644"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Geen systemen beschikbaar. Voer Database bijwerken uit via Instellingen.</translation>
     </message>
@@ -438,104 +542,124 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="755"/>
+        <location filename="../app/Main.qml" line="1206"/>
         <source>Launch core</source>
         <translation>Core starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="958"/>
+        <location filename="../app/Main.qml" line="1212"/>
+        <location filename="../app/Main.qml" line="1420"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="786"/>
+        <location filename="../app/Main.qml" line="1247"/>
         <source>Remove from favorites</source>
         <translation>Uit favorieten verwijderen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="786"/>
+        <location filename="../app/Main.qml" line="1247"/>
         <source>Add to favorites</source>
         <translation>Aan favorieten toevoegen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="791"/>
+        <location filename="../app/Main.qml" line="1252"/>
         <source>Write to NFC token</source>
         <translation>Naar NFC-token schrijven</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="795"/>
+        <location filename="../app/Main.qml" line="1256"/>
         <source>QR code</source>
         <translation>QR-code</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="770"/>
-        <location filename="../app/Main.qml" line="805"/>
+        <location filename="../app/Main.qml" line="1231"/>
+        <location filename="../app/Main.qml" line="1266"/>
         <source>Launch game</source>
         <translation>Game starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1776"/>
+        <location filename="../app/Main.qml" line="2368"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1780"/>
+        <location filename="../app/Main.qml" line="2374"/>
         <source>Loading favorites…</source>
         <translation>Favorieten laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1778"/>
+        <location filename="../app/Main.qml" line="2370"/>
         <source>Loading games…</source>
         <translation>Games laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="954"/>
+        <location filename="../app/Main.qml" line="1219"/>
+        <source>Update media database</source>
+        <translation type="unfinished">Mediadatabase bijwerken</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1222"/>
+        <source>Scrape metadata</source>
+        <translation type="unfinished">Metadata ophalen</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1416"/>
         <source>Default</source>
         <translation type="unfinished">Standaard</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="954"/>
+        <location filename="../app/Main.qml" line="1416"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1230"/>
+        <location filename="../app/Main.qml" line="1708"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1234"/>
+        <location filename="../app/Main.qml" line="1712"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1248"/>
+        <location filename="../app/Main.qml" line="1726"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1252"/>
+        <location filename="../app/Main.qml" line="1730"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1256"/>
+        <location filename="../app/Main.qml" line="1734"/>
         <source>Retry</source>
         <translation type="unfinished">Opnieuw proberen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1260"/>
+        <location filename="../app/Main.qml" line="1738"/>
         <source>Cancel</source>
         <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1782"/>
+        <location filename="../app/Main.qml" line="2372"/>
+        <source>Loading game…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2376"/>
         <source>Loading recently played…</source>
         <translation>Recent gespeeld laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="2378"/>
+        <source>Loading settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2380"/>
         <source>Loading…</source>
         <translation>Laden…</translation>
     </message>
@@ -543,161 +667,161 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="581"/>
+        <location filename="../app/MainLayout.qml" line="680"/>
         <source>Writing failed</source>
         <translation>Schrijven mislukt</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="581"/>
+        <location filename="../app/MainLayout.qml" line="680"/>
         <source>Put a writable card near the reader</source>
         <translation>Houd een beschrijfbare kaart bij de lezer</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="669"/>
+        <location filename="../app/MainLayout.qml" line="807"/>
         <source>Are you sure you want to exit?</source>
         <translation>Weet u zeker dat u wilt afsluiten?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="745"/>
-        <location filename="../app/MainLayout.qml" line="817"/>
+        <location filename="../app/MainLayout.qml" line="890"/>
+        <location filename="../app/MainLayout.qml" line="964"/>
         <source>Select</source>
         <translation>Selecteren</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="749"/>
-        <location filename="../app/MainLayout.qml" line="753"/>
-        <location filename="../app/MainLayout.qml" line="767"/>
-        <location filename="../app/MainLayout.qml" line="780"/>
-        <location filename="../app/MainLayout.qml" line="791"/>
+        <location filename="../app/MainLayout.qml" line="894"/>
+        <location filename="../app/MainLayout.qml" line="898"/>
+        <location filename="../app/MainLayout.qml" line="912"/>
+        <location filename="../app/MainLayout.qml" line="927"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
         <source>Close</source>
         <translation>Sluiten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="760"/>
-        <location filename="../app/MainLayout.qml" line="798"/>
-        <location filename="../app/MainLayout.qml" line="821"/>
-        <location filename="../app/MainLayout.qml" line="832"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
+        <location filename="../app/MainLayout.qml" line="945"/>
+        <location filename="../app/MainLayout.qml" line="968"/>
+        <location filename="../app/MainLayout.qml" line="979"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="776"/>
+        <location filename="../app/MainLayout.qml" line="923"/>
         <source>Done</source>
         <translation>Klaar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="806"/>
+        <location filename="../app/MainLayout.qml" line="953"/>
         <source>I understand</source>
         <translation>Ik begrijp het</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="840"/>
+        <location filename="../app/MainLayout.qml" line="987"/>
         <source>Start</source>
         <translation>Starten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1009"/>
+        <location filename="../app/MainLayout.qml" line="1165"/>
         <source>Scroll</source>
         <translation>Scrollen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="741"/>
-        <location filename="../app/MainLayout.qml" line="813"/>
-        <location filename="../app/MainLayout.qml" line="856"/>
-        <location filename="../app/MainLayout.qml" line="885"/>
-        <location filename="../app/MainLayout.qml" line="932"/>
-        <location filename="../app/MainLayout.qml" line="973"/>
-        <location filename="../app/MainLayout.qml" line="1037"/>
+        <location filename="../app/MainLayout.qml" line="886"/>
+        <location filename="../app/MainLayout.qml" line="960"/>
+        <location filename="../app/MainLayout.qml" line="1003"/>
+        <location filename="../app/MainLayout.qml" line="1034"/>
+        <location filename="../app/MainLayout.qml" line="1084"/>
+        <location filename="../app/MainLayout.qml" line="1127"/>
+        <location filename="../app/MainLayout.qml" line="1195"/>
         <source>Move</source>
         <translation>Bewegen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="141"/>
+        <location filename="../app/MainLayout.qml" line="170"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="323"/>
+        <location filename="../app/MainLayout.qml" line="364"/>
         <source>Favorites</source>
         <translation type="unfinished">Favorieten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="325"/>
+        <location filename="../app/MainLayout.qml" line="366"/>
         <source>Recently Played</source>
         <translation type="unfinished">Recent gespeeld</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="592"/>
+        <location filename="../app/MainLayout.qml" line="695"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="593"/>
+        <location filename="../app/MainLayout.qml" line="696"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="668"/>
+        <location filename="../app/MainLayout.qml" line="806"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="860"/>
-        <location filename="../app/MainLayout.qml" line="895"/>
-        <location filename="../app/MainLayout.qml" line="942"/>
-        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1007"/>
+        <location filename="../app/MainLayout.qml" line="1044"/>
+        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Open</source>
         <translation>Openen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="864"/>
+        <location filename="../app/MainLayout.qml" line="1011"/>
         <source>Quit</source>
         <translation>Afsluiten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="873"/>
-        <location filename="../app/MainLayout.qml" line="901"/>
-        <location filename="../app/MainLayout.qml" line="912"/>
-        <location filename="../app/MainLayout.qml" line="924"/>
-        <location filename="../app/MainLayout.qml" line="951"/>
-        <location filename="../app/MainLayout.qml" line="962"/>
-        <location filename="../app/MainLayout.qml" line="997"/>
-        <location filename="../app/MainLayout.qml" line="1013"/>
-        <location filename="../app/MainLayout.qml" line="1022"/>
-        <location filename="../app/MainLayout.qml" line="1056"/>
-        <location filename="../app/MainLayout.qml" line="1067"/>
+        <location filename="../app/MainLayout.qml" line="1020"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1061"/>
+        <location filename="../app/MainLayout.qml" line="1076"/>
+        <location filename="../app/MainLayout.qml" line="1103"/>
+        <location filename="../app/MainLayout.qml" line="1114"/>
+        <location filename="../app/MainLayout.qml" line="1151"/>
+        <location filename="../app/MainLayout.qml" line="1169"/>
+        <location filename="../app/MainLayout.qml" line="1178"/>
+        <location filename="../app/MainLayout.qml" line="1214"/>
+        <location filename="../app/MainLayout.qml" line="1225"/>
         <source>Back</source>
         <translation>Terug</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="891"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1043"/>
+        <location filename="../app/MainLayout.qml" line="1040"/>
+        <location filename="../app/MainLayout.qml" line="1090"/>
+        <location filename="../app/MainLayout.qml" line="1201"/>
         <source>Page</source>
         <translation>Pagina</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="947"/>
-        <location filename="../app/MainLayout.qml" line="1052"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1210"/>
         <source>Options</source>
         <translation>Opties</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="787"/>
-        <location filename="../app/MainLayout.qml" line="908"/>
-        <location filename="../app/MainLayout.qml" line="958"/>
-        <location filename="../app/MainLayout.qml" line="1063"/>
+        <location filename="../app/MainLayout.qml" line="934"/>
+        <location filename="../app/MainLayout.qml" line="1057"/>
+        <location filename="../app/MainLayout.qml" line="1110"/>
+        <location filename="../app/MainLayout.qml" line="1221"/>
         <source>Retry</source>
         <translation>Opnieuw proberen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="982"/>
+        <location filename="../app/MainLayout.qml" line="1136"/>
         <source>Change</source>
         <translation>Wijzigen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="988"/>
+        <location filename="../app/MainLayout.qml" line="1142"/>
         <source>Toggle</source>
         <translation>Schakelen</translation>
     </message>
@@ -710,12 +834,12 @@
         <translation type="unfinished">Laden…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="306"/>
+        <location filename="../screens/MediaListScreen.qml" line="351"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 items</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="307"/>
+        <location filename="../screens/MediaListScreen.qml" line="352"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -764,17 +888,17 @@
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="26"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
         <source>Nothing here</source>
         <translation>Niets hier</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="28"/>
         <source>Loading…</source>
         <translation>Laden…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="57"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="58"/>
         <source>Failed to load</source>
         <translation>Laden mislukt</translation>
     </message>
@@ -782,387 +906,423 @@
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="73"/>
-        <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
         <source>Language</source>
         <translation>Taal</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="516"/>
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Browsing layout</source>
         <translation>Bladerlayout</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="130"/>
         <source>Mouse support</source>
         <translation>Muisondersteuning</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="112"/>
+        <location filename="../screens/SettingsScreen.qml" line="137"/>
         <source>Update media database</source>
         <translation>Mediadatabase bijwerken</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="61"/>
         <source>General</source>
-        <translation>Algemeen</translation>
+        <translation type="vanished">Algemeen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78"/>
-        <location filename="../screens/SettingsScreen.qml" line="507"/>
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <location filename="../screens/SettingsScreen.qml" line="618"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88"/>
-        <location filename="../screens/SettingsScreen.qml" line="525"/>
+        <location filename="../screens/SettingsScreen.qml" line="125"/>
+        <location filename="../screens/SettingsScreen.qml" line="636"/>
         <source>Button style</source>
         <translation>Knopstijl</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="93"/>
-        <location filename="../screens/SettingsScreen.qml" line="534"/>
+        <location filename="../screens/SettingsScreen.qml" line="112"/>
+        <location filename="../screens/SettingsScreen.qml" line="645"/>
         <source>Screensaver</source>
         <translation>Schermbeveiliging</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97"/>
         <source>Library</source>
-        <translation>Bibliotheek</translation>
+        <translation type="vanished">Bibliotheek</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="142"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="543"/>
+        <location filename="../screens/SettingsScreen.qml" line="654"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
         <source>Scrape metadata</source>
         <translation>Metadata ophalen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Advanced</source>
-        <translation>Geavanceerd</translation>
+        <translation type="vanished">Geavanceerd</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="136"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
         <source>Debug logging</source>
         <translation>Debug-logging</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="141"/>
+        <location filename="../screens/SettingsScreen.qml" line="169"/>
         <source>Upload log file</source>
         <translation>Logbestand uploaden</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="146"/>
+        <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>About / License</source>
         <translation>Over / Licentie</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="162"/>
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
+        <source>Display &amp; Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="72"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <source>Controls &amp; Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="189"/>
+        <source>Library &amp; Data Management</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="82"/>
+        <location filename="../screens/SettingsScreen.qml" line="191"/>
+        <source>Support &amp; About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="206"/>
         <source>Optimizing</source>
         <translation>Optimaliseren</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
-        <location filename="../screens/SettingsScreen.qml" line="173"/>
+        <location filename="../screens/SettingsScreen.qml" line="208"/>
+        <location filename="../screens/SettingsScreen.qml" line="217"/>
         <source>Paused</source>
         <translation>Gepauzeerd</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
-        <location filename="../screens/SettingsScreen.qml" line="173"/>
+        <location filename="../screens/SettingsScreen.qml" line="208"/>
+        <location filename="../screens/SettingsScreen.qml" line="217"/>
         <source>In progress</source>
         <translation>Bezig</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="167"/>
+        <location filename="../screens/SettingsScreen.qml" line="211"/>
         <source>%1 indexed</source>
         <translation>%1 geïndexeerd</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="176"/>
+        <location filename="../screens/SettingsScreen.qml" line="220"/>
         <source>%1 scraped</source>
         <translation>%1 opgehaald</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="284"/>
+        <location filename="../screens/SettingsScreen.qml" line="393"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="284"/>
+        <location filename="../screens/SettingsScreen.qml" line="393"/>
         <source>Start</source>
         <translation>Starten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="286"/>
+        <location filename="../screens/SettingsScreen.qml" line="395"/>
         <source>Upload</source>
         <translation>Uploaden</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="288"/>
+        <location filename="../screens/SettingsScreen.qml" line="396"/>
         <source>Open</source>
         <translation>Openen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="365"/>
+        <location filename="../screens/SettingsScreen.qml" line="472"/>
         <source>English</source>
         <translation>Engels</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="367"/>
+        <location filename="../screens/SettingsScreen.qml" line="474"/>
         <source>Italian</source>
         <translation>Italiaans</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="476"/>
+        <source>Spanish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="478"/>
+        <source>Basque</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="480"/>
         <source>German</source>
         <translation>Duits</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
+        <location filename="../screens/SettingsScreen.qml" line="482"/>
         <source>Greek</source>
         <translation>Grieks</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="373"/>
+        <location filename="../screens/SettingsScreen.qml" line="484"/>
         <source>Japanese</source>
         <translation>Japans</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="375"/>
+        <location filename="../screens/SettingsScreen.qml" line="486"/>
         <source>Korean</source>
         <translation>Koreaans</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Dutch</source>
         <translation>Nederlands</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="379"/>
+        <location filename="../screens/SettingsScreen.qml" line="490"/>
         <source>Romanian</source>
         <translation>Roemeens</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="381"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Slovak</source>
         <translation>Slowaaks</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="383"/>
+        <location filename="../screens/SettingsScreen.qml" line="494"/>
         <source>Ukrainian</source>
         <translation>Oekraïens</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="385"/>
+        <location filename="../screens/SettingsScreen.qml" line="496"/>
         <source>Chinese (Simplified)</source>
         <translation>Chinees (vereenvoudigd)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="387"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Hebrew</source>
         <translation>Hebreeuws</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="389"/>
+        <location filename="../screens/SettingsScreen.qml" line="500"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="391"/>
+        <location filename="../screens/SettingsScreen.qml" line="502"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="392"/>
-        <location filename="../screens/SettingsScreen.qml" line="451"/>
+        <location filename="../screens/SettingsScreen.qml" line="503"/>
+        <location filename="../screens/SettingsScreen.qml" line="562"/>
         <source>Auto</source>
         <translation>Automatisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <location filename="../screens/SettingsScreen.qml" line="508"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <location filename="../screens/SettingsScreen.qml" line="510"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="400"/>
+        <location filename="../screens/SettingsScreen.qml" line="511"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405"/>
+        <location filename="../screens/SettingsScreen.qml" line="516"/>
         <source>Detailed list view</source>
         <translation>Gedetailleerde lijstweergave</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="406"/>
+        <location filename="../screens/SettingsScreen.qml" line="517"/>
         <source>Grid view</source>
         <translation>Rasterweergave</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="411"/>
+        <location filename="../screens/SettingsScreen.qml" line="522"/>
         <source>Style B</source>
         <translation>Stijl B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="413"/>
+        <location filename="../screens/SettingsScreen.qml" line="524"/>
         <source>Style C</source>
         <translation>Stijl C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="415"/>
+        <location filename="../screens/SettingsScreen.qml" line="526"/>
         <source>Style D</source>
         <translation>Stijl D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="416"/>
+        <location filename="../screens/SettingsScreen.qml" line="527"/>
         <source>Style A</source>
         <translation>Stijl A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="340"/>
+        <location filename="../screens/SettingsScreen.qml" line="1032"/>
+        <source>Loading settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="447"/>
         <source>Default</source>
         <translation>Standaard</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="431"/>
+        <location filename="../screens/SettingsScreen.qml" line="542"/>
         <source>Off</source>
         <translation>Uit</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="433"/>
+        <location filename="../screens/SettingsScreen.qml" line="544"/>
         <source>1 second (testing)</source>
         <translation>1 seconde (test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="435"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>1 minute</source>
         <translation>1 minuut</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="437"/>
+        <location filename="../screens/SettingsScreen.qml" line="548"/>
         <source>2 minutes</source>
         <translation>2 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="439"/>
+        <location filename="../screens/SettingsScreen.qml" line="550"/>
         <source>5 minutes</source>
         <translation>5 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="441"/>
+        <location filename="../screens/SettingsScreen.qml" line="552"/>
         <source>10 minutes</source>
         <translation>10 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="443"/>
+        <location filename="../screens/SettingsScreen.qml" line="554"/>
         <source>15 minutes</source>
         <translation>15 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="445"/>
+        <location filename="../screens/SettingsScreen.qml" line="556"/>
         <source>30 minutes</source>
         <translation>30 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="446"/>
+        <location filename="../screens/SettingsScreen.qml" line="557"/>
         <source>%1 seconds</source>
         <translation>%1 seconden</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="489"/>
+        <location filename="../screens/SettingsScreen.qml" line="91"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Resolution</source>
         <translation>Resolutie</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="453"/>
+        <location filename="../screens/SettingsScreen.qml" line="564"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="455"/>
+        <location filename="../screens/SettingsScreen.qml" line="566"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="457"/>
+        <location filename="../screens/SettingsScreen.qml" line="568"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <location filename="../screens/SettingsScreen.qml" line="570"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="461"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="463"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="465"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="467"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="469"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="471"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="473"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="663"/>
+        <location filename="../screens/SettingsScreen.qml" line="192"/>
         <source>Settings</source>
         <translation>Instellingen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="857"/>
+        <location filename="../screens/SettingsScreen.qml" line="1020"/>
         <source>No settings available on this platform</source>
         <translation>Geen instellingen beschikbaar op dit platform</translation>
     </message>
@@ -1170,24 +1330,24 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="195"/>
-        <location filename="../screens/SystemsScreen.qml" line="292"/>
+        <location filename="../screens/SystemsScreen.qml" line="197"/>
+        <location filename="../screens/SystemsScreen.qml" line="295"/>
         <source>%1 systems</source>
         <translation>%1 systemen</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="196"/>
-        <location filename="../screens/SystemsScreen.qml" line="309"/>
+        <location filename="../screens/SystemsScreen.qml" line="198"/>
+        <location filename="../screens/SystemsScreen.qml" line="312"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="324"/>
+        <location filename="../screens/SystemsScreen.qml" line="328"/>
         <source>No systems in this category</source>
         <translation>Geen systemen in deze categorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="325"/>
+        <location filename="../screens/SystemsScreen.qml" line="329"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -54,6 +54,13 @@
         <translation>Traduceri</translation>
     </message>
     <message>
+        <location filename="../screens/AboutScreen.qml" line="267"/>
+        <source>Italiano - Andrea Bogazzi
+Español - Carlos R.
+Euskara - devilschile2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/AboutScreen.qml" line="278"/>
         <source>Full license text in COPYING.</source>
         <translation>Textul complet al licenței se găsește în COPYING.</translation>
@@ -907,13 +914,13 @@
     <name>SettingsScreen</name>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="611"/>
         <source>Language</source>
         <translation>Limbă</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="627"/>
+        <location filename="../screens/SettingsScreen.qml" line="629"/>
         <source>Browsing layout</source>
         <translation>Aspect navigare</translation>
     </message>
@@ -933,19 +940,19 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="97"/>
-        <location filename="../screens/SettingsScreen.qml" line="618"/>
+        <location filename="../screens/SettingsScreen.qml" line="620"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="125"/>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="638"/>
         <source>Button style</source>
         <translation>Stil butoane</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="112"/>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
+        <location filename="../screens/SettingsScreen.qml" line="647"/>
         <source>Screensaver</source>
         <translation>Economizor de ecran</translation>
     </message>
@@ -960,7 +967,7 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="654"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1131,72 +1138,77 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <source>Chinese (Traditional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="500"/>
         <source>Hebrew</source>
         <translation>Ebraică</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="500"/>
+        <location filename="../screens/SettingsScreen.qml" line="502"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="502"/>
+        <location filename="../screens/SettingsScreen.qml" line="504"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="503"/>
-        <location filename="../screens/SettingsScreen.qml" line="562"/>
+        <location filename="../screens/SettingsScreen.qml" line="505"/>
+        <location filename="../screens/SettingsScreen.qml" line="564"/>
         <source>Auto</source>
         <translation>Automat</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="508"/>
+        <location filename="../screens/SettingsScreen.qml" line="510"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="510"/>
+        <location filename="../screens/SettingsScreen.qml" line="512"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="511"/>
+        <location filename="../screens/SettingsScreen.qml" line="513"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="516"/>
+        <location filename="../screens/SettingsScreen.qml" line="518"/>
         <source>Detailed list view</source>
         <translation>Vizualizare listă detaliată</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="517"/>
+        <location filename="../screens/SettingsScreen.qml" line="519"/>
         <source>Grid view</source>
         <translation>Vizualizare grilă</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="522"/>
+        <location filename="../screens/SettingsScreen.qml" line="524"/>
         <source>Style B</source>
         <translation>Stil B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="524"/>
+        <location filename="../screens/SettingsScreen.qml" line="526"/>
         <source>Style C</source>
         <translation>Stil C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="526"/>
+        <location filename="../screens/SettingsScreen.qml" line="528"/>
         <source>Style D</source>
         <translation>Stil D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="527"/>
+        <location filename="../screens/SettingsScreen.qml" line="529"/>
         <source>Style A</source>
         <translation>Stil A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1032"/>
+        <location filename="../screens/SettingsScreen.qml" line="1034"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1206,113 +1218,113 @@
         <translation>Implicit</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="542"/>
+        <location filename="../screens/SettingsScreen.qml" line="544"/>
         <source>Off</source>
         <translation>Dezactivat</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="544"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>1 second (testing)</source>
         <translation>1 secundă (test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="546"/>
+        <location filename="../screens/SettingsScreen.qml" line="548"/>
         <source>1 minute</source>
         <translation>1 minut</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="548"/>
+        <location filename="../screens/SettingsScreen.qml" line="550"/>
         <source>2 minutes</source>
         <translation>2 minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="550"/>
+        <location filename="../screens/SettingsScreen.qml" line="552"/>
         <source>5 minutes</source>
         <translation>5 minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="552"/>
+        <location filename="../screens/SettingsScreen.qml" line="554"/>
         <source>10 minutes</source>
         <translation>10 minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="554"/>
+        <location filename="../screens/SettingsScreen.qml" line="556"/>
         <source>15 minutes</source>
         <translation>15 minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="556"/>
+        <location filename="../screens/SettingsScreen.qml" line="558"/>
         <source>30 minutes</source>
         <translation>30 de minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="557"/>
+        <location filename="../screens/SettingsScreen.qml" line="559"/>
         <source>%1 seconds</source>
         <translation>%1 secunde</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="91"/>
-        <location filename="../screens/SettingsScreen.qml" line="600"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Resolution</source>
         <translation>Rezoluție</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="564"/>
+        <location filename="../screens/SettingsScreen.qml" line="566"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="566"/>
+        <location filename="../screens/SettingsScreen.qml" line="568"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="568"/>
+        <location filename="../screens/SettingsScreen.qml" line="570"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="570"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1322,7 +1334,7 @@
         <translation>Setări</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1020"/>
+        <location filename="../screens/SettingsScreen.qml" line="1022"/>
         <source>No settings available on this platform</source>
         <translation>Nicio setare disponibilă pe această platformă</translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -4,57 +4,57 @@
 <context>
     <name>AboutScreen</name>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="71"/>
+        <location filename="../screens/AboutScreen.qml" line="73"/>
         <source>About / License</source>
         <translation>Despre / Licență</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="153"/>
+        <location filename="../screens/AboutScreen.qml" line="155"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="164"/>
+        <location filename="../screens/AboutScreen.qml" line="166"/>
         <source>Version %1 · %2 · %3</source>
         <translation>Versiune %1 · %2 · %3</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="174"/>
+        <location filename="../screens/AboutScreen.qml" line="176"/>
         <source>Built %1</source>
         <translation>Compilat %1</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="185"/>
+        <location filename="../screens/AboutScreen.qml" line="187"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>Copyright 2026 Wizzo Pty Ltd și colaboratorii proiectului Zaparoo.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="196"/>
+        <location filename="../screens/AboutScreen.qml" line="198"/>
         <source>Source available under the PolyForm Noncommercial License 1.0.0. Free for personal, non-commercial use. Commercial use requires a separate license.</source>
         <translation>Sursa este disponibilă sub licența PolyForm Noncommercial License 1.0.0. Gratuit pentru uz personal, necomercial. Utilizarea comercială necesită o licență separată.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="207"/>
+        <location filename="../screens/AboutScreen.qml" line="209"/>
         <source>Commercial licensing: legal@zaparoo.org</source>
         <translation>Licențiere comercială: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="218"/>
+        <location filename="../screens/AboutScreen.qml" line="220"/>
         <source>Project: https://zaparoo.org</source>
         <translation>Proiect: https://zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="228"/>
+        <location filename="../screens/AboutScreen.qml" line="230"/>
         <source>Created by</source>
         <translation>Creat de</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="252"/>
+        <location filename="../screens/AboutScreen.qml" line="254"/>
         <source>Translations</source>
         <translation>Traduceri</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="276"/>
+        <location filename="../screens/AboutScreen.qml" line="278"/>
         <source>Full license text in COPYING.</source>
         <translation>Textul complet al licenței se găsește în COPYING.</translation>
     </message>
@@ -90,48 +90,102 @@
         <translation type="unfinished">Se încarcă…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="77"/>
+        <location filename="../components/BrowseDetailPane.qml" line="138"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="79"/>
+        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <source>Yr</source>
+        <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="81"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <source>Gen</source>
+        <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="83"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <source>Plyr</source>
+        <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="85"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <source>Dev</source>
+        <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="87"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <source>Pub</source>
+        <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="89"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <source>Rtg</source>
+        <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="91"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <source>Cat</source>
+        <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="93"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <source>Date</source>
+        <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Manufacturer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <source>Mfr</source>
+        <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -176,68 +230,103 @@
 <context>
     <name>CoreStatusPill</name>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="44"/>
-        <location filename="../components/CoreStatusPill.qml" line="50"/>
+        <location filename="../components/CoreStatusPill.qml" line="46"/>
+        <location filename="../components/CoreStatusPill.qml" line="52"/>
         <source>Disconnected</source>
         <translation>Deconectat</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="47"/>
+        <location filename="../components/CoreStatusPill.qml" line="49"/>
         <source>Reconnecting…</source>
         <translation>Reconectare…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="53"/>
+        <location filename="../components/CoreStatusPill.qml" line="55"/>
         <source>Connecting…</source>
         <translation>Conectare…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="56"/>
+        <location filename="../components/CoreStatusPill.qml" line="58"/>
         <source>Core error</source>
         <translation>Eroare Core</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="60"/>
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <source>Paused %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <source>Paused</source>
+        <translation type="unfinished">În pauză</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="78"/>
+        <source>Opt…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="78"/>
+        <source>Optimizing</source>
+        <translation type="unfinished">Optimizare</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
+        <source>Idx…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
+        <source>Scr…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Optimizing database</source>
-        <translation>Optimizare bază de date</translation>
+        <translation type="vanished">Optimizare bază de date</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="67"/>
         <source>Indexing paused</source>
-        <translation>Indexare în pauză</translation>
+        <translation type="vanished">Indexare în pauză</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="70"/>
         <source>Indexing %1/%2 - %3</source>
-        <translation>Indexare %1/%2 – %3</translation>
+        <translation type="vanished">Indexare %1/%2 – %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="86"/>
         <source>Scraping %1/%2 - %3</source>
-        <translation>Scraping %1/%2 – %3</translation>
+        <translation type="vanished">Scraping %1/%2 – %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="73"/>
+        <location filename="../components/CoreStatusPill.qml" line="82"/>
         <source>Indexing %1/%2</source>
         <translation>Indexare %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <location filename="../components/CoreStatusPill.qml" line="82"/>
+        <source>Idx %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Indexing…</source>
         <translation>Indexare…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Scrape paused</source>
-        <translation>Scraping în pauză</translation>
+        <translation type="vanished">Scraping în pauză</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="89"/>
+        <location filename="../components/CoreStatusPill.qml" line="88"/>
         <source>Scraping %1/%2</source>
         <translation>Preluare %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="91"/>
+        <location filename="../components/CoreStatusPill.qml" line="88"/>
+        <source>Scr %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
         <source>Scraping…</source>
         <translation>Se preiau datele…</translation>
     </message>
@@ -329,34 +418,34 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="117"/>
-        <location filename="../screens/GamesScreen.qml" line="145"/>
+        <location filename="../screens/GamesScreen.qml" line="122"/>
+        <location filename="../screens/GamesScreen.qml" line="157"/>
         <source>%1 files</source>
         <translation>%1 fișiere</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="51"/>
+        <location filename="../screens/GamesScreen.qml" line="55"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="126"/>
-        <location filename="../screens/GamesScreen.qml" line="146"/>
+        <location filename="../screens/GamesScreen.qml" line="131"/>
+        <location filename="../screens/GamesScreen.qml" line="158"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="45"/>
+        <location filename="../screens/GamesScreen.qml" line="49"/>
         <source>Loading games…</source>
         <translation>Se încarcă jocurile…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="122"/>
+        <location filename="../screens/GamesScreen.qml" line="127"/>
         <source>Loading more…</source>
         <translation>Se încarcă mai multe…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="44"/>
+        <location filename="../screens/GamesScreen.qml" line="48"/>
         <source>No games in this system</source>
         <translation>Niciun joc în acest sistem</translation>
     </message>
@@ -364,32 +453,47 @@
 <context>
     <name>HubScreen</name>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
-        <source>Resume: %1</source>
+        <location filename="../screens/HubScreen.qml" line="56"/>
+        <source>Arcade</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
-        <source>Resume Game</source>
+        <location filename="../screens/HubScreen.qml" line="61"/>
+        <source>Computers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
+        <location filename="../screens/HubScreen.qml" line="66"/>
+        <source>Consoles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="71"/>
+        <source>Handhelds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="134"/>
+        <source>Resume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="140"/>
         <source>Favorites</source>
         <translation>Favorite</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="96"/>
+        <location filename="../screens/HubScreen.qml" line="145"/>
         <source>Recently Played</source>
         <translation>Recent Jucate</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="101"/>
+        <location filename="../screens/HubScreen.qml" line="150"/>
         <source>Settings</source>
         <translation>Setări</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="537"/>
+        <location filename="../screens/HubScreen.qml" line="644"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Niciun sistem disponibil. Rulați Actualizare bază de date din Setări.</translation>
     </message>
@@ -438,104 +542,124 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="755"/>
+        <location filename="../app/Main.qml" line="1206"/>
         <source>Launch core</source>
         <translation>Lansare core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="958"/>
+        <location filename="../app/Main.qml" line="1212"/>
+        <location filename="../app/Main.qml" line="1420"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="786"/>
+        <location filename="../app/Main.qml" line="1247"/>
         <source>Remove from favorites</source>
         <translation>Elimină din favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="786"/>
+        <location filename="../app/Main.qml" line="1247"/>
         <source>Add to favorites</source>
         <translation>Adaugă la favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="791"/>
+        <location filename="../app/Main.qml" line="1252"/>
         <source>Write to NFC token</source>
         <translation>Scriere pe token NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="795"/>
+        <location filename="../app/Main.qml" line="1256"/>
         <source>QR code</source>
         <translation>Cod QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="770"/>
-        <location filename="../app/Main.qml" line="805"/>
+        <location filename="../app/Main.qml" line="1231"/>
+        <location filename="../app/Main.qml" line="1266"/>
         <source>Launch game</source>
         <translation>Lansare joc</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1776"/>
+        <location filename="../app/Main.qml" line="2368"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1780"/>
+        <location filename="../app/Main.qml" line="2374"/>
         <source>Loading favorites…</source>
         <translation>Se încarcă favoritele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1778"/>
+        <location filename="../app/Main.qml" line="2370"/>
         <source>Loading games…</source>
         <translation>Se încarcă jocurile…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="954"/>
+        <location filename="../app/Main.qml" line="1219"/>
+        <source>Update media database</source>
+        <translation type="unfinished">Actualizare bază de date media</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1222"/>
+        <source>Scrape metadata</source>
+        <translation type="unfinished">Extragere metadate</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1416"/>
         <source>Default</source>
         <translation type="unfinished">Implicit</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="954"/>
+        <location filename="../app/Main.qml" line="1416"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1230"/>
+        <location filename="../app/Main.qml" line="1708"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1234"/>
+        <location filename="../app/Main.qml" line="1712"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1248"/>
+        <location filename="../app/Main.qml" line="1726"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1252"/>
+        <location filename="../app/Main.qml" line="1730"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1256"/>
+        <location filename="../app/Main.qml" line="1734"/>
         <source>Retry</source>
         <translation type="unfinished">Reîncercare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1260"/>
+        <location filename="../app/Main.qml" line="1738"/>
         <source>Cancel</source>
         <translation type="unfinished">Anulare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1782"/>
+        <location filename="../app/Main.qml" line="2372"/>
+        <source>Loading game…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2376"/>
         <source>Loading recently played…</source>
         <translation>Se încarcă recent jucatele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="2378"/>
+        <source>Loading settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2380"/>
         <source>Loading…</source>
         <translation>Se încarcă…</translation>
     </message>
@@ -543,161 +667,161 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="581"/>
+        <location filename="../app/MainLayout.qml" line="680"/>
         <source>Writing failed</source>
         <translation>Scriere eșuată</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="581"/>
+        <location filename="../app/MainLayout.qml" line="680"/>
         <source>Put a writable card near the reader</source>
         <translation>Apropiați un card inscriptibil de cititor</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="669"/>
+        <location filename="../app/MainLayout.qml" line="807"/>
         <source>Are you sure you want to exit?</source>
         <translation>Sigur doriți să ieșiți?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="745"/>
-        <location filename="../app/MainLayout.qml" line="817"/>
+        <location filename="../app/MainLayout.qml" line="890"/>
+        <location filename="../app/MainLayout.qml" line="964"/>
         <source>Select</source>
         <translation>Selectare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="749"/>
-        <location filename="../app/MainLayout.qml" line="753"/>
-        <location filename="../app/MainLayout.qml" line="767"/>
-        <location filename="../app/MainLayout.qml" line="780"/>
-        <location filename="../app/MainLayout.qml" line="791"/>
+        <location filename="../app/MainLayout.qml" line="894"/>
+        <location filename="../app/MainLayout.qml" line="898"/>
+        <location filename="../app/MainLayout.qml" line="912"/>
+        <location filename="../app/MainLayout.qml" line="927"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
         <source>Close</source>
         <translation>Închidere</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="760"/>
-        <location filename="../app/MainLayout.qml" line="798"/>
-        <location filename="../app/MainLayout.qml" line="821"/>
-        <location filename="../app/MainLayout.qml" line="832"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
+        <location filename="../app/MainLayout.qml" line="945"/>
+        <location filename="../app/MainLayout.qml" line="968"/>
+        <location filename="../app/MainLayout.qml" line="979"/>
         <source>Cancel</source>
         <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="776"/>
+        <location filename="../app/MainLayout.qml" line="923"/>
         <source>Done</source>
         <translation>Gata</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="806"/>
+        <location filename="../app/MainLayout.qml" line="953"/>
         <source>I understand</source>
         <translation>Am înțeles</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="840"/>
+        <location filename="../app/MainLayout.qml" line="987"/>
         <source>Start</source>
         <translation>Pornire</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1009"/>
+        <location filename="../app/MainLayout.qml" line="1165"/>
         <source>Scroll</source>
         <translation>Derulare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="741"/>
-        <location filename="../app/MainLayout.qml" line="813"/>
-        <location filename="../app/MainLayout.qml" line="856"/>
-        <location filename="../app/MainLayout.qml" line="885"/>
-        <location filename="../app/MainLayout.qml" line="932"/>
-        <location filename="../app/MainLayout.qml" line="973"/>
-        <location filename="../app/MainLayout.qml" line="1037"/>
+        <location filename="../app/MainLayout.qml" line="886"/>
+        <location filename="../app/MainLayout.qml" line="960"/>
+        <location filename="../app/MainLayout.qml" line="1003"/>
+        <location filename="../app/MainLayout.qml" line="1034"/>
+        <location filename="../app/MainLayout.qml" line="1084"/>
+        <location filename="../app/MainLayout.qml" line="1127"/>
+        <location filename="../app/MainLayout.qml" line="1195"/>
         <source>Move</source>
         <translation>Mutare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="141"/>
+        <location filename="../app/MainLayout.qml" line="170"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="323"/>
+        <location filename="../app/MainLayout.qml" line="364"/>
         <source>Favorites</source>
         <translation type="unfinished">Favorite</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="325"/>
+        <location filename="../app/MainLayout.qml" line="366"/>
         <source>Recently Played</source>
         <translation type="unfinished">Recent Jucate</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="592"/>
+        <location filename="../app/MainLayout.qml" line="695"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="593"/>
+        <location filename="../app/MainLayout.qml" line="696"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="668"/>
+        <location filename="../app/MainLayout.qml" line="806"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="860"/>
-        <location filename="../app/MainLayout.qml" line="895"/>
-        <location filename="../app/MainLayout.qml" line="942"/>
-        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1007"/>
+        <location filename="../app/MainLayout.qml" line="1044"/>
+        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Open</source>
         <translation>Deschidere</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="864"/>
+        <location filename="../app/MainLayout.qml" line="1011"/>
         <source>Quit</source>
         <translation>Ieșire</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="873"/>
-        <location filename="../app/MainLayout.qml" line="901"/>
-        <location filename="../app/MainLayout.qml" line="912"/>
-        <location filename="../app/MainLayout.qml" line="924"/>
-        <location filename="../app/MainLayout.qml" line="951"/>
-        <location filename="../app/MainLayout.qml" line="962"/>
-        <location filename="../app/MainLayout.qml" line="997"/>
-        <location filename="../app/MainLayout.qml" line="1013"/>
-        <location filename="../app/MainLayout.qml" line="1022"/>
-        <location filename="../app/MainLayout.qml" line="1056"/>
-        <location filename="../app/MainLayout.qml" line="1067"/>
+        <location filename="../app/MainLayout.qml" line="1020"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1061"/>
+        <location filename="../app/MainLayout.qml" line="1076"/>
+        <location filename="../app/MainLayout.qml" line="1103"/>
+        <location filename="../app/MainLayout.qml" line="1114"/>
+        <location filename="../app/MainLayout.qml" line="1151"/>
+        <location filename="../app/MainLayout.qml" line="1169"/>
+        <location filename="../app/MainLayout.qml" line="1178"/>
+        <location filename="../app/MainLayout.qml" line="1214"/>
+        <location filename="../app/MainLayout.qml" line="1225"/>
         <source>Back</source>
         <translation>Înapoi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="891"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1043"/>
+        <location filename="../app/MainLayout.qml" line="1040"/>
+        <location filename="../app/MainLayout.qml" line="1090"/>
+        <location filename="../app/MainLayout.qml" line="1201"/>
         <source>Page</source>
         <translation>Pagină</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="947"/>
-        <location filename="../app/MainLayout.qml" line="1052"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1210"/>
         <source>Options</source>
         <translation>Opțiuni</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="787"/>
-        <location filename="../app/MainLayout.qml" line="908"/>
-        <location filename="../app/MainLayout.qml" line="958"/>
-        <location filename="../app/MainLayout.qml" line="1063"/>
+        <location filename="../app/MainLayout.qml" line="934"/>
+        <location filename="../app/MainLayout.qml" line="1057"/>
+        <location filename="../app/MainLayout.qml" line="1110"/>
+        <location filename="../app/MainLayout.qml" line="1221"/>
         <source>Retry</source>
         <translation>Reîncercare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="982"/>
+        <location filename="../app/MainLayout.qml" line="1136"/>
         <source>Change</source>
         <translation>Schimbare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="988"/>
+        <location filename="../app/MainLayout.qml" line="1142"/>
         <source>Toggle</source>
         <translation>Comutare</translation>
     </message>
@@ -710,12 +834,12 @@
         <translation type="unfinished">Se încarcă…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="306"/>
+        <location filename="../screens/MediaListScreen.qml" line="351"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 intrări</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="307"/>
+        <location filename="../screens/MediaListScreen.qml" line="352"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -764,17 +888,17 @@
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="26"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
         <source>Nothing here</source>
         <translation>Nimic aici</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="28"/>
         <source>Loading…</source>
         <translation>Se încarcă…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="57"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="58"/>
         <source>Failed to load</source>
         <translation>Încărcare eșuată</translation>
     </message>
@@ -782,387 +906,423 @@
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="73"/>
-        <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
         <source>Language</source>
         <translation>Limbă</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="516"/>
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Browsing layout</source>
         <translation>Aspect navigare</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="130"/>
         <source>Mouse support</source>
         <translation>Suport mouse</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="112"/>
+        <location filename="../screens/SettingsScreen.qml" line="137"/>
         <source>Update media database</source>
         <translation>Actualizare bază de date media</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="61"/>
         <source>General</source>
-        <translation>Generale</translation>
+        <translation type="vanished">Generale</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78"/>
-        <location filename="../screens/SettingsScreen.qml" line="507"/>
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <location filename="../screens/SettingsScreen.qml" line="618"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88"/>
-        <location filename="../screens/SettingsScreen.qml" line="525"/>
+        <location filename="../screens/SettingsScreen.qml" line="125"/>
+        <location filename="../screens/SettingsScreen.qml" line="636"/>
         <source>Button style</source>
         <translation>Stil butoane</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="93"/>
-        <location filename="../screens/SettingsScreen.qml" line="534"/>
+        <location filename="../screens/SettingsScreen.qml" line="112"/>
+        <location filename="../screens/SettingsScreen.qml" line="645"/>
         <source>Screensaver</source>
         <translation>Economizor de ecran</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97"/>
         <source>Library</source>
-        <translation>Bibliotecă</translation>
+        <translation type="vanished">Bibliotecă</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="142"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="543"/>
+        <location filename="../screens/SettingsScreen.qml" line="654"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
         <source>Scrape metadata</source>
         <translation>Extragere metadate</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Advanced</source>
-        <translation>Avansat</translation>
+        <translation type="vanished">Avansat</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="136"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
         <source>Debug logging</source>
         <translation>Jurnal depanare</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="141"/>
+        <location filename="../screens/SettingsScreen.qml" line="169"/>
         <source>Upload log file</source>
         <translation>Încărcare fișier jurnal</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="146"/>
+        <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>About / License</source>
         <translation>Despre / Licență</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="162"/>
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
+        <source>Display &amp; Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="72"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <source>Controls &amp; Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="189"/>
+        <source>Library &amp; Data Management</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="82"/>
+        <location filename="../screens/SettingsScreen.qml" line="191"/>
+        <source>Support &amp; About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="206"/>
         <source>Optimizing</source>
         <translation>Optimizare</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
-        <location filename="../screens/SettingsScreen.qml" line="173"/>
+        <location filename="../screens/SettingsScreen.qml" line="208"/>
+        <location filename="../screens/SettingsScreen.qml" line="217"/>
         <source>Paused</source>
         <translation>În pauză</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
-        <location filename="../screens/SettingsScreen.qml" line="173"/>
+        <location filename="../screens/SettingsScreen.qml" line="208"/>
+        <location filename="../screens/SettingsScreen.qml" line="217"/>
         <source>In progress</source>
         <translation>În curs</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="167"/>
+        <location filename="../screens/SettingsScreen.qml" line="211"/>
         <source>%1 indexed</source>
         <translation>%1 indexate</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="176"/>
+        <location filename="../screens/SettingsScreen.qml" line="220"/>
         <source>%1 scraped</source>
         <translation>%1 extrase</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="284"/>
+        <location filename="../screens/SettingsScreen.qml" line="393"/>
         <source>Cancel</source>
         <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="284"/>
+        <location filename="../screens/SettingsScreen.qml" line="393"/>
         <source>Start</source>
         <translation>Pornire</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="286"/>
+        <location filename="../screens/SettingsScreen.qml" line="395"/>
         <source>Upload</source>
         <translation>Încărcare</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="288"/>
+        <location filename="../screens/SettingsScreen.qml" line="396"/>
         <source>Open</source>
         <translation>Deschidere</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="365"/>
+        <location filename="../screens/SettingsScreen.qml" line="472"/>
         <source>English</source>
         <translation>Engleză</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="367"/>
+        <location filename="../screens/SettingsScreen.qml" line="474"/>
         <source>Italian</source>
         <translation>Italiană</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="476"/>
+        <source>Spanish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="478"/>
+        <source>Basque</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="480"/>
         <source>German</source>
         <translation>Germană</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
+        <location filename="../screens/SettingsScreen.qml" line="482"/>
         <source>Greek</source>
         <translation>Greacă</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="373"/>
+        <location filename="../screens/SettingsScreen.qml" line="484"/>
         <source>Japanese</source>
         <translation>Japoneză</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="375"/>
+        <location filename="../screens/SettingsScreen.qml" line="486"/>
         <source>Korean</source>
         <translation>Coreeană</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Dutch</source>
         <translation>Olandeză</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="379"/>
+        <location filename="../screens/SettingsScreen.qml" line="490"/>
         <source>Romanian</source>
         <translation>Română</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="381"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Slovak</source>
         <translation>Slovacă</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="383"/>
+        <location filename="../screens/SettingsScreen.qml" line="494"/>
         <source>Ukrainian</source>
         <translation>Ucraineană</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="385"/>
+        <location filename="../screens/SettingsScreen.qml" line="496"/>
         <source>Chinese (Simplified)</source>
         <translation>Chineză (simplificată)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="387"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Hebrew</source>
         <translation>Ebraică</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="389"/>
+        <location filename="../screens/SettingsScreen.qml" line="500"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="391"/>
+        <location filename="../screens/SettingsScreen.qml" line="502"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="392"/>
-        <location filename="../screens/SettingsScreen.qml" line="451"/>
+        <location filename="../screens/SettingsScreen.qml" line="503"/>
+        <location filename="../screens/SettingsScreen.qml" line="562"/>
         <source>Auto</source>
         <translation>Automat</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <location filename="../screens/SettingsScreen.qml" line="508"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <location filename="../screens/SettingsScreen.qml" line="510"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="400"/>
+        <location filename="../screens/SettingsScreen.qml" line="511"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405"/>
+        <location filename="../screens/SettingsScreen.qml" line="516"/>
         <source>Detailed list view</source>
         <translation>Vizualizare listă detaliată</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="406"/>
+        <location filename="../screens/SettingsScreen.qml" line="517"/>
         <source>Grid view</source>
         <translation>Vizualizare grilă</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="411"/>
+        <location filename="../screens/SettingsScreen.qml" line="522"/>
         <source>Style B</source>
         <translation>Stil B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="413"/>
+        <location filename="../screens/SettingsScreen.qml" line="524"/>
         <source>Style C</source>
         <translation>Stil C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="415"/>
+        <location filename="../screens/SettingsScreen.qml" line="526"/>
         <source>Style D</source>
         <translation>Stil D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="416"/>
+        <location filename="../screens/SettingsScreen.qml" line="527"/>
         <source>Style A</source>
         <translation>Stil A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="340"/>
+        <location filename="../screens/SettingsScreen.qml" line="1032"/>
+        <source>Loading settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="447"/>
         <source>Default</source>
         <translation>Implicit</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="431"/>
+        <location filename="../screens/SettingsScreen.qml" line="542"/>
         <source>Off</source>
         <translation>Dezactivat</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="433"/>
+        <location filename="../screens/SettingsScreen.qml" line="544"/>
         <source>1 second (testing)</source>
         <translation>1 secundă (test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="435"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>1 minute</source>
         <translation>1 minut</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="437"/>
+        <location filename="../screens/SettingsScreen.qml" line="548"/>
         <source>2 minutes</source>
         <translation>2 minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="439"/>
+        <location filename="../screens/SettingsScreen.qml" line="550"/>
         <source>5 minutes</source>
         <translation>5 minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="441"/>
+        <location filename="../screens/SettingsScreen.qml" line="552"/>
         <source>10 minutes</source>
         <translation>10 minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="443"/>
+        <location filename="../screens/SettingsScreen.qml" line="554"/>
         <source>15 minutes</source>
         <translation>15 minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="445"/>
+        <location filename="../screens/SettingsScreen.qml" line="556"/>
         <source>30 minutes</source>
         <translation>30 de minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="446"/>
+        <location filename="../screens/SettingsScreen.qml" line="557"/>
         <source>%1 seconds</source>
         <translation>%1 secunde</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="489"/>
+        <location filename="../screens/SettingsScreen.qml" line="91"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Resolution</source>
         <translation>Rezoluție</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="453"/>
+        <location filename="../screens/SettingsScreen.qml" line="564"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="455"/>
+        <location filename="../screens/SettingsScreen.qml" line="566"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="457"/>
+        <location filename="../screens/SettingsScreen.qml" line="568"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <location filename="../screens/SettingsScreen.qml" line="570"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="461"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="463"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="465"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="467"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="469"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="471"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="473"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="663"/>
+        <location filename="../screens/SettingsScreen.qml" line="192"/>
         <source>Settings</source>
         <translation>Setări</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="857"/>
+        <location filename="../screens/SettingsScreen.qml" line="1020"/>
         <source>No settings available on this platform</source>
         <translation>Nicio setare disponibilă pe această platformă</translation>
     </message>
@@ -1170,24 +1330,24 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="195"/>
-        <location filename="../screens/SystemsScreen.qml" line="292"/>
+        <location filename="../screens/SystemsScreen.qml" line="197"/>
+        <location filename="../screens/SystemsScreen.qml" line="295"/>
         <source>%1 systems</source>
         <translation>%1 sisteme</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="196"/>
-        <location filename="../screens/SystemsScreen.qml" line="309"/>
+        <location filename="../screens/SystemsScreen.qml" line="198"/>
+        <location filename="../screens/SystemsScreen.qml" line="312"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="324"/>
+        <location filename="../screens/SystemsScreen.qml" line="328"/>
         <source>No systems in this category</source>
         <translation>Niciun sistem în această categorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="325"/>
+        <location filename="../screens/SystemsScreen.qml" line="329"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -54,6 +54,13 @@
         <translation>Preklady</translation>
     </message>
     <message>
+        <location filename="../screens/AboutScreen.qml" line="267"/>
+        <source>Italiano - Andrea Bogazzi
+Español - Carlos R.
+Euskara - devilschile2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/AboutScreen.qml" line="278"/>
         <source>Full license text in COPYING.</source>
         <translation>Úplný text licencie v súbore COPYING.</translation>
@@ -907,13 +914,13 @@
     <name>SettingsScreen</name>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="611"/>
         <source>Language</source>
         <translation>Jazyk</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="627"/>
+        <location filename="../screens/SettingsScreen.qml" line="629"/>
         <source>Browsing layout</source>
         <translation>Rozloženie prehliadania</translation>
     </message>
@@ -933,19 +940,19 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="97"/>
-        <location filename="../screens/SettingsScreen.qml" line="618"/>
+        <location filename="../screens/SettingsScreen.qml" line="620"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="125"/>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="638"/>
         <source>Button style</source>
         <translation>Štýl tlačidiel</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="112"/>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
+        <location filename="../screens/SettingsScreen.qml" line="647"/>
         <source>Screensaver</source>
         <translation>Šetrič obrazovky</translation>
     </message>
@@ -960,7 +967,7 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="654"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1131,72 +1138,77 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <source>Chinese (Traditional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="500"/>
         <source>Hebrew</source>
         <translation>Hebrejčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="500"/>
+        <location filename="../screens/SettingsScreen.qml" line="502"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="502"/>
+        <location filename="../screens/SettingsScreen.qml" line="504"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="503"/>
-        <location filename="../screens/SettingsScreen.qml" line="562"/>
+        <location filename="../screens/SettingsScreen.qml" line="505"/>
+        <location filename="../screens/SettingsScreen.qml" line="564"/>
         <source>Auto</source>
         <translation>Automaticky</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="508"/>
+        <location filename="../screens/SettingsScreen.qml" line="510"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="510"/>
+        <location filename="../screens/SettingsScreen.qml" line="512"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="511"/>
+        <location filename="../screens/SettingsScreen.qml" line="513"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="516"/>
+        <location filename="../screens/SettingsScreen.qml" line="518"/>
         <source>Detailed list view</source>
         <translation>Podrobné zobrazenie zoznamu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="517"/>
+        <location filename="../screens/SettingsScreen.qml" line="519"/>
         <source>Grid view</source>
         <translation>Zobrazenie mriežky</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="522"/>
+        <location filename="../screens/SettingsScreen.qml" line="524"/>
         <source>Style B</source>
         <translation>Štýl B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="524"/>
+        <location filename="../screens/SettingsScreen.qml" line="526"/>
         <source>Style C</source>
         <translation>Štýl C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="526"/>
+        <location filename="../screens/SettingsScreen.qml" line="528"/>
         <source>Style D</source>
         <translation>Štýl D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="527"/>
+        <location filename="../screens/SettingsScreen.qml" line="529"/>
         <source>Style A</source>
         <translation>Štýl A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1032"/>
+        <location filename="../screens/SettingsScreen.qml" line="1034"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1206,113 +1218,113 @@
         <translation>Predvolené</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="542"/>
+        <location filename="../screens/SettingsScreen.qml" line="544"/>
         <source>Off</source>
         <translation>Vypnuté</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="544"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>1 second (testing)</source>
         <translation>1 sekunda (test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="546"/>
+        <location filename="../screens/SettingsScreen.qml" line="548"/>
         <source>1 minute</source>
         <translation>1 minúta</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="548"/>
+        <location filename="../screens/SettingsScreen.qml" line="550"/>
         <source>2 minutes</source>
         <translation>2 minúty</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="550"/>
+        <location filename="../screens/SettingsScreen.qml" line="552"/>
         <source>5 minutes</source>
         <translation>5 minút</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="552"/>
+        <location filename="../screens/SettingsScreen.qml" line="554"/>
         <source>10 minutes</source>
         <translation>10 minút</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="554"/>
+        <location filename="../screens/SettingsScreen.qml" line="556"/>
         <source>15 minutes</source>
         <translation>15 minút</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="556"/>
+        <location filename="../screens/SettingsScreen.qml" line="558"/>
         <source>30 minutes</source>
         <translation>30 minút</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="557"/>
+        <location filename="../screens/SettingsScreen.qml" line="559"/>
         <source>%1 seconds</source>
         <translation>%1 sekúnd</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="91"/>
-        <location filename="../screens/SettingsScreen.qml" line="600"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Resolution</source>
         <translation>Rozlíšenie</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="564"/>
+        <location filename="../screens/SettingsScreen.qml" line="566"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="566"/>
+        <location filename="../screens/SettingsScreen.qml" line="568"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="568"/>
+        <location filename="../screens/SettingsScreen.qml" line="570"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="570"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1322,7 +1334,7 @@
         <translation>Nastavenia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1020"/>
+        <location filename="../screens/SettingsScreen.qml" line="1022"/>
         <source>No settings available on this platform</source>
         <translation>Na tejto platforme nie sú dostupné žiadne nastavenia</translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -4,57 +4,57 @@
 <context>
     <name>AboutScreen</name>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="71"/>
+        <location filename="../screens/AboutScreen.qml" line="73"/>
         <source>About / License</source>
         <translation>O aplikácii / Licencia</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="153"/>
+        <location filename="../screens/AboutScreen.qml" line="155"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="164"/>
+        <location filename="../screens/AboutScreen.qml" line="166"/>
         <source>Version %1 · %2 · %3</source>
         <translation>Verzia %1 · %2 · %3</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="174"/>
+        <location filename="../screens/AboutScreen.qml" line="176"/>
         <source>Built %1</source>
         <translation>Zostavené %1</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="185"/>
+        <location filename="../screens/AboutScreen.qml" line="187"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>Autorské práva 2026 Wizzo Pty Ltd a prispievatelia projektu Zaparoo.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="196"/>
+        <location filename="../screens/AboutScreen.qml" line="198"/>
         <source>Source available under the PolyForm Noncommercial License 1.0.0. Free for personal, non-commercial use. Commercial use requires a separate license.</source>
         <translation>Zdrojový kód je dostupný pod licenciou PolyForm Noncommercial License 1.0.0. Bezplatne na osobné, nekomerčné použitie. Komerčné použitie alebo redistribúcia vyžaduje samostatnú licenciu.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="207"/>
+        <location filename="../screens/AboutScreen.qml" line="209"/>
         <source>Commercial licensing: legal@zaparoo.org</source>
         <translation>Komerčné licencovanie: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="218"/>
+        <location filename="../screens/AboutScreen.qml" line="220"/>
         <source>Project: https://zaparoo.org</source>
         <translation>Projekt: https://zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="228"/>
+        <location filename="../screens/AboutScreen.qml" line="230"/>
         <source>Created by</source>
         <translation>Vytvorili</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="252"/>
+        <location filename="../screens/AboutScreen.qml" line="254"/>
         <source>Translations</source>
         <translation>Preklady</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="276"/>
+        <location filename="../screens/AboutScreen.qml" line="278"/>
         <source>Full license text in COPYING.</source>
         <translation>Úplný text licencie v súbore COPYING.</translation>
     </message>
@@ -90,48 +90,102 @@
         <translation type="unfinished">Načítanie…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="77"/>
+        <location filename="../components/BrowseDetailPane.qml" line="138"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="79"/>
+        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <source>Yr</source>
+        <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="81"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <source>Gen</source>
+        <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="83"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <source>Plyr</source>
+        <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="85"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <source>Dev</source>
+        <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="87"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <source>Pub</source>
+        <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="89"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <source>Rtg</source>
+        <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="91"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <source>Cat</source>
+        <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="93"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <source>Date</source>
+        <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Manufacturer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <source>Mfr</source>
+        <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -176,68 +230,103 @@
 <context>
     <name>CoreStatusPill</name>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="44"/>
-        <location filename="../components/CoreStatusPill.qml" line="50"/>
+        <location filename="../components/CoreStatusPill.qml" line="46"/>
+        <location filename="../components/CoreStatusPill.qml" line="52"/>
         <source>Disconnected</source>
         <translation>Odpojené</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="47"/>
+        <location filename="../components/CoreStatusPill.qml" line="49"/>
         <source>Reconnecting…</source>
         <translation>Opätovné pripojenie…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="53"/>
+        <location filename="../components/CoreStatusPill.qml" line="55"/>
         <source>Connecting…</source>
         <translation>Pripájanie…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="56"/>
+        <location filename="../components/CoreStatusPill.qml" line="58"/>
         <source>Core error</source>
         <translation>Chyba Core</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="60"/>
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <source>Paused %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <source>Paused</source>
+        <translation type="unfinished">Pozastavené</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="78"/>
+        <source>Opt…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="78"/>
+        <source>Optimizing</source>
+        <translation type="unfinished">Optimalizácia</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
+        <source>Idx…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
+        <source>Scr…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Optimizing database</source>
-        <translation>Optimalizácia databázy</translation>
+        <translation type="vanished">Optimalizácia databázy</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="67"/>
         <source>Indexing paused</source>
-        <translation>Indexovanie pozastavené</translation>
+        <translation type="vanished">Indexovanie pozastavené</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="70"/>
         <source>Indexing %1/%2 - %3</source>
-        <translation>Indexovanie %1/%2 – %3</translation>
+        <translation type="vanished">Indexovanie %1/%2 – %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="86"/>
         <source>Scraping %1/%2 - %3</source>
-        <translation>Scraping %1/%2 – %3</translation>
+        <translation type="vanished">Scraping %1/%2 – %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="73"/>
+        <location filename="../components/CoreStatusPill.qml" line="82"/>
         <source>Indexing %1/%2</source>
         <translation>Indexovanie %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <location filename="../components/CoreStatusPill.qml" line="82"/>
+        <source>Idx %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Indexing…</source>
         <translation>Indexovanie…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Scrape paused</source>
-        <translation>Scraping pozastavený</translation>
+        <translation type="vanished">Scraping pozastavený</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="89"/>
+        <location filename="../components/CoreStatusPill.qml" line="88"/>
         <source>Scraping %1/%2</source>
         <translation>Sťahovanie %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="91"/>
+        <location filename="../components/CoreStatusPill.qml" line="88"/>
+        <source>Scr %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
         <source>Scraping…</source>
         <translation>Prebieha sťahovanie…</translation>
     </message>
@@ -329,34 +418,34 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="117"/>
-        <location filename="../screens/GamesScreen.qml" line="145"/>
+        <location filename="../screens/GamesScreen.qml" line="122"/>
+        <location filename="../screens/GamesScreen.qml" line="157"/>
         <source>%1 files</source>
         <translation>%1 súborov</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="51"/>
+        <location filename="../screens/GamesScreen.qml" line="55"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="126"/>
-        <location filename="../screens/GamesScreen.qml" line="146"/>
+        <location filename="../screens/GamesScreen.qml" line="131"/>
+        <location filename="../screens/GamesScreen.qml" line="158"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="45"/>
+        <location filename="../screens/GamesScreen.qml" line="49"/>
         <source>Loading games…</source>
         <translation>Načítanie hier…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="122"/>
+        <location filename="../screens/GamesScreen.qml" line="127"/>
         <source>Loading more…</source>
         <translation>Načítava sa viac…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="44"/>
+        <location filename="../screens/GamesScreen.qml" line="48"/>
         <source>No games in this system</source>
         <translation>V tomto systéme nie sú žiadne hry</translation>
     </message>
@@ -364,32 +453,47 @@
 <context>
     <name>HubScreen</name>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
-        <source>Resume: %1</source>
+        <location filename="../screens/HubScreen.qml" line="56"/>
+        <source>Arcade</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
-        <source>Resume Game</source>
+        <location filename="../screens/HubScreen.qml" line="61"/>
+        <source>Computers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
+        <location filename="../screens/HubScreen.qml" line="66"/>
+        <source>Consoles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="71"/>
+        <source>Handhelds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="134"/>
+        <source>Resume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="140"/>
         <source>Favorites</source>
         <translation>Obľúbené</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="96"/>
+        <location filename="../screens/HubScreen.qml" line="145"/>
         <source>Recently Played</source>
         <translation>Nedávno hrané</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="101"/>
+        <location filename="../screens/HubScreen.qml" line="150"/>
         <source>Settings</source>
         <translation>Nastavenia</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="537"/>
+        <location filename="../screens/HubScreen.qml" line="644"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Žiadne systémy nie sú dostupné. Spustite Aktualizovať databázu médií v Nastaveniach.</translation>
     </message>
@@ -438,104 +542,124 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="755"/>
+        <location filename="../app/Main.qml" line="1206"/>
         <source>Launch core</source>
         <translation>Spustiť core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="958"/>
+        <location filename="../app/Main.qml" line="1212"/>
+        <location filename="../app/Main.qml" line="1420"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="786"/>
+        <location filename="../app/Main.qml" line="1247"/>
         <source>Remove from favorites</source>
         <translation>Odstrániť z obľúbených</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="786"/>
+        <location filename="../app/Main.qml" line="1247"/>
         <source>Add to favorites</source>
         <translation>Pridať do obľúbených</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="791"/>
+        <location filename="../app/Main.qml" line="1252"/>
         <source>Write to NFC token</source>
         <translation>Zapísať na NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="795"/>
+        <location filename="../app/Main.qml" line="1256"/>
         <source>QR code</source>
         <translation>QR kód</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="770"/>
-        <location filename="../app/Main.qml" line="805"/>
+        <location filename="../app/Main.qml" line="1231"/>
+        <location filename="../app/Main.qml" line="1266"/>
         <source>Launch game</source>
         <translation>Spustiť hru</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1776"/>
+        <location filename="../app/Main.qml" line="2368"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1780"/>
+        <location filename="../app/Main.qml" line="2374"/>
         <source>Loading favorites…</source>
         <translation>Načítanie obľúbených…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1778"/>
+        <location filename="../app/Main.qml" line="2370"/>
         <source>Loading games…</source>
         <translation>Načítanie hier…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="954"/>
+        <location filename="../app/Main.qml" line="1219"/>
+        <source>Update media database</source>
+        <translation type="unfinished">Aktualizovať databázu médií</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1222"/>
+        <source>Scrape metadata</source>
+        <translation type="unfinished">Získať metadáta</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1416"/>
         <source>Default</source>
         <translation type="unfinished">Predvolené</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="954"/>
+        <location filename="../app/Main.qml" line="1416"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1230"/>
+        <location filename="../app/Main.qml" line="1708"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1234"/>
+        <location filename="../app/Main.qml" line="1712"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1248"/>
+        <location filename="../app/Main.qml" line="1726"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1252"/>
+        <location filename="../app/Main.qml" line="1730"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1256"/>
+        <location filename="../app/Main.qml" line="1734"/>
         <source>Retry</source>
         <translation type="unfinished">Skúsiť znova</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1260"/>
+        <location filename="../app/Main.qml" line="1738"/>
         <source>Cancel</source>
         <translation type="unfinished">Zrušiť</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1782"/>
+        <location filename="../app/Main.qml" line="2372"/>
+        <source>Loading game…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2376"/>
         <source>Loading recently played…</source>
         <translation>Načítanie nedávno hraných…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="2378"/>
+        <source>Loading settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2380"/>
         <source>Loading…</source>
         <translation>Načítanie…</translation>
     </message>
@@ -543,161 +667,161 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="581"/>
+        <location filename="../app/MainLayout.qml" line="680"/>
         <source>Writing failed</source>
         <translation>Zápis zlyhal</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="581"/>
+        <location filename="../app/MainLayout.qml" line="680"/>
         <source>Put a writable card near the reader</source>
         <translation>Priložte zapisovateľnú kartu k čítačke</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="669"/>
+        <location filename="../app/MainLayout.qml" line="807"/>
         <source>Are you sure you want to exit?</source>
         <translation>Naozaj chcete ukončiť?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="745"/>
-        <location filename="../app/MainLayout.qml" line="817"/>
+        <location filename="../app/MainLayout.qml" line="890"/>
+        <location filename="../app/MainLayout.qml" line="964"/>
         <source>Select</source>
         <translation>Vybrať</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="749"/>
-        <location filename="../app/MainLayout.qml" line="753"/>
-        <location filename="../app/MainLayout.qml" line="767"/>
-        <location filename="../app/MainLayout.qml" line="780"/>
-        <location filename="../app/MainLayout.qml" line="791"/>
+        <location filename="../app/MainLayout.qml" line="894"/>
+        <location filename="../app/MainLayout.qml" line="898"/>
+        <location filename="../app/MainLayout.qml" line="912"/>
+        <location filename="../app/MainLayout.qml" line="927"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
         <source>Close</source>
         <translation>Zavrieť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="760"/>
-        <location filename="../app/MainLayout.qml" line="798"/>
-        <location filename="../app/MainLayout.qml" line="821"/>
-        <location filename="../app/MainLayout.qml" line="832"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
+        <location filename="../app/MainLayout.qml" line="945"/>
+        <location filename="../app/MainLayout.qml" line="968"/>
+        <location filename="../app/MainLayout.qml" line="979"/>
         <source>Cancel</source>
         <translation>Zrušiť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="776"/>
+        <location filename="../app/MainLayout.qml" line="923"/>
         <source>Done</source>
         <translation>Hotovo</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="806"/>
+        <location filename="../app/MainLayout.qml" line="953"/>
         <source>I understand</source>
         <translation>Rozumiem</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="840"/>
+        <location filename="../app/MainLayout.qml" line="987"/>
         <source>Start</source>
         <translation>Spustiť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1009"/>
+        <location filename="../app/MainLayout.qml" line="1165"/>
         <source>Scroll</source>
         <translation>Posúvať</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="741"/>
-        <location filename="../app/MainLayout.qml" line="813"/>
-        <location filename="../app/MainLayout.qml" line="856"/>
-        <location filename="../app/MainLayout.qml" line="885"/>
-        <location filename="../app/MainLayout.qml" line="932"/>
-        <location filename="../app/MainLayout.qml" line="973"/>
-        <location filename="../app/MainLayout.qml" line="1037"/>
+        <location filename="../app/MainLayout.qml" line="886"/>
+        <location filename="../app/MainLayout.qml" line="960"/>
+        <location filename="../app/MainLayout.qml" line="1003"/>
+        <location filename="../app/MainLayout.qml" line="1034"/>
+        <location filename="../app/MainLayout.qml" line="1084"/>
+        <location filename="../app/MainLayout.qml" line="1127"/>
+        <location filename="../app/MainLayout.qml" line="1195"/>
         <source>Move</source>
         <translation>Presunúť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="141"/>
+        <location filename="../app/MainLayout.qml" line="170"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="323"/>
+        <location filename="../app/MainLayout.qml" line="364"/>
         <source>Favorites</source>
         <translation type="unfinished">Obľúbené</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="325"/>
+        <location filename="../app/MainLayout.qml" line="366"/>
         <source>Recently Played</source>
         <translation type="unfinished">Nedávno hrané</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="592"/>
+        <location filename="../app/MainLayout.qml" line="695"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="593"/>
+        <location filename="../app/MainLayout.qml" line="696"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="668"/>
+        <location filename="../app/MainLayout.qml" line="806"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="860"/>
-        <location filename="../app/MainLayout.qml" line="895"/>
-        <location filename="../app/MainLayout.qml" line="942"/>
-        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1007"/>
+        <location filename="../app/MainLayout.qml" line="1044"/>
+        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Open</source>
         <translation>Otvoriť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="864"/>
+        <location filename="../app/MainLayout.qml" line="1011"/>
         <source>Quit</source>
         <translation>Ukončiť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="873"/>
-        <location filename="../app/MainLayout.qml" line="901"/>
-        <location filename="../app/MainLayout.qml" line="912"/>
-        <location filename="../app/MainLayout.qml" line="924"/>
-        <location filename="../app/MainLayout.qml" line="951"/>
-        <location filename="../app/MainLayout.qml" line="962"/>
-        <location filename="../app/MainLayout.qml" line="997"/>
-        <location filename="../app/MainLayout.qml" line="1013"/>
-        <location filename="../app/MainLayout.qml" line="1022"/>
-        <location filename="../app/MainLayout.qml" line="1056"/>
-        <location filename="../app/MainLayout.qml" line="1067"/>
+        <location filename="../app/MainLayout.qml" line="1020"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1061"/>
+        <location filename="../app/MainLayout.qml" line="1076"/>
+        <location filename="../app/MainLayout.qml" line="1103"/>
+        <location filename="../app/MainLayout.qml" line="1114"/>
+        <location filename="../app/MainLayout.qml" line="1151"/>
+        <location filename="../app/MainLayout.qml" line="1169"/>
+        <location filename="../app/MainLayout.qml" line="1178"/>
+        <location filename="../app/MainLayout.qml" line="1214"/>
+        <location filename="../app/MainLayout.qml" line="1225"/>
         <source>Back</source>
         <translation>Späť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="891"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1043"/>
+        <location filename="../app/MainLayout.qml" line="1040"/>
+        <location filename="../app/MainLayout.qml" line="1090"/>
+        <location filename="../app/MainLayout.qml" line="1201"/>
         <source>Page</source>
         <translation>Stránka</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="947"/>
-        <location filename="../app/MainLayout.qml" line="1052"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1210"/>
         <source>Options</source>
         <translation>Možnosti</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="787"/>
-        <location filename="../app/MainLayout.qml" line="908"/>
-        <location filename="../app/MainLayout.qml" line="958"/>
-        <location filename="../app/MainLayout.qml" line="1063"/>
+        <location filename="../app/MainLayout.qml" line="934"/>
+        <location filename="../app/MainLayout.qml" line="1057"/>
+        <location filename="../app/MainLayout.qml" line="1110"/>
+        <location filename="../app/MainLayout.qml" line="1221"/>
         <source>Retry</source>
         <translation>Skúsiť znova</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="982"/>
+        <location filename="../app/MainLayout.qml" line="1136"/>
         <source>Change</source>
         <translation>Zmeniť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="988"/>
+        <location filename="../app/MainLayout.qml" line="1142"/>
         <source>Toggle</source>
         <translation>Prepínať</translation>
     </message>
@@ -710,12 +834,12 @@
         <translation type="unfinished">Načítanie…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="306"/>
+        <location filename="../screens/MediaListScreen.qml" line="351"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 položiek</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="307"/>
+        <location filename="../screens/MediaListScreen.qml" line="352"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -764,17 +888,17 @@
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="26"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
         <source>Nothing here</source>
         <translation>Nič tu nie je</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="28"/>
         <source>Loading…</source>
         <translation>Načítanie…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="57"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="58"/>
         <source>Failed to load</source>
         <translation>Načítanie zlyhalo</translation>
     </message>
@@ -782,387 +906,423 @@
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="73"/>
-        <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
         <source>Language</source>
         <translation>Jazyk</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="516"/>
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Browsing layout</source>
         <translation>Rozloženie prehliadania</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="130"/>
         <source>Mouse support</source>
         <translation>Podpora myši</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="112"/>
+        <location filename="../screens/SettingsScreen.qml" line="137"/>
         <source>Update media database</source>
         <translation>Aktualizovať databázu médií</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="61"/>
         <source>General</source>
-        <translation>Všeobecné</translation>
+        <translation type="vanished">Všeobecné</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78"/>
-        <location filename="../screens/SettingsScreen.qml" line="507"/>
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <location filename="../screens/SettingsScreen.qml" line="618"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88"/>
-        <location filename="../screens/SettingsScreen.qml" line="525"/>
+        <location filename="../screens/SettingsScreen.qml" line="125"/>
+        <location filename="../screens/SettingsScreen.qml" line="636"/>
         <source>Button style</source>
         <translation>Štýl tlačidiel</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="93"/>
-        <location filename="../screens/SettingsScreen.qml" line="534"/>
+        <location filename="../screens/SettingsScreen.qml" line="112"/>
+        <location filename="../screens/SettingsScreen.qml" line="645"/>
         <source>Screensaver</source>
         <translation>Šetrič obrazovky</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97"/>
         <source>Library</source>
-        <translation>Knižnica</translation>
+        <translation type="vanished">Knižnica</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="142"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="543"/>
+        <location filename="../screens/SettingsScreen.qml" line="654"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
         <source>Scrape metadata</source>
         <translation>Získať metadáta</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Advanced</source>
-        <translation>Rozšírené</translation>
+        <translation type="vanished">Rozšírené</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="136"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
         <source>Debug logging</source>
         <translation>Ladiace záznamy</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="141"/>
+        <location filename="../screens/SettingsScreen.qml" line="169"/>
         <source>Upload log file</source>
         <translation>Nahrať súbor protokolu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="146"/>
+        <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>About / License</source>
         <translation>O aplikácii / Licencia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="162"/>
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
+        <source>Display &amp; Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="72"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <source>Controls &amp; Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="189"/>
+        <source>Library &amp; Data Management</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="82"/>
+        <location filename="../screens/SettingsScreen.qml" line="191"/>
+        <source>Support &amp; About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="206"/>
         <source>Optimizing</source>
         <translation>Optimalizácia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
-        <location filename="../screens/SettingsScreen.qml" line="173"/>
+        <location filename="../screens/SettingsScreen.qml" line="208"/>
+        <location filename="../screens/SettingsScreen.qml" line="217"/>
         <source>Paused</source>
         <translation>Pozastavené</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
-        <location filename="../screens/SettingsScreen.qml" line="173"/>
+        <location filename="../screens/SettingsScreen.qml" line="208"/>
+        <location filename="../screens/SettingsScreen.qml" line="217"/>
         <source>In progress</source>
         <translation>Prebieha</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="167"/>
+        <location filename="../screens/SettingsScreen.qml" line="211"/>
         <source>%1 indexed</source>
         <translation>%1 indexovaných</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="176"/>
+        <location filename="../screens/SettingsScreen.qml" line="220"/>
         <source>%1 scraped</source>
         <translation>%1 zozbieraných</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="284"/>
+        <location filename="../screens/SettingsScreen.qml" line="393"/>
         <source>Cancel</source>
         <translation>Zrušiť</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="284"/>
+        <location filename="../screens/SettingsScreen.qml" line="393"/>
         <source>Start</source>
         <translation>Spustiť</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="286"/>
+        <location filename="../screens/SettingsScreen.qml" line="395"/>
         <source>Upload</source>
         <translation>Nahrať</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="288"/>
+        <location filename="../screens/SettingsScreen.qml" line="396"/>
         <source>Open</source>
         <translation>Otvoriť</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="365"/>
+        <location filename="../screens/SettingsScreen.qml" line="472"/>
         <source>English</source>
         <translation>Angličtina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="367"/>
+        <location filename="../screens/SettingsScreen.qml" line="474"/>
         <source>Italian</source>
         <translation>Taliančina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="476"/>
+        <source>Spanish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="478"/>
+        <source>Basque</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="480"/>
         <source>German</source>
         <translation>Nemčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
+        <location filename="../screens/SettingsScreen.qml" line="482"/>
         <source>Greek</source>
         <translation>Gréčtina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="373"/>
+        <location filename="../screens/SettingsScreen.qml" line="484"/>
         <source>Japanese</source>
         <translation>Japončina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="375"/>
+        <location filename="../screens/SettingsScreen.qml" line="486"/>
         <source>Korean</source>
         <translation>Kórejčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Dutch</source>
         <translation>Holandčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="379"/>
+        <location filename="../screens/SettingsScreen.qml" line="490"/>
         <source>Romanian</source>
         <translation>Rumunčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="381"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Slovak</source>
         <translation>Slovenčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="383"/>
+        <location filename="../screens/SettingsScreen.qml" line="494"/>
         <source>Ukrainian</source>
         <translation>Ukrajinčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="385"/>
+        <location filename="../screens/SettingsScreen.qml" line="496"/>
         <source>Chinese (Simplified)</source>
         <translation>Čínština (zjednodušená)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="387"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Hebrew</source>
         <translation>Hebrejčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="389"/>
+        <location filename="../screens/SettingsScreen.qml" line="500"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="391"/>
+        <location filename="../screens/SettingsScreen.qml" line="502"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="392"/>
-        <location filename="../screens/SettingsScreen.qml" line="451"/>
+        <location filename="../screens/SettingsScreen.qml" line="503"/>
+        <location filename="../screens/SettingsScreen.qml" line="562"/>
         <source>Auto</source>
         <translation>Automaticky</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <location filename="../screens/SettingsScreen.qml" line="508"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <location filename="../screens/SettingsScreen.qml" line="510"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="400"/>
+        <location filename="../screens/SettingsScreen.qml" line="511"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405"/>
+        <location filename="../screens/SettingsScreen.qml" line="516"/>
         <source>Detailed list view</source>
         <translation>Podrobné zobrazenie zoznamu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="406"/>
+        <location filename="../screens/SettingsScreen.qml" line="517"/>
         <source>Grid view</source>
         <translation>Zobrazenie mriežky</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="411"/>
+        <location filename="../screens/SettingsScreen.qml" line="522"/>
         <source>Style B</source>
         <translation>Štýl B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="413"/>
+        <location filename="../screens/SettingsScreen.qml" line="524"/>
         <source>Style C</source>
         <translation>Štýl C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="415"/>
+        <location filename="../screens/SettingsScreen.qml" line="526"/>
         <source>Style D</source>
         <translation>Štýl D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="416"/>
+        <location filename="../screens/SettingsScreen.qml" line="527"/>
         <source>Style A</source>
         <translation>Štýl A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="340"/>
+        <location filename="../screens/SettingsScreen.qml" line="1032"/>
+        <source>Loading settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="447"/>
         <source>Default</source>
         <translation>Predvolené</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="431"/>
+        <location filename="../screens/SettingsScreen.qml" line="542"/>
         <source>Off</source>
         <translation>Vypnuté</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="433"/>
+        <location filename="../screens/SettingsScreen.qml" line="544"/>
         <source>1 second (testing)</source>
         <translation>1 sekunda (test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="435"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>1 minute</source>
         <translation>1 minúta</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="437"/>
+        <location filename="../screens/SettingsScreen.qml" line="548"/>
         <source>2 minutes</source>
         <translation>2 minúty</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="439"/>
+        <location filename="../screens/SettingsScreen.qml" line="550"/>
         <source>5 minutes</source>
         <translation>5 minút</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="441"/>
+        <location filename="../screens/SettingsScreen.qml" line="552"/>
         <source>10 minutes</source>
         <translation>10 minút</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="443"/>
+        <location filename="../screens/SettingsScreen.qml" line="554"/>
         <source>15 minutes</source>
         <translation>15 minút</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="445"/>
+        <location filename="../screens/SettingsScreen.qml" line="556"/>
         <source>30 minutes</source>
         <translation>30 minút</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="446"/>
+        <location filename="../screens/SettingsScreen.qml" line="557"/>
         <source>%1 seconds</source>
         <translation>%1 sekúnd</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="489"/>
+        <location filename="../screens/SettingsScreen.qml" line="91"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Resolution</source>
         <translation>Rozlíšenie</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="453"/>
+        <location filename="../screens/SettingsScreen.qml" line="564"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="455"/>
+        <location filename="../screens/SettingsScreen.qml" line="566"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="457"/>
+        <location filename="../screens/SettingsScreen.qml" line="568"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <location filename="../screens/SettingsScreen.qml" line="570"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="461"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="463"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="465"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="467"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="469"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="471"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="473"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="663"/>
+        <location filename="../screens/SettingsScreen.qml" line="192"/>
         <source>Settings</source>
         <translation>Nastavenia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="857"/>
+        <location filename="../screens/SettingsScreen.qml" line="1020"/>
         <source>No settings available on this platform</source>
         <translation>Na tejto platforme nie sú dostupné žiadne nastavenia</translation>
     </message>
@@ -1170,24 +1330,24 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="195"/>
-        <location filename="../screens/SystemsScreen.qml" line="292"/>
+        <location filename="../screens/SystemsScreen.qml" line="197"/>
+        <location filename="../screens/SystemsScreen.qml" line="295"/>
         <source>%1 systems</source>
         <translation>%1 systémov</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="196"/>
-        <location filename="../screens/SystemsScreen.qml" line="309"/>
+        <location filename="../screens/SystemsScreen.qml" line="198"/>
+        <location filename="../screens/SystemsScreen.qml" line="312"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="324"/>
+        <location filename="../screens/SystemsScreen.qml" line="328"/>
         <source>No systems in this category</source>
         <translation>V tejto kategórii nie sú žiadne systémy</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="325"/>
+        <location filename="../screens/SystemsScreen.qml" line="329"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -54,6 +54,13 @@
         <translation>Переклади</translation>
     </message>
     <message>
+        <location filename="../screens/AboutScreen.qml" line="267"/>
+        <source>Italiano - Andrea Bogazzi
+Español - Carlos R.
+Euskara - devilschile2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/AboutScreen.qml" line="278"/>
         <source>Full license text in COPYING.</source>
         <translation>Повний текст ліцензії у файлі COPYING.</translation>
@@ -907,13 +914,13 @@
     <name>SettingsScreen</name>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="611"/>
         <source>Language</source>
         <translation>Мова</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="627"/>
+        <location filename="../screens/SettingsScreen.qml" line="629"/>
         <source>Browsing layout</source>
         <translation>Режим перегляду</translation>
     </message>
@@ -933,19 +940,19 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="97"/>
-        <location filename="../screens/SettingsScreen.qml" line="618"/>
+        <location filename="../screens/SettingsScreen.qml" line="620"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="125"/>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="638"/>
         <source>Button style</source>
         <translation>Стиль кнопок</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="112"/>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
+        <location filename="../screens/SettingsScreen.qml" line="647"/>
         <source>Screensaver</source>
         <translation>Заставка</translation>
     </message>
@@ -960,7 +967,7 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="654"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1131,72 +1138,77 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <source>Chinese (Traditional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="500"/>
         <source>Hebrew</source>
         <translation>Іврит</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="500"/>
+        <location filename="../screens/SettingsScreen.qml" line="502"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="502"/>
+        <location filename="../screens/SettingsScreen.qml" line="504"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="503"/>
-        <location filename="../screens/SettingsScreen.qml" line="562"/>
+        <location filename="../screens/SettingsScreen.qml" line="505"/>
+        <location filename="../screens/SettingsScreen.qml" line="564"/>
         <source>Auto</source>
         <translation>Автоматично</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="508"/>
+        <location filename="../screens/SettingsScreen.qml" line="510"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="510"/>
+        <location filename="../screens/SettingsScreen.qml" line="512"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="511"/>
+        <location filename="../screens/SettingsScreen.qml" line="513"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="516"/>
+        <location filename="../screens/SettingsScreen.qml" line="518"/>
         <source>Detailed list view</source>
         <translation>Детальний перегляд списку</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="517"/>
+        <location filename="../screens/SettingsScreen.qml" line="519"/>
         <source>Grid view</source>
         <translation>Перегляд сіткою</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="522"/>
+        <location filename="../screens/SettingsScreen.qml" line="524"/>
         <source>Style B</source>
         <translation>Стиль B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="524"/>
+        <location filename="../screens/SettingsScreen.qml" line="526"/>
         <source>Style C</source>
         <translation>Стиль C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="526"/>
+        <location filename="../screens/SettingsScreen.qml" line="528"/>
         <source>Style D</source>
         <translation>Стиль D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="527"/>
+        <location filename="../screens/SettingsScreen.qml" line="529"/>
         <source>Style A</source>
         <translation>Стиль A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1032"/>
+        <location filename="../screens/SettingsScreen.qml" line="1034"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1206,113 +1218,113 @@
         <translation>Типовий</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="542"/>
+        <location filename="../screens/SettingsScreen.qml" line="544"/>
         <source>Off</source>
         <translation>Вимкнено</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="544"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>1 second (testing)</source>
         <translation>1 секунда (тест)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="546"/>
+        <location filename="../screens/SettingsScreen.qml" line="548"/>
         <source>1 minute</source>
         <translation>1 хвилина</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="548"/>
+        <location filename="../screens/SettingsScreen.qml" line="550"/>
         <source>2 minutes</source>
         <translation>2 хвилини</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="550"/>
+        <location filename="../screens/SettingsScreen.qml" line="552"/>
         <source>5 minutes</source>
         <translation>5 хвилин</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="552"/>
+        <location filename="../screens/SettingsScreen.qml" line="554"/>
         <source>10 minutes</source>
         <translation>10 хвилин</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="554"/>
+        <location filename="../screens/SettingsScreen.qml" line="556"/>
         <source>15 minutes</source>
         <translation>15 хвилин</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="556"/>
+        <location filename="../screens/SettingsScreen.qml" line="558"/>
         <source>30 minutes</source>
         <translation>30 хвилин</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="557"/>
+        <location filename="../screens/SettingsScreen.qml" line="559"/>
         <source>%1 seconds</source>
         <translation>%1 секунд</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="91"/>
-        <location filename="../screens/SettingsScreen.qml" line="600"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Resolution</source>
         <translation>Роздільна здатність</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="564"/>
+        <location filename="../screens/SettingsScreen.qml" line="566"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="566"/>
+        <location filename="../screens/SettingsScreen.qml" line="568"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="568"/>
+        <location filename="../screens/SettingsScreen.qml" line="570"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="570"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1322,7 +1334,7 @@
         <translation>Налаштування</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1020"/>
+        <location filename="../screens/SettingsScreen.qml" line="1022"/>
         <source>No settings available on this platform</source>
         <translation>На цій платформі налаштування недоступні</translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -4,57 +4,57 @@
 <context>
     <name>AboutScreen</name>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="71"/>
+        <location filename="../screens/AboutScreen.qml" line="73"/>
         <source>About / License</source>
         <translation>Про програму / Ліцензія</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="153"/>
+        <location filename="../screens/AboutScreen.qml" line="155"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="164"/>
+        <location filename="../screens/AboutScreen.qml" line="166"/>
         <source>Version %1 · %2 · %3</source>
         <translation>Версія %1 · %2 · %3</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="174"/>
+        <location filename="../screens/AboutScreen.qml" line="176"/>
         <source>Built %1</source>
         <translation>Зібрано %1</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="185"/>
+        <location filename="../screens/AboutScreen.qml" line="187"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>Авторські права 2026 Wizzo Pty Ltd та учасники проєкту Zaparoo.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="196"/>
+        <location filename="../screens/AboutScreen.qml" line="198"/>
         <source>Source available under the PolyForm Noncommercial License 1.0.0. Free for personal, non-commercial use. Commercial use requires a separate license.</source>
         <translation>Вихідний код доступний за ліцензією PolyForm Noncommercial License 1.0.0. Безкоштовно для особистого некомерційного використання. Комерційне використання або розповсюдження потребує окремої ліцензії.</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="207"/>
+        <location filename="../screens/AboutScreen.qml" line="209"/>
         <source>Commercial licensing: legal@zaparoo.org</source>
         <translation>Комерційне ліцензування: legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="218"/>
+        <location filename="../screens/AboutScreen.qml" line="220"/>
         <source>Project: https://zaparoo.org</source>
         <translation>Проєкт: https://zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="228"/>
+        <location filename="../screens/AboutScreen.qml" line="230"/>
         <source>Created by</source>
         <translation>Створено</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="252"/>
+        <location filename="../screens/AboutScreen.qml" line="254"/>
         <source>Translations</source>
         <translation>Переклади</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="276"/>
+        <location filename="../screens/AboutScreen.qml" line="278"/>
         <source>Full license text in COPYING.</source>
         <translation>Повний текст ліцензії у файлі COPYING.</translation>
     </message>
@@ -90,48 +90,102 @@
         <translation type="unfinished">Завантаження…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="77"/>
+        <location filename="../components/BrowseDetailPane.qml" line="138"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="79"/>
+        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <source>Yr</source>
+        <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="81"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <source>Gen</source>
+        <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="83"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <source>Plyr</source>
+        <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="85"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <source>Dev</source>
+        <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="87"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <source>Pub</source>
+        <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="89"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <source>Rtg</source>
+        <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="91"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <source>Cat</source>
+        <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="93"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <source>Date</source>
+        <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Manufacturer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <source>Mfr</source>
+        <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -176,68 +230,103 @@
 <context>
     <name>CoreStatusPill</name>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="44"/>
-        <location filename="../components/CoreStatusPill.qml" line="50"/>
+        <location filename="../components/CoreStatusPill.qml" line="46"/>
+        <location filename="../components/CoreStatusPill.qml" line="52"/>
         <source>Disconnected</source>
         <translation>Відключено</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="47"/>
+        <location filename="../components/CoreStatusPill.qml" line="49"/>
         <source>Reconnecting…</source>
         <translation>Повторне підключення…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="53"/>
+        <location filename="../components/CoreStatusPill.qml" line="55"/>
         <source>Connecting…</source>
         <translation>Підключення…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="56"/>
+        <location filename="../components/CoreStatusPill.qml" line="58"/>
         <source>Core error</source>
         <translation>Помилка Core</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="60"/>
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <source>Paused %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <source>Paused</source>
+        <translation type="unfinished">Призупинено</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="78"/>
+        <source>Opt…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="78"/>
+        <source>Optimizing</source>
+        <translation type="unfinished">Оптимізація</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
+        <source>Idx…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
+        <source>Scr…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Optimizing database</source>
-        <translation>Оптимізація бази даних</translation>
+        <translation type="vanished">Оптимізація бази даних</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="67"/>
         <source>Indexing paused</source>
-        <translation>Індексування призупинено</translation>
+        <translation type="vanished">Індексування призупинено</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="70"/>
         <source>Indexing %1/%2 - %3</source>
-        <translation>Індексування %1/%2 – %3</translation>
+        <translation type="vanished">Індексування %1/%2 – %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="86"/>
         <source>Scraping %1/%2 - %3</source>
-        <translation>Скрейпінг %1/%2 – %3</translation>
+        <translation type="vanished">Скрейпінг %1/%2 – %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="73"/>
+        <location filename="../components/CoreStatusPill.qml" line="82"/>
         <source>Indexing %1/%2</source>
         <translation>Індексування %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <location filename="../components/CoreStatusPill.qml" line="82"/>
+        <source>Idx %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Indexing…</source>
         <translation>Індексування…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Scrape paused</source>
-        <translation>Скрейпінг призупинено</translation>
+        <translation type="vanished">Скрейпінг призупинено</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="89"/>
+        <location filename="../components/CoreStatusPill.qml" line="88"/>
         <source>Scraping %1/%2</source>
         <translation>Скрейпінг %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="91"/>
+        <location filename="../components/CoreStatusPill.qml" line="88"/>
+        <source>Scr %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
         <source>Scraping…</source>
         <translation>Скрейпінг…</translation>
     </message>
@@ -329,34 +418,34 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="117"/>
-        <location filename="../screens/GamesScreen.qml" line="145"/>
+        <location filename="../screens/GamesScreen.qml" line="122"/>
+        <location filename="../screens/GamesScreen.qml" line="157"/>
         <source>%1 files</source>
         <translation>%1 файлів</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="51"/>
+        <location filename="../screens/GamesScreen.qml" line="55"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="126"/>
-        <location filename="../screens/GamesScreen.qml" line="146"/>
+        <location filename="../screens/GamesScreen.qml" line="131"/>
+        <location filename="../screens/GamesScreen.qml" line="158"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="45"/>
+        <location filename="../screens/GamesScreen.qml" line="49"/>
         <source>Loading games…</source>
         <translation>Завантаження ігор…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="122"/>
+        <location filename="../screens/GamesScreen.qml" line="127"/>
         <source>Loading more…</source>
         <translation>Завантаження ще…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="44"/>
+        <location filename="../screens/GamesScreen.qml" line="48"/>
         <source>No games in this system</source>
         <translation>У цій системі немає ігор</translation>
     </message>
@@ -364,32 +453,47 @@
 <context>
     <name>HubScreen</name>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
-        <source>Resume: %1</source>
+        <location filename="../screens/HubScreen.qml" line="56"/>
+        <source>Arcade</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
-        <source>Resume Game</source>
+        <location filename="../screens/HubScreen.qml" line="61"/>
+        <source>Computers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
+        <location filename="../screens/HubScreen.qml" line="66"/>
+        <source>Consoles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="71"/>
+        <source>Handhelds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="134"/>
+        <source>Resume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="140"/>
         <source>Favorites</source>
         <translation>Вибране</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="96"/>
+        <location filename="../screens/HubScreen.qml" line="145"/>
         <source>Recently Played</source>
         <translation>Нещодавно зіграні</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="101"/>
+        <location filename="../screens/HubScreen.qml" line="150"/>
         <source>Settings</source>
         <translation>Налаштування</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="537"/>
+        <location filename="../screens/HubScreen.qml" line="644"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Немає доступних систем. Запустіть Оновлення бази даних з Налаштувань.</translation>
     </message>
@@ -438,104 +542,124 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="755"/>
+        <location filename="../app/Main.qml" line="1206"/>
         <source>Launch core</source>
         <translation>Запустити core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="958"/>
+        <location filename="../app/Main.qml" line="1212"/>
+        <location filename="../app/Main.qml" line="1420"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="786"/>
+        <location filename="../app/Main.qml" line="1247"/>
         <source>Remove from favorites</source>
         <translation>Видалити з вибраного</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="786"/>
+        <location filename="../app/Main.qml" line="1247"/>
         <source>Add to favorites</source>
         <translation>Додати до вибраного</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="791"/>
+        <location filename="../app/Main.qml" line="1252"/>
         <source>Write to NFC token</source>
         <translation>Записати на NFC-токен</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="795"/>
+        <location filename="../app/Main.qml" line="1256"/>
         <source>QR code</source>
         <translation>QR-код</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="770"/>
-        <location filename="../app/Main.qml" line="805"/>
+        <location filename="../app/Main.qml" line="1231"/>
+        <location filename="../app/Main.qml" line="1266"/>
         <source>Launch game</source>
         <translation>Запустити гру</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1776"/>
+        <location filename="../app/Main.qml" line="2368"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1780"/>
+        <location filename="../app/Main.qml" line="2374"/>
         <source>Loading favorites…</source>
         <translation>Завантаження вибраного…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1778"/>
+        <location filename="../app/Main.qml" line="2370"/>
         <source>Loading games…</source>
         <translation>Завантаження ігор…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="954"/>
+        <location filename="../app/Main.qml" line="1219"/>
+        <source>Update media database</source>
+        <translation type="unfinished">Оновити базу медіа</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1222"/>
+        <source>Scrape metadata</source>
+        <translation type="unfinished">Отримати метадані</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1416"/>
         <source>Default</source>
         <translation type="unfinished">Типовий</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="954"/>
+        <location filename="../app/Main.qml" line="1416"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1230"/>
+        <location filename="../app/Main.qml" line="1708"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1234"/>
+        <location filename="../app/Main.qml" line="1712"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1248"/>
+        <location filename="../app/Main.qml" line="1726"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1252"/>
+        <location filename="../app/Main.qml" line="1730"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1256"/>
+        <location filename="../app/Main.qml" line="1734"/>
         <source>Retry</source>
         <translation type="unfinished">Повторити</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1260"/>
+        <location filename="../app/Main.qml" line="1738"/>
         <source>Cancel</source>
         <translation type="unfinished">Скасувати</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1782"/>
+        <location filename="../app/Main.qml" line="2372"/>
+        <source>Loading game…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2376"/>
         <source>Loading recently played…</source>
         <translation>Завантаження нещодавніх…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="2378"/>
+        <source>Loading settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2380"/>
         <source>Loading…</source>
         <translation>Завантаження…</translation>
     </message>
@@ -543,161 +667,161 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="581"/>
+        <location filename="../app/MainLayout.qml" line="680"/>
         <source>Writing failed</source>
         <translation>Помилка запису</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="581"/>
+        <location filename="../app/MainLayout.qml" line="680"/>
         <source>Put a writable card near the reader</source>
         <translation>Прикладіть картку для запису до зчитувача</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="669"/>
+        <location filename="../app/MainLayout.qml" line="807"/>
         <source>Are you sure you want to exit?</source>
         <translation>Ви впевнені, що хочете вийти?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="745"/>
-        <location filename="../app/MainLayout.qml" line="817"/>
+        <location filename="../app/MainLayout.qml" line="890"/>
+        <location filename="../app/MainLayout.qml" line="964"/>
         <source>Select</source>
         <translation>Вибрати</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="749"/>
-        <location filename="../app/MainLayout.qml" line="753"/>
-        <location filename="../app/MainLayout.qml" line="767"/>
-        <location filename="../app/MainLayout.qml" line="780"/>
-        <location filename="../app/MainLayout.qml" line="791"/>
+        <location filename="../app/MainLayout.qml" line="894"/>
+        <location filename="../app/MainLayout.qml" line="898"/>
+        <location filename="../app/MainLayout.qml" line="912"/>
+        <location filename="../app/MainLayout.qml" line="927"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
         <source>Close</source>
         <translation>Закрити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="760"/>
-        <location filename="../app/MainLayout.qml" line="798"/>
-        <location filename="../app/MainLayout.qml" line="821"/>
-        <location filename="../app/MainLayout.qml" line="832"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
+        <location filename="../app/MainLayout.qml" line="945"/>
+        <location filename="../app/MainLayout.qml" line="968"/>
+        <location filename="../app/MainLayout.qml" line="979"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="776"/>
+        <location filename="../app/MainLayout.qml" line="923"/>
         <source>Done</source>
         <translation>Готово</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="806"/>
+        <location filename="../app/MainLayout.qml" line="953"/>
         <source>I understand</source>
         <translation>Я розумію</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="840"/>
+        <location filename="../app/MainLayout.qml" line="987"/>
         <source>Start</source>
         <translation>Почати</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1009"/>
+        <location filename="../app/MainLayout.qml" line="1165"/>
         <source>Scroll</source>
         <translation>Прокрутка</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="741"/>
-        <location filename="../app/MainLayout.qml" line="813"/>
-        <location filename="../app/MainLayout.qml" line="856"/>
-        <location filename="../app/MainLayout.qml" line="885"/>
-        <location filename="../app/MainLayout.qml" line="932"/>
-        <location filename="../app/MainLayout.qml" line="973"/>
-        <location filename="../app/MainLayout.qml" line="1037"/>
+        <location filename="../app/MainLayout.qml" line="886"/>
+        <location filename="../app/MainLayout.qml" line="960"/>
+        <location filename="../app/MainLayout.qml" line="1003"/>
+        <location filename="../app/MainLayout.qml" line="1034"/>
+        <location filename="../app/MainLayout.qml" line="1084"/>
+        <location filename="../app/MainLayout.qml" line="1127"/>
+        <location filename="../app/MainLayout.qml" line="1195"/>
         <source>Move</source>
         <translation>Переміщення</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="141"/>
+        <location filename="../app/MainLayout.qml" line="170"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="323"/>
+        <location filename="../app/MainLayout.qml" line="364"/>
         <source>Favorites</source>
         <translation type="unfinished">Вибране</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="325"/>
+        <location filename="../app/MainLayout.qml" line="366"/>
         <source>Recently Played</source>
         <translation type="unfinished">Нещодавно зіграні</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="592"/>
+        <location filename="../app/MainLayout.qml" line="695"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="593"/>
+        <location filename="../app/MainLayout.qml" line="696"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="668"/>
+        <location filename="../app/MainLayout.qml" line="806"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="860"/>
-        <location filename="../app/MainLayout.qml" line="895"/>
-        <location filename="../app/MainLayout.qml" line="942"/>
-        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1007"/>
+        <location filename="../app/MainLayout.qml" line="1044"/>
+        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Open</source>
         <translation>Відкрити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="864"/>
+        <location filename="../app/MainLayout.qml" line="1011"/>
         <source>Quit</source>
         <translation>Вийти</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="873"/>
-        <location filename="../app/MainLayout.qml" line="901"/>
-        <location filename="../app/MainLayout.qml" line="912"/>
-        <location filename="../app/MainLayout.qml" line="924"/>
-        <location filename="../app/MainLayout.qml" line="951"/>
-        <location filename="../app/MainLayout.qml" line="962"/>
-        <location filename="../app/MainLayout.qml" line="997"/>
-        <location filename="../app/MainLayout.qml" line="1013"/>
-        <location filename="../app/MainLayout.qml" line="1022"/>
-        <location filename="../app/MainLayout.qml" line="1056"/>
-        <location filename="../app/MainLayout.qml" line="1067"/>
+        <location filename="../app/MainLayout.qml" line="1020"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1061"/>
+        <location filename="../app/MainLayout.qml" line="1076"/>
+        <location filename="../app/MainLayout.qml" line="1103"/>
+        <location filename="../app/MainLayout.qml" line="1114"/>
+        <location filename="../app/MainLayout.qml" line="1151"/>
+        <location filename="../app/MainLayout.qml" line="1169"/>
+        <location filename="../app/MainLayout.qml" line="1178"/>
+        <location filename="../app/MainLayout.qml" line="1214"/>
+        <location filename="../app/MainLayout.qml" line="1225"/>
         <source>Back</source>
         <translation>Назад</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="891"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1043"/>
+        <location filename="../app/MainLayout.qml" line="1040"/>
+        <location filename="../app/MainLayout.qml" line="1090"/>
+        <location filename="../app/MainLayout.qml" line="1201"/>
         <source>Page</source>
         <translation>Сторінка</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="947"/>
-        <location filename="../app/MainLayout.qml" line="1052"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1210"/>
         <source>Options</source>
         <translation>Параметри</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="787"/>
-        <location filename="../app/MainLayout.qml" line="908"/>
-        <location filename="../app/MainLayout.qml" line="958"/>
-        <location filename="../app/MainLayout.qml" line="1063"/>
+        <location filename="../app/MainLayout.qml" line="934"/>
+        <location filename="../app/MainLayout.qml" line="1057"/>
+        <location filename="../app/MainLayout.qml" line="1110"/>
+        <location filename="../app/MainLayout.qml" line="1221"/>
         <source>Retry</source>
         <translation>Повторити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="982"/>
+        <location filename="../app/MainLayout.qml" line="1136"/>
         <source>Change</source>
         <translation>Змінити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="988"/>
+        <location filename="../app/MainLayout.qml" line="1142"/>
         <source>Toggle</source>
         <translation>Перемкнути</translation>
     </message>
@@ -710,12 +834,12 @@
         <translation type="unfinished">Завантаження…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="306"/>
+        <location filename="../screens/MediaListScreen.qml" line="351"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 записів</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="307"/>
+        <location filename="../screens/MediaListScreen.qml" line="352"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -764,17 +888,17 @@
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="26"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
         <source>Nothing here</source>
         <translation>Тут нічого немає</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="28"/>
         <source>Loading…</source>
         <translation>Завантаження…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="57"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="58"/>
         <source>Failed to load</source>
         <translation>Не вдалося завантажити</translation>
     </message>
@@ -782,387 +906,423 @@
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="73"/>
-        <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
         <source>Language</source>
         <translation>Мова</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="516"/>
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Browsing layout</source>
         <translation>Режим перегляду</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="130"/>
         <source>Mouse support</source>
         <translation>Підтримка миші</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="112"/>
+        <location filename="../screens/SettingsScreen.qml" line="137"/>
         <source>Update media database</source>
         <translation>Оновити базу медіа</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="61"/>
         <source>General</source>
-        <translation>Загальні</translation>
+        <translation type="vanished">Загальні</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78"/>
-        <location filename="../screens/SettingsScreen.qml" line="507"/>
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <location filename="../screens/SettingsScreen.qml" line="618"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88"/>
-        <location filename="../screens/SettingsScreen.qml" line="525"/>
+        <location filename="../screens/SettingsScreen.qml" line="125"/>
+        <location filename="../screens/SettingsScreen.qml" line="636"/>
         <source>Button style</source>
         <translation>Стиль кнопок</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="93"/>
-        <location filename="../screens/SettingsScreen.qml" line="534"/>
+        <location filename="../screens/SettingsScreen.qml" line="112"/>
+        <location filename="../screens/SettingsScreen.qml" line="645"/>
         <source>Screensaver</source>
         <translation>Заставка</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97"/>
         <source>Library</source>
-        <translation>Бібліотека</translation>
+        <translation type="vanished">Бібліотека</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="142"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="543"/>
+        <location filename="../screens/SettingsScreen.qml" line="654"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
         <source>Scrape metadata</source>
         <translation>Отримати метадані</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Advanced</source>
-        <translation>Розширені</translation>
+        <translation type="vanished">Розширені</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="136"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
         <source>Debug logging</source>
         <translation>Журнал відлагодження</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="141"/>
+        <location filename="../screens/SettingsScreen.qml" line="169"/>
         <source>Upload log file</source>
         <translation>Завантажити файл журналу</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="146"/>
+        <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>About / License</source>
         <translation>Про програму / Ліцензія</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="162"/>
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
+        <source>Display &amp; Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="72"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <source>Controls &amp; Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="189"/>
+        <source>Library &amp; Data Management</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="82"/>
+        <location filename="../screens/SettingsScreen.qml" line="191"/>
+        <source>Support &amp; About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="206"/>
         <source>Optimizing</source>
         <translation>Оптимізація</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
-        <location filename="../screens/SettingsScreen.qml" line="173"/>
+        <location filename="../screens/SettingsScreen.qml" line="208"/>
+        <location filename="../screens/SettingsScreen.qml" line="217"/>
         <source>Paused</source>
         <translation>Призупинено</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
-        <location filename="../screens/SettingsScreen.qml" line="173"/>
+        <location filename="../screens/SettingsScreen.qml" line="208"/>
+        <location filename="../screens/SettingsScreen.qml" line="217"/>
         <source>In progress</source>
         <translation>Виконується</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="167"/>
+        <location filename="../screens/SettingsScreen.qml" line="211"/>
         <source>%1 indexed</source>
         <translation>%1 проіндексовано</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="176"/>
+        <location filename="../screens/SettingsScreen.qml" line="220"/>
         <source>%1 scraped</source>
         <translation>%1 зібрано</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="284"/>
+        <location filename="../screens/SettingsScreen.qml" line="393"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="284"/>
+        <location filename="../screens/SettingsScreen.qml" line="393"/>
         <source>Start</source>
         <translation>Почати</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="286"/>
+        <location filename="../screens/SettingsScreen.qml" line="395"/>
         <source>Upload</source>
         <translation>Вивантажити</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="288"/>
+        <location filename="../screens/SettingsScreen.qml" line="396"/>
         <source>Open</source>
         <translation>Відкрити</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="365"/>
+        <location filename="../screens/SettingsScreen.qml" line="472"/>
         <source>English</source>
         <translation>Англійська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="367"/>
+        <location filename="../screens/SettingsScreen.qml" line="474"/>
         <source>Italian</source>
         <translation>Італійська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="476"/>
+        <source>Spanish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="478"/>
+        <source>Basque</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="480"/>
         <source>German</source>
         <translation>Німецька</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
+        <location filename="../screens/SettingsScreen.qml" line="482"/>
         <source>Greek</source>
         <translation>Грецька</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="373"/>
+        <location filename="../screens/SettingsScreen.qml" line="484"/>
         <source>Japanese</source>
         <translation>Японська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="375"/>
+        <location filename="../screens/SettingsScreen.qml" line="486"/>
         <source>Korean</source>
         <translation>Корейська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Dutch</source>
         <translation>Нідерландська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="379"/>
+        <location filename="../screens/SettingsScreen.qml" line="490"/>
         <source>Romanian</source>
         <translation>Румунська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="381"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Slovak</source>
         <translation>Словацька</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="383"/>
+        <location filename="../screens/SettingsScreen.qml" line="494"/>
         <source>Ukrainian</source>
         <translation>Українська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="385"/>
+        <location filename="../screens/SettingsScreen.qml" line="496"/>
         <source>Chinese (Simplified)</source>
         <translation>Китайська (спрощена)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="387"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Hebrew</source>
         <translation>Іврит</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="389"/>
+        <location filename="../screens/SettingsScreen.qml" line="500"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="391"/>
+        <location filename="../screens/SettingsScreen.qml" line="502"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="392"/>
-        <location filename="../screens/SettingsScreen.qml" line="451"/>
+        <location filename="../screens/SettingsScreen.qml" line="503"/>
+        <location filename="../screens/SettingsScreen.qml" line="562"/>
         <source>Auto</source>
         <translation>Автоматично</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <location filename="../screens/SettingsScreen.qml" line="508"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <location filename="../screens/SettingsScreen.qml" line="510"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="400"/>
+        <location filename="../screens/SettingsScreen.qml" line="511"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405"/>
+        <location filename="../screens/SettingsScreen.qml" line="516"/>
         <source>Detailed list view</source>
         <translation>Детальний перегляд списку</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="406"/>
+        <location filename="../screens/SettingsScreen.qml" line="517"/>
         <source>Grid view</source>
         <translation>Перегляд сіткою</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="411"/>
+        <location filename="../screens/SettingsScreen.qml" line="522"/>
         <source>Style B</source>
         <translation>Стиль B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="413"/>
+        <location filename="../screens/SettingsScreen.qml" line="524"/>
         <source>Style C</source>
         <translation>Стиль C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="415"/>
+        <location filename="../screens/SettingsScreen.qml" line="526"/>
         <source>Style D</source>
         <translation>Стиль D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="416"/>
+        <location filename="../screens/SettingsScreen.qml" line="527"/>
         <source>Style A</source>
         <translation>Стиль A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="340"/>
+        <location filename="../screens/SettingsScreen.qml" line="1032"/>
+        <source>Loading settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="447"/>
         <source>Default</source>
         <translation>Типовий</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="431"/>
+        <location filename="../screens/SettingsScreen.qml" line="542"/>
         <source>Off</source>
         <translation>Вимкнено</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="433"/>
+        <location filename="../screens/SettingsScreen.qml" line="544"/>
         <source>1 second (testing)</source>
         <translation>1 секунда (тест)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="435"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>1 minute</source>
         <translation>1 хвилина</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="437"/>
+        <location filename="../screens/SettingsScreen.qml" line="548"/>
         <source>2 minutes</source>
         <translation>2 хвилини</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="439"/>
+        <location filename="../screens/SettingsScreen.qml" line="550"/>
         <source>5 minutes</source>
         <translation>5 хвилин</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="441"/>
+        <location filename="../screens/SettingsScreen.qml" line="552"/>
         <source>10 minutes</source>
         <translation>10 хвилин</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="443"/>
+        <location filename="../screens/SettingsScreen.qml" line="554"/>
         <source>15 minutes</source>
         <translation>15 хвилин</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="445"/>
+        <location filename="../screens/SettingsScreen.qml" line="556"/>
         <source>30 minutes</source>
         <translation>30 хвилин</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="446"/>
+        <location filename="../screens/SettingsScreen.qml" line="557"/>
         <source>%1 seconds</source>
         <translation>%1 секунд</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="489"/>
+        <location filename="../screens/SettingsScreen.qml" line="91"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Resolution</source>
         <translation>Роздільна здатність</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="453"/>
+        <location filename="../screens/SettingsScreen.qml" line="564"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="455"/>
+        <location filename="../screens/SettingsScreen.qml" line="566"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="457"/>
+        <location filename="../screens/SettingsScreen.qml" line="568"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <location filename="../screens/SettingsScreen.qml" line="570"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="461"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="463"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="465"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="467"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="469"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="471"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="473"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="663"/>
+        <location filename="../screens/SettingsScreen.qml" line="192"/>
         <source>Settings</source>
         <translation>Налаштування</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="857"/>
+        <location filename="../screens/SettingsScreen.qml" line="1020"/>
         <source>No settings available on this platform</source>
         <translation>На цій платформі налаштування недоступні</translation>
     </message>
@@ -1170,24 +1330,24 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="195"/>
-        <location filename="../screens/SystemsScreen.qml" line="292"/>
+        <location filename="../screens/SystemsScreen.qml" line="197"/>
+        <location filename="../screens/SystemsScreen.qml" line="295"/>
         <source>%1 systems</source>
         <translation>%1 систем</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="196"/>
-        <location filename="../screens/SystemsScreen.qml" line="309"/>
+        <location filename="../screens/SystemsScreen.qml" line="198"/>
+        <location filename="../screens/SystemsScreen.qml" line="312"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="324"/>
+        <location filename="../screens/SystemsScreen.qml" line="328"/>
         <source>No systems in this category</source>
         <translation>У цій категорії немає систем</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="325"/>
+        <location filename="../screens/SystemsScreen.qml" line="329"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -4,57 +4,57 @@
 <context>
     <name>AboutScreen</name>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="71"/>
+        <location filename="../screens/AboutScreen.qml" line="73"/>
         <source>About / License</source>
         <translation>关于 / 许可</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="153"/>
+        <location filename="../screens/AboutScreen.qml" line="155"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="164"/>
+        <location filename="../screens/AboutScreen.qml" line="166"/>
         <source>Version %1 · %2 · %3</source>
         <translation>版本 %1 · %2 · %3</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="174"/>
+        <location filename="../screens/AboutScreen.qml" line="176"/>
         <source>Built %1</source>
         <translation>构建于 %1</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="185"/>
+        <location filename="../screens/AboutScreen.qml" line="187"/>
         <source>Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.</source>
         <translation>版权所有 2026 Wizzo Pty Ltd 及 Zaparoo Project 贡献者。</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="196"/>
+        <location filename="../screens/AboutScreen.qml" line="198"/>
         <source>Source available under the PolyForm Noncommercial License 1.0.0. Free for personal, non-commercial use. Commercial use requires a separate license.</source>
         <translation>源码依据 PolyForm Noncommercial License 1.0.0 提供。可免费用于个人和非商业用途。商业使用或重新分发需要单独许可。</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="207"/>
+        <location filename="../screens/AboutScreen.qml" line="209"/>
         <source>Commercial licensing: legal@zaparoo.org</source>
         <translation>商业许可：legal@zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="218"/>
+        <location filename="../screens/AboutScreen.qml" line="220"/>
         <source>Project: https://zaparoo.org</source>
         <translation>项目：https://zaparoo.org</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="228"/>
+        <location filename="../screens/AboutScreen.qml" line="230"/>
         <source>Created by</source>
         <translation>创作者</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="252"/>
+        <location filename="../screens/AboutScreen.qml" line="254"/>
         <source>Translations</source>
         <translation>翻译</translation>
     </message>
     <message>
-        <location filename="../screens/AboutScreen.qml" line="276"/>
+        <location filename="../screens/AboutScreen.qml" line="278"/>
         <source>Full license text in COPYING.</source>
         <translation>完整许可文本见 COPYING。</translation>
     </message>
@@ -90,48 +90,102 @@
         <translation type="unfinished">正在加载…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="77"/>
+        <location filename="../components/BrowseDetailPane.qml" line="138"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="79"/>
+        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <source>Yr</source>
+        <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="81"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <source>Gen</source>
+        <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="83"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <source>Plyr</source>
+        <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="85"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <source>Dev</source>
+        <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="87"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <source>Pub</source>
+        <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="89"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <source>Rtg</source>
+        <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="91"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <source>Cat</source>
+        <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="93"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <source>Date</source>
+        <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Manufacturer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <source>Mfr</source>
+        <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -176,68 +230,103 @@
 <context>
     <name>CoreStatusPill</name>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="44"/>
-        <location filename="../components/CoreStatusPill.qml" line="50"/>
+        <location filename="../components/CoreStatusPill.qml" line="46"/>
+        <location filename="../components/CoreStatusPill.qml" line="52"/>
         <source>Disconnected</source>
         <translation>已断开</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="47"/>
+        <location filename="../components/CoreStatusPill.qml" line="49"/>
         <source>Reconnecting…</source>
         <translation>正在重新连接…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="53"/>
+        <location filename="../components/CoreStatusPill.qml" line="55"/>
         <source>Connecting…</source>
         <translation>正在连接…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="56"/>
+        <location filename="../components/CoreStatusPill.qml" line="58"/>
         <source>Core error</source>
         <translation>Core 错误</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="60"/>
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <source>Paused %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <source>Paused</source>
+        <translation type="unfinished">已暂停</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="78"/>
+        <source>Opt…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="78"/>
+        <source>Optimizing</source>
+        <translation type="unfinished">正在优化</translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
+        <source>Idx…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
+        <source>Scr…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Optimizing database</source>
-        <translation>正在优化数据库</translation>
+        <translation type="vanished">正在优化数据库</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="67"/>
         <source>Indexing paused</source>
-        <translation>索引已暂停</translation>
+        <translation type="vanished">索引已暂停</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="70"/>
         <source>Indexing %1/%2 - %3</source>
-        <translation>正在索引 %1/%2 - %3</translation>
+        <translation type="vanished">正在索引 %1/%2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="73"/>
+        <location filename="../components/CoreStatusPill.qml" line="82"/>
         <source>Indexing %1/%2</source>
         <translation>正在索引 %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="75"/>
+        <location filename="../components/CoreStatusPill.qml" line="82"/>
+        <source>Idx %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Indexing…</source>
         <translation>正在索引…</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="83"/>
         <source>Scrape paused</source>
-        <translation>抓取已暂停</translation>
+        <translation type="vanished">抓取已暂停</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="86"/>
         <source>Scraping %1/%2 - %3</source>
-        <translation>正在抓取 %1/%2 - %3</translation>
+        <translation type="vanished">正在抓取 %1/%2 - %3</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="89"/>
+        <location filename="../components/CoreStatusPill.qml" line="88"/>
         <source>Scraping %1/%2</source>
         <translation>正在抓取 %1/%2</translation>
     </message>
     <message>
-        <location filename="../components/CoreStatusPill.qml" line="91"/>
+        <location filename="../components/CoreStatusPill.qml" line="88"/>
+        <source>Scr %1/%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/CoreStatusPill.qml" line="89"/>
         <source>Scraping…</source>
         <translation>正在抓取…</translation>
     </message>
@@ -329,34 +418,34 @@
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="117"/>
-        <location filename="../screens/GamesScreen.qml" line="145"/>
+        <location filename="../screens/GamesScreen.qml" line="122"/>
+        <location filename="../screens/GamesScreen.qml" line="157"/>
         <source>%1 files</source>
         <translation>%1 个文件</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="51"/>
+        <location filename="../screens/GamesScreen.qml" line="55"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="126"/>
-        <location filename="../screens/GamesScreen.qml" line="146"/>
+        <location filename="../screens/GamesScreen.qml" line="131"/>
+        <location filename="../screens/GamesScreen.qml" line="158"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="44"/>
+        <location filename="../screens/GamesScreen.qml" line="48"/>
         <source>No games in this system</source>
         <translation>此系统中没有游戏</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="45"/>
+        <location filename="../screens/GamesScreen.qml" line="49"/>
         <source>Loading games…</source>
         <translation>正在加载游戏…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="122"/>
+        <location filename="../screens/GamesScreen.qml" line="127"/>
         <source>Loading more…</source>
         <translation>正在加载更多…</translation>
     </message>
@@ -364,32 +453,47 @@
 <context>
     <name>HubScreen</name>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
-        <source>Resume: %1</source>
+        <location filename="../screens/HubScreen.qml" line="56"/>
+        <source>Arcade</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
-        <source>Resume Game</source>
+        <location filename="../screens/HubScreen.qml" line="61"/>
+        <source>Computers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="91"/>
+        <location filename="../screens/HubScreen.qml" line="66"/>
+        <source>Consoles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="71"/>
+        <source>Handhelds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="134"/>
+        <source>Resume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="140"/>
         <source>Favorites</source>
         <translation>收藏</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="96"/>
+        <location filename="../screens/HubScreen.qml" line="145"/>
         <source>Recently Played</source>
         <translation>最近游玩</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="101"/>
+        <location filename="../screens/HubScreen.qml" line="150"/>
         <source>Settings</source>
         <translation>设置</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="537"/>
+        <location filename="../screens/HubScreen.qml" line="644"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>没有可用系统。请在“设置”中运行“更新媒体数据库”。</translation>
     </message>
@@ -438,104 +542,124 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="755"/>
+        <location filename="../app/Main.qml" line="1206"/>
         <source>Launch core</source>
         <translation>启动核心</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="761"/>
-        <location filename="../app/Main.qml" line="958"/>
+        <location filename="../app/Main.qml" line="1212"/>
+        <location filename="../app/Main.qml" line="1420"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="770"/>
-        <location filename="../app/Main.qml" line="805"/>
+        <location filename="../app/Main.qml" line="1219"/>
+        <source>Update media database</source>
+        <translation type="unfinished">更新媒体数据库</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1222"/>
+        <source>Scrape metadata</source>
+        <translation type="unfinished">抓取元数据</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1231"/>
+        <location filename="../app/Main.qml" line="1266"/>
         <source>Launch game</source>
         <translation>启动游戏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="786"/>
+        <location filename="../app/Main.qml" line="1247"/>
         <source>Remove from favorites</source>
         <translation>从收藏中移除</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="786"/>
+        <location filename="../app/Main.qml" line="1247"/>
         <source>Add to favorites</source>
         <translation>添加到收藏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="791"/>
+        <location filename="../app/Main.qml" line="1252"/>
         <source>Write to NFC token</source>
         <translation>写入 NFC 令牌</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="795"/>
+        <location filename="../app/Main.qml" line="1256"/>
         <source>QR code</source>
         <translation>二维码</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="954"/>
+        <location filename="../app/Main.qml" line="1416"/>
         <source>Default</source>
         <translation type="unfinished">默认</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="954"/>
+        <location filename="../app/Main.qml" line="1416"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1230"/>
+        <location filename="../app/Main.qml" line="1708"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1234"/>
+        <location filename="../app/Main.qml" line="1712"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1248"/>
+        <location filename="../app/Main.qml" line="1726"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1252"/>
+        <location filename="../app/Main.qml" line="1730"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1256"/>
+        <location filename="../app/Main.qml" line="1734"/>
         <source>Retry</source>
         <translation type="unfinished">重试</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1260"/>
+        <location filename="../app/Main.qml" line="1738"/>
         <source>Cancel</source>
         <translation type="unfinished">取消</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1776"/>
+        <location filename="../app/Main.qml" line="2368"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1778"/>
+        <location filename="../app/Main.qml" line="2370"/>
         <source>Loading games…</source>
         <translation>正在加载游戏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1780"/>
+        <location filename="../app/Main.qml" line="2372"/>
+        <source>Loading game…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2374"/>
         <source>Loading favorites…</source>
         <translation>正在加载收藏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1782"/>
+        <location filename="../app/Main.qml" line="2376"/>
         <source>Loading recently played…</source>
         <translation>正在加载最近游玩…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="2378"/>
+        <source>Loading settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2380"/>
         <source>Loading…</source>
         <translation>正在加载…</translation>
     </message>
@@ -543,161 +667,161 @@
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="581"/>
+        <location filename="../app/MainLayout.qml" line="680"/>
         <source>Writing failed</source>
         <translation>写入失败</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="581"/>
+        <location filename="../app/MainLayout.qml" line="680"/>
         <source>Put a writable card near the reader</source>
         <translation>将可写卡片放在读卡器附近</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="141"/>
+        <location filename="../app/MainLayout.qml" line="170"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="323"/>
+        <location filename="../app/MainLayout.qml" line="364"/>
         <source>Favorites</source>
         <translation type="unfinished">收藏</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="325"/>
+        <location filename="../app/MainLayout.qml" line="366"/>
         <source>Recently Played</source>
         <translation type="unfinished">最近游玩</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="592"/>
+        <location filename="../app/MainLayout.qml" line="695"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="593"/>
+        <location filename="../app/MainLayout.qml" line="696"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="668"/>
+        <location filename="../app/MainLayout.qml" line="806"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="669"/>
+        <location filename="../app/MainLayout.qml" line="807"/>
         <source>Are you sure you want to exit?</source>
         <translation>确定要退出吗？</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="741"/>
-        <location filename="../app/MainLayout.qml" line="813"/>
-        <location filename="../app/MainLayout.qml" line="856"/>
-        <location filename="../app/MainLayout.qml" line="885"/>
-        <location filename="../app/MainLayout.qml" line="932"/>
-        <location filename="../app/MainLayout.qml" line="973"/>
-        <location filename="../app/MainLayout.qml" line="1037"/>
+        <location filename="../app/MainLayout.qml" line="886"/>
+        <location filename="../app/MainLayout.qml" line="960"/>
+        <location filename="../app/MainLayout.qml" line="1003"/>
+        <location filename="../app/MainLayout.qml" line="1034"/>
+        <location filename="../app/MainLayout.qml" line="1084"/>
+        <location filename="../app/MainLayout.qml" line="1127"/>
+        <location filename="../app/MainLayout.qml" line="1195"/>
         <source>Move</source>
         <translation>移动</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="745"/>
-        <location filename="../app/MainLayout.qml" line="817"/>
+        <location filename="../app/MainLayout.qml" line="890"/>
+        <location filename="../app/MainLayout.qml" line="964"/>
         <source>Select</source>
         <translation>选择</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="749"/>
-        <location filename="../app/MainLayout.qml" line="753"/>
-        <location filename="../app/MainLayout.qml" line="767"/>
-        <location filename="../app/MainLayout.qml" line="780"/>
-        <location filename="../app/MainLayout.qml" line="791"/>
+        <location filename="../app/MainLayout.qml" line="894"/>
+        <location filename="../app/MainLayout.qml" line="898"/>
+        <location filename="../app/MainLayout.qml" line="912"/>
+        <location filename="../app/MainLayout.qml" line="927"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="760"/>
-        <location filename="../app/MainLayout.qml" line="798"/>
-        <location filename="../app/MainLayout.qml" line="821"/>
-        <location filename="../app/MainLayout.qml" line="832"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
+        <location filename="../app/MainLayout.qml" line="945"/>
+        <location filename="../app/MainLayout.qml" line="968"/>
+        <location filename="../app/MainLayout.qml" line="979"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="776"/>
+        <location filename="../app/MainLayout.qml" line="923"/>
         <source>Done</source>
         <translation>完成</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="787"/>
-        <location filename="../app/MainLayout.qml" line="908"/>
-        <location filename="../app/MainLayout.qml" line="958"/>
-        <location filename="../app/MainLayout.qml" line="1063"/>
+        <location filename="../app/MainLayout.qml" line="934"/>
+        <location filename="../app/MainLayout.qml" line="1057"/>
+        <location filename="../app/MainLayout.qml" line="1110"/>
+        <location filename="../app/MainLayout.qml" line="1221"/>
         <source>Retry</source>
         <translation>重试</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="806"/>
+        <location filename="../app/MainLayout.qml" line="953"/>
         <source>I understand</source>
         <translation>我明白了</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="840"/>
+        <location filename="../app/MainLayout.qml" line="987"/>
         <source>Start</source>
         <translation>开始</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="860"/>
-        <location filename="../app/MainLayout.qml" line="895"/>
-        <location filename="../app/MainLayout.qml" line="942"/>
-        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1007"/>
+        <location filename="../app/MainLayout.qml" line="1044"/>
+        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Open</source>
         <translation>打开</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="864"/>
+        <location filename="../app/MainLayout.qml" line="1011"/>
         <source>Quit</source>
         <translation>退出</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="873"/>
-        <location filename="../app/MainLayout.qml" line="901"/>
-        <location filename="../app/MainLayout.qml" line="912"/>
-        <location filename="../app/MainLayout.qml" line="924"/>
-        <location filename="../app/MainLayout.qml" line="951"/>
-        <location filename="../app/MainLayout.qml" line="962"/>
-        <location filename="../app/MainLayout.qml" line="997"/>
-        <location filename="../app/MainLayout.qml" line="1013"/>
-        <location filename="../app/MainLayout.qml" line="1022"/>
-        <location filename="../app/MainLayout.qml" line="1056"/>
-        <location filename="../app/MainLayout.qml" line="1067"/>
+        <location filename="../app/MainLayout.qml" line="1020"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1061"/>
+        <location filename="../app/MainLayout.qml" line="1076"/>
+        <location filename="../app/MainLayout.qml" line="1103"/>
+        <location filename="../app/MainLayout.qml" line="1114"/>
+        <location filename="../app/MainLayout.qml" line="1151"/>
+        <location filename="../app/MainLayout.qml" line="1169"/>
+        <location filename="../app/MainLayout.qml" line="1178"/>
+        <location filename="../app/MainLayout.qml" line="1214"/>
+        <location filename="../app/MainLayout.qml" line="1225"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="891"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1043"/>
+        <location filename="../app/MainLayout.qml" line="1040"/>
+        <location filename="../app/MainLayout.qml" line="1090"/>
+        <location filename="../app/MainLayout.qml" line="1201"/>
         <source>Page</source>
         <translation>页面</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="947"/>
-        <location filename="../app/MainLayout.qml" line="1052"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1210"/>
         <source>Options</source>
         <translation>选项</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="982"/>
+        <location filename="../app/MainLayout.qml" line="1136"/>
         <source>Change</source>
         <translation>更改</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="988"/>
+        <location filename="../app/MainLayout.qml" line="1142"/>
         <source>Toggle</source>
         <translation>切换</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1009"/>
+        <location filename="../app/MainLayout.qml" line="1165"/>
         <source>Scroll</source>
         <translation>滚动</translation>
     </message>
@@ -710,12 +834,12 @@
         <translation type="unfinished">正在加载…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="306"/>
+        <location filename="../screens/MediaListScreen.qml" line="351"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 个条目</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="307"/>
+        <location filename="../screens/MediaListScreen.qml" line="352"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -764,17 +888,17 @@
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="26"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
         <source>Nothing here</source>
         <translation>这里什么都没有</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="28"/>
         <source>Loading…</source>
         <translation>正在加载…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="57"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="58"/>
         <source>Failed to load</source>
         <translation>加载失败</translation>
     </message>
@@ -782,387 +906,423 @@
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="61"/>
         <source>General</source>
-        <translation>常规</translation>
+        <translation type="vanished">常规</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="73"/>
-        <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
         <source>Language</source>
         <translation>语言</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="78"/>
-        <location filename="../screens/SettingsScreen.qml" line="507"/>
+        <location filename="../screens/SettingsScreen.qml" line="97"/>
+        <location filename="../screens/SettingsScreen.qml" line="618"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="516"/>
+        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Browsing layout</source>
         <translation>浏览布局</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="88"/>
-        <location filename="../screens/SettingsScreen.qml" line="525"/>
+        <location filename="../screens/SettingsScreen.qml" line="125"/>
+        <location filename="../screens/SettingsScreen.qml" line="636"/>
         <source>Button style</source>
         <translation>按钮样式</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="93"/>
-        <location filename="../screens/SettingsScreen.qml" line="534"/>
+        <location filename="../screens/SettingsScreen.qml" line="112"/>
+        <location filename="../screens/SettingsScreen.qml" line="645"/>
         <source>Screensaver</source>
         <translation>屏幕保护程序</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="97"/>
         <source>Library</source>
-        <translation>资料库</translation>
+        <translation type="vanished">资料库</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
+        <location filename="../screens/SettingsScreen.qml" line="142"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="543"/>
+        <location filename="../screens/SettingsScreen.qml" line="654"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="112"/>
+        <location filename="../screens/SettingsScreen.qml" line="137"/>
         <source>Update media database</source>
         <translation>更新媒体数据库</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
         <source>Scrape metadata</source>
         <translation>抓取元数据</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
         <source>Advanced</source>
-        <translation>高级</translation>
+        <translation type="vanished">高级</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="130"/>
         <source>Mouse support</source>
         <translation>鼠标支持</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="136"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
         <source>Debug logging</source>
         <translation>调试日志</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="141"/>
+        <location filename="../screens/SettingsScreen.qml" line="169"/>
         <source>Upload log file</source>
         <translation>上传日志文件</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="146"/>
+        <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>About / License</source>
         <translation>关于 / 许可</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="162"/>
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
+        <source>Display &amp; Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="72"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <source>Controls &amp; Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="189"/>
+        <source>Library &amp; Data Management</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="82"/>
+        <location filename="../screens/SettingsScreen.qml" line="191"/>
+        <source>Support &amp; About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="206"/>
         <source>Optimizing</source>
         <translation>正在优化</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
-        <location filename="../screens/SettingsScreen.qml" line="173"/>
+        <location filename="../screens/SettingsScreen.qml" line="208"/>
+        <location filename="../screens/SettingsScreen.qml" line="217"/>
         <source>Paused</source>
         <translation>已暂停</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
-        <location filename="../screens/SettingsScreen.qml" line="173"/>
+        <location filename="../screens/SettingsScreen.qml" line="208"/>
+        <location filename="../screens/SettingsScreen.qml" line="217"/>
         <source>In progress</source>
         <translation>进行中</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="167"/>
+        <location filename="../screens/SettingsScreen.qml" line="211"/>
         <source>%1 indexed</source>
         <translation>已索引 %1 个</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="176"/>
+        <location filename="../screens/SettingsScreen.qml" line="220"/>
         <source>%1 scraped</source>
         <translation>已抓取 %1 个</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="284"/>
+        <location filename="../screens/SettingsScreen.qml" line="393"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="284"/>
+        <location filename="../screens/SettingsScreen.qml" line="393"/>
         <source>Start</source>
         <translation>开始</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="286"/>
+        <location filename="../screens/SettingsScreen.qml" line="395"/>
         <source>Upload</source>
         <translation>上传</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="288"/>
+        <location filename="../screens/SettingsScreen.qml" line="396"/>
         <source>Open</source>
         <translation>打开</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="340"/>
+        <location filename="../screens/SettingsScreen.qml" line="447"/>
         <source>Default</source>
         <translation>默认</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="365"/>
+        <location filename="../screens/SettingsScreen.qml" line="472"/>
         <source>English</source>
         <translation>英语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="367"/>
+        <location filename="../screens/SettingsScreen.qml" line="474"/>
         <source>Italian</source>
         <translation>意大利语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="476"/>
+        <source>Spanish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="478"/>
+        <source>Basque</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="480"/>
         <source>German</source>
         <translation>德语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
+        <location filename="../screens/SettingsScreen.qml" line="482"/>
         <source>Greek</source>
         <translation>希腊语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="373"/>
+        <location filename="../screens/SettingsScreen.qml" line="484"/>
         <source>Japanese</source>
         <translation>日语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="375"/>
+        <location filename="../screens/SettingsScreen.qml" line="486"/>
         <source>Korean</source>
         <translation>韩语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Dutch</source>
         <translation>荷兰语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="379"/>
+        <location filename="../screens/SettingsScreen.qml" line="490"/>
         <source>Romanian</source>
         <translation>罗马尼亚语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="381"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Slovak</source>
         <translation>斯洛伐克语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="383"/>
+        <location filename="../screens/SettingsScreen.qml" line="494"/>
         <source>Ukrainian</source>
         <translation>乌克兰语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="385"/>
+        <location filename="../screens/SettingsScreen.qml" line="496"/>
         <source>Chinese (Simplified)</source>
         <translation>简体中文</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="387"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Hebrew</source>
         <translation>希伯来语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="389"/>
+        <location filename="../screens/SettingsScreen.qml" line="500"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="391"/>
+        <location filename="../screens/SettingsScreen.qml" line="502"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="392"/>
-        <location filename="../screens/SettingsScreen.qml" line="451"/>
+        <location filename="../screens/SettingsScreen.qml" line="503"/>
+        <location filename="../screens/SettingsScreen.qml" line="562"/>
         <source>Auto</source>
         <translation>自动</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="397"/>
+        <location filename="../screens/SettingsScreen.qml" line="508"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="399"/>
+        <location filename="../screens/SettingsScreen.qml" line="510"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="400"/>
+        <location filename="../screens/SettingsScreen.qml" line="511"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="405"/>
+        <location filename="../screens/SettingsScreen.qml" line="516"/>
         <source>Detailed list view</source>
         <translation>详细列表视图</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="406"/>
+        <location filename="../screens/SettingsScreen.qml" line="517"/>
         <source>Grid view</source>
         <translation>网格视图</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="411"/>
+        <location filename="../screens/SettingsScreen.qml" line="522"/>
         <source>Style B</source>
         <translation>样式 B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="413"/>
+        <location filename="../screens/SettingsScreen.qml" line="524"/>
         <source>Style C</source>
         <translation>样式 C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="415"/>
+        <location filename="../screens/SettingsScreen.qml" line="526"/>
         <source>Style D</source>
         <translation>样式 D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="416"/>
+        <location filename="../screens/SettingsScreen.qml" line="527"/>
         <source>Style A</source>
         <translation>样式 A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="431"/>
+        <location filename="../screens/SettingsScreen.qml" line="542"/>
         <source>Off</source>
         <translation>关闭</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="433"/>
+        <location filename="../screens/SettingsScreen.qml" line="544"/>
         <source>1 second (testing)</source>
         <translation>1 秒（测试）</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="435"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>1 minute</source>
         <translation>1 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="437"/>
+        <location filename="../screens/SettingsScreen.qml" line="548"/>
         <source>2 minutes</source>
         <translation>2 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="439"/>
+        <location filename="../screens/SettingsScreen.qml" line="550"/>
         <source>5 minutes</source>
         <translation>5 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="441"/>
+        <location filename="../screens/SettingsScreen.qml" line="552"/>
         <source>10 minutes</source>
         <translation>10 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="443"/>
+        <location filename="../screens/SettingsScreen.qml" line="554"/>
         <source>15 minutes</source>
         <translation>15 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="445"/>
+        <location filename="../screens/SettingsScreen.qml" line="556"/>
         <source>30 minutes</source>
         <translation>30 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="446"/>
+        <location filename="../screens/SettingsScreen.qml" line="557"/>
         <source>%1 seconds</source>
         <translation>%1 秒</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="489"/>
+        <location filename="../screens/SettingsScreen.qml" line="1032"/>
+        <source>Loading settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="91"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Resolution</source>
         <translation>分辨率</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="453"/>
+        <location filename="../screens/SettingsScreen.qml" line="564"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="455"/>
+        <location filename="../screens/SettingsScreen.qml" line="566"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="457"/>
+        <location filename="../screens/SettingsScreen.qml" line="568"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="459"/>
+        <location filename="../screens/SettingsScreen.qml" line="570"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="461"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="463"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="465"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="467"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="469"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="471"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="473"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="663"/>
+        <location filename="../screens/SettingsScreen.qml" line="192"/>
         <source>Settings</source>
         <translation>设置</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="857"/>
+        <location filename="../screens/SettingsScreen.qml" line="1020"/>
         <source>No settings available on this platform</source>
         <translation>此平台上没有可用设置</translation>
     </message>
@@ -1170,24 +1330,24 @@
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="195"/>
-        <location filename="../screens/SystemsScreen.qml" line="292"/>
+        <location filename="../screens/SystemsScreen.qml" line="197"/>
+        <location filename="../screens/SystemsScreen.qml" line="295"/>
         <source>%1 systems</source>
         <translation>%1 个系统</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="196"/>
-        <location filename="../screens/SystemsScreen.qml" line="309"/>
+        <location filename="../screens/SystemsScreen.qml" line="198"/>
+        <location filename="../screens/SystemsScreen.qml" line="312"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="324"/>
+        <location filename="../screens/SystemsScreen.qml" line="328"/>
         <source>No systems in this category</source>
         <translation>此类别中没有系统</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="325"/>
+        <location filename="../screens/SystemsScreen.qml" line="329"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -54,6 +54,13 @@
         <translation>翻译</translation>
     </message>
     <message>
+        <location filename="../screens/AboutScreen.qml" line="267"/>
+        <source>Italiano - Andrea Bogazzi
+Español - Carlos R.
+Euskara - devilschile2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/AboutScreen.qml" line="278"/>
         <source>Full license text in COPYING.</source>
         <translation>完整许可文本见 COPYING。</translation>
@@ -911,31 +918,31 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="611"/>
         <source>Language</source>
         <translation>语言</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="97"/>
-        <location filename="../screens/SettingsScreen.qml" line="618"/>
+        <location filename="../screens/SettingsScreen.qml" line="620"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="627"/>
+        <location filename="../screens/SettingsScreen.qml" line="629"/>
         <source>Browsing layout</source>
         <translation>浏览布局</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="125"/>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="638"/>
         <source>Button style</source>
         <translation>按钮样式</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="112"/>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
+        <location filename="../screens/SettingsScreen.qml" line="647"/>
         <source>Screensaver</source>
         <translation>屏幕保护程序</translation>
     </message>
@@ -950,7 +957,7 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="654"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1136,183 +1143,188 @@
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <source>Chinese (Traditional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="500"/>
         <source>Hebrew</source>
         <translation>希伯来语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="500"/>
+        <location filename="../screens/SettingsScreen.qml" line="502"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="502"/>
+        <location filename="../screens/SettingsScreen.qml" line="504"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="503"/>
-        <location filename="../screens/SettingsScreen.qml" line="562"/>
+        <location filename="../screens/SettingsScreen.qml" line="505"/>
+        <location filename="../screens/SettingsScreen.qml" line="564"/>
         <source>Auto</source>
         <translation>自动</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="508"/>
+        <location filename="../screens/SettingsScreen.qml" line="510"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="510"/>
+        <location filename="../screens/SettingsScreen.qml" line="512"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="511"/>
+        <location filename="../screens/SettingsScreen.qml" line="513"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="516"/>
+        <location filename="../screens/SettingsScreen.qml" line="518"/>
         <source>Detailed list view</source>
         <translation>详细列表视图</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="517"/>
+        <location filename="../screens/SettingsScreen.qml" line="519"/>
         <source>Grid view</source>
         <translation>网格视图</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="522"/>
+        <location filename="../screens/SettingsScreen.qml" line="524"/>
         <source>Style B</source>
         <translation>样式 B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="524"/>
+        <location filename="../screens/SettingsScreen.qml" line="526"/>
         <source>Style C</source>
         <translation>样式 C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="526"/>
+        <location filename="../screens/SettingsScreen.qml" line="528"/>
         <source>Style D</source>
         <translation>样式 D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="527"/>
+        <location filename="../screens/SettingsScreen.qml" line="529"/>
         <source>Style A</source>
         <translation>样式 A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="542"/>
+        <location filename="../screens/SettingsScreen.qml" line="544"/>
         <source>Off</source>
         <translation>关闭</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="544"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>1 second (testing)</source>
         <translation>1 秒（测试）</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="546"/>
+        <location filename="../screens/SettingsScreen.qml" line="548"/>
         <source>1 minute</source>
         <translation>1 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="548"/>
+        <location filename="../screens/SettingsScreen.qml" line="550"/>
         <source>2 minutes</source>
         <translation>2 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="550"/>
+        <location filename="../screens/SettingsScreen.qml" line="552"/>
         <source>5 minutes</source>
         <translation>5 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="552"/>
+        <location filename="../screens/SettingsScreen.qml" line="554"/>
         <source>10 minutes</source>
         <translation>10 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="554"/>
+        <location filename="../screens/SettingsScreen.qml" line="556"/>
         <source>15 minutes</source>
         <translation>15 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="556"/>
+        <location filename="../screens/SettingsScreen.qml" line="558"/>
         <source>30 minutes</source>
         <translation>30 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="557"/>
+        <location filename="../screens/SettingsScreen.qml" line="559"/>
         <source>%1 seconds</source>
         <translation>%1 秒</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1032"/>
+        <location filename="../screens/SettingsScreen.qml" line="1034"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="91"/>
-        <location filename="../screens/SettingsScreen.qml" line="600"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Resolution</source>
         <translation>分辨率</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="564"/>
+        <location filename="../screens/SettingsScreen.qml" line="566"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="566"/>
+        <location filename="../screens/SettingsScreen.qml" line="568"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="568"/>
+        <location filename="../screens/SettingsScreen.qml" line="570"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="570"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1322,7 +1334,7 @@
         <translation>设置</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1020"/>
+        <location filename="../screens/SettingsScreen.qml" line="1022"/>
         <source>No settings available on this platform</source>
         <translation>此平台上没有可用设置</translation>
     </message>

--- a/tests/ui/tst_navigation.qml
+++ b/tests/ui/tst_navigation.qml
@@ -438,18 +438,20 @@ TestCase {
     }
     // qmllint enable compiler
 
-    function test_context_menu_systems_owner_is_single_launch_core(): void {
+    function test_context_menu_systems_owner_includes_media_actions(): void {
         // qmllint disable compiler
         const entries = main.buildContextMenuEntries("systems", "", false, false, false, "");
-        compare(_idsOf(entries), ["launch_system"], "Systems context menu is just Launch core regardless of has_nfc");
+        compare(_idsOf(entries), ["launch_system", "index_system", "scrape_system"], "Systems context menu includes system-scoped maintenance actions");
         verify(entries[0].label.length > 0, "Launch core label is set (not asserted in English for translation)");
+        verify(entries[1].label.length > 0, "Update media database label is set");
+        verify(entries[2].label.length > 0, "Scrape metadata label is set");
     // qmllint enable compiler
     }
 
     function test_context_menu_systems_has_nfc_does_not_add_entries(): void {
         // qmllint disable compiler
         const entries = main.buildContextMenuEntries("systems", "", false, true, false, "");
-        compare(_idsOf(entries), ["launch_system"], "has_nfc must not affect the systems menu");
+        compare(_idsOf(entries), ["launch_system", "index_system", "scrape_system"], "has_nfc must not affect the systems menu");
     // qmllint enable compiler
     }
 


### PR DESCRIPTION
## Summary
- compact CRT metadata labels and fix context menu loader sizing
- reorganize Settings into console-style subpages with focus memory
- improve media indexing/scraping status pills with progress fill and spinner
- add system-scoped index/scrape actions to the Systems options menu
- hook up Basque and Spanish language selection and refresh translation catalogs

## Tests
- just fmt
- just lint
- just test-qml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Basque (Euskara) language added to the frontend
  * Context menu supports updating media database and scraping metadata per system
  * Settings reorganized into page-based navigation (Display & Interface, Controls & Input, Library & Data Management, Support & About)

* **Improvements**
  * Core status indicator now shows media progress with animated spinner
  * Browse detail pane improves metadata label sizing and short-form labels

* **Documentation**
  * Added Basque translator credit
<!-- end of auto-generated comment: release notes by coderabbit.ai -->