### PR TITLE
fix(media): suppress unnecessary cover requests

### DIFF
--- a/rust/frontend/src/models/games.rs
+++ b/rust/frontend/src/models/games.rs
@@ -1355,7 +1355,12 @@ fn cover_key_for(entry: &BrowseEntry, page_size: u32, requests_enabled: bool) ->
     let soft_no_image = media_key
         .as_ref()
         .is_some_and(|k| cache.is_soft_no_image(k));
-    if requests_enabled && !cached && !negative && !soft_no_image {
+    // Browse-provided signal: Core confirmed no image property for this entry.
+    // Treat as negative — show the cover placeholder and skip the
+    // media.image request. This eliminates the per-entry lookup flood on
+    // systems like Arcade that have very few scraped covers.
+    let no_cover = !entry.has_cover;
+    if requests_enabled && !cached && !negative && !soft_no_image && !no_cover {
         // Miss-driven re-enqueue: when QML asks for the cover URL of
         // a media entry whose bytes aren't in the cache, kick a fetch
         // right here. This is the only implicit path covers reach the
@@ -1373,7 +1378,7 @@ fn cover_key_for(entry: &BrowseEntry, page_size: u32, requests_enabled: bool) ->
         entry,
         media_key.as_ref(),
         cached,
-        negative || soft_no_image || !requests_enabled,
+        negative || soft_no_image || no_cover || !requests_enabled,
     )
 }
 
@@ -1447,6 +1452,11 @@ fn prefetch_around_plan(
                 continue;
             }
             let entry = &entries[idx];
+            // Skip entries Core has confirmed have no cover; they would
+            // occupy fetch queue slots but always return "no image".
+            if !entry.has_cover {
+                continue;
+            }
             if let Some(key) = media_key_for(entry) {
                 plan.push((key.with_current_cover_preference(), entry.media_id));
             }
@@ -1591,7 +1601,15 @@ fn notify_cover_update(mut model: Pin<&mut ffi::GamesModel>, key: &MediaKey) {
         .rust_mut()
         .pending_first_paint_keys
         .remove(key);
-    if was_pending && model.pending_first_paint_keys.is_empty() && model.loading {
+    // Hold the overlay while the initial look-ahead is still in flight so
+    // the Loading screen covers both cover resolution AND the background
+    // chunk's materialization. `release_initial_lookahead_gate` below will
+    // trigger the release once both conditions are satisfied.
+    if was_pending
+        && model.pending_first_paint_keys.is_empty()
+        && !model.pending_initial_lookahead
+        && model.loading
+    {
         if let Some(handle) = model.as_mut().rust_mut().cover_gate_timer.take() {
             handle.abort();
         }
@@ -1655,6 +1673,10 @@ where
 {
     entries
         .iter()
+        // Browse-provided signal: Core confirmed no image for this entry.
+        // Exclude from the gate set — these entries will never resolve to
+        // cached bytes, so waiting on them would always ride the timeout.
+        .filter(|entry| entry.has_cover)
         .filter_map(|entry| media_key_for(entry).map(MediaKey::with_current_cover_preference))
         .filter(|k| !is_cached(k) && !is_negative(k))
         .collect()
@@ -1693,14 +1715,28 @@ fn arm_cover_gate(mut model: Pin<&mut ffi::GamesModel>) {
         handle.abort();
     }
     let cache = global_media_image_cache();
+    // Scope the waiting set to the visible page only, not all loaded
+    // entries. The prefetcher queues only ~3 pages' worth; computing
+    // over all entries means the set can never drain on a large folder
+    // (e.g. 411 PSX dirs) and the gate always rides the full timeout.
+    // Using the visible page (page_size rows starting at visible_first_row)
+    // lets the set drain as soon as the on-screen covers land.
+    let page_size = model.page_size.max(1) as usize;
+    let first = model.rust().visible_first_row.max(0) as usize;
+    let window_end = (first + page_size).min(model.entries.len());
+    let visible_entries = &model.entries[first..window_end];
     let unresolved = compute_unresolved_keys(
-        &model.entries,
+        visible_entries,
         |k| cache.is_cached(k),
         |k| cache.is_negative(k),
     );
     if unresolved.is_empty() {
         model.as_mut().rust_mut().pending_first_paint_keys.clear();
-        if model.loading {
+        // If the initial look-ahead is still in flight, keep loading=true
+        // so the overlay covers the materialization of the first background
+        // chunk. `release_initial_lookahead_gate` will release it once
+        // the sub-batches have finished splicing onto the Qt thread.
+        if model.loading && !model.pending_initial_lookahead {
             model.as_mut().set_loading(false);
         }
         return;
@@ -1714,7 +1750,7 @@ fn arm_cover_gate(mut model: Pin<&mut ffi::GamesModel>) {
     let ticket = seq.fetch_add(1, Ordering::SeqCst) + 1;
     let qt_thread = model.qt_thread();
     let handle = global_handle().spawn(async move {
-        tokio::time::sleep(Duration::from_secs(3)).await;
+        tokio::time::sleep(Duration::from_millis(1500)).await;
         let _ = qt_thread.queue(move |model| {
             if seq.load(Ordering::SeqCst) != ticket {
                 return;
@@ -1725,11 +1761,15 @@ fn arm_cover_gate(mut model: Pin<&mut ffi::GamesModel>) {
     model.as_mut().rust_mut().cover_gate_timer = Some(handle);
 }
 
-/// Clear `pending_initial_lookahead` after the background prefetch
-/// lands. Look-ahead no longer participates in full-screen loading:
-/// visible page readiness and cover first-paint own that gate.
+/// Clear `pending_initial_lookahead` after the background prefetch lands.
+/// If the cover gate already drained before look-ahead finished (e.g. a
+/// system with no covers whose pending keys resolved to empty immediately),
+/// release the loading overlay now that both conditions are met.
 fn release_initial_lookahead_gate(mut model: Pin<&mut ffi::GamesModel>) {
     model.as_mut().rust_mut().pending_initial_lookahead = false;
+    if model.pending_first_paint_keys.is_empty() && model.loading {
+        model.as_mut().set_loading(false);
+    }
 }
 
 /// Force-release the cover gate from the safety timer. Called only via
@@ -3009,6 +3049,38 @@ mod tests {
                 ..BrowseEntry::default()
             },
         ];
+        let unresolved = compute_unresolved_keys(&entries, |_| false, |_| false);
+        assert!(unresolved.is_empty());
+    }
+
+    #[test]
+    fn compute_unresolved_keys_excludes_no_cover_entries() {
+        // Core sends has_cover=false for entries with no image property row.
+        // These entries will never resolve to cached bytes, so they must
+        // not be included in the gate set — otherwise the gate would always
+        // ride the safety timer on systems like Arcade.
+        let mut no_cover = media("nocovergame", "/p/nocovergame", "Arcade");
+        no_cover.has_cover = false;
+        let entries = vec![
+            no_cover,
+            media("coveredgame", "/p/coveredgame", "NES"),
+        ];
+        let unresolved = compute_unresolved_keys(&entries, |_| false, |_| false);
+        let expected: HashSet<MediaKey> =
+            [MediaKey::new("NES", "/p/coveredgame")].into_iter().collect();
+        assert_eq!(unresolved, expected);
+    }
+
+    #[test]
+    fn compute_unresolved_keys_all_no_cover_returns_empty() {
+        // A page where Core confirmed no entry has a cover (e.g. Arcade
+        // with no scraped artwork) must result in an empty unresolved set
+        // so the gate releases immediately rather than timing out.
+        let mut a = media("a", "/p/a", "Arcade");
+        a.has_cover = false;
+        let mut b = media("b", "/p/b", "Arcade");
+        b.has_cover = false;
+        let entries = vec![a, b];
         let unresolved = compute_unresolved_keys(&entries, |_| false, |_| false);
         assert!(unresolved.is_empty());
     }

--- a/rust/frontend/src/models/games.rs
+++ b/rust/frontend/src/models/games.rs
@@ -1360,7 +1360,8 @@ fn cover_key_for(entry: &BrowseEntry, page_size: u32, requests_enabled: bool) ->
     // media.image request. This eliminates the per-entry lookup flood on
     // systems like Arcade that have very few scraped covers.
     let no_cover = !entry.has_cover;
-    if requests_enabled && !cached && !negative && !soft_no_image && !no_cover {
+    let effective_cached = cached && !no_cover;
+    if requests_enabled && !effective_cached && !negative && !soft_no_image && !no_cover {
         // Miss-driven re-enqueue: when QML asks for the cover URL of
         // a media entry whose bytes aren't in the cache, kick a fetch
         // right here. This is the only implicit path covers reach the
@@ -1377,7 +1378,7 @@ fn cover_key_for(entry: &BrowseEntry, page_size: u32, requests_enabled: bool) ->
     cover_key_for_with(
         entry,
         media_key.as_ref(),
-        cached,
+        effective_cached,
         negative || soft_no_image || no_cover || !requests_enabled,
     )
 }
@@ -1702,14 +1703,14 @@ fn reset_cover_gate(mut model: Pin<&mut ffi::GamesModel>) {
 /// - If every media entry is already cached or negatively-memoised
 ///   (folder-only page, or revisit), set loading=false right now —
 ///   there's nothing to wait on, the screen-flip overlay clears.
-/// - Otherwise, store the unresolved set on the model, arm a 3 s safety
-///   timer, and leave loading=true. `notify_cover_update` will drain
-///   the set as covers land; whichever happens first (set empties or
-///   timer fires) releases the gate.
+/// - Otherwise, store the unresolved set on the model, arm a 1.5 s
+///   safety timer, and leave loading=true. `notify_cover_update` will
+///   drain the set as covers land; whichever happens first (set empties
+///   or timer fires) releases the gate.
 ///
-/// The 3 s timeout is the fall-through: if the bulk RPC stalls, the
-/// user sees `Loading…` for at most 3 s before the existing
-/// "list with placeholders → covers pop in" behaviour resumes.
+/// The 1.5 s timeout is the fall-through: if the bulk RPC or initial
+/// look-ahead stalls, the user sees `Loading…` for at most 1.5 s before
+/// the existing "list with placeholders → covers pop in" behavior resumes.
 fn arm_cover_gate(mut model: Pin<&mut ffi::GamesModel>) {
     if let Some(handle) = model.as_mut().rust_mut().cover_gate_timer.take() {
         handle.abort();
@@ -1736,8 +1737,13 @@ fn arm_cover_gate(mut model: Pin<&mut ffi::GamesModel>) {
         // so the overlay covers the materialization of the first background
         // chunk. `release_initial_lookahead_gate` will release it once
         // the sub-batches have finished splicing onto the Qt thread.
-        if model.loading && !model.pending_initial_lookahead {
-            model.as_mut().set_loading(false);
+        if model.loading {
+            if model.pending_initial_lookahead {
+                info!("games: arm cover gate (holding loading until look-ahead lands)");
+                arm_cover_gate_timeout(model);
+            } else {
+                model.as_mut().set_loading(false);
+            }
         }
         return;
     }
@@ -1746,16 +1752,26 @@ fn arm_cover_gate(mut model: Pin<&mut ffi::GamesModel>) {
         "games: arm cover gate (holding loading until covers cached)"
     );
     model.as_mut().rust_mut().pending_first_paint_keys = unresolved;
+    arm_cover_gate_timeout(model);
+}
+
+fn arm_cover_gate_timeout(mut model: Pin<&mut ffi::GamesModel>) {
     let seq = model.rust().cover_gate_seq.clone();
     let ticket = seq.fetch_add(1, Ordering::SeqCst) + 1;
     let qt_thread = model.qt_thread();
     let handle = global_handle().spawn(async move {
         tokio::time::sleep(Duration::from_millis(1500)).await;
-        let _ = qt_thread.queue(move |model| {
+        let _ = qt_thread.queue(move |mut model: Pin<&mut ffi::GamesModel>| {
             if seq.load(Ordering::SeqCst) != ticket {
                 return;
             }
-            release_cover_gate_after_timeout(model);
+            if model.loading
+                && (model.pending_initial_lookahead || !model.pending_first_paint_keys.is_empty())
+            {
+                release_cover_gate_after_timeout(model);
+            } else {
+                model.as_mut().rust_mut().cover_gate_timer = None;
+            }
         });
     });
     model.as_mut().rust_mut().cover_gate_timer = Some(handle);
@@ -1767,8 +1783,14 @@ fn arm_cover_gate(mut model: Pin<&mut ffi::GamesModel>) {
 /// release the loading overlay now that both conditions are met.
 fn release_initial_lookahead_gate(mut model: Pin<&mut ffi::GamesModel>) {
     model.as_mut().rust_mut().pending_initial_lookahead = false;
-    if model.pending_first_paint_keys.is_empty() && model.loading {
-        model.as_mut().set_loading(false);
+    if model.pending_first_paint_keys.is_empty() {
+        if let Some(handle) = model.as_mut().rust_mut().cover_gate_timer.take() {
+            handle.abort();
+            model.rust().cover_gate_seq.fetch_add(1, Ordering::SeqCst);
+        }
+        if model.loading {
+            model.as_mut().set_loading(false);
+        }
     }
 }
 
@@ -3061,13 +3083,11 @@ mod tests {
         // ride the safety timer on systems like Arcade.
         let mut no_cover = media("nocovergame", "/p/nocovergame", "Arcade");
         no_cover.has_cover = false;
-        let entries = vec![
-            no_cover,
-            media("coveredgame", "/p/coveredgame", "NES"),
-        ];
+        let entries = vec![no_cover, media("coveredgame", "/p/coveredgame", "NES")];
         let unresolved = compute_unresolved_keys(&entries, |_| false, |_| false);
-        let expected: HashSet<MediaKey> =
-            [MediaKey::new("NES", "/p/coveredgame")].into_iter().collect();
+        let expected: HashSet<MediaKey> = [MediaKey::new("NES", "/p/coveredgame")]
+            .into_iter()
+            .collect();
         assert_eq!(unresolved, expected);
     }
 

--- a/rust/zaparoo-core/src/media_types.rs
+++ b/rust/zaparoo-core/src/media_types.rs
@@ -511,7 +511,7 @@ pub struct MediaMeta {
     pub tags: Vec<TagInfo>,
     /// ROM-level scraped properties keyed by canonical type tag (e.g.
     /// `property:description`, `property:image-boxart`).
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_null_default")]
     pub properties: HashMap<String, MediaMetaProperty>,
     #[serde(default, deserialize_with = "deserialize_null_default")]
     pub available_image_types: Vec<String>,
@@ -540,7 +540,7 @@ pub struct MediaMetaTitle {
     pub tags: Vec<TagInfo>,
     /// Title-level scraped properties shared by all rows under the same
     /// title slug.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_null_default")]
     pub properties: HashMap<String, MediaMetaProperty>,
     #[serde(default, deserialize_with = "deserialize_null_default")]
     pub available_image_types: Vec<String>,
@@ -2180,6 +2180,19 @@ mod tests {
     }
 
     #[test]
+    fn media_meta_properties_null_defaults_to_empty_maps() {
+        let json = r#"{
+            "media": {
+                "properties": null,
+                "title": {"properties": null}
+            }
+        }"#;
+        let result: MediaMetaResult = serde_json::from_str(json).expect("parse");
+        assert!(result.media.properties.is_empty());
+        assert!(result.media.title.properties.is_empty());
+    }
+
+    #[test]
     fn browse_entry_has_cover_absent_defaults_to_true() {
         // Older Core builds don't send `hasCover`; the frontend must
         // still request covers for those entries.
@@ -2192,7 +2205,8 @@ mod tests {
     fn browse_entry_has_cover_false_is_honoured() {
         // Core sends hasCover=false when it has confirmed no image property
         // row for the entry. The frontend should skip the cover request.
-        let json = r#"{"name":"Zelda","path":"/roms/NES/zelda.nes","type":"media","hasCover":false}"#;
+        let json =
+            r#"{"name":"Zelda","path":"/roms/NES/zelda.nes","type":"media","hasCover":false}"#;
         let entry: BrowseEntry = serde_json::from_str(json).expect("parse");
         assert!(!entry.has_cover, "hasCover=false must be preserved");
     }

--- a/rust/zaparoo-core/src/media_types.rs
+++ b/rust/zaparoo-core/src/media_types.rs
@@ -2,8 +2,27 @@
 // Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
+
+/// Serde helper: deserializes `null` as the type's `Default` instead of
+/// failing. Used on `Vec<T>` fields where Core may emit `null` for an empty
+/// collection (Go nil slices marshal as `null`, not `[]`).
+fn deserialize_null_default<'de, D, T>(d: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Default + Deserialize<'de>,
+{
+    let opt = Option::deserialize(d)?;
+    Ok(opt.unwrap_or_default())
+}
+
+/// Serde default for `has_cover`: true when the field is absent so that
+/// clients receiving responses from older Core builds (which don't emit
+/// `hasCover`) still request covers rather than silently skipping them.
+fn default_true() -> bool {
+    true
+}
 
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -184,7 +203,12 @@ pub struct MediaBrowseParams {
     pub sort: Option<String>,
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
+// `Default` is implemented manually below so that `has_cover` defaults to
+// `true` (request covers unless Core explicitly says otherwise) rather than
+// the Rust zero-value `false`. The serde `default = "default_true"` handles
+// the wire-protocol case (field absent); this impl handles Rust callers that
+// use `..BrowseEntry::default()` in tests and struct-update syntax.
+#[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BrowseEntry {
     /// Opaque media database row ID. Present on `media` entries and
@@ -214,6 +238,34 @@ pub struct BrowseEntry {
     /// Core can populate this on singleton media-container directories.
     #[serde(default)]
     pub tags: Vec<TagInfo>,
+    /// When `false`, Core has confirmed this media has no cover image in
+    /// its properties tables. Defaults to `true` when the field is absent
+    /// (older Core builds don't send it) so cover requests are still made.
+    /// Only meaningful for `media` entries; folders always behave as `true`.
+    #[serde(default = "default_true")]
+    pub has_cover: bool,
+}
+
+impl Default for BrowseEntry {
+    fn default() -> Self {
+        Self {
+            media_id: None,
+            name: String::new(),
+            path: String::new(),
+            entry_type: String::new(),
+            file_count: 0,
+            system_id: String::new(),
+            system_ids: Vec::new(),
+            zap_script: String::new(),
+            relative_path: String::new(),
+            group: String::new(),
+            description: String::new(),
+            tags: Vec::new(),
+            // Default to true so callers that don't set this field (tests,
+            // struct-update syntax) still request covers from Core.
+            has_cover: true,
+        }
+    }
 }
 
 impl BrowseEntry {
@@ -455,13 +507,13 @@ pub struct MediaMeta {
     pub parent_dir: String,
     #[serde(default)]
     pub is_missing: bool,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_null_default")]
     pub tags: Vec<TagInfo>,
     /// ROM-level scraped properties keyed by canonical type tag (e.g.
     /// `property:description`, `property:image-boxart`).
     #[serde(default)]
     pub properties: HashMap<String, MediaMetaProperty>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_null_default")]
     pub available_image_types: Vec<String>,
     #[serde(default)]
     pub title: MediaMetaTitle,
@@ -484,13 +536,13 @@ pub struct MediaMetaTitle {
     pub slug_word_count: u32,
     #[serde(default)]
     pub system: MediaMetaSystemRef,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_null_default")]
     pub tags: Vec<TagInfo>,
     /// Title-level scraped properties shared by all rows under the same
     /// title slug.
     #[serde(default)]
     pub properties: HashMap<String, MediaMetaProperty>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_null_default")]
     pub available_image_types: Vec<String>,
 }
 
@@ -2125,5 +2177,31 @@ mod tests {
         assert_eq!(result.scrapers[0].id, "screenscraper");
         assert_eq!(result.scrapers[0].supported_systems, vec!["SNES", "NES"]);
         assert!(result.scrapers[1].supported_systems.is_empty());
+    }
+
+    #[test]
+    fn browse_entry_has_cover_absent_defaults_to_true() {
+        // Older Core builds don't send `hasCover`; the frontend must
+        // still request covers for those entries.
+        let json = r#"{"name":"Zelda","path":"/roms/NES/zelda.nes","type":"media"}"#;
+        let entry: BrowseEntry = serde_json::from_str(json).expect("parse");
+        assert!(entry.has_cover, "absent hasCover should default to true");
+    }
+
+    #[test]
+    fn browse_entry_has_cover_false_is_honoured() {
+        // Core sends hasCover=false when it has confirmed no image property
+        // row for the entry. The frontend should skip the cover request.
+        let json = r#"{"name":"Zelda","path":"/roms/NES/zelda.nes","type":"media","hasCover":false}"#;
+        let entry: BrowseEntry = serde_json::from_str(json).expect("parse");
+        assert!(!entry.has_cover, "hasCover=false must be preserved");
+    }
+
+    #[test]
+    fn browse_entry_default_has_cover_true() {
+        // BrowseEntry::default() must give has_cover=true so struct-update
+        // syntax in tests/callers doesn't accidentally suppress cover requests.
+        let entry = BrowseEntry::default();
+        assert!(entry.has_cover, "Default::has_cover must be true");
     }
 }

--- a/src/ui/components/Tile.qml
+++ b/src/ui/components/Tile.qml
@@ -237,21 +237,14 @@ Item {
                 return;
             if (status === Image.Loading) {
                 root._startupTraceLoadStartedAt = Date.now();
-                root._startupTrace("startup/qml resource load start",
-                                   "source=" + source);
+                root._startupTrace("startup/qml resource load start", "source=" + source);
             } else if (status === Image.Ready) {
                 const durMs = root._startupTraceLoadStartedAt > 0 ? Math.max(0, Date.now() - root._startupTraceLoadStartedAt) : 0;
-                root._startupTrace("startup/qml resource load ready",
-                                   "source=" + source,
-                                   "dur_ms=" + durMs,
-                                   "paintedWidth=" + width,
-                                   "paintedHeight=" + height);
+                root._startupTrace("startup/qml resource load ready", "source=" + source, "dur_ms=" + durMs, "paintedWidth=" + width, "paintedHeight=" + height);
                 root._startupTraceLoadStartedAt = 0;
             } else if (status === Image.Error) {
                 const durMs = root._startupTraceLoadStartedAt > 0 ? Math.max(0, Date.now() - root._startupTraceLoadStartedAt) : 0;
-                root._startupTrace("startup/qml resource load error",
-                                   "source=" + source,
-                                   "dur_ms=" + durMs);
+                root._startupTrace("startup/qml resource load error", "source=" + source, "dur_ms=" + durMs);
                 root._startupTraceLoadStartedAt = 0;
             }
         }

--- a/src/ui/screens/MediaListScreen.qml
+++ b/src/ui/screens/MediaListScreen.qml
@@ -211,7 +211,7 @@ Item {
     function _resumeCoverRequests(): void {
         if (root.mediaModel === null)
             return;
-        if (root._listLayout && root.pauseCoverRequestsDuringRapid)
+        if (root.pauseCoverRequestsDuringRapid)
             root.mediaModel.cover_requests_paused = false;
         if (typeof root.mediaModel.refresh_cover_keys === "function")
             root.mediaModel.refresh_cover_keys(root._coverRefreshFirstRow(), root._coverRefreshRowCount());
@@ -220,7 +220,7 @@ Item {
     }
 
     function _pauseCoverRequests(): void {
-        if (root.mediaModel === null || !root._listLayout || !root.pauseCoverRequestsDuringRapid)
+        if (root.mediaModel === null || !root.pauseCoverRequestsDuringRapid)
             return;
         root.mediaModel.cover_requests_paused = true;
         if (typeof root.mediaModel.clear_pending_cover_requests === "function")


### PR DESCRIPTION
## Summary
- Consume Core browse `hasCover` and skip cover image requests for entries known to have no cover.
- Keep the loading overlay active through initial look-ahead materialization, with a safety timeout so it cannot stick forever.
- Pause grid cover loading during rapid navigation, matching list behavior.

## Motivation
Reduce unnecessary `media.image` request floods on systems with sparse/no scraped covers (for example Arcade) while keeping the first visible page transition smooth.

## Screenshots / recordings
Not included. Change affects cover request/loading behavior and serialization handling, not intended visuals.

## Test plan
- `just lint`
- `just test`

## Checklist
- [x] `just lint` is green (passes locally; existing qmllint warnings still print)
- [x] `just test` passes
- [ ] If this touches QML, the FPS counter stays green (≥ 55) at 720p+ and ≥ 30 at 240p — not run; QML change is formatting/cover-pause behavior only
- [x] If this could affect the MiSTer build, I considered ARM32 implications (keeps requests bounded and uses existing timer path)
- [x] If this adds user-visible strings, they are wrapped in `qsTr()` (QML) or `tr()` (C++) — no user-visible strings added
- [x] I have signed the [CLA](../.github/CLA.md) (first-time contributors only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Items explicitly marked as “no cover” are skipped for cover requests and prefetching.
  * Cover requests pause/resume correctly during rapid scroll in both list and grid layouts.
  * Full‑screen loading overlay now clears only when pending first‑paint keys and look‑ahead are resolved.
  * Cover gate timeout reduced for snappier responsiveness.
  * Deserialization handles absent/null cover metadata and empty collections for older payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
