### PR TITLE
Improve loading indicators during navigation

### DIFF
--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -374,6 +374,22 @@ MainLayout {
         Browse.AppState.active_screen = screen;
     }
 
+    // Back transitions need the same delayed loading cue as forward
+    // model fills. Request the destination first so lazy Loaders can
+    // mount behind the cue, then cut after the cue has had one frame to
+    // paint.
+    function _navigateBackToScreen(screen: string): void {
+        if (screen === root.activeScreen)
+            return;
+        root._backTransitionTarget = screen;
+        root.pendingTransition = "back";
+        root._whenScreenReady(screen, function () {
+            if (root.pendingTransition !== "back" || root._backTransitionTarget !== screen)
+                return;
+            backTransitionTimer.restart();
+        });
+    }
+
     // Single-shot callback slots fired by the loadingChanged
     // listeners below. Only one transition is in flight at a time
     // (input gate guarantees this), so two scalars are enough.
@@ -394,6 +410,7 @@ MainLayout {
     // complete the transition before our own `set_category` has been
     // issued.
     property bool _deferredCategoryPending: false
+    property bool _deferredSystemPending: false
     // Saved games-screen entry path that wasn't on the freshly seeded
     // page 1 of MediaBrowse. The GamesModel.onCountChanged watcher
     // below paginates forward via fetch_more until the path is found
@@ -401,6 +418,9 @@ MainLayout {
     // any navigation that starts a new browse target so a stale
     // restore can't keep paginating after the user moves on.
     property string _pendingGameRestorePath: ""
+    property string _backTransitionTarget: ""
+    property string _pendingFolderBackTargetPath: ""
+    property string _pendingFolderBackSystemId: ""
 
     function _catalogStillBooting(): bool {
         return !Browse.CategoriesModel.loaded && (Browse.CategoriesModel.error_message ?? "") === "";
@@ -418,6 +438,20 @@ MainLayout {
         root._startupTrace("startup/qml deferred category ready", "category=" + targetCategory + " count=" + Browse.SystemsModel.count);
         const cb = root._categoryReadyCallback;
         root._categoryReadyCallback = null;
+        cb();
+        return true;
+    }
+
+    function _completeDeferredSystemIfReady(targetSystemId: string): bool {
+        if (root._systemReadyCallback === null)
+            return false;
+        if (Browse.GamesModel.loading)
+            return false;
+        if (Browse.GamesModel.current_system_id !== targetSystemId)
+            return false;
+        root._startupTrace("startup/qml deferred system ready", "systemId=" + targetSystemId + " count=" + Browse.GamesModel.count);
+        const cb = root._systemReadyCallback;
+        root._systemReadyCallback = null;
         cb();
         return true;
     }
@@ -481,6 +515,10 @@ MainLayout {
         function onLoadingChanged(): void {
             if (Browse.GamesModel.loading)
                 return;
+            if (root._deferredSystemPending) {
+                root._startupTrace("startup/qml system loading edge ignored", "reason=deferred-pending systemId=" + Browse.GamesModel.current_system_id + " count=" + Browse.GamesModel.count);
+                return;
+            }
             const cb = root._systemReadyCallback;
             if (cb === null)
                 return;
@@ -523,13 +561,12 @@ MainLayout {
     // populated — a re-Accept after Esc-back); the set_category call
     // is still made for parity with the prior behaviour even though
     // Rust early-returns when the category already matches. Async
-    // path waits for loadingChanged; the 50 ms defer hides
-    // set_category's synchronous teardown of SystemsScreen's bound
-    // tile delegates behind the transition overlay, so the user sees
-    // overlay → frozen-under-overlay → grid instead of freeze →
-    // flash → grid. Qt.callLater is not enough; it fires inside the
-    // same event loop iteration before the next render polish/sync
-    // pass.
+    // path waits for loadingChanged. When replacing an already-populated
+    // SystemsModel during a transition, defer until the delayed loading cue
+    // has had one frame to paint; otherwise set_category's synchronous
+    // delegate teardown can freeze the GUI before any feedback appears.
+    // Qt.callLater is not enough; it fires inside the same event loop
+    // iteration before the next render polish/sync pass.
     function _ensureCategory(category: string, cb, waitForCatalog): void {
         if (waitForCatalog && root._catalogStillBooting()) {
             root._startupTrace("startup/qml catalog wait arm", "category=" + category);
@@ -547,6 +584,7 @@ MainLayout {
         root._categoryReadyCallback = cb;
         root._deferredCategoryPending = true;
         deferredCategorySetTimer.targetCategory = category;
+        deferredCategorySetTimer.interval = root.pendingTransition !== "" && Browse.SystemsModel.count > 0 ? root.loadingIndicatorDelayMs + 50 : 50;
         deferredCategorySetTimer.restart();
     }
 
@@ -556,7 +594,9 @@ MainLayout {
     // but the cached result applies inline through the watcher's seed
     // — loading flips back to false before set_system returns — so we
     // can call cb() synchronously on this path. Cold-load goes through
-    // the systemReadyCallback waiter below.
+    // the systemReadyCallback waiter below; when replacing populated
+    // games rows during a transition, defer to the delayed loading cue
+    // for the same pre-feedback-freeze reason as _ensureCategory.
     function _ensureSystem(systemId: string, cb): void {
         if (Browse.GamesModel.current_system_id === systemId && Browse.GamesModel.count > 0) {
             Browse.GamesModel.set_system(systemId);
@@ -564,7 +604,10 @@ MainLayout {
             return;
         }
         root._systemReadyCallback = cb;
-        Browse.GamesModel.set_system(systemId);
+        root._deferredSystemPending = true;
+        deferredSystemSetTimer.targetSystemId = systemId;
+        deferredSystemSetTimer.interval = root.pendingTransition !== "" && Browse.GamesModel.count > 0 ? root.loadingIndicatorDelayMs + 50 : 1;
+        deferredSystemSetTimer.restart();
     }
 
     // Hub Accept routing. Empty-row passthrough preserves the committed
@@ -836,26 +879,41 @@ MainLayout {
         Browse.GamesModel.set_path(path);
     }
 
-    // Folder pop-up inside the games screen. Pops the deepest level off
-    // the stack, then drives the model back to the parent path. If we
-    // pop to the root level (path_stack[0] is always "") the call goes
-    // through `set_system` so the model re-runs the
-    // single-root-auto-nav decision rather than browsing the literal
-    // empty path with no system filter.
+    // Folder pop-up inside the games screen. Pop persistence immediately
+    // so kill-resume observes the back intent, then defer the model rebrowse
+    // until LoadingIndicator has painted. If we pop to the root level
+    // (path_stack[0] is always "") the call goes through `set_system` so
+    // the model re-runs single-root auto-nav rather than browsing the
+    // literal empty path with no system filter.
     function _navigateOutOfFolder(): void {
         const stack = Browse.GamesState.path_stack;
         if (stack.length <= 1)
             return;
+        root.pendingTransition = "folder_back";
         Browse.GamesState.pop_level();
         const newStack = Browse.GamesState.path_stack;
         const target = newStack[newStack.length - 1];
+        root._pendingFolderBackTargetPath = target;
+        root._pendingFolderBackSystemId = target === "" ? Browse.GamesState.system_id : "";
+        folderBackTransitionTimer.restart();
+    }
+
+    function _completeFolderBackTransition(): void {
+        const target = root._pendingFolderBackTargetPath;
+        const systemId = root._pendingFolderBackSystemId;
+        root._pendingFolderBackTargetPath = "";
+        root._pendingFolderBackSystemId = "";
+        if (root.pendingTransition !== "folder_back")
+            return;
         if (target === "") {
-            const sid = Browse.GamesState.system_id;
-            if (sid !== "")
-                Browse.GamesModel.set_system(sid);
+            if (systemId !== "")
+                Browse.GamesModel.set_system(systemId);
         } else {
             Browse.GamesModel.set_path(target);
         }
+        if (root.pendingTransition === "folder_back")
+            root.pendingTransition = "";
+        root._resetIdle();
     }
 
     // Clear the pending flag, then flip. Order matters: clearing
@@ -1055,7 +1113,7 @@ MainLayout {
     Connections {
         target: root.favoritesScreen
         function onRequestHubScreen(): void {
-            root._goto(root.screenHub);
+            root._navigateBackToScreen(root.screenHub);
         }
         function onRequestContextMenu(index: int, anchorRect): void {
             root.openContextMenu("favorites", index, anchorRect);
@@ -1064,7 +1122,7 @@ MainLayout {
     Connections {
         target: root.recentsScreen
         function onRequestHubScreen(): void {
-            root._goto(root.screenHub);
+            root._navigateBackToScreen(root.screenHub);
         }
         function onRequestContextMenu(index: int, anchorRect): void {
             root.openContextMenu("recents", index, anchorRect);
@@ -1108,7 +1166,7 @@ MainLayout {
             root._navigateFromSystems(systemId);
         }
         function onRequestHubScreen(): void {
-            root._goto(root.screenHub);
+            root._navigateBackToScreen(root.screenHub);
         }
         function onRequestContextMenu(index: int, anchorRect): void {
             root.openContextMenu("systems", index, anchorRect);
@@ -1149,10 +1207,10 @@ MainLayout {
         function onRequestSystemsScreen(): void {
             const arcadeBypassActive = Browse.Platform.is_mister && Browse.Platform.ready && Browse.SystemsModel.current_category === CategoryIds.arcadeId && Browse.SystemsModel.count === 1 && Browse.GamesModel.current_system_id === CategoryIds.arcadeId;
             if (arcadeBypassActive) {
-                root._goto(root.screenHub);
+                root._navigateBackToScreen(root.screenHub);
                 return;
             }
-            root._goto(root.screenSystems);
+            root._navigateBackToScreen(root.screenSystems);
         }
         function onRequestNavigateIntoFolder(path: string): void {
             root._navigateIntoFolder(path);
@@ -1934,8 +1992,8 @@ MainLayout {
         // first so an Accept/Esc on a card-write modal isn't
         // accidentally swallowed if a transition is pending behind
         // it (the modal owns input regardless).
-        if (root.pendingTransition !== "" && !ScreenManager.hasModal) {
-            root._startupTrace("input/qml drop", "reason=pending-transition", "action=" + action, "pendingTransition=" + root.pendingTransition);
+        if ((root.pendingTransition !== "" || root.transitionCueVisible) && !ScreenManager.hasModal) {
+            root._startupTrace("input/qml drop", "reason=pending-transition", "action=" + action, "pendingTransition=" + root.pendingTransition, "transitionCueVisible=" + root.transitionCueVisible);
             return;
         }
         if (ScreenManager.hasModal) {
@@ -2221,7 +2279,7 @@ MainLayout {
         // `_maybeCompleteBoot` and `_completeTransition` call
         // `_resetIdle()` so the countdown restarts cleanly the moment
         // the gate clears.
-        if (!root.bootComplete || root.pendingTransition !== "")
+        if (!root.bootComplete || root.pendingTransition !== "" || root.transitionCueVisible)
             return;
         const lg = root.headerBar.logoItem;
         if (!lg)
@@ -2355,24 +2413,30 @@ MainLayout {
         }
     }
 
-    // Forward-transition cue. Item, not Rectangle — the source
-    // screen's existing background and circuit-trace texture stay
-    // visible underneath; never paint a full-screen fill. The
-    // source screen's primary content is hidden by `transitioning`
-    // bindings so the centred "Loading…" reads alone in the cleared
-    // band. Sized to the full window so anchors.centerIn parks
-    // the row in the geometric centre regardless of which screen
-    // is the source.
+    // Transition cue. Item, not Rectangle — the source screen's existing
+    // background and circuit-trace texture stay visible underneath; never
+    // paint a full-screen fill. The delayed indicator suppresses flashes
+    // for quick loads; once it appears, screen `transitioning` bindings hide
+    // primary content so the centred "Loading…" reads alone in the cleared
+    // band. Sized to the full window so anchors.centerIn parks the row in
+    // the geometric centre regardless of which screen is the source.
     Item {
         anchors.fill: parent
-        visible: (root.pendingTransition !== "" && !root.startupRestoreCurtainVisible) || (root.startupRestoreCurtainVisible && root._startupRestoreScreen !== "")
+        visible: transitionCueActive || transitionCue.showing
         z: 100
 
+        readonly property bool transitionCueActive: (root.pendingTransition !== "" && !root.startupRestoreCurtainVisible) || (root.startupRestoreCurtainVisible && root._startupRestoreScreen !== "")
         readonly property string cueScreen: root.pendingTransition !== "" ? root.pendingTransition : root._startupRestoreScreen
 
-        LoadingIndicator {
+        DelayedLoadingIndicator {
+            id: transitionCue
+            active: parent.transitionCueActive
+            delayMs: root.loadingIndicatorDelayMs
+            minimumVisibleMs: root.minimumLoadingVisibleMs
             x: Sizing.center(parent.width, width)
             y: Sizing.center(parent.height, height)
+            onShowingChanged: root.transitionCueVisible = showing
+            Component.onCompleted: root.transitionCueVisible = showing
             text: {
                 switch (parent.cueScreen) {
                 case "systems":
@@ -2513,12 +2577,36 @@ MainLayout {
         onTriggered: root._startRecentsTransitionLoad()
     }
 
-    // Deferred set_category trigger. Lets the transition overlay
-    // paint a frame before set_category's synchronous teardown of
-    // SystemsScreen's tile delegates freezes the GUI thread. The
-    // 50 ms interval covers a single frame even at MiSTer's ~20 fps
-    // software renderer; Qt.callLater / interval 0 fire inside the
-    // same event loop iteration before the next render.
+    Timer {
+        id: backTransitionTimer
+        interval: root.loadingIndicatorDelayMs + 50
+        repeat: false
+        onTriggered: {
+            const target = root._backTransitionTarget;
+            root._backTransitionTarget = "";
+            if (target === "") {
+                if (root.pendingTransition === "back")
+                    root.pendingTransition = "";
+                return;
+            }
+            if (root.pendingTransition !== "back")
+                return;
+            root._completeTransition(target);
+        }
+    }
+
+    Timer {
+        id: folderBackTransitionTimer
+        interval: root.loadingIndicatorDelayMs + 50
+        repeat: false
+        onTriggered: root._completeFolderBackTransition()
+    }
+
+    // Deferred set_category trigger. When the existing model has rows,
+    // the caller stretches the interval to the delayed cue threshold plus
+    // one frame so the transition indicator is visible before synchronous
+    // delegate teardown can freeze the GUI thread. Qt.callLater / interval
+    // 0 fire inside the same event loop iteration before the next render.
     Timer {
         id: deferredCategorySetTimer
         interval: 50
@@ -2534,6 +2622,20 @@ MainLayout {
             // edge will arrive; complete synchronously in that no-op case.
             root._deferredCategoryPending = false;
             root._completeDeferredCategoryIfReady(category);
+        }
+    }
+
+    Timer {
+        id: deferredSystemSetTimer
+        interval: 1
+        repeat: false
+        property string targetSystemId: ""
+        onTriggered: {
+            const systemId = deferredSystemSetTimer.targetSystemId;
+            root._startupTrace("startup/qml deferred system trigger", "systemId=" + systemId);
+            Browse.GamesModel.set_system(systemId);
+            root._deferredSystemPending = false;
+            root._completeDeferredSystemIfReady(systemId);
         }
     }
 }

--- a/src/ui/app/MainLayout.qml
+++ b/src/ui/app/MainLayout.qml
@@ -297,12 +297,15 @@ ApplicationWindow {
     signal contextMenuCloseRequested
     signal closeGameInfoRequested
 
-    // Forward-transition state owned by Main.qml. "" while idle;
-    // "systems" or "games" while waiting on a model fill before
-    // flipping `activeScreen`. Declared here so the source-screen
-    // content-hiding bindings (row/grid `visible`) resolve statically
-    // in qmllint.
+    // Transition state owned by Main.qml. "" while idle; non-empty while
+    // the router is waiting on a model fill or a delayed loading cue
+    // before flipping `activeScreen` / rebrowsing. Declared here so the
+    // source-screen content-hiding bindings (row/grid `visible`) resolve
+    // statically in qmllint.
     property string pendingTransition: ""
+    readonly property int loadingIndicatorDelayMs: 300
+    readonly property int minimumLoadingVisibleMs: 200
+    property bool transitionCueVisible: false
 
     // Cold-launch curtain. False until the catalog has loaded for the
     // first time this session; while false the host screens are
@@ -552,11 +555,10 @@ ApplicationWindow {
             // docs/qml-gotchas.md → "Software-renderer animation costs"
             // for the full reasoning.
             //
-            // No additional cue on screen change: the help-bar text changes
-            // instantly, the screen body swaps, and the user just pressed
-            // OK or Esc — the action is deliberate and the feedback is
-            // immediate. The page-dot pulse inside `PagedGrid` is the only
-            // animated transition cue in the frontend.
+            // Transition feedback is a delayed static LoadingIndicator, not
+            // an animated screen effect. Quick swaps cut directly; slower
+            // model fills hide source content only after the loading cue is
+            // visible, avoiding both spinner flashes and pre-feedback freezes.
             //
             // The wrapper `Item` stays for grouping clarity; with no fade
             // machinery it carries no buffered state. Model bindings stay
@@ -574,7 +576,7 @@ ApplicationWindow {
                     id: hubScreen
                     anchors.fill: parent
                     visible: root.activeScreen === root.screenHub
-                    transitioning: root.pendingTransition !== ""
+                    transitioning: root.transitionCueVisible
                     onVisibleChanged: {
                         if (!visible || !root._startupTraceActive)
                             return;
@@ -591,7 +593,7 @@ ApplicationWindow {
                     sourceComponent: Component {
                         SystemsScreen {
                             anchors.fill: parent
-                            transitioning: root.pendingTransition !== ""
+                            transitioning: root.transitionCueVisible
                             optimisticLoading: root.activeScreen === root.screenSystems && root.catalogStillBooting
                         }
                     }
@@ -605,7 +607,7 @@ ApplicationWindow {
                     sourceComponent: Component {
                         GamesScreen {
                             anchors.fill: parent
-                            transitioning: root.pendingTransition !== ""
+                            transitioning: root.transitionCueVisible
                             optimisticLoading: root.activeScreen === root.screenGames && root.catalogStillBooting
                         }
                     }
@@ -619,7 +621,7 @@ ApplicationWindow {
                     sourceComponent: Component {
                         FavoritesScreen {
                             anchors.fill: parent
-                            transitioning: root.pendingTransition !== ""
+                            transitioning: root.transitionCueVisible
                             optimisticLoading: root.activeScreen === root.screenFavorites && root.catalogStillBooting
                         }
                     }
@@ -633,7 +635,7 @@ ApplicationWindow {
                     sourceComponent: Component {
                         RecentsScreen {
                             anchors.fill: parent
-                            transitioning: root.pendingTransition !== ""
+                            transitioning: root.transitionCueVisible
                             optimisticLoading: root.activeScreen === root.screenRecents && root.catalogStillBooting
                         }
                     }
@@ -647,7 +649,7 @@ ApplicationWindow {
                     sourceComponent: Component {
                         SettingsScreen {
                             anchors.fill: parent
-                            transitioning: root.pendingTransition !== ""
+                            transitioning: root.transitionCueVisible
                             optimisticLoading: root.activeScreen === root.screenSettings && root.catalogStillBooting
                         }
                     }
@@ -661,7 +663,7 @@ ApplicationWindow {
                     sourceComponent: Component {
                         AboutScreen {
                             anchors.fill: parent
-                            transitioning: root.pendingTransition !== ""
+                            transitioning: root.transitionCueVisible
                         }
                     }
                 }
@@ -989,7 +991,7 @@ ApplicationWindow {
                             }
                         ];
                     }
-                    if (root.pendingTransition !== "")
+                    if (root.pendingTransition !== "" || root.transitionCueVisible)
                         return [];
                     if (root.activeScreen === root.screenHub) {
                         // Hub always has the actions row (Recently Played /

--- a/src/ui/components/CMakeLists.txt
+++ b/src/ui/components/CMakeLists.txt
@@ -18,6 +18,7 @@ qt_add_qml_module(
         CommercialNoticeModal.qml
         ContextMenu.qml
         CoreStatusPill.qml
+        DelayedLoadingIndicator.qml
         FirstRunIndexModal.qml
         FocusedMediaDetailController.qml
         GameInfoModal.qml

--- a/src/ui/components/DelayedLoadingIndicator.qml
+++ b/src/ui/components/DelayedLoadingIndicator.qml
@@ -1,0 +1,99 @@
+// Zaparoo Frontend
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+import QtQuick
+
+// LoadingIndicator with anti-flicker timing. Fast operations complete
+// without showing anything; once the cue appears it remains up briefly
+// so it does not flash for a single frame.
+Item {
+    id: root
+
+    property bool active: false
+    property int delayMs: 300
+    property int minimumVisibleMs: 200
+    property alias text: indicator.text
+    property alias glyphSize: indicator.glyphSize
+    readonly property bool showing: root._showing
+
+    property bool _showing: false
+    property double _shownAtMs: 0
+
+    width: indicator.width
+    height: indicator.height
+    visible: root._showing
+
+    onActiveChanged: root._sync()
+    onDelayMsChanged: root._sync()
+    onMinimumVisibleMsChanged: root._sync()
+    Component.onCompleted: root._sync()
+
+    function _show(): void {
+        if (!root.active)
+            return;
+        hideTimer.stop();
+        if (!root._showing) {
+            root._shownAtMs = Date.now();
+            root._showing = true;
+        }
+    }
+
+    function _hide(): void {
+        root._showing = false;
+        root._shownAtMs = 0;
+        hideTimer.stop();
+    }
+
+    function _hideWhenAllowed(): void {
+        delayTimer.stop();
+        if (!root._showing) {
+            hideTimer.stop();
+            return;
+        }
+        const elapsed = Math.max(0, Date.now() - root._shownAtMs);
+        const remaining = Math.max(0, root.minimumVisibleMs - elapsed);
+        if (remaining <= 0) {
+            root._hide();
+            return;
+        }
+        hideTimer.interval = remaining;
+        hideTimer.restart();
+    }
+
+    function _sync(): void {
+        if (root.active) {
+            hideTimer.stop();
+            if (root._showing)
+                return;
+            delayTimer.stop();
+            if (root.delayMs <= 0) {
+                root._show();
+                return;
+            }
+            delayTimer.interval = root.delayMs;
+            delayTimer.restart();
+            return;
+        }
+        root._hideWhenAllowed();
+    }
+
+    Timer {
+        id: delayTimer
+        repeat: false
+        onTriggered: root._show()
+    }
+
+    Timer {
+        id: hideTimer
+        repeat: false
+        onTriggered: {
+            if (!root.active)
+                root._hide();
+        }
+    }
+
+    LoadingIndicator {
+        id: indicator
+    }
+}

--- a/src/ui/components/ScreenStateOverlay.qml
+++ b/src/ui/components/ScreenStateOverlay.qml
@@ -26,11 +26,16 @@ Item {
     property int count: 0
     property string emptyText: qsTr("Nothing here")
     property string loadingText: qsTr("Loading…")
+    property int loadingDelayMs: 300
+    property int minimumLoadingVisibleMs: 200
+    readonly property bool loadingVisible: overlay.enabled && delayedLoading.showing
     // Named `viewState` rather than `state` — `Item.state` is a
     // built-in slot wired to `states:` / `transitions:`, and shadowing
     // it would silently break any future maintainer who adds state
-    // animations to the overlay or a subclass.
-    readonly property string viewState: overlay.loading ? "loading" : (overlay.errorMessage !== "" ? "error" : (overlay.count === 0 ? "empty" : "ready"))
+    // animations to the overlay or a subclass. During the loading-delay
+    // window, report Ready so Empty/Error text does not flash before the
+    // async result settles.
+    readonly property string viewState: overlay.loadingVisible ? "loading" : (overlay.loading ? "ready" : (overlay.errorMessage !== "" ? "error" : (overlay.count === 0 ? "empty" : "ready")))
 
     visible: overlay.enabled && overlay.viewState !== "ready"
 
@@ -39,14 +44,16 @@ Item {
         y: Sizing.center(parent.height, height)
         spacing: Sizing.pctH(0.6)
 
-        // Loading state shares the LoadingIndicator with the global
-        // forward-transition overlay and the GamesScreen pagination
-        // cue — single component, single visual vocabulary for "in
-        // flight". Error/Empty stay as plain text since they are
-        // terminal states, not in-flight ones.
-        LoadingIndicator {
+        // Loading state shares the delayed LoadingIndicator path with the
+        // global transition overlay — single visual vocabulary for "in
+        // flight" without flashing on sub-threshold loads. Error/Empty
+        // stay as plain text since they are terminal states.
+        DelayedLoadingIndicator {
+            id: delayedLoading
             anchors.horizontalCenter: parent.horizontalCenter
-            visible: overlay.viewState === "loading"
+            active: overlay.enabled && overlay.loading
+            delayMs: overlay.loadingDelayMs
+            minimumVisibleMs: overlay.minimumLoadingVisibleMs
             text: overlay.loadingText
         }
 

--- a/src/ui/screens/MediaListScreen.qml
+++ b/src/ui/screens/MediaListScreen.qml
@@ -104,7 +104,8 @@ Item {
     readonly property var _footerProfile: root._gridLayoutProfile && root._gridLayoutProfile.footer ? root._gridLayoutProfile.footer : null
     readonly property bool _crtListStrip: Theme.crtNativePath && root._listLayout
     readonly property int _listOverlayBottomMargin: root._listLayoutProfile && root._listLayoutProfile.list ? root._listLayoutProfile.list.overlayBottomMargin : Sizing.pctH(15)
-    readonly property bool _gateHide: root.transitioning || root._loading()
+    property bool _stateOverlayLoadingVisible: false
+    readonly property bool _gateHide: root.transitioning || root._stateOverlayLoadingVisible
 
     signal requestHubScreen
     signal requestContextMenu(int index, var anchorRect)
@@ -506,6 +507,7 @@ Item {
     }
 
     ScreenStateOverlay {
+        id: screenStateOverlay
         x: root._listLayout ? listCard.x : mediaGrid.x
         y: root._listLayout ? listCard.y : mediaGrid.y
         width: root._listLayout ? listCard.width : mediaGrid.width
@@ -516,5 +518,7 @@ Item {
         count: root._count()
         emptyText: root.emptyText
         loadingText: root.loadingText
+        onLoadingVisibleChanged: root._stateOverlayLoadingVisible = loadingVisible
+        Component.onCompleted: root._stateOverlayLoadingVisible = loadingVisible
     }
 }

--- a/tests/ui/tst_navigation.qml
+++ b/tests/ui/tst_navigation.qml
@@ -37,6 +37,7 @@ TestCase {
         main.settingsScreenRequested = true;
         main.activeScreen = main.screenHub;
         main.pendingTransition = "";
+        tryCompare(main, "transitionCueVisible", false);
         // Hub focus is two rows now (categories + actions); reset both
         // axes so a prior test's row-jump doesn't leak into the next.
         // qmllint disable compiler
@@ -107,18 +108,27 @@ TestCase {
         compare(main.activeScreen, main.screenSystems, "Enter on an empty systems screen must retry, not flip to games");
     }
 
-    // Escape on games goes back to systems (one peer up the stack).
+    // Escape on games goes back to systems (one peer up the stack) after
+    // a one-frame Loading cue, matching heavy forward transitions.
     function test_escape_on_games_returns_to_systems(): void {
         main.activeScreen = main.screenGames;
         main.handleKey(Qt.Key_Escape);
-        compare(main.activeScreen, main.screenSystems);
+        compare(main.pendingTransition, "back");
+        compare(main.activeScreen, main.screenGames);
+        tryCompare(main, "activeScreen", main.screenSystems);
+        compare(main.pendingTransition, "");
+        tryCompare(main, "transitionCueVisible", false);
     }
 
-    // Escape on systems goes back to hub.
+    // Escape on systems goes back to hub after the same Loading cue.
     function test_escape_on_systems_returns_to_hub(): void {
         main.activeScreen = main.screenSystems;
         main.handleKey(Qt.Key_Escape);
-        compare(main.activeScreen, main.screenHub);
+        compare(main.pendingTransition, "back");
+        compare(main.activeScreen, main.screenSystems);
+        tryCompare(main, "activeScreen", main.screenHub);
+        compare(main.pendingTransition, "");
+        tryCompare(main, "transitionCueVisible", false);
     }
 
     // Up on systems is a grid-internal move; at the top row (or on an
@@ -134,7 +144,10 @@ TestCase {
     function test_backspace_behaves_like_escape_on_games(): void {
         main.activeScreen = main.screenGames;
         main.handleKey(Qt.Key_Backspace);
-        compare(main.activeScreen, main.screenSystems);
+        compare(main.pendingTransition, "back");
+        tryCompare(main, "activeScreen", main.screenSystems);
+        compare(main.pendingTransition, "");
+        tryCompare(main, "transitionCueVisible", false);
     }
 
     // Cross-row mapping. The test harness has no live CategoriesModel


### PR DESCRIPTION
## Summary
- add a delayed loading indicator (300ms delay, 200ms minimum visible) for centered loading states
- use delayed cues for heavy back navigation and folder-pop paths while preserving input gating
- keep existing content visible until the delayed cue appears to avoid loading flashes

## Tests
- just test-qml
- just lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consistent back-navigation flow with a visible delayed loading cue and deferred folder rebrowse.
  * New anti-flicker delayed-loading indicator to keep brief loads from strobing UI.

* **Bug Fixes**
  * Deferred system initialization to avoid GUI freezes during transitions.
  * Input and screensaver activation now respect the visible loading cue; help/instructions suppress during cue.

* **Tests**
  * Navigation tests updated to assert intermediate back transitions and cue visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->