### PR TITLE
Fix detail pane loading flicker

### DIFF
--- a/src/ui/components/BrowseDetailPane.qml
+++ b/src/ui/components/BrowseDetailPane.qml
@@ -59,10 +59,11 @@ Item {
     readonly property int _carouselGutter: (canPreviousImage || canNextImage) ? Sizing.pctW(4) : 0
     readonly property bool _coverPending: coverKey === "icons/Loading"
     readonly property url _coverSource: _coverPending ? "" : Resources.coverUrl(coverKey)
-    readonly property bool _coverBusy: root._coverPending || cover.status === Image.Loading
+    readonly property bool _coverMediaImagePending: coverKey.startsWith("media-image/") && cover.status !== Image.Ready && cover.status !== Image.Error
+    readonly property bool _coverBusy: root._coverPending || root._coverMediaImagePending || cover.status === Image.Loading
     readonly property bool _paneLoading: root.loading
     readonly property bool _delayedPaneLoading: root._paneLoading && root._paneLoadingDelayElapsed
-    readonly property bool _coverBusyIndicatorVisible: root._coverBusy && (root._coverLoadingDelayElapsed || root._paneLoadingDelayElapsed)
+    readonly property bool _coverBusyIndicatorVisible: root._coverPending || root._coverMediaImagePending || (cover.status === Image.Loading && root._coverLoadingDelayElapsed)
     readonly property bool _detailVisible: !root.detailSuppressed
     readonly property bool _emptyPaneLoading: root._delayedPaneLoading && !root._coverBusyIndicatorVisible && root._coverSource === "" && root._detailRows.length === 0 && root.title === ""
     readonly property bool _suppressedPlaceholderCover: root.detailSuppressed && coverKey.startsWith("icons/") && root._coverSource !== ""

--- a/src/ui/components/BrowseDetailPane.qml
+++ b/src/ui/components/BrowseDetailPane.qml
@@ -62,8 +62,9 @@ Item {
     readonly property bool _coverBusy: root._coverPending || cover.status === Image.Loading
     readonly property bool _paneLoading: root.loading
     readonly property bool _delayedPaneLoading: root._paneLoading && root._paneLoadingDelayElapsed
-    readonly property bool _delayedCoverBusy: root._coverBusy && root._coverLoadingDelayElapsed
-    readonly property bool _detailVisible: !root._paneLoading && !root.detailSuppressed
+    readonly property bool _coverBusyIndicatorVisible: root._coverBusy && (root._coverLoadingDelayElapsed || root._paneLoadingDelayElapsed)
+    readonly property bool _detailVisible: !root.detailSuppressed
+    readonly property bool _emptyPaneLoading: root._delayedPaneLoading && !root._coverBusyIndicatorVisible && root._coverSource === "" && root._detailRows.length === 0 && root.title === ""
     readonly property bool _suppressedPlaceholderCover: root.detailSuppressed && coverKey.startsWith("icons/") && root._coverSource !== ""
     readonly property var _detailRows: _parseDetailTags(detailTags)
     readonly property int _tagRowCount: _detailRows.length
@@ -241,10 +242,13 @@ Item {
                     sourceSize.width: 512
                     smooth: true
                     asynchronous: true
-                    visible: !root._paneLoading && root._coverSource !== "" && status === Image.Ready && (!root.detailSuppressed || root._suppressedPlaceholderCover)
+                    visible: root._coverSource !== "" && status === Image.Ready && (!root.detailSuppressed || root._suppressedPlaceholderCover)
                 }
 
                 Image {
+                    id: placeholderIcon
+
+                    objectName: "detailPlaceholderIcon"
                     x: Sizing.center(parent.width, width)
                     y: Sizing.center(parent.height, height)
                     width: Math.min(Sizing.pctH(10), parent.width, parent.height)
@@ -255,7 +259,7 @@ Item {
                     fillMode: Image.PreserveAspectFit
                     smooth: true
                     asynchronous: false
-                    visible: !root._paneLoading && !root._suppressedPlaceholderCover && (root.detailSuppressed || root._delayedCoverBusy || (!root._coverBusy && (root._coverSource === "" || cover.status === Image.Error)))
+                    visible: !root._suppressedPlaceholderCover && (root.detailSuppressed || root._coverBusyIndicatorVisible || (!root._coverBusy && (root._coverSource === "" || cover.status === Image.Error)))
                 }
             }
         }
@@ -304,6 +308,7 @@ Item {
                 Text {
                     id: titleText
 
+                    objectName: "detailTitleText"
                     anchors.left: parent.left
                     anchors.right: parent.right
                     anchors.top: parent.top
@@ -342,6 +347,7 @@ Item {
                     Column {
                         id: tagTable
 
+                        objectName: "detailTagTable"
                         anchors.left: parent.left
                         anchors.right: parent.right
                         anchors.top: root._metadataBottomAligned && !titleText.visible ? undefined : parent.top
@@ -413,7 +419,8 @@ Item {
         }
 
         LoadingIndicator {
-            visible: root._delayedPaneLoading && !root.detailSuppressed
+            objectName: "detailLoadingIndicator"
+            visible: root._emptyPaneLoading && !root.detailSuppressed
             x: Sizing.center(parent.width, width)
             y: Sizing.center(parent.height, height)
             text: root.loadingText

--- a/tests/ui/CMakeLists.txt
+++ b/tests/ui/CMakeLists.txt
@@ -16,6 +16,7 @@ qt_add_qml_module(
         tst_persistence.qml
         tst_paged_grid.qml
         tst_focused_media_detail_controller.qml
+        tst_browse_detail_pane.qml
         tst_list_picker_modal.qml
     IMPORTS
         Zaparoo.App

--- a/tests/ui/tst_browse_detail_pane.qml
+++ b/tests/ui/tst_browse_detail_pane.qml
@@ -25,7 +25,7 @@ TestCase {
 
         width: 320
         height: 240
-        loadingDelayMs: 0
+        loadingDelayMs: 150
         showTitle: true
     }
 
@@ -57,6 +57,15 @@ TestCase {
         verify(findChild(pane, "detailTagTable").visible);
         verify(findChild(pane, "detailPlaceholderIcon").visible);
         verify(!findChild(pane, "detailLoadingIndicator").visible);
+    }
+
+    function test_loading_icon_survives_media_image_handoff(): void {
+        pane.coverKey = "icons/Loading";
+        wait(1);
+        verify(findChild(pane, "detailPlaceholderIcon").visible);
+
+        pane.coverKey = "media-image/not-ready";
+        verify(findChild(pane, "detailPlaceholderIcon").visible);
     }
 
     function test_suppressed_detail_still_hides_metadata(): void {

--- a/tests/ui/tst_browse_detail_pane.qml
+++ b/tests/ui/tst_browse_detail_pane.qml
@@ -1,0 +1,71 @@
+// Zaparoo Frontend
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+import QtQuick
+import QtTest
+import Zaparoo.Theme
+import Zaparoo.Ui
+
+TestCase {
+    id: testCase
+    name: "BrowseDetailPane"
+    when: windowShown
+    width: 320
+    height: 240
+    visible: true
+
+    Component.onCompleted: {
+        Sizing.screenWidth = testCase.width;
+        Sizing.screenHeight = testCase.height;
+    }
+
+    BrowseDetailPane {
+        id: pane
+
+        width: 320
+        height: 240
+        loadingDelayMs: 0
+        showTitle: true
+    }
+
+    function resetPane(): void {
+        pane.loading = false;
+        pane.detailSuppressed = false;
+        pane.title = "";
+        pane.detailTags = "";
+        pane.coverKey = "";
+        wait(1);
+    }
+
+    function init(): void {
+        resetPane();
+    }
+
+    function cleanup(): void {
+        resetPane();
+    }
+
+    function test_metadata_stays_visible_while_loading(): void {
+        pane.title = "Selected Game";
+        pane.detailTags = "Year\t1990\nGenre\tAction";
+        pane.coverKey = "icons/Loading";
+        pane.loading = true;
+        wait(1);
+
+        verify(findChild(pane, "detailTitleText").visible);
+        verify(findChild(pane, "detailTagTable").visible);
+        verify(findChild(pane, "detailPlaceholderIcon").visible);
+        verify(!findChild(pane, "detailLoadingIndicator").visible);
+    }
+
+    function test_suppressed_detail_still_hides_metadata(): void {
+        pane.title = "Selected Game";
+        pane.detailTags = "Year\t1990";
+        pane.detailSuppressed = true;
+        wait(1);
+
+        verify(!findChild(pane, "detailTitleText").visible);
+        verify(!findChild(pane, "detailTagTable").visible);
+    }
+}


### PR DESCRIPTION
## Summary
- Keep detail metadata labels visible while selected game details load
- Keep the cover loading icon visible through the media-image handoff
- Add QML regression tests for detail-pane loading, suppression, and image handoff states

## Tests
- just test-qml

## Notes
- Manual MiSTer deploy verified by Callan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined loading indicator and placeholder visibility logic in the browse detail pane for improved state management during cover transitions.
  * Enhanced metadata visibility behavior when detail suppression is enabled.

* **Tests**
  * Added comprehensive test coverage for browse detail pane visibility states and metadata display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->