### PR TITLE
Improve cover prefetch and settings polish

### DIFF
--- a/rust/frontend/src/media_image_cache.rs
+++ b/rust/frontend/src/media_image_cache.rs
@@ -34,6 +34,7 @@
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::ffi::{c_char, c_void};
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex, OnceLock, RwLock};
 
 use base64::engine::general_purpose::{STANDARD as BASE64_STANDARD, URL_SAFE_NO_PAD};
@@ -57,13 +58,15 @@ const KEY_SEPARATOR: u8 = 0x1F;
 /// `system_id/path` pair (~64 B) → roughly 400 KiB worst-case.
 const NEGATIVE_MEMO_CAP: usize = 4096;
 
-/// Hard cap on cached image bytes. Sized to comfortably hold one or two
-/// pages of typical Games tiles plus the occasional ~5 MiB boxart
-/// outlier without LRU-evicting prefetched-but-not-yet-read entries.
-/// On `MiSTer` (492 MiB total, no swap) this still leaves ~300 MiB for
-/// Core, the FPGA wrapper, and a loaded game core; measured headroom
-/// with the frontend running was 367 MiB available.
-const CACHE_CAP_BYTES: usize = 64 * 1024 * 1024;
+/// Hard cap on cached image bytes. Sized to hold several pages of
+/// full-resolution tiles while leaving headroom for Core, the FPGA
+/// wrapper, and a loaded game core. On `MiSTer` (492 MiB total, no swap)
+/// measured free RAM with the frontend running was ~367 MiB, so 128 MiB
+/// leaves ~239 MiB for the rest of the system. When `max_cover_size` is
+/// set (resized covers average ~30 KB), this cap holds thousands of
+/// tiles rather than the ~110 full-resolution SNES covers that fit at
+/// 64 MiB.
+const CACHE_CAP_BYTES: usize = 128 * 1024 * 1024;
 
 /// Maximum retries for a single key after a transient fetch failure
 /// (RPC error, base64 decode error). Generous enough to ride through
@@ -76,16 +79,16 @@ const CACHE_CAP_BYTES: usize = 64 * 1024 * 1024;
 const MAX_FETCH_ATTEMPTS: u8 = 3;
 
 /// Number of fetch worker tasks pulling from the shared LIFO queue.
-/// Two workers let visible pages fill more than one cover at a time
+/// Two workers let visible pages fill multiple covers at a time
 /// while keeping Core/WebSocket pressure low on `MiSTer`. If runtime
-/// logs show resets or media.image rate-limit errors, drop this back
-/// to one before trying any broader queue changes.
+/// logs show stalls, resets, or media.image rate-limit errors, tune
+/// this before trying any broader queue changes.
 const FETCH_DRIVER_WORKERS: usize = 2;
 
-/// Hard cap on pending enqueues in the fetch queue. Sized for three
-/// dense visual pages (current, next, previous) plus margin, so an
-/// explicit page-window rebuild does not drop the previous-page warm
-/// on a 30-tile layout while still bounding stale queue memory.
+/// Hard cap on pending enqueues in the fetch queue. Sized for a few
+/// dense visual pages (current, lookahead, previous) plus margin, so
+/// an explicit page-window rebuild does not drop the previous-page
+/// warm on a 30-tile layout while still bounding stale queue memory.
 const MAX_QUEUE_LEN: usize = 96;
 
 /// MIME content-type → on-disk extension for the formats we are willing
@@ -601,6 +604,9 @@ pub struct MediaImageCache {
     /// `notify_one()` per enqueue.
     queue_notify: Arc<Notify>,
     updates_tx: broadcast::Sender<MediaImageUpdate>,
+    /// Maximum cover dimension requested from Core. 0 = full resolution.
+    /// Set by QML via `set_max_cover_size` when the grid shape changes.
+    max_cover_size: Arc<AtomicU32>,
 }
 
 impl MediaImageCache {
@@ -613,6 +619,7 @@ impl MediaImageCache {
         let queue: Arc<Mutex<VecDeque<QueueEntry>>> = Arc::new(Mutex::new(VecDeque::new()));
         let queue_notify = Arc::new(Notify::new());
         let (updates_tx, _) = broadcast::channel::<MediaImageUpdate>(64);
+        let max_cover_size = Arc::new(AtomicU32::new(0));
 
         spawn_fetch_driver(
             runtime,
@@ -621,6 +628,7 @@ impl MediaImageCache {
             &updates_tx,
             &queue,
             &queue_notify,
+            &max_cover_size,
             store_factory,
         );
 
@@ -629,7 +637,17 @@ impl MediaImageCache {
             queue,
             queue_notify,
             updates_tx,
+            max_cover_size,
         }
+    }
+
+    /// Set the maximum cover dimension (pixels) sent to Core with every
+    /// `media.image` request. Core resizes the image to fit within a
+    /// `size × size` bounding box before returning it, so the cached
+    /// bytes are smaller and more covers fit in the fixed-size cache.
+    /// Pass `0` to request full-resolution images (default).
+    pub fn set_max_cover_size(&self, size: u32) {
+        self.max_cover_size.store(size, Ordering::Relaxed);
     }
 
     /// Bytes for `key`, if cached. Bumps `last_used` so the entry's
@@ -733,7 +751,7 @@ impl MediaImageCache {
         self.release_drained_pending(&drained);
         debug!(
             dropped = drained.len(),
-            "media_image_cache: cleared queued cover requests"
+            "media_image_cache: cleared pending cover fetches"
         );
     }
 
@@ -798,7 +816,7 @@ impl MediaImageCache {
         debug!(
             dropped = drained.len(),
             queued = queued_len,
-            "media_image_cache: replaced queued cover requests"
+            "media_image_cache: replaced pending cover fetches"
         );
         for _ in 0..FETCH_DRIVER_WORKERS {
             self.queue_notify.notify_one();
@@ -935,6 +953,10 @@ fn pop_one(queue: &Arc<Mutex<VecDeque<QueueEntry>>>) -> Option<QueueEntry> {
     queue.lock().unwrap().pop_back()
 }
 
+#[allow(
+    clippy::too_many_arguments,
+    reason = "private constructor; adding max_cover_size pushed it to 8"
+)]
 fn spawn_fetch_driver<F>(
     runtime: &Handle,
     cap_bytes: usize,
@@ -942,6 +964,7 @@ fn spawn_fetch_driver<F>(
     updates_tx: &broadcast::Sender<MediaImageUpdate>,
     queue: &Arc<Mutex<VecDeque<QueueEntry>>>,
     queue_notify: &Arc<Notify>,
+    max_cover_size: &Arc<AtomicU32>,
     store_factory: F,
 ) where
     F: Fn() -> Arc<Store> + Send + Sync + 'static,
@@ -956,6 +979,7 @@ fn spawn_fetch_driver<F>(
         let queue = queue.clone();
         let queue_notify = queue_notify.clone();
         let store_factory = store_factory.clone();
+        let max_cover_size = max_cover_size.clone();
         runtime.spawn(async move {
             loop {
                 let Some(entry) = pop_one(&queue) else {
@@ -963,7 +987,7 @@ fn spawn_fetch_driver<F>(
                     continue;
                 };
                 let store = store_factory();
-                let outcome = fetch_one(&store, &state, entry).await;
+                let outcome = fetch_one(&store, &state, &max_cover_size, entry).await;
                 process_batch_outcomes(
                     &state,
                     cap_bytes,
@@ -1136,6 +1160,7 @@ enum FetchOutcome {
 async fn fetch_one(
     store: &Arc<Store>,
     state: &Arc<RwLock<CacheState>>,
+    max_cover_size: &Arc<AtomicU32>,
     entry: QueueEntry,
 ) -> (QueueEntry, FetchOutcome) {
     let key = entry.key.clone();
@@ -1155,6 +1180,10 @@ async fn fetch_one(
     } else if let Some(image_type) = key.image_type.as_ref() {
         params.image_types.push(image_type.to_string());
     }
+    let max_size = max_cover_size.load(Ordering::Relaxed);
+    if max_size > 0 {
+        params.max_size = Some(max_size);
+    }
     debug!(
         system_id = %key.system_id,
         path = %key.path,
@@ -1162,6 +1191,7 @@ async fn fetch_one(
         had_id_hint,
         policy = ?entry.no_image_policy,
         page_size = entry.page_size,
+        max_size,
         "media_image_cache: media.image request"
     );
     match store.client().media_image(params).await {
@@ -1454,6 +1484,7 @@ mod tests {
         QueueEntry, MAX_QUEUE_LEN, NEGATIVE_MEMO_CAP,
     };
     use std::collections::VecDeque;
+    use std::sync::atomic::AtomicU32;
     use std::sync::{Arc, Mutex, RwLock};
     use tokio::sync::{broadcast, Notify};
 
@@ -1472,6 +1503,7 @@ mod tests {
             queue,
             queue_notify,
             updates_tx,
+            max_cover_size: Arc::new(AtomicU32::new(0)),
         }
     }
 

--- a/rust/frontend/src/models/games.rs
+++ b/rust/frontend/src/models/games.rs
@@ -97,6 +97,8 @@ const DEFAULT_PAGE_SIZE: i32 = 15;
 // longer floods the cover queue.
 const FETCH_MORE_CHUNK_SIZE: i32 = 100;
 const FETCH_MORE_RAPID_CHUNK_SIZE: i32 = 300;
+const COVER_PREFETCH_NEXT_PAGES: i32 = 2;
+const COVER_PREFETCH_PREVIOUS_PAGES: i32 = 1;
 
 // `apply_append_page` sub-batches the model insert into chunks of this
 // many rows so the Repeater's per-delegate `createObject` cost (the
@@ -229,6 +231,7 @@ pub struct GamesModelRust {
     // so a freshly-landed metadata chunk can re-issue the prefetch
     // window for whatever row the user is currently looking at.
     visible_first_row: i32,
+    cover_max_size: i32,
 }
 
 impl Default for GamesModelRust {
@@ -272,6 +275,7 @@ impl Default for GamesModelRust {
             append_seq: Arc::new(AtomicU64::new(0)),
             pending_initial_lookahead: false,
             visible_first_row: 0,
+            cover_max_size: 0,
         }
     }
 }
@@ -320,7 +324,11 @@ pub mod ffi {
         #[qproperty(bool, cover_key_roles_enabled)]
         #[qproperty(bool, cover_requests_paused)]
         #[qproperty(i32, visible_first_row)]
+        #[qproperty(i32, cover_max_size, READ, WRITE = set_cover_max_size, NOTIFY)]
         type GamesModel = super::GamesModelRust;
+
+        #[qinvokable]
+        fn set_cover_max_size(self: Pin<&mut GamesModel>, size: i32);
 
         #[qinvokable]
         fn set_system(self: Pin<&mut GamesModel>, system_id: QString);
@@ -497,6 +505,12 @@ impl ffi::GamesModel {
         h
     }
 
+    fn set_cover_max_size(mut self: Pin<&mut Self>, size: i32) {
+        let clamped = size.max(0);
+        self.as_mut().rust_mut().cover_max_size = clamped;
+        global_media_image_cache().set_max_cover_size(u32::try_from(clamped).unwrap_or(0));
+    }
+
     fn set_system(mut self: Pin<&mut Self>, system_id: QString) {
         let sid = system_id.to_string();
         self.as_mut().set_current_system_id(system_id);
@@ -598,9 +612,10 @@ impl ffi::GamesModel {
     ///
     /// `first_visible_row` is the row index of the topmost visible
     /// tile (`gamesGrid.currentPage * gamesGrid.pageSize` from QML).
-    /// The replacement queue drains current page first, then next
-    /// page, then previous page. Queued stale requests are dropped so
-    /// a page change immediately makes the new visible page win.
+    /// The replacement queue drains current page first, then several
+    /// next pages, then the previous page. Queued stale requests are
+    /// dropped so a page change immediately makes the new visible page
+    /// win.
     fn prefetch_around(self: Pin<&mut Self>, first_visible_row: i32) {
         let cache = global_media_image_cache();
         if self.cover_requests_paused {
@@ -1404,8 +1419,8 @@ fn media_key_for(entry: &BrowseEntry) -> Option<MediaKey> {
 
 /// Pure ordering helper for `prefetch_around`. Returns
 /// (`MediaKey`, `media_id`) pairs in desired fetch order: current page
-/// top-to-bottom, then next page, then previous page. Folders and
-/// entries without a `media_key` are skipped.
+/// top-to-bottom, then configured next pages, then configured previous
+/// pages. Folders and entries without a `media_key` are skipped.
 fn prefetch_around_plan(
     entries: &[BrowseEntry],
     count: i32,
@@ -1418,29 +1433,28 @@ fn prefetch_around_plan(
     let page_size = page_size.max(1);
     let first = first_visible_row.clamp(0, count.saturating_sub(1));
     let current_end = first.saturating_add(page_size).min(count);
-    let next_end = current_end.saturating_add(page_size).min(count);
-    let previous_start = first.saturating_sub(page_size);
+    let next_end = current_end
+        .saturating_add(page_size.saturating_mul(COVER_PREFETCH_NEXT_PAGES))
+        .min(count);
+    let previous_start =
+        first.saturating_sub(page_size.saturating_mul(COVER_PREFETCH_PREVIOUS_PAGES));
     let mut plan: Vec<(MediaKey, Option<i64>)> =
         Vec::with_capacity(((next_end - previous_start) as usize).min(entries.len()));
-    let push = |row: i32, plan: &mut Vec<(MediaKey, Option<i64>)>| {
-        let idx = row as usize;
-        if idx >= entries.len() {
-            return;
-        }
-        let entry = &entries[idx];
-        if let Some(key) = media_key_for(entry) {
-            plan.push((key.with_current_cover_preference(), entry.media_id));
+    let push_range = |range: std::ops::Range<i32>, plan: &mut Vec<(MediaKey, Option<i64>)>| {
+        for row in range {
+            let idx = row as usize;
+            if idx >= entries.len() {
+                continue;
+            }
+            let entry = &entries[idx];
+            if let Some(key) = media_key_for(entry) {
+                plan.push((key.with_current_cover_preference(), entry.media_id));
+            }
         }
     };
-    for row in first..current_end {
-        push(row, &mut plan);
-    }
-    for row in current_end..next_end {
-        push(row, &mut plan);
-    }
-    for row in previous_start..first {
-        push(row, &mut plan);
-    }
+    push_range(first..current_end, &mut plan);
+    push_range(current_end..next_end, &mut plan);
+    push_range(previous_start..first, &mut plan);
     plan
 }
 
@@ -3058,14 +3072,14 @@ mod tests {
     }
 
     #[test]
-    fn prefetch_around_plan_orders_current_next_previous() {
-        let entries: Vec<BrowseEntry> = (0..45)
+    fn prefetch_around_plan_orders_current_next_pages_previous() {
+        let entries: Vec<BrowseEntry> = (0..60)
             .map(|i| media(&format!("g{i}"), &format!("/g/{i}"), "NES"))
             .collect();
-        let plan = prefetch_around_plan(&entries, 45, 15, 15);
+        let plan = prefetch_around_plan(&entries, 60, 15, 15);
         let paths: Vec<String> = plan.iter().map(|(k, _)| k.path.to_string()).collect();
         let mut expected: Vec<String> = (15..30).map(|i| format!("/g/{i}")).collect();
-        expected.extend((30..45).map(|i| format!("/g/{i}")));
+        expected.extend((30..60).map(|i| format!("/g/{i}")));
         expected.extend((0..15).map(|i| format!("/g/{i}")));
         assert_eq!(paths, expected);
     }

--- a/rust/frontend/src/models/settings.rs
+++ b/rust/frontend/src/models/settings.rs
@@ -81,6 +81,7 @@ const MISTER_RESOLUTIONS: &[&str] = &[
     "",
     "1280x720",
     "1920x1080",
+    "2560x1440",
     "1920x1200",
     "1920x1440",
     "640x480",
@@ -666,12 +667,13 @@ mod tests {
     }
 
     #[test]
-    fn curated_list_contains_720p_and_1080p() {
+    fn curated_list_contains_common_16_9_resolutions() {
         // Mostly a sanity guard — if a future edit silently drops the
-        // two most-likely-to-work resolutions, this test catches it.
+        // most-likely-to-work 16:9 resolutions, this test catches it.
         let collected: Vec<&str> = MISTER_RESOLUTIONS.to_vec();
         assert!(collected.contains(&"1280x720"));
         assert!(collected.contains(&"1920x1080"));
+        assert!(collected.contains(&"2560x1440"));
     }
 
     #[test]

--- a/rust/zaparoo-core/src/media_types.rs
+++ b/rust/zaparoo-core/src/media_types.rs
@@ -360,6 +360,11 @@ pub struct MediaImageParams {
     pub path: String,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub image_types: Vec<String>,
+    /// Maximum dimension (width or height) in pixels. Core resizes the
+    /// image to fit within a `max_size × max_size` bounding box before
+    /// returning it. Omit (or send 0) to receive the full-resolution blob.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_size: Option<u32>,
 }
 
 impl MediaImageParams {
@@ -369,6 +374,7 @@ impl MediaImageParams {
             system: system.into(),
             path: path.into(),
             image_types: Vec::new(),
+            max_size: None,
         }
     }
 
@@ -378,6 +384,7 @@ impl MediaImageParams {
             system: String::new(),
             path: String::new(),
             image_types: Vec::new(),
+            max_size: None,
         }
     }
 }

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -78,6 +78,17 @@ MainLayout {
     readonly property int _gamesGridRows: root._gamesGridShape.rows
     readonly property int _gamesPageSize: Browse.Settings.current_browse_layout === "list" ? root._gamesListFetchSize : root._gamesGridColumns * root._gamesGridRows
     on_GamesPageSizeChanged: Browse.GamesModel.page_size = root._gamesPageSize
+    // Maximum cover dimension requested from Core. Computed from the tile
+    // pixel size with 2x headroom so the resized image looks sharp even
+    // when the grid zooms slightly. Core fits the image within a
+    // maxSize x maxSize box before returning it, so the cache holds far
+    // more covers at the same byte cap.
+    readonly property int _gamesCoverMaxSize: {
+        const tileW = Math.ceil(Sizing.screenWidth / Math.max(1, root._gamesGridColumns));
+        const tileH = Math.ceil(Sizing.screenHeight / Math.max(1, root._gamesGridRows));
+        return Math.max(tileW, tileH) * 2;
+    }
+    on_GamesCoverMaxSizeChanged: Browse.GamesModel.set_cover_max_size(root._gamesCoverMaxSize)
 
     // Bind Sizing to the scene's logical dimensions, not the
     // ApplicationWindow's. Outside CRT preview the scene fills the

--- a/src/ui/app/MainLayout.qml
+++ b/src/ui/app/MainLayout.qml
@@ -1182,13 +1182,12 @@ ApplicationWindow {
                         if (root.gamesScreen === null)
                             return [];
                         const pages = root.gamesScreen.gamesGrid.pageCount;
-                        // Options menu is only meaningful on media leaves —
-                        // folder/root entries open via Accept and have no
-                        // per-entry actions. Drop the X cue so the bar
-                        // doesn't promise a press that no-ops.
+                        // Mirror the real context-menu gate used by
+                        // GamesScreen/openContextMenu. Singleton folders
+                        // with media identity can launch and be favorited,
+                        // so they should advertise Options too.
                         const idx = root.gamesScreen.gamesGrid.currentIndex;
-                        const entryType = Browse.GamesModel.entry_type_at(idx);
-                        const isFolder = entryType === "directory" || entryType === "root";
+                        const mediaCapable = Browse.GamesModel.is_media_capable_at(idx);
                         let row = [
                             {
                                 button: "Dpad",
@@ -1204,7 +1203,7 @@ ApplicationWindow {
                             button: "ButtonA",
                             label: qsTr("Open")
                         });
-                        if (!isFolder)
+                        if (mediaCapable)
                             row.push({
                                 button: "ButtonX",
                                 label: qsTr("Options")

--- a/src/ui/components/ListPickerModal.qml
+++ b/src/ui/components/ListPickerModal.qml
@@ -52,6 +52,13 @@ Item {
     readonly property int _visibleRows: Math.max(1, Math.min(entries.length, Math.floor((_maxViewportHeight + _rowSpacing) / (_rowHeight + _rowSpacing))))
     readonly property int _viewportHeight: _visibleRows * _rowHeight + Math.max(0, _visibleRows - 1) * _rowSpacing
     readonly property int _contentHeight: Math.max(1, entries.length) * _rowHeight + Math.max(0, entries.length - 1) * _rowSpacing
+    readonly property bool _scrollable: entries.length > _visibleRows
+    readonly property int _scrollArrowSize: Sizing.pctH(3)
+    readonly property int _scrollArrowGap: Sizing.pctH(0.5)
+    readonly property int _scrollIndicatorBand: _scrollable ? _scrollArrowSize + _scrollArrowGap : 0
+    readonly property int _viewportSlotHeight: _viewportHeight + 2 * _scrollIndicatorBand
+    readonly property bool _hasContentAbove: viewport.contentY > 1
+    readonly property bool _hasContentBelow: viewport.contentY + viewport.height < viewport.contentHeight - 1
 
     visible: modal.open
     anchors.fill: parent
@@ -69,7 +76,20 @@ Item {
                 }
             }
         }
+        viewport.contentY = 0;
         modal.currentIndex = next;
+        modal._scrollCurrentIntoView();
+    }
+
+    function _scrollCurrentIntoView(): void {
+        const stride = modal._rowHeight + modal._rowSpacing;
+        const top = modal.currentIndex * stride;
+        const bottom = top + modal._rowHeight;
+        if (top < viewport.contentY) {
+            viewport.contentY = top;
+        } else if (bottom > viewport.contentY + viewport.height) {
+            viewport.contentY = bottom - viewport.height;
+        }
     }
 
     function move(delta: int): void {
@@ -103,12 +123,14 @@ Item {
             id: viewportSlot
 
             width: parent.width
-            height: modal._viewportHeight
+            height: modal._viewportSlotHeight
 
             Flickable {
                 id: viewport
 
                 anchors.fill: parent
+                anchors.topMargin: modal._scrollIndicatorBand
+                anchors.bottomMargin: modal._scrollIndicatorBand
                 contentWidth: width
                 contentHeight: modal._contentHeight
                 clip: true
@@ -166,6 +188,30 @@ Item {
                     }
                 }
             }
+
+            Image {
+                source: Resources.iconUrl("ScrollUp")
+                width: modal._scrollArrowSize
+                height: width
+                anchors.bottom: viewport.top
+                anchors.bottomMargin: modal._scrollArrowGap
+                anchors.horizontalCenter: viewport.horizontalCenter
+                fillMode: Image.PreserveAspectFit
+                smooth: true
+                visible: modal._hasContentAbove
+            }
+
+            Image {
+                source: Resources.iconUrl("ScrollDown")
+                width: modal._scrollArrowSize
+                height: width
+                anchors.top: viewport.bottom
+                anchors.topMargin: modal._scrollArrowGap
+                anchors.horizontalCenter: viewport.horizontalCenter
+                fillMode: Image.PreserveAspectFit
+                smooth: true
+                visible: modal._hasContentBelow
+            }
         }
     }
 
@@ -176,14 +222,7 @@ Item {
     Connections {
         target: modal
         function onCurrentIndexChanged(): void {
-            const stride = modal._rowHeight + modal._rowSpacing;
-            const top = modal.currentIndex * stride;
-            const bottom = top + modal._rowHeight;
-            if (top < viewport.contentY) {
-                viewport.contentY = top;
-            } else if (bottom > viewport.contentY + viewport.height) {
-                viewport.contentY = bottom - viewport.height;
-            }
+            modal._scrollCurrentIntoView();
         }
     }
 }

--- a/src/ui/components/PagedGrid.qml
+++ b/src/ui/components/PagedGrid.qml
@@ -52,7 +52,7 @@ Item {
     property bool focused: true
     property bool coverLoadingPaused: false
     property bool rapidRenderMode: false
-    readonly property int _coverRetentionPages: 7
+    readonly property int _coverRetentionPages: Math.max(1, Math.ceil(Sizing.visibleCovers))
     property var layoutProfile: null
     readonly property var _gridProfile: root.layoutProfile && root.layoutProfile.grid ? root.layoutProfile.grid : null
 
@@ -551,9 +551,9 @@ Item {
                 // collapses to the procedural fallback and the
                 // texture reference drops.
                 //
-                // Memory ceiling: ±7 around currentPage = up to 15
-                // pages × pageSize covers ≈ 150 covers ≈ 55 MB
-                // decoded - OK on MiSTer's shared 512 MB. Re-decode
+                // Memory ceiling tracks visible cover density: ±
+                // _coverRetentionPages around currentPage keeps enough
+                // decoded pages warm for the current UI scale. Re-decode
                 // after crossing past the retention edge runs at
                 // nice +10 (see media_image_provider.cpp) and is
                 // invisible to the renderer.

--- a/src/ui/components/PagedGrid.qml
+++ b/src/ui/components/PagedGrid.qml
@@ -52,6 +52,7 @@ Item {
     property bool focused: true
     property bool coverLoadingPaused: false
     property bool rapidRenderMode: false
+    readonly property int _coverRetentionPages: 7
     property var layoutProfile: null
     readonly property var _gridProfile: root.layoutProfile && root.layoutProfile.grid ? root.layoutProfile.grid : null
 
@@ -550,14 +551,14 @@ Item {
                 // collapses to the procedural fallback and the
                 // texture reference drops.
                 //
-                // Memory ceiling: ±5 around currentPage = up to 11
-                // pages × pageSize covers ≈ 110 covers ≈ 40 MB
+                // Memory ceiling: ±7 around currentPage = up to 15
+                // pages × pageSize covers ≈ 150 covers ≈ 55 MB
                 // decoded - OK on MiSTer's shared 512 MB. Re-decode
                 // after crossing past the retention edge runs at
                 // nice +10 (see media_image_provider.cpp) and is
                 // invisible to the renderer.
                 readonly property bool _coverInRange: !root.rapidRenderMode && cellPage >= root.currentPage && cellPage <= root.currentPage + 1
-                readonly property bool _coverInRetentionRange: !root.rapidRenderMode && Math.abs(cellPage - root.currentPage) <= (root.coverLoadingPaused ? 1 : 5)
+                readonly property bool _coverInRetentionRange: !root.rapidRenderMode && Math.abs(cellPage - root.currentPage) <= (root.coverLoadingPaused ? 1 : root._coverRetentionPages)
                 property bool _coverEverRequested: false
                 Binding on _coverEverRequested {
                     when: cellItem._coverInRange
@@ -639,13 +640,13 @@ Item {
                     // binding cost stays roughly constant as the
                     // dataset grows.
                     active: cellItem._coverInRetentionRange && !root.rapidRenderMode
-                    // Incubate Tile construction on background frames
-                    // so a retention-edge crossing (10 cells flipping
-                    // active) doesn't block the main thread. The
-                    // newly-revealed cells fill in over the next
-                    // frame or two; the user's selection move lands
-                    // immediately.
-                    asynchronous: true
+                    // Current-page delegates complete synchronously so
+                    // tile content appears with the page instead of
+                    // revealing icon/logo Images one-by-one as the
+                    // Loader incubates across frames. Off-page retained
+                    // delegates still incubate asynchronously so
+                    // retention-edge warmup does not block input.
+                    asynchronous: cellItem.cellPage !== root.currentPage
                     isSelected: cellItem.isSelected
                     isFocused: root.focused
                     name: cellItem.name

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -144,7 +144,7 @@ MediaListScreen {
     gridCurrentPageChangedAction: () => {
         const first = games.gamesGrid.currentPage * games.gamesGrid.pageSize;
         Browse.GamesModel.visible_first_row = first;
-        if (!games._listLayout && !games.detailRapidScrollActive)
+        if (!games._listLayout)
             Browse.GamesModel.prefetch_around(first);
     }
     activeLabelTextProvider: () => games.gamesGrid.itemCount > 0 ? Browse.GamesModel.name_at(games.gamesGrid.currentIndex) : ""

--- a/src/ui/screens/MediaListScreen.qml
+++ b/src/ui/screens/MediaListScreen.qml
@@ -211,7 +211,7 @@ Item {
     function _resumeCoverRequests(): void {
         if (root.mediaModel === null)
             return;
-        if (root.pauseCoverRequestsDuringRapid)
+        if (root._listLayout && root.pauseCoverRequestsDuringRapid)
             root.mediaModel.cover_requests_paused = false;
         if (typeof root.mediaModel.refresh_cover_keys === "function")
             root.mediaModel.refresh_cover_keys(root._coverRefreshFirstRow(), root._coverRefreshRowCount());
@@ -220,7 +220,7 @@ Item {
     }
 
     function _pauseCoverRequests(): void {
-        if (root.mediaModel === null || !root.pauseCoverRequestsDuringRapid)
+        if (root.mediaModel === null || !root._listLayout || !root.pauseCoverRequestsDuringRapid)
             return;
         root.mediaModel.cover_requests_paused = true;
         if (typeof root.mediaModel.clear_pending_cover_requests === "function")

--- a/src/ui/screens/SettingsScreen.qml
+++ b/src/ui/screens/SettingsScreen.qml
@@ -64,22 +64,22 @@ Item {
         {
             kind: "field",
             id: "pageDisplayInterface",
-            label: qsTr("Display & Interface")
+            label: qsTr("Display")
         },
         {
             kind: "field",
             id: "pageControlsInput",
-            label: qsTr("Controls & Input")
+            label: qsTr("Controls")
         },
         {
             kind: "field",
             id: "pageLibraryData",
-            label: qsTr("Library & Data Management")
+            label: qsTr("Library")
         },
         {
             kind: "field",
             id: "pageSupportAbout",
-            label: qsTr("Support & About")
+            label: qsTr("Support")
         }
     ]
     readonly property var displayInterfaceFields: {
@@ -182,13 +182,13 @@ Item {
     }
     readonly property string pageTitle: {
         if (settings.currentPage === settings.pageDisplayInterface)
-            return qsTr("Display & Interface");
+            return qsTr("Display");
         if (settings.currentPage === settings.pageControlsInput)
-            return qsTr("Controls & Input");
+            return qsTr("Controls");
         if (settings.currentPage === settings.pageLibraryData)
-            return qsTr("Library & Data Management");
+            return qsTr("Library");
         if (settings.currentPage === settings.pageSupportAbout)
-            return qsTr("Support & About");
+            return qsTr("Support");
         return qsTr("Settings");
     }
 

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -549,124 +549,124 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1206"/>
+        <location filename="../app/Main.qml" line="1217"/>
         <source>Launch core</source>
         <translation>تشغيل النواة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1212"/>
-        <location filename="../app/Main.qml" line="1420"/>
+        <location filename="../app/Main.qml" line="1223"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1219"/>
+        <location filename="../app/Main.qml" line="1230"/>
         <source>Update media database</source>
         <translation type="unfinished">تحديث قاعدة بيانات الوسائط</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1222"/>
+        <location filename="../app/Main.qml" line="1233"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">استخراج البيانات الوصفية</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1231"/>
-        <location filename="../app/Main.qml" line="1266"/>
+        <location filename="../app/Main.qml" line="1242"/>
+        <location filename="../app/Main.qml" line="1277"/>
         <source>Launch game</source>
         <translation>تشغيل اللعبة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1247"/>
+        <location filename="../app/Main.qml" line="1258"/>
         <source>Remove from favorites</source>
         <translation>إزالة من المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1247"/>
+        <location filename="../app/Main.qml" line="1258"/>
         <source>Add to favorites</source>
         <translation>أضف إلى المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1252"/>
+        <location filename="../app/Main.qml" line="1263"/>
         <source>Write to NFC token</source>
         <translation>الكتابة إلى رمز NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1256"/>
+        <location filename="../app/Main.qml" line="1267"/>
         <source>QR code</source>
         <translation>رمز QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1416"/>
+        <location filename="../app/Main.qml" line="1427"/>
         <source>Default</source>
         <translation type="unfinished">افتراضي</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1416"/>
+        <location filename="../app/Main.qml" line="1427"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1708"/>
+        <location filename="../app/Main.qml" line="1719"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1712"/>
+        <location filename="../app/Main.qml" line="1723"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1726"/>
+        <location filename="../app/Main.qml" line="1737"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1730"/>
+        <location filename="../app/Main.qml" line="1741"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1734"/>
+        <location filename="../app/Main.qml" line="1745"/>
         <source>Retry</source>
         <translation type="unfinished">إعادة المحاولة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1738"/>
+        <location filename="../app/Main.qml" line="1749"/>
         <source>Cancel</source>
         <translation type="unfinished">إلغاء</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2368"/>
+        <location filename="../app/Main.qml" line="2379"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2370"/>
+        <location filename="../app/Main.qml" line="2381"/>
         <source>Loading games…</source>
         <translation>جارٍ تحميل الألعاب…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2372"/>
+        <location filename="../app/Main.qml" line="2383"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2374"/>
+        <location filename="../app/Main.qml" line="2385"/>
         <source>Loading favorites…</source>
         <translation>جارٍ تحميل المفضلة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2376"/>
+        <location filename="../app/Main.qml" line="2387"/>
         <source>Loading recently played…</source>
         <translation>جارٍ تحميل آخر ما تم لعبه…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="2389"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2380"/>
+        <location filename="../app/Main.qml" line="2391"/>
         <source>Loading…</source>
         <translation>جارٍ التحميل…</translation>
     </message>
@@ -947,8 +947,10 @@ Euskara - devilschile2</source>
         <translation>شاشة التوقف</translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="189"/>
         <source>Library</source>
-        <translation type="vanished">المكتبة</translation>
+        <translation>المكتبة</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="142"/>
@@ -999,30 +1001,6 @@ Euskara - devilschile2</source>
         <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>About / License</source>
         <translation>حول / الترخيص</translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="185"/>
-        <source>Display &amp; Interface</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="72"/>
-        <location filename="../screens/SettingsScreen.qml" line="187"/>
-        <source>Controls &amp; Input</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="77"/>
-        <location filename="../screens/SettingsScreen.qml" line="189"/>
-        <source>Library &amp; Data Management</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="82"/>
-        <location filename="../screens/SettingsScreen.qml" line="191"/>
-        <source>Support &amp; About</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="206"/>
@@ -1267,6 +1245,24 @@ Euskara - devilschile2</source>
         <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Resolution</source>
         <translation>الدقة</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
+        <source>Display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="72"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="82"/>
+        <location filename="../screens/SettingsScreen.qml" line="191"/>
+        <source>Support</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="566"/>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -549,124 +549,124 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1206"/>
+        <location filename="../app/Main.qml" line="1217"/>
         <source>Launch core</source>
         <translation>Core starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1212"/>
-        <location filename="../app/Main.qml" line="1420"/>
+        <location filename="../app/Main.qml" line="1223"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1247"/>
+        <location filename="../app/Main.qml" line="1258"/>
         <source>Remove from favorites</source>
         <translation>Aus Favoriten entfernen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1247"/>
+        <location filename="../app/Main.qml" line="1258"/>
         <source>Add to favorites</source>
         <translation>Zu Favoriten hinzufügen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1252"/>
+        <location filename="../app/Main.qml" line="1263"/>
         <source>Write to NFC token</source>
         <translation>Auf NFC-Token schreiben</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1256"/>
+        <location filename="../app/Main.qml" line="1267"/>
         <source>QR code</source>
         <translation>QR-Code</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1231"/>
-        <location filename="../app/Main.qml" line="1266"/>
+        <location filename="../app/Main.qml" line="1242"/>
+        <location filename="../app/Main.qml" line="1277"/>
         <source>Launch game</source>
         <translation>Spiel starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2368"/>
+        <location filename="../app/Main.qml" line="2379"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2374"/>
+        <location filename="../app/Main.qml" line="2385"/>
         <source>Loading favorites…</source>
         <translation>Favoriten werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2370"/>
+        <location filename="../app/Main.qml" line="2381"/>
         <source>Loading games…</source>
         <translation>Spiele werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1219"/>
+        <location filename="../app/Main.qml" line="1230"/>
         <source>Update media database</source>
         <translation type="unfinished">Mediendatenbank aktualisieren</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1222"/>
+        <location filename="../app/Main.qml" line="1233"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadaten abrufen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1416"/>
+        <location filename="../app/Main.qml" line="1427"/>
         <source>Default</source>
         <translation type="unfinished">Standard</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1416"/>
+        <location filename="../app/Main.qml" line="1427"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1708"/>
+        <location filename="../app/Main.qml" line="1719"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1712"/>
+        <location filename="../app/Main.qml" line="1723"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1726"/>
+        <location filename="../app/Main.qml" line="1737"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1730"/>
+        <location filename="../app/Main.qml" line="1741"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1734"/>
+        <location filename="../app/Main.qml" line="1745"/>
         <source>Retry</source>
         <translation type="unfinished">Wiederholen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1738"/>
+        <location filename="../app/Main.qml" line="1749"/>
         <source>Cancel</source>
         <translation type="unfinished">Abbrechen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2372"/>
+        <location filename="../app/Main.qml" line="2383"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2376"/>
+        <location filename="../app/Main.qml" line="2387"/>
         <source>Loading recently played…</source>
         <translation>Zuletzt gespielte werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="2389"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2380"/>
+        <location filename="../app/Main.qml" line="2391"/>
         <source>Loading…</source>
         <translation>Wird geladen…</translation>
     </message>
@@ -957,8 +957,10 @@ Euskara - devilschile2</source>
         <translation>Bildschirmschoner</translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="189"/>
         <source>Library</source>
-        <translation type="vanished">Bibliothek</translation>
+        <translation>Bibliothek</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="142"/>
@@ -999,30 +1001,6 @@ Euskara - devilschile2</source>
         <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>About / License</source>
         <translation>Über / Lizenz</translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="185"/>
-        <source>Display &amp; Interface</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="72"/>
-        <location filename="../screens/SettingsScreen.qml" line="187"/>
-        <source>Controls &amp; Input</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="77"/>
-        <location filename="../screens/SettingsScreen.qml" line="189"/>
-        <source>Library &amp; Data Management</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="82"/>
-        <location filename="../screens/SettingsScreen.qml" line="191"/>
-        <source>Support &amp; About</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="206"/>
@@ -1267,6 +1245,24 @@ Euskara - devilschile2</source>
         <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Resolution</source>
         <translation>Auflösung</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
+        <source>Display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="72"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="82"/>
+        <location filename="../screens/SettingsScreen.qml" line="191"/>
+        <source>Support</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="566"/>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -549,124 +549,124 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1206"/>
+        <location filename="../app/Main.qml" line="1217"/>
         <source>Launch core</source>
         <translation>Εκκίνηση Core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1212"/>
-        <location filename="../app/Main.qml" line="1420"/>
+        <location filename="../app/Main.qml" line="1223"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1247"/>
+        <location filename="../app/Main.qml" line="1258"/>
         <source>Remove from favorites</source>
         <translation>Αφαίρεση από αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1247"/>
+        <location filename="../app/Main.qml" line="1258"/>
         <source>Add to favorites</source>
         <translation>Προσθήκη στα αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1252"/>
+        <location filename="../app/Main.qml" line="1263"/>
         <source>Write to NFC token</source>
         <translation>Εγγραφή σε NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1256"/>
+        <location filename="../app/Main.qml" line="1267"/>
         <source>QR code</source>
         <translation>Κωδικός QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1231"/>
-        <location filename="../app/Main.qml" line="1266"/>
+        <location filename="../app/Main.qml" line="1242"/>
+        <location filename="../app/Main.qml" line="1277"/>
         <source>Launch game</source>
         <translation>Εκκίνηση παιχνιδιού</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2368"/>
+        <location filename="../app/Main.qml" line="2379"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2374"/>
+        <location filename="../app/Main.qml" line="2385"/>
         <source>Loading favorites…</source>
         <translation>Φόρτωση αγαπημένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2370"/>
+        <location filename="../app/Main.qml" line="2381"/>
         <source>Loading games…</source>
         <translation>Φόρτωση παιχνιδιών…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1219"/>
+        <location filename="../app/Main.qml" line="1230"/>
         <source>Update media database</source>
         <translation type="unfinished">Ενημέρωση βάσης δεδομένων</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1222"/>
+        <location filename="../app/Main.qml" line="1233"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Ανάκτηση μεταδεδομένων</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1416"/>
+        <location filename="../app/Main.qml" line="1427"/>
         <source>Default</source>
         <translation type="unfinished">Προεπιλογή</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1416"/>
+        <location filename="../app/Main.qml" line="1427"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1708"/>
+        <location filename="../app/Main.qml" line="1719"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1712"/>
+        <location filename="../app/Main.qml" line="1723"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1726"/>
+        <location filename="../app/Main.qml" line="1737"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1730"/>
+        <location filename="../app/Main.qml" line="1741"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1734"/>
+        <location filename="../app/Main.qml" line="1745"/>
         <source>Retry</source>
         <translation type="unfinished">Επανάληψη</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1738"/>
+        <location filename="../app/Main.qml" line="1749"/>
         <source>Cancel</source>
         <translation type="unfinished">Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2372"/>
+        <location filename="../app/Main.qml" line="2383"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2376"/>
+        <location filename="../app/Main.qml" line="2387"/>
         <source>Loading recently played…</source>
         <translation>Φόρτωση πρόσφατα παιγμένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="2389"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2380"/>
+        <location filename="../app/Main.qml" line="2391"/>
         <source>Loading…</source>
         <translation>Φόρτωση…</translation>
     </message>
@@ -957,8 +957,10 @@ Euskara - devilschile2</source>
         <translation>Προφύλαξη οθόνης</translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="189"/>
         <source>Library</source>
-        <translation type="vanished">Βιβλιοθήκη</translation>
+        <translation>Βιβλιοθήκη</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="142"/>
@@ -999,30 +1001,6 @@ Euskara - devilschile2</source>
         <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>About / License</source>
         <translation>Σχετικά / Άδεια</translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="185"/>
-        <source>Display &amp; Interface</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="72"/>
-        <location filename="../screens/SettingsScreen.qml" line="187"/>
-        <source>Controls &amp; Input</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="77"/>
-        <location filename="../screens/SettingsScreen.qml" line="189"/>
-        <source>Library &amp; Data Management</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="82"/>
-        <location filename="../screens/SettingsScreen.qml" line="191"/>
-        <source>Support &amp; About</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="206"/>
@@ -1267,6 +1245,24 @@ Euskara - devilschile2</source>
         <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Resolution</source>
         <translation>Ανάλυση</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
+        <source>Display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="72"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="82"/>
+        <location filename="../screens/SettingsScreen.qml" line="191"/>
+        <source>Support</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="566"/>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -537,124 +537,124 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1206"/>
+        <location filename="../app/Main.qml" line="1217"/>
         <source>Launch core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1212"/>
-        <location filename="../app/Main.qml" line="1420"/>
+        <location filename="../app/Main.qml" line="1223"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1247"/>
+        <location filename="../app/Main.qml" line="1258"/>
         <source>Remove from favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1247"/>
+        <location filename="../app/Main.qml" line="1258"/>
         <source>Add to favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1252"/>
+        <location filename="../app/Main.qml" line="1263"/>
         <source>Write to NFC token</source>
         <translation type="unfinished">Write to NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1256"/>
+        <location filename="../app/Main.qml" line="1267"/>
         <source>QR code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1231"/>
-        <location filename="../app/Main.qml" line="1266"/>
+        <location filename="../app/Main.qml" line="1242"/>
+        <location filename="../app/Main.qml" line="1277"/>
         <source>Launch game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2368"/>
+        <location filename="../app/Main.qml" line="2379"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2374"/>
+        <location filename="../app/Main.qml" line="2385"/>
         <source>Loading favorites…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2370"/>
+        <location filename="../app/Main.qml" line="2381"/>
         <source>Loading games…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1219"/>
+        <location filename="../app/Main.qml" line="1230"/>
         <source>Update media database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1222"/>
+        <location filename="../app/Main.qml" line="1233"/>
         <source>Scrape metadata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1416"/>
+        <location filename="../app/Main.qml" line="1427"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1416"/>
+        <location filename="../app/Main.qml" line="1427"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1708"/>
+        <location filename="../app/Main.qml" line="1719"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1712"/>
+        <location filename="../app/Main.qml" line="1723"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1726"/>
+        <location filename="../app/Main.qml" line="1737"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1730"/>
+        <location filename="../app/Main.qml" line="1741"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1734"/>
+        <location filename="../app/Main.qml" line="1745"/>
         <source>Retry</source>
         <translation type="unfinished">Retry</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1738"/>
+        <location filename="../app/Main.qml" line="1749"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2372"/>
+        <location filename="../app/Main.qml" line="2383"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2376"/>
+        <location filename="../app/Main.qml" line="2387"/>
         <source>Loading recently played…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="2389"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2380"/>
+        <location filename="../app/Main.qml" line="2391"/>
         <source>Loading…</source>
         <translation type="unfinished">Loading…</translation>
     </message>
@@ -977,30 +977,6 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="185"/>
-        <source>Display &amp; Interface</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="72"/>
-        <location filename="../screens/SettingsScreen.qml" line="187"/>
-        <source>Controls &amp; Input</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="77"/>
-        <location filename="../screens/SettingsScreen.qml" line="189"/>
-        <source>Library &amp; Data Management</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="82"/>
-        <location filename="../screens/SettingsScreen.qml" line="191"/>
-        <source>Support &amp; About</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../screens/SettingsScreen.qml" line="206"/>
         <source>Optimizing</source>
         <translation type="unfinished"></translation>
@@ -1242,6 +1218,30 @@ Euskara - devilschile2</source>
         <location filename="../screens/SettingsScreen.qml" line="91"/>
         <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Resolution</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
+        <source>Display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="72"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="189"/>
+        <source>Library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="82"/>
+        <location filename="../screens/SettingsScreen.qml" line="191"/>
+        <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -549,124 +549,124 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1206"/>
+        <location filename="../app/Main.qml" line="1217"/>
         <source>Launch core</source>
         <translation>Lanzar core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1212"/>
-        <location filename="../app/Main.qml" line="1420"/>
+        <location filename="../app/Main.qml" line="1223"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1247"/>
+        <location filename="../app/Main.qml" line="1258"/>
         <source>Remove from favorites</source>
         <translation>Eliminar de favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1247"/>
+        <location filename="../app/Main.qml" line="1258"/>
         <source>Add to favorites</source>
         <translation>Agregar a favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1252"/>
+        <location filename="../app/Main.qml" line="1263"/>
         <source>Write to NFC token</source>
         <translation>Escribir en token NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1256"/>
+        <location filename="../app/Main.qml" line="1267"/>
         <source>QR code</source>
         <translation>Código QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1231"/>
-        <location filename="../app/Main.qml" line="1266"/>
+        <location filename="../app/Main.qml" line="1242"/>
+        <location filename="../app/Main.qml" line="1277"/>
         <source>Launch game</source>
         <translation>Iniciar juego</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2368"/>
+        <location filename="../app/Main.qml" line="2379"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2374"/>
+        <location filename="../app/Main.qml" line="2385"/>
         <source>Loading favorites…</source>
         <translation>Cargando favoritos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2370"/>
+        <location filename="../app/Main.qml" line="2381"/>
         <source>Loading games…</source>
         <translation>Cargando juegos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1219"/>
+        <location filename="../app/Main.qml" line="1230"/>
         <source>Update media database</source>
         <translation type="unfinished">Actualizar base de datos de medios</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1222"/>
+        <location filename="../app/Main.qml" line="1233"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Extraer metadatos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1416"/>
+        <location filename="../app/Main.qml" line="1427"/>
         <source>Default</source>
         <translation type="unfinished">Por defecto</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1416"/>
+        <location filename="../app/Main.qml" line="1427"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1708"/>
+        <location filename="../app/Main.qml" line="1719"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1712"/>
+        <location filename="../app/Main.qml" line="1723"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1726"/>
+        <location filename="../app/Main.qml" line="1737"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1730"/>
+        <location filename="../app/Main.qml" line="1741"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1734"/>
+        <location filename="../app/Main.qml" line="1745"/>
         <source>Retry</source>
         <translation type="unfinished">Reintentar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1738"/>
+        <location filename="../app/Main.qml" line="1749"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2372"/>
+        <location filename="../app/Main.qml" line="2383"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2376"/>
+        <location filename="../app/Main.qml" line="2387"/>
         <source>Loading recently played…</source>
         <translation>Cargando jugados recientemente…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="2389"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2380"/>
+        <location filename="../app/Main.qml" line="2391"/>
         <source>Loading…</source>
         <translation>Cargando…</translation>
     </message>
@@ -957,8 +957,10 @@ Euskara - devilschile2</source>
         <translation>Salvapantallas</translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="189"/>
         <source>Library</source>
-        <translation type="vanished">Biblioteca</translation>
+        <translation>Biblioteca</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="142"/>
@@ -999,30 +1001,6 @@ Euskara - devilschile2</source>
         <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>About / License</source>
         <translation>Acerca de / Licencia</translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="185"/>
-        <source>Display &amp; Interface</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="72"/>
-        <location filename="../screens/SettingsScreen.qml" line="187"/>
-        <source>Controls &amp; Input</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="77"/>
-        <location filename="../screens/SettingsScreen.qml" line="189"/>
-        <source>Library &amp; Data Management</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="82"/>
-        <location filename="../screens/SettingsScreen.qml" line="191"/>
-        <source>Support &amp; About</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="206"/>
@@ -1267,6 +1245,24 @@ Euskara - devilschile2</source>
         <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Resolution</source>
         <translation>Resolución</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
+        <source>Display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="72"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="82"/>
+        <location filename="../screens/SettingsScreen.qml" line="191"/>
+        <source>Support</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="566"/>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -557,124 +557,124 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1206"/>
+        <location filename="../app/Main.qml" line="1217"/>
         <source>Launch core</source>
         <translation type="unfinished">Exekutatu nukleoa</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1212"/>
-        <location filename="../app/Main.qml" line="1420"/>
+        <location filename="../app/Main.qml" line="1223"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Change launcher</source>
         <translation type="unfinished">Aldatu abiarazlea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1247"/>
+        <location filename="../app/Main.qml" line="1258"/>
         <source>Remove from favorites</source>
         <translation type="unfinished">Kendu gogokoetatik</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1247"/>
+        <location filename="../app/Main.qml" line="1258"/>
         <source>Add to favorites</source>
         <translation type="unfinished">Gehitu gogokoetan</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1252"/>
+        <location filename="../app/Main.qml" line="1263"/>
         <source>Write to NFC token</source>
         <translation type="unfinished">Idatzi NFC token-a</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1256"/>
+        <location filename="../app/Main.qml" line="1267"/>
         <source>QR code</source>
         <translation type="unfinished">QR kodea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1231"/>
-        <location filename="../app/Main.qml" line="1266"/>
+        <location filename="../app/Main.qml" line="1242"/>
+        <location filename="../app/Main.qml" line="1277"/>
         <source>Launch game</source>
         <translation type="unfinished">Abiarazi jokua</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2368"/>
+        <location filename="../app/Main.qml" line="2379"/>
         <source>Loading systems…</source>
         <translation type="unfinished">Sistemak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2374"/>
+        <location filename="../app/Main.qml" line="2385"/>
         <source>Loading favorites…</source>
         <translation type="unfinished">Gogokoak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2370"/>
+        <location filename="../app/Main.qml" line="2381"/>
         <source>Loading games…</source>
         <translation type="unfinished">Jokoak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1219"/>
+        <location filename="../app/Main.qml" line="1230"/>
         <source>Update media database</source>
         <translation type="unfinished">Eguneratu multimedia datu-basea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1222"/>
+        <location filename="../app/Main.qml" line="1233"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadatuak scrapeatu</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1416"/>
+        <location filename="../app/Main.qml" line="1427"/>
         <source>Default</source>
         <translation type="unfinished">Lehenetsia</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1416"/>
+        <location filename="../app/Main.qml" line="1427"/>
         <source>Current: %1</source>
         <translation type="unfinished">Unekoa: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1708"/>
+        <location filename="../app/Main.qml" line="1719"/>
         <source>Saving launcher</source>
         <translation type="unfinished">Abiarazlea gordetzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1712"/>
+        <location filename="../app/Main.qml" line="1723"/>
         <source>Saving…</source>
         <translation type="unfinished">Gordetzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1726"/>
+        <location filename="../app/Main.qml" line="1737"/>
         <source>Launcher update failed</source>
         <translation type="unfinished">Abiarazle egukeraketak huts egin du</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1730"/>
+        <location filename="../app/Main.qml" line="1741"/>
         <source>Error: %1</source>
         <translation type="unfinished">Errorea: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1734"/>
+        <location filename="../app/Main.qml" line="1745"/>
         <source>Retry</source>
         <translation type="unfinished">Berriro saiatu</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1738"/>
+        <location filename="../app/Main.qml" line="1749"/>
         <source>Cancel</source>
         <translation type="unfinished">Utzi</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2372"/>
+        <location filename="../app/Main.qml" line="2383"/>
         <source>Loading game…</source>
         <translation type="unfinished">Jokua kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2376"/>
+        <location filename="../app/Main.qml" line="2387"/>
         <source>Loading recently played…</source>
         <translation type="unfinished">Duela gutxi jokatutakoak kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="2389"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2380"/>
+        <location filename="../app/Main.qml" line="2391"/>
         <source>Loading…</source>
         <translation type="unfinished">Kargatzen…</translation>
     </message>
@@ -965,8 +965,10 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Pantaila babeslea</translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="189"/>
         <source>Library</source>
-        <translation type="obsolete">Liburutegia</translation>
+        <translation type="unfinished">Liburutegia</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="142"/>
@@ -1007,30 +1009,6 @@ Euskara - devilschile2</source>
         <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>About / License</source>
         <translation type="unfinished">Buruz / Lizentzia</translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="185"/>
-        <source>Display &amp; Interface</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="72"/>
-        <location filename="../screens/SettingsScreen.qml" line="187"/>
-        <source>Controls &amp; Input</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="77"/>
-        <location filename="../screens/SettingsScreen.qml" line="189"/>
-        <source>Library &amp; Data Management</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="82"/>
-        <location filename="../screens/SettingsScreen.qml" line="191"/>
-        <source>Support &amp; About</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="206"/>
@@ -1275,6 +1253,24 @@ Euskara - devilschile2</source>
         <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Resolution</source>
         <translation type="unfinished">Bereizmena</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
+        <source>Display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="72"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="82"/>
+        <location filename="../screens/SettingsScreen.qml" line="191"/>
+        <source>Support</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="566"/>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -549,124 +549,124 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1206"/>
+        <location filename="../app/Main.qml" line="1217"/>
         <source>Launch core</source>
         <translation>הפעל את הליבה</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1212"/>
-        <location filename="../app/Main.qml" line="1420"/>
+        <location filename="../app/Main.qml" line="1223"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1219"/>
+        <location filename="../app/Main.qml" line="1230"/>
         <source>Update media database</source>
         <translation type="unfinished">עדכון מסד נתוני המדיה</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1222"/>
+        <location filename="../app/Main.qml" line="1233"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">איסוף מטא-נתונים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1231"/>
-        <location filename="../app/Main.qml" line="1266"/>
+        <location filename="../app/Main.qml" line="1242"/>
+        <location filename="../app/Main.qml" line="1277"/>
         <source>Launch game</source>
         <translation>הפעל משחק</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1247"/>
+        <location filename="../app/Main.qml" line="1258"/>
         <source>Remove from favorites</source>
         <translation>הסר מהמועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1247"/>
+        <location filename="../app/Main.qml" line="1258"/>
         <source>Add to favorites</source>
         <translation>הוסף למועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1252"/>
+        <location filename="../app/Main.qml" line="1263"/>
         <source>Write to NFC token</source>
         <translation>כתוב לטוקן NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1256"/>
+        <location filename="../app/Main.qml" line="1267"/>
         <source>QR code</source>
         <translation>קוד QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1416"/>
+        <location filename="../app/Main.qml" line="1427"/>
         <source>Default</source>
         <translation type="unfinished">ברירת מחדל</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1416"/>
+        <location filename="../app/Main.qml" line="1427"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1708"/>
+        <location filename="../app/Main.qml" line="1719"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1712"/>
+        <location filename="../app/Main.qml" line="1723"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1726"/>
+        <location filename="../app/Main.qml" line="1737"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1730"/>
+        <location filename="../app/Main.qml" line="1741"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1734"/>
+        <location filename="../app/Main.qml" line="1745"/>
         <source>Retry</source>
         <translation type="unfinished">נסה שוב</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1738"/>
+        <location filename="../app/Main.qml" line="1749"/>
         <source>Cancel</source>
         <translation type="unfinished">ביטול</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2368"/>
+        <location filename="../app/Main.qml" line="2379"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2370"/>
+        <location filename="../app/Main.qml" line="2381"/>
         <source>Loading games…</source>
         <translation>טוען משחקים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2372"/>
+        <location filename="../app/Main.qml" line="2383"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2374"/>
+        <location filename="../app/Main.qml" line="2385"/>
         <source>Loading favorites…</source>
         <translation>טוען מועדפים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2376"/>
+        <location filename="../app/Main.qml" line="2387"/>
         <source>Loading recently played…</source>
         <translation>טוען את הפריטים ששוחקו לאחרונה…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="2389"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2380"/>
+        <location filename="../app/Main.qml" line="2391"/>
         <source>Loading…</source>
         <translation>טוען…</translation>
     </message>
@@ -947,8 +947,10 @@ Euskara - devilschile2</source>
         <translation>שומר מסך</translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="189"/>
         <source>Library</source>
-        <translation type="vanished">ספרייה</translation>
+        <translation>ספרייה</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="142"/>
@@ -999,30 +1001,6 @@ Euskara - devilschile2</source>
         <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>About / License</source>
         <translation>אודות / רישיון</translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="185"/>
-        <source>Display &amp; Interface</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="72"/>
-        <location filename="../screens/SettingsScreen.qml" line="187"/>
-        <source>Controls &amp; Input</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="77"/>
-        <location filename="../screens/SettingsScreen.qml" line="189"/>
-        <source>Library &amp; Data Management</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="82"/>
-        <location filename="../screens/SettingsScreen.qml" line="191"/>
-        <source>Support &amp; About</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="206"/>
@@ -1267,6 +1245,24 @@ Euskara - devilschile2</source>
         <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Resolution</source>
         <translation>רזולוציה</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
+        <source>Display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="72"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="82"/>
+        <location filename="../screens/SettingsScreen.qml" line="191"/>
+        <source>Support</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="566"/>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -549,124 +549,124 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1206"/>
+        <location filename="../app/Main.qml" line="1217"/>
         <source>Launch core</source>
         <translation>कोर चलाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1212"/>
-        <location filename="../app/Main.qml" line="1420"/>
+        <location filename="../app/Main.qml" line="1223"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1219"/>
+        <location filename="../app/Main.qml" line="1230"/>
         <source>Update media database</source>
         <translation type="unfinished">मीडिया डेटाबेस अपडेट करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1222"/>
+        <location filename="../app/Main.qml" line="1233"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">मेटाडेटा स्क्रैप करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1231"/>
-        <location filename="../app/Main.qml" line="1266"/>
+        <location filename="../app/Main.qml" line="1242"/>
+        <location filename="../app/Main.qml" line="1277"/>
         <source>Launch game</source>
         <translation>गेम चलाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1247"/>
+        <location filename="../app/Main.qml" line="1258"/>
         <source>Remove from favorites</source>
         <translation>पसंदीदा से हटाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1247"/>
+        <location filename="../app/Main.qml" line="1258"/>
         <source>Add to favorites</source>
         <translation>पसंदीदा में जोड़ें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1252"/>
+        <location filename="../app/Main.qml" line="1263"/>
         <source>Write to NFC token</source>
         <translation>NFC टोकन पर लिखें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1256"/>
+        <location filename="../app/Main.qml" line="1267"/>
         <source>QR code</source>
         <translation>QR कोड</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1416"/>
+        <location filename="../app/Main.qml" line="1427"/>
         <source>Default</source>
         <translation type="unfinished">डिफ़ॉल्ट</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1416"/>
+        <location filename="../app/Main.qml" line="1427"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1708"/>
+        <location filename="../app/Main.qml" line="1719"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1712"/>
+        <location filename="../app/Main.qml" line="1723"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1726"/>
+        <location filename="../app/Main.qml" line="1737"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1730"/>
+        <location filename="../app/Main.qml" line="1741"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1734"/>
+        <location filename="../app/Main.qml" line="1745"/>
         <source>Retry</source>
         <translation type="unfinished">फिर से प्रयास करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1738"/>
+        <location filename="../app/Main.qml" line="1749"/>
         <source>Cancel</source>
         <translation type="unfinished">रद्द करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2368"/>
+        <location filename="../app/Main.qml" line="2379"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2370"/>
+        <location filename="../app/Main.qml" line="2381"/>
         <source>Loading games…</source>
         <translation>गेम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2372"/>
+        <location filename="../app/Main.qml" line="2383"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2374"/>
+        <location filename="../app/Main.qml" line="2385"/>
         <source>Loading favorites…</source>
         <translation>पसंदीदा लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2376"/>
+        <location filename="../app/Main.qml" line="2387"/>
         <source>Loading recently played…</source>
         <translation>हाल ही में खेले गए लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="2389"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2380"/>
+        <location filename="../app/Main.qml" line="2391"/>
         <source>Loading…</source>
         <translation>लोड हो रहा है…</translation>
     </message>
@@ -947,8 +947,10 @@ Euskara - devilschile2</source>
         <translation>स्क्रीनसेवर</translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="189"/>
         <source>Library</source>
-        <translation type="vanished">लाइब्रेरी</translation>
+        <translation>लाइब्रेरी</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="142"/>
@@ -999,30 +1001,6 @@ Euskara - devilschile2</source>
         <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>About / License</source>
         <translation>परिचय / लाइसेंस</translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="185"/>
-        <source>Display &amp; Interface</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="72"/>
-        <location filename="../screens/SettingsScreen.qml" line="187"/>
-        <source>Controls &amp; Input</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="77"/>
-        <location filename="../screens/SettingsScreen.qml" line="189"/>
-        <source>Library &amp; Data Management</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="82"/>
-        <location filename="../screens/SettingsScreen.qml" line="191"/>
-        <source>Support &amp; About</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="206"/>
@@ -1267,6 +1245,24 @@ Euskara - devilschile2</source>
         <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Resolution</source>
         <translation>रिज़ॉल्यूशन</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
+        <source>Display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="72"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="82"/>
+        <location filename="../screens/SettingsScreen.qml" line="191"/>
+        <source>Support</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="566"/>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -549,124 +549,124 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1206"/>
+        <location filename="../app/Main.qml" line="1217"/>
         <source>Launch core</source>
         <translation>Avvia core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1212"/>
-        <location filename="../app/Main.qml" line="1420"/>
+        <location filename="../app/Main.qml" line="1223"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1247"/>
+        <location filename="../app/Main.qml" line="1258"/>
         <source>Remove from favorites</source>
         <translation>Rimuovi dai preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1247"/>
+        <location filename="../app/Main.qml" line="1258"/>
         <source>Add to favorites</source>
         <translation>Aggiungi ai preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1252"/>
+        <location filename="../app/Main.qml" line="1263"/>
         <source>Write to NFC token</source>
         <translation>Scrivi sul token NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1256"/>
+        <location filename="../app/Main.qml" line="1267"/>
         <source>QR code</source>
         <translation>Codice QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1231"/>
-        <location filename="../app/Main.qml" line="1266"/>
+        <location filename="../app/Main.qml" line="1242"/>
+        <location filename="../app/Main.qml" line="1277"/>
         <source>Launch game</source>
         <translation>Avvia gioco</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2368"/>
+        <location filename="../app/Main.qml" line="2379"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2374"/>
+        <location filename="../app/Main.qml" line="2385"/>
         <source>Loading favorites…</source>
         <translation>Caricamento preferiti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2370"/>
+        <location filename="../app/Main.qml" line="2381"/>
         <source>Loading games…</source>
         <translation>Caricamento giochi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1219"/>
+        <location filename="../app/Main.qml" line="1230"/>
         <source>Update media database</source>
         <translation type="unfinished">Aggiorna database multimediale</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1222"/>
+        <location filename="../app/Main.qml" line="1233"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Recupera metadati</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1416"/>
+        <location filename="../app/Main.qml" line="1427"/>
         <source>Default</source>
         <translation type="unfinished">Predefinito</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1416"/>
+        <location filename="../app/Main.qml" line="1427"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1708"/>
+        <location filename="../app/Main.qml" line="1719"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1712"/>
+        <location filename="../app/Main.qml" line="1723"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1726"/>
+        <location filename="../app/Main.qml" line="1737"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1730"/>
+        <location filename="../app/Main.qml" line="1741"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1734"/>
+        <location filename="../app/Main.qml" line="1745"/>
         <source>Retry</source>
         <translation type="unfinished">Riprova</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1738"/>
+        <location filename="../app/Main.qml" line="1749"/>
         <source>Cancel</source>
         <translation type="unfinished">Annulla</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2372"/>
+        <location filename="../app/Main.qml" line="2383"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2376"/>
+        <location filename="../app/Main.qml" line="2387"/>
         <source>Loading recently played…</source>
         <translation>Caricamento recenti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="2389"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2380"/>
+        <location filename="../app/Main.qml" line="2391"/>
         <source>Loading…</source>
         <translation>Caricamento…</translation>
     </message>
@@ -957,8 +957,10 @@ Euskara - devilschile2</source>
         <translation>Salvaschermo</translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="189"/>
         <source>Library</source>
-        <translation type="vanished">Libreria</translation>
+        <translation>Libreria</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="142"/>
@@ -999,30 +1001,6 @@ Euskara - devilschile2</source>
         <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>About / License</source>
         <translation>Informazioni / Licenza</translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="185"/>
-        <source>Display &amp; Interface</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="72"/>
-        <location filename="../screens/SettingsScreen.qml" line="187"/>
-        <source>Controls &amp; Input</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="77"/>
-        <location filename="../screens/SettingsScreen.qml" line="189"/>
-        <source>Library &amp; Data Management</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="82"/>
-        <location filename="../screens/SettingsScreen.qml" line="191"/>
-        <source>Support &amp; About</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="206"/>
@@ -1267,6 +1245,24 @@ Euskara - devilschile2</source>
         <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Resolution</source>
         <translation>Risoluzione</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
+        <source>Display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="72"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="82"/>
+        <location filename="../screens/SettingsScreen.qml" line="191"/>
+        <source>Support</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="566"/>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -549,124 +549,124 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1206"/>
+        <location filename="../app/Main.qml" line="1217"/>
         <source>Launch core</source>
         <translation>コアを起動</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1212"/>
-        <location filename="../app/Main.qml" line="1420"/>
+        <location filename="../app/Main.qml" line="1223"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1247"/>
+        <location filename="../app/Main.qml" line="1258"/>
         <source>Remove from favorites</source>
         <translation>お気に入りから削除</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1247"/>
+        <location filename="../app/Main.qml" line="1258"/>
         <source>Add to favorites</source>
         <translation>お気に入りに追加</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1252"/>
+        <location filename="../app/Main.qml" line="1263"/>
         <source>Write to NFC token</source>
         <translation>NFC トークンに書き込む</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1256"/>
+        <location filename="../app/Main.qml" line="1267"/>
         <source>QR code</source>
         <translation>QR コード</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1231"/>
-        <location filename="../app/Main.qml" line="1266"/>
+        <location filename="../app/Main.qml" line="1242"/>
+        <location filename="../app/Main.qml" line="1277"/>
         <source>Launch game</source>
         <translation>ゲームを起動</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2368"/>
+        <location filename="../app/Main.qml" line="2379"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2374"/>
+        <location filename="../app/Main.qml" line="2385"/>
         <source>Loading favorites…</source>
         <translation>お気に入りを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2370"/>
+        <location filename="../app/Main.qml" line="2381"/>
         <source>Loading games…</source>
         <translation>ゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1219"/>
+        <location filename="../app/Main.qml" line="1230"/>
         <source>Update media database</source>
         <translation type="unfinished">メディアデータベースを更新</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1222"/>
+        <location filename="../app/Main.qml" line="1233"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">メタデータをスクレイピング</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1416"/>
+        <location filename="../app/Main.qml" line="1427"/>
         <source>Default</source>
         <translation type="unfinished">デフォルト</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1416"/>
+        <location filename="../app/Main.qml" line="1427"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1708"/>
+        <location filename="../app/Main.qml" line="1719"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1712"/>
+        <location filename="../app/Main.qml" line="1723"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1726"/>
+        <location filename="../app/Main.qml" line="1737"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1730"/>
+        <location filename="../app/Main.qml" line="1741"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1734"/>
+        <location filename="../app/Main.qml" line="1745"/>
         <source>Retry</source>
         <translation type="unfinished">再試行</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1738"/>
+        <location filename="../app/Main.qml" line="1749"/>
         <source>Cancel</source>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2372"/>
+        <location filename="../app/Main.qml" line="2383"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2376"/>
+        <location filename="../app/Main.qml" line="2387"/>
         <source>Loading recently played…</source>
         <translation>最近プレイしたゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="2389"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2380"/>
+        <location filename="../app/Main.qml" line="2391"/>
         <source>Loading…</source>
         <translation>読み込み中…</translation>
     </message>
@@ -957,8 +957,10 @@ Euskara - devilschile2</source>
         <translation>スクリーンセーバー</translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="189"/>
         <source>Library</source>
-        <translation type="vanished">ライブラリ</translation>
+        <translation>ライブラリ</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="142"/>
@@ -999,30 +1001,6 @@ Euskara - devilschile2</source>
         <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>About / License</source>
         <translation>情報 / ライセンス</translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="185"/>
-        <source>Display &amp; Interface</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="72"/>
-        <location filename="../screens/SettingsScreen.qml" line="187"/>
-        <source>Controls &amp; Input</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="77"/>
-        <location filename="../screens/SettingsScreen.qml" line="189"/>
-        <source>Library &amp; Data Management</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="82"/>
-        <location filename="../screens/SettingsScreen.qml" line="191"/>
-        <source>Support &amp; About</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="206"/>
@@ -1267,6 +1245,24 @@ Euskara - devilschile2</source>
         <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Resolution</source>
         <translation>解像度</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
+        <source>Display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="72"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="82"/>
+        <location filename="../screens/SettingsScreen.qml" line="191"/>
+        <source>Support</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="566"/>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -549,124 +549,124 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1206"/>
+        <location filename="../app/Main.qml" line="1217"/>
         <source>Launch core</source>
         <translation>코어 실행</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1212"/>
-        <location filename="../app/Main.qml" line="1420"/>
+        <location filename="../app/Main.qml" line="1223"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1219"/>
+        <location filename="../app/Main.qml" line="1230"/>
         <source>Update media database</source>
         <translation type="unfinished">미디어 데이터베이스 업데이트</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1222"/>
+        <location filename="../app/Main.qml" line="1233"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">메타데이터 수집</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1231"/>
-        <location filename="../app/Main.qml" line="1266"/>
+        <location filename="../app/Main.qml" line="1242"/>
+        <location filename="../app/Main.qml" line="1277"/>
         <source>Launch game</source>
         <translation>게임 실행</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1247"/>
+        <location filename="../app/Main.qml" line="1258"/>
         <source>Remove from favorites</source>
         <translation>즐겨찾기에서 제거</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1247"/>
+        <location filename="../app/Main.qml" line="1258"/>
         <source>Add to favorites</source>
         <translation>즐겨찾기에 추가</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1252"/>
+        <location filename="../app/Main.qml" line="1263"/>
         <source>Write to NFC token</source>
         <translation>NFC 토큰에 쓰기</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1256"/>
+        <location filename="../app/Main.qml" line="1267"/>
         <source>QR code</source>
         <translation>QR 코드</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1416"/>
+        <location filename="../app/Main.qml" line="1427"/>
         <source>Default</source>
         <translation type="unfinished">기본값</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1416"/>
+        <location filename="../app/Main.qml" line="1427"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1708"/>
+        <location filename="../app/Main.qml" line="1719"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1712"/>
+        <location filename="../app/Main.qml" line="1723"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1726"/>
+        <location filename="../app/Main.qml" line="1737"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1730"/>
+        <location filename="../app/Main.qml" line="1741"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1734"/>
+        <location filename="../app/Main.qml" line="1745"/>
         <source>Retry</source>
         <translation type="unfinished">다시 시도</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1738"/>
+        <location filename="../app/Main.qml" line="1749"/>
         <source>Cancel</source>
         <translation type="unfinished">취소</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2368"/>
+        <location filename="../app/Main.qml" line="2379"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2370"/>
+        <location filename="../app/Main.qml" line="2381"/>
         <source>Loading games…</source>
         <translation>게임 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2372"/>
+        <location filename="../app/Main.qml" line="2383"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2374"/>
+        <location filename="../app/Main.qml" line="2385"/>
         <source>Loading favorites…</source>
         <translation>즐겨찾기 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2376"/>
+        <location filename="../app/Main.qml" line="2387"/>
         <source>Loading recently played…</source>
         <translation>최근 플레이 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="2389"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2380"/>
+        <location filename="../app/Main.qml" line="2391"/>
         <source>Loading…</source>
         <translation>불러오는 중…</translation>
     </message>
@@ -947,8 +947,10 @@ Euskara - devilschile2</source>
         <translation>화면 보호기</translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="189"/>
         <source>Library</source>
-        <translation type="vanished">라이브러리</translation>
+        <translation>라이브러리</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="142"/>
@@ -999,30 +1001,6 @@ Euskara - devilschile2</source>
         <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>About / License</source>
         <translation>정보 / 라이선스</translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="185"/>
-        <source>Display &amp; Interface</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="72"/>
-        <location filename="../screens/SettingsScreen.qml" line="187"/>
-        <source>Controls &amp; Input</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="77"/>
-        <location filename="../screens/SettingsScreen.qml" line="189"/>
-        <source>Library &amp; Data Management</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="82"/>
-        <location filename="../screens/SettingsScreen.qml" line="191"/>
-        <source>Support &amp; About</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="206"/>
@@ -1267,6 +1245,24 @@ Euskara - devilschile2</source>
         <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Resolution</source>
         <translation>해상도</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
+        <source>Display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="72"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="82"/>
+        <location filename="../screens/SettingsScreen.qml" line="191"/>
+        <source>Support</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="566"/>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -549,124 +549,124 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1206"/>
+        <location filename="../app/Main.qml" line="1217"/>
         <source>Launch core</source>
         <translation>Core starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1212"/>
-        <location filename="../app/Main.qml" line="1420"/>
+        <location filename="../app/Main.qml" line="1223"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1247"/>
+        <location filename="../app/Main.qml" line="1258"/>
         <source>Remove from favorites</source>
         <translation>Uit favorieten verwijderen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1247"/>
+        <location filename="../app/Main.qml" line="1258"/>
         <source>Add to favorites</source>
         <translation>Aan favorieten toevoegen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1252"/>
+        <location filename="../app/Main.qml" line="1263"/>
         <source>Write to NFC token</source>
         <translation>Naar NFC-token schrijven</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1256"/>
+        <location filename="../app/Main.qml" line="1267"/>
         <source>QR code</source>
         <translation>QR-code</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1231"/>
-        <location filename="../app/Main.qml" line="1266"/>
+        <location filename="../app/Main.qml" line="1242"/>
+        <location filename="../app/Main.qml" line="1277"/>
         <source>Launch game</source>
         <translation>Game starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2368"/>
+        <location filename="../app/Main.qml" line="2379"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2374"/>
+        <location filename="../app/Main.qml" line="2385"/>
         <source>Loading favorites…</source>
         <translation>Favorieten laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2370"/>
+        <location filename="../app/Main.qml" line="2381"/>
         <source>Loading games…</source>
         <translation>Games laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1219"/>
+        <location filename="../app/Main.qml" line="1230"/>
         <source>Update media database</source>
         <translation type="unfinished">Mediadatabase bijwerken</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1222"/>
+        <location filename="../app/Main.qml" line="1233"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadata ophalen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1416"/>
+        <location filename="../app/Main.qml" line="1427"/>
         <source>Default</source>
         <translation type="unfinished">Standaard</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1416"/>
+        <location filename="../app/Main.qml" line="1427"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1708"/>
+        <location filename="../app/Main.qml" line="1719"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1712"/>
+        <location filename="../app/Main.qml" line="1723"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1726"/>
+        <location filename="../app/Main.qml" line="1737"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1730"/>
+        <location filename="../app/Main.qml" line="1741"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1734"/>
+        <location filename="../app/Main.qml" line="1745"/>
         <source>Retry</source>
         <translation type="unfinished">Opnieuw proberen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1738"/>
+        <location filename="../app/Main.qml" line="1749"/>
         <source>Cancel</source>
         <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2372"/>
+        <location filename="../app/Main.qml" line="2383"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2376"/>
+        <location filename="../app/Main.qml" line="2387"/>
         <source>Loading recently played…</source>
         <translation>Recent gespeeld laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="2389"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2380"/>
+        <location filename="../app/Main.qml" line="2391"/>
         <source>Loading…</source>
         <translation>Laden…</translation>
     </message>
@@ -957,8 +957,10 @@ Euskara - devilschile2</source>
         <translation>Schermbeveiliging</translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="189"/>
         <source>Library</source>
-        <translation type="vanished">Bibliotheek</translation>
+        <translation>Bibliotheek</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="142"/>
@@ -999,30 +1001,6 @@ Euskara - devilschile2</source>
         <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>About / License</source>
         <translation>Over / Licentie</translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="185"/>
-        <source>Display &amp; Interface</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="72"/>
-        <location filename="../screens/SettingsScreen.qml" line="187"/>
-        <source>Controls &amp; Input</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="77"/>
-        <location filename="../screens/SettingsScreen.qml" line="189"/>
-        <source>Library &amp; Data Management</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="82"/>
-        <location filename="../screens/SettingsScreen.qml" line="191"/>
-        <source>Support &amp; About</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="206"/>
@@ -1267,6 +1245,24 @@ Euskara - devilschile2</source>
         <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Resolution</source>
         <translation>Resolutie</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
+        <source>Display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="72"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="82"/>
+        <location filename="../screens/SettingsScreen.qml" line="191"/>
+        <source>Support</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="566"/>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -549,124 +549,124 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1206"/>
+        <location filename="../app/Main.qml" line="1217"/>
         <source>Launch core</source>
         <translation>Lansare core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1212"/>
-        <location filename="../app/Main.qml" line="1420"/>
+        <location filename="../app/Main.qml" line="1223"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1247"/>
+        <location filename="../app/Main.qml" line="1258"/>
         <source>Remove from favorites</source>
         <translation>Elimină din favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1247"/>
+        <location filename="../app/Main.qml" line="1258"/>
         <source>Add to favorites</source>
         <translation>Adaugă la favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1252"/>
+        <location filename="../app/Main.qml" line="1263"/>
         <source>Write to NFC token</source>
         <translation>Scriere pe token NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1256"/>
+        <location filename="../app/Main.qml" line="1267"/>
         <source>QR code</source>
         <translation>Cod QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1231"/>
-        <location filename="../app/Main.qml" line="1266"/>
+        <location filename="../app/Main.qml" line="1242"/>
+        <location filename="../app/Main.qml" line="1277"/>
         <source>Launch game</source>
         <translation>Lansare joc</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2368"/>
+        <location filename="../app/Main.qml" line="2379"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2374"/>
+        <location filename="../app/Main.qml" line="2385"/>
         <source>Loading favorites…</source>
         <translation>Se încarcă favoritele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2370"/>
+        <location filename="../app/Main.qml" line="2381"/>
         <source>Loading games…</source>
         <translation>Se încarcă jocurile…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1219"/>
+        <location filename="../app/Main.qml" line="1230"/>
         <source>Update media database</source>
         <translation type="unfinished">Actualizare bază de date media</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1222"/>
+        <location filename="../app/Main.qml" line="1233"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Extragere metadate</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1416"/>
+        <location filename="../app/Main.qml" line="1427"/>
         <source>Default</source>
         <translation type="unfinished">Implicit</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1416"/>
+        <location filename="../app/Main.qml" line="1427"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1708"/>
+        <location filename="../app/Main.qml" line="1719"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1712"/>
+        <location filename="../app/Main.qml" line="1723"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1726"/>
+        <location filename="../app/Main.qml" line="1737"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1730"/>
+        <location filename="../app/Main.qml" line="1741"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1734"/>
+        <location filename="../app/Main.qml" line="1745"/>
         <source>Retry</source>
         <translation type="unfinished">Reîncercare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1738"/>
+        <location filename="../app/Main.qml" line="1749"/>
         <source>Cancel</source>
         <translation type="unfinished">Anulare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2372"/>
+        <location filename="../app/Main.qml" line="2383"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2376"/>
+        <location filename="../app/Main.qml" line="2387"/>
         <source>Loading recently played…</source>
         <translation>Se încarcă recent jucatele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="2389"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2380"/>
+        <location filename="../app/Main.qml" line="2391"/>
         <source>Loading…</source>
         <translation>Se încarcă…</translation>
     </message>
@@ -957,8 +957,10 @@ Euskara - devilschile2</source>
         <translation>Economizor de ecran</translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="189"/>
         <source>Library</source>
-        <translation type="vanished">Bibliotecă</translation>
+        <translation>Bibliotecă</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="142"/>
@@ -999,30 +1001,6 @@ Euskara - devilschile2</source>
         <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>About / License</source>
         <translation>Despre / Licență</translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="185"/>
-        <source>Display &amp; Interface</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="72"/>
-        <location filename="../screens/SettingsScreen.qml" line="187"/>
-        <source>Controls &amp; Input</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="77"/>
-        <location filename="../screens/SettingsScreen.qml" line="189"/>
-        <source>Library &amp; Data Management</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="82"/>
-        <location filename="../screens/SettingsScreen.qml" line="191"/>
-        <source>Support &amp; About</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="206"/>
@@ -1267,6 +1245,24 @@ Euskara - devilschile2</source>
         <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Resolution</source>
         <translation>Rezoluție</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
+        <source>Display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="72"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="82"/>
+        <location filename="../screens/SettingsScreen.qml" line="191"/>
+        <source>Support</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="566"/>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -549,124 +549,124 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1206"/>
+        <location filename="../app/Main.qml" line="1217"/>
         <source>Launch core</source>
         <translation>Spustiť core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1212"/>
-        <location filename="../app/Main.qml" line="1420"/>
+        <location filename="../app/Main.qml" line="1223"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1247"/>
+        <location filename="../app/Main.qml" line="1258"/>
         <source>Remove from favorites</source>
         <translation>Odstrániť z obľúbených</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1247"/>
+        <location filename="../app/Main.qml" line="1258"/>
         <source>Add to favorites</source>
         <translation>Pridať do obľúbených</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1252"/>
+        <location filename="../app/Main.qml" line="1263"/>
         <source>Write to NFC token</source>
         <translation>Zapísať na NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1256"/>
+        <location filename="../app/Main.qml" line="1267"/>
         <source>QR code</source>
         <translation>QR kód</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1231"/>
-        <location filename="../app/Main.qml" line="1266"/>
+        <location filename="../app/Main.qml" line="1242"/>
+        <location filename="../app/Main.qml" line="1277"/>
         <source>Launch game</source>
         <translation>Spustiť hru</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2368"/>
+        <location filename="../app/Main.qml" line="2379"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2374"/>
+        <location filename="../app/Main.qml" line="2385"/>
         <source>Loading favorites…</source>
         <translation>Načítanie obľúbených…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2370"/>
+        <location filename="../app/Main.qml" line="2381"/>
         <source>Loading games…</source>
         <translation>Načítanie hier…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1219"/>
+        <location filename="../app/Main.qml" line="1230"/>
         <source>Update media database</source>
         <translation type="unfinished">Aktualizovať databázu médií</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1222"/>
+        <location filename="../app/Main.qml" line="1233"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Získať metadáta</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1416"/>
+        <location filename="../app/Main.qml" line="1427"/>
         <source>Default</source>
         <translation type="unfinished">Predvolené</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1416"/>
+        <location filename="../app/Main.qml" line="1427"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1708"/>
+        <location filename="../app/Main.qml" line="1719"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1712"/>
+        <location filename="../app/Main.qml" line="1723"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1726"/>
+        <location filename="../app/Main.qml" line="1737"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1730"/>
+        <location filename="../app/Main.qml" line="1741"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1734"/>
+        <location filename="../app/Main.qml" line="1745"/>
         <source>Retry</source>
         <translation type="unfinished">Skúsiť znova</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1738"/>
+        <location filename="../app/Main.qml" line="1749"/>
         <source>Cancel</source>
         <translation type="unfinished">Zrušiť</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2372"/>
+        <location filename="../app/Main.qml" line="2383"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2376"/>
+        <location filename="../app/Main.qml" line="2387"/>
         <source>Loading recently played…</source>
         <translation>Načítanie nedávno hraných…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="2389"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2380"/>
+        <location filename="../app/Main.qml" line="2391"/>
         <source>Loading…</source>
         <translation>Načítanie…</translation>
     </message>
@@ -957,8 +957,10 @@ Euskara - devilschile2</source>
         <translation>Šetrič obrazovky</translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="189"/>
         <source>Library</source>
-        <translation type="vanished">Knižnica</translation>
+        <translation>Knižnica</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="142"/>
@@ -999,30 +1001,6 @@ Euskara - devilschile2</source>
         <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>About / License</source>
         <translation>O aplikácii / Licencia</translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="185"/>
-        <source>Display &amp; Interface</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="72"/>
-        <location filename="../screens/SettingsScreen.qml" line="187"/>
-        <source>Controls &amp; Input</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="77"/>
-        <location filename="../screens/SettingsScreen.qml" line="189"/>
-        <source>Library &amp; Data Management</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="82"/>
-        <location filename="../screens/SettingsScreen.qml" line="191"/>
-        <source>Support &amp; About</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="206"/>
@@ -1267,6 +1245,24 @@ Euskara - devilschile2</source>
         <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Resolution</source>
         <translation>Rozlíšenie</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
+        <source>Display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="72"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="82"/>
+        <location filename="../screens/SettingsScreen.qml" line="191"/>
+        <source>Support</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="566"/>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -549,124 +549,124 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1206"/>
+        <location filename="../app/Main.qml" line="1217"/>
         <source>Launch core</source>
         <translation>Запустити core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1212"/>
-        <location filename="../app/Main.qml" line="1420"/>
+        <location filename="../app/Main.qml" line="1223"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1247"/>
+        <location filename="../app/Main.qml" line="1258"/>
         <source>Remove from favorites</source>
         <translation>Видалити з вибраного</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1247"/>
+        <location filename="../app/Main.qml" line="1258"/>
         <source>Add to favorites</source>
         <translation>Додати до вибраного</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1252"/>
+        <location filename="../app/Main.qml" line="1263"/>
         <source>Write to NFC token</source>
         <translation>Записати на NFC-токен</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1256"/>
+        <location filename="../app/Main.qml" line="1267"/>
         <source>QR code</source>
         <translation>QR-код</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1231"/>
-        <location filename="../app/Main.qml" line="1266"/>
+        <location filename="../app/Main.qml" line="1242"/>
+        <location filename="../app/Main.qml" line="1277"/>
         <source>Launch game</source>
         <translation>Запустити гру</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2368"/>
+        <location filename="../app/Main.qml" line="2379"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2374"/>
+        <location filename="../app/Main.qml" line="2385"/>
         <source>Loading favorites…</source>
         <translation>Завантаження вибраного…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2370"/>
+        <location filename="../app/Main.qml" line="2381"/>
         <source>Loading games…</source>
         <translation>Завантаження ігор…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1219"/>
+        <location filename="../app/Main.qml" line="1230"/>
         <source>Update media database</source>
         <translation type="unfinished">Оновити базу медіа</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1222"/>
+        <location filename="../app/Main.qml" line="1233"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Отримати метадані</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1416"/>
+        <location filename="../app/Main.qml" line="1427"/>
         <source>Default</source>
         <translation type="unfinished">Типовий</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1416"/>
+        <location filename="../app/Main.qml" line="1427"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1708"/>
+        <location filename="../app/Main.qml" line="1719"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1712"/>
+        <location filename="../app/Main.qml" line="1723"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1726"/>
+        <location filename="../app/Main.qml" line="1737"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1730"/>
+        <location filename="../app/Main.qml" line="1741"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1734"/>
+        <location filename="../app/Main.qml" line="1745"/>
         <source>Retry</source>
         <translation type="unfinished">Повторити</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1738"/>
+        <location filename="../app/Main.qml" line="1749"/>
         <source>Cancel</source>
         <translation type="unfinished">Скасувати</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2372"/>
+        <location filename="../app/Main.qml" line="2383"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2376"/>
+        <location filename="../app/Main.qml" line="2387"/>
         <source>Loading recently played…</source>
         <translation>Завантаження нещодавніх…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="2389"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2380"/>
+        <location filename="../app/Main.qml" line="2391"/>
         <source>Loading…</source>
         <translation>Завантаження…</translation>
     </message>
@@ -957,8 +957,10 @@ Euskara - devilschile2</source>
         <translation>Заставка</translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="189"/>
         <source>Library</source>
-        <translation type="vanished">Бібліотека</translation>
+        <translation>Бібліотека</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="142"/>
@@ -999,30 +1001,6 @@ Euskara - devilschile2</source>
         <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>About / License</source>
         <translation>Про програму / Ліцензія</translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="185"/>
-        <source>Display &amp; Interface</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="72"/>
-        <location filename="../screens/SettingsScreen.qml" line="187"/>
-        <source>Controls &amp; Input</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="77"/>
-        <location filename="../screens/SettingsScreen.qml" line="189"/>
-        <source>Library &amp; Data Management</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="82"/>
-        <location filename="../screens/SettingsScreen.qml" line="191"/>
-        <source>Support &amp; About</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="206"/>
@@ -1267,6 +1245,24 @@ Euskara - devilschile2</source>
         <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Resolution</source>
         <translation>Роздільна здатність</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
+        <source>Display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="72"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="82"/>
+        <location filename="../screens/SettingsScreen.qml" line="191"/>
+        <source>Support</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="566"/>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -549,124 +549,124 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1206"/>
+        <location filename="../app/Main.qml" line="1217"/>
         <source>Launch core</source>
         <translation>启动核心</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1212"/>
-        <location filename="../app/Main.qml" line="1420"/>
+        <location filename="../app/Main.qml" line="1223"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1219"/>
+        <location filename="../app/Main.qml" line="1230"/>
         <source>Update media database</source>
         <translation type="unfinished">更新媒体数据库</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1222"/>
+        <location filename="../app/Main.qml" line="1233"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">抓取元数据</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1231"/>
-        <location filename="../app/Main.qml" line="1266"/>
+        <location filename="../app/Main.qml" line="1242"/>
+        <location filename="../app/Main.qml" line="1277"/>
         <source>Launch game</source>
         <translation>启动游戏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1247"/>
+        <location filename="../app/Main.qml" line="1258"/>
         <source>Remove from favorites</source>
         <translation>从收藏中移除</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1247"/>
+        <location filename="../app/Main.qml" line="1258"/>
         <source>Add to favorites</source>
         <translation>添加到收藏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1252"/>
+        <location filename="../app/Main.qml" line="1263"/>
         <source>Write to NFC token</source>
         <translation>写入 NFC 令牌</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1256"/>
+        <location filename="../app/Main.qml" line="1267"/>
         <source>QR code</source>
         <translation>二维码</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1416"/>
+        <location filename="../app/Main.qml" line="1427"/>
         <source>Default</source>
         <translation type="unfinished">默认</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1416"/>
+        <location filename="../app/Main.qml" line="1427"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1708"/>
+        <location filename="../app/Main.qml" line="1719"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1712"/>
+        <location filename="../app/Main.qml" line="1723"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1726"/>
+        <location filename="../app/Main.qml" line="1737"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1730"/>
+        <location filename="../app/Main.qml" line="1741"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1734"/>
+        <location filename="../app/Main.qml" line="1745"/>
         <source>Retry</source>
         <translation type="unfinished">重试</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1738"/>
+        <location filename="../app/Main.qml" line="1749"/>
         <source>Cancel</source>
         <translation type="unfinished">取消</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2368"/>
+        <location filename="../app/Main.qml" line="2379"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2370"/>
+        <location filename="../app/Main.qml" line="2381"/>
         <source>Loading games…</source>
         <translation>正在加载游戏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2372"/>
+        <location filename="../app/Main.qml" line="2383"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2374"/>
+        <location filename="../app/Main.qml" line="2385"/>
         <source>Loading favorites…</source>
         <translation>正在加载收藏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2376"/>
+        <location filename="../app/Main.qml" line="2387"/>
         <source>Loading recently played…</source>
         <translation>正在加载最近游玩…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="2389"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2380"/>
+        <location filename="../app/Main.qml" line="2391"/>
         <source>Loading…</source>
         <translation>正在加载…</translation>
     </message>
@@ -947,8 +947,10 @@ Euskara - devilschile2</source>
         <translation>屏幕保护程序</translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="189"/>
         <source>Library</source>
-        <translation type="vanished">资料库</translation>
+        <translation>资料库</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="142"/>
@@ -999,30 +1001,6 @@ Euskara - devilschile2</source>
         <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>About / License</source>
         <translation>关于 / 许可</translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="67"/>
-        <location filename="../screens/SettingsScreen.qml" line="185"/>
-        <source>Display &amp; Interface</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="72"/>
-        <location filename="../screens/SettingsScreen.qml" line="187"/>
-        <source>Controls &amp; Input</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="77"/>
-        <location filename="../screens/SettingsScreen.qml" line="189"/>
-        <source>Library &amp; Data Management</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="82"/>
-        <location filename="../screens/SettingsScreen.qml" line="191"/>
-        <source>Support &amp; About</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="206"/>
@@ -1267,6 +1245,24 @@ Euskara - devilschile2</source>
         <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Resolution</source>
         <translation>分辨率</translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="67"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
+        <source>Display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="72"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="82"/>
+        <location filename="../screens/SettingsScreen.qml" line="191"/>
+        <source>Support</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="566"/>


### PR DESCRIPTION
## Summary

- request resized cover images from Core, expand the in-memory cover cache, and keep more nearby covers warm to reduce browse cover churn
- polish media browsing UX: keep current-page tiles synchronous, keep grid prefetch active during rapid navigation, and show Options help for launchable singleton folders
- add list-picker scroll indicators, add the 2560x1440 MiSTer resolution option, and simplify top-level settings category labels

## Motivation

Improve cover loading responsiveness and make settings/menu cues match actual behavior.

## Screenshots / recordings

Not captured.

## Test plan

- `just lint` (passes; existing qmllint warnings remain)
- `just test-rust` (passes)
- `cmake --build build --target update_translations`

## Checklist

- [ ] `just lint` is green (zero warnings)
- [ ] `just test` passes
- [ ] If this touches QML, the FPS counter stays green (≥ 55) at 720p+ and ≥ 30 at 240p
- [x] If this could affect the MiSTer build, I considered ARM32 implications (see `docs/architecture.md`)
- [x] If this adds user-visible strings, they are wrapped in `qsTr()` (QML) or `tr()` (C++)
- [x] I have signed the [CLA](../.github/CLA.md) (first-time contributors only)

Notes: `just lint` completed successfully but emitted existing qmllint warnings, so output is not warning-free. Full `just test` and FPS capture were not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic cover image sizing driven by grid/screen dimensions and a new cover-size control.
  * Configurable cover prefetch window and smarter prefetch ordering.
  * List picker now auto-scrolls selection into view with visible scroll indicators.

* **Bug Fixes**
  * Options hint now appears correctly for media-capable items (including single-item folders).
  * Improved cover-request pause/resume and prefetch behavior during rapid scrolling.

* **UI Improvements**
  * Settings sections reorganized into clearer headings.
  * Added 2560×1440 resolution option for MiSTer.

* **Localization**
  * Updated translations across many languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->