### PR TITLE
Prepare v1.1 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.22)
 
 project(
     zaparoo-frontend
-    VERSION 1.0.3
+    VERSION 1.1.0
     DESCRIPTION "Zaparoo Core frontend"
     HOMEPAGE_URL "https://zaparoo.org"
     LANGUAGES CXX

--- a/README.md
+++ b/README.md
@@ -3,14 +3,6 @@
 Zaparoo Frontend is the game frontend for
 [Zaparoo Core](https://zaparoo.org).
 
-## Early beta rename
-
-This project was renamed from Zaparoo Launcher to Zaparoo Frontend.
-The repository slug is now `zaparoo-frontend`, the binary is `frontend`,
-the config file is `frontend.toml`, and the log file is `frontend.log`.
-No automatic migration is provided for old beta installs; copy any settings
-from `launcher.toml` to `frontend.toml` manually if needed.
-
 ## Build
 
 Start with [docs/building.md](docs/building.md). It covers the packages you

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -679,7 +679,7 @@ dependencies = [
 
 [[package]]
 name = "mock-core"
-version = "1.0.3"
+version = "1.1.0"
 dependencies = [
  "futures-util",
  "serde",
@@ -1629,7 +1629,7 @@ dependencies = [
 
 [[package]]
 name = "zaparoo-core"
-version = "1.0.3"
+version = "1.1.0"
 dependencies = [
  "dirs-next",
  "futures-util",
@@ -1649,7 +1649,7 @@ dependencies = [
 
 [[package]]
 name = "zaparoo-frontend-rs"
-version = "1.0.3"
+version = "1.1.0"
 dependencies = [
  "base64",
  "cxx",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ members = ["frontend", "mock-core", "zaparoo-core"]
 resolver = "2"
 
 [workspace.package]
-version      = "1.0.3"
+version      = "1.1.0"
 edition      = "2021"
 rust-version = "1.90"
 license      = "LicenseRef-PolyForm-Noncommercial-1.0.0"

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -163,7 +163,7 @@ int main(int argc, char* argv[]) // NOLINT
     }
 
     QGuiApplication::setApplicationName("Zaparoo Frontend");
-    QGuiApplication::setApplicationVersion("1.0.3");
+    QGuiApplication::setApplicationVersion("1.1.0");
     QGuiApplication::setOrganizationName("Zaparoo");
     QGuiApplication::setOrganizationDomain("zaparoo.org");
 


### PR DESCRIPTION
## Summary

- bump app/project versions to 1.1.0 for the v1.1 release
- remove the obsolete early beta rename note from the README

## Motivation

Prep the frontend for the v1.1 release.

## Screenshots / recordings

Not applicable.

## Test plan

- `just lint` (passes; existing qmllint warnings remain)

## Checklist

- [ ] `just lint` is green (zero warnings)
- [ ] `just test` passes
- [ ] If this touches QML, the FPS counter stays green (≥ 55) at 720p+ and ≥ 30 at 240p
- [x] If this could affect the MiSTer build, I considered ARM32 implications (see `docs/architecture.md`)
- [x] If this adds user-visible strings, they are wrapped in `qsTr()` (QML) or `tr()` (C++)
- [x] I have signed the [CLA](../.github/CLA.md) (first-time contributors only)

Notes: `just lint` completed successfully but emitted existing qmllint warnings, so output is not warning-free. Full `just test` and FPS capture were not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 1.1.0 across the project.

* **Documentation**
  * Removed outdated early beta documentation from the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->