### PR TITLE
Fix browse title consistency

### DIFF
--- a/rust/frontend/src/models/games.rs
+++ b/rust/frontend/src/models/games.rs
@@ -464,7 +464,7 @@ impl ffi::GamesModel {
         }
         let entry = &self.entries[index.row() as usize];
         match role {
-            NAME_ROLE => QVariant::from(&QString::from(entry.name.as_str())),
+            NAME_ROLE => QVariant::from(&QString::from(display_title_for_entry(entry).as_ref())),
             PATH_ROLE => QVariant::from(&QString::from(entry.path.as_str())),
             ZAP_SCRIPT_ROLE => QVariant::from(&QString::from(entry.zap_script.as_str())),
             SYSTEM_ID_ROLE => QVariant::from(&QString::from(entry_system_id(entry).as_str())),
@@ -791,7 +791,7 @@ impl ffi::GamesModel {
         if index < 0 || index >= self.count {
             return QString::default();
         }
-        QString::from(self.entries[index as usize].name.as_str())
+        QString::from(display_title_for_entry(&self.entries[index as usize]).as_ref())
     }
 
     fn description_at(&self, index: i32) -> QString {
@@ -1371,6 +1371,14 @@ fn detail_value_for_aliases(source: &[TagInfo], aliases: &[&str]) -> String {
         .map(tag_display_value)
         .collect::<Vec<_>>()
         .join(", ")
+}
+
+fn display_title_for_entry(entry: &BrowseEntry) -> std::borrow::Cow<'_, str> {
+    if entry.name.is_empty() {
+        std::borrow::Cow::Owned(file_stem_or_name(&entry.path, &entry.name))
+    } else {
+        std::borrow::Cow::Borrowed(entry.name.as_str())
+    }
 }
 
 fn file_stem_or_name(path: &str, name: &str) -> String {
@@ -2514,11 +2522,11 @@ mod tests {
     use super::{
         child_launch_text_from_browse_result, chunk_for_subbatching, compute_unresolved_keys,
         cover_key_for_with, cover_placeholder_for, decide_initial, dedup_roots_drop_ancestors,
-        detail_tags_from_tags, display_name, entry_system_id, is_media_capable_entry,
-        is_strict_ancestor_path, leading_dir_count, media_capable_directory_browse_params,
-        media_key_for, meta_params_for_entry, position_of_game_path, prefetch_around_plan,
-        project_status, run_text_for_entry, singleton_directory_needs_launch_resolution,
-        transform_entries, InitialAction, Projection,
+        detail_tags_from_tags, display_name, display_title_for_entry, entry_system_id,
+        is_media_capable_entry, is_strict_ancestor_path, leading_dir_count,
+        media_capable_directory_browse_params, media_key_for, meta_params_for_entry,
+        position_of_game_path, prefetch_around_plan, project_status, run_text_for_entry,
+        singleton_directory_needs_launch_resolution, transform_entries, InitialAction, Projection,
     };
     use crate::media_image_cache::{MediaImageCache, MediaKey};
     use std::collections::HashSet;
@@ -2773,6 +2781,27 @@ mod tests {
             decide_initial(&result, true, None, ""),
             InitialAction::Apply
         );
+    }
+
+    #[test]
+    fn display_title_prefers_core_name_with_disc_marker() {
+        let entry = media("D (Disc 1)", "/roms/PSX/D.cue", "PSX");
+        assert_eq!(display_title_for_entry(&entry).as_ref(), "D (Disc 1)");
+    }
+
+    #[test]
+    fn display_title_prefers_singleton_directory_alias() {
+        let mut entry = folder("Friendly Alias", "/roms/PSX/InternalContainer");
+        entry.media_id = Some(42);
+        entry.system_id = "PSX".into();
+        entry.zap_script = "@PSX/Friendly Alias".into();
+        assert_eq!(display_title_for_entry(&entry).as_ref(), "Friendly Alias");
+    }
+
+    #[test]
+    fn display_title_falls_back_to_file_stem_when_name_empty() {
+        let entry = media("", "/roms/PSX/D (Disc 2).cue", "PSX");
+        assert_eq!(display_title_for_entry(&entry).as_ref(), "D (Disc 2)");
     }
 
     #[test]

--- a/src/ui/components/BrowseList.qml
+++ b/src/ui/components/BrowseList.qml
@@ -15,7 +15,6 @@ Item {
     property string currentCoverKey: ""
     property int totalItemsOverride: -1
     property int targetVisibleRowCount: 0
-    property bool showFileStem: false
     property bool showChrome: true
     property var layoutProfile: null
     readonly property var _list: root.layoutProfile && root.layoutProfile.list ? root.layoutProfile.list : null
@@ -142,12 +141,13 @@ Item {
             height: root.rowHeight
 
             readonly property bool selected: row.index === root.currentIndex
+            readonly property string displayTitle: row.name !== "" ? row.name : row.fileStem
 
             Binding {
                 target: root
                 property: "currentName"
                 when: row.selected
-                value: row.name
+                value: row.displayTitle
                 restoreMode: Binding.RestoreNone
             }
 
@@ -194,7 +194,7 @@ Item {
                 anchors.right: parent.right
                 anchors.rightMargin: row.favorite !== 0 ? root._favoriteRightPadding + Sizing.pctH(3.2) + root._rowTextRightPadding : root._rowTextRightPadding
                 anchors.verticalCenter: parent.verticalCenter
-                text: root.showFileStem && row.fileStem !== "" ? row.fileStem : row.name
+                text: row.displayTitle
                 color: row.selected ? Theme.textPrimary : Theme.textLabel
                 font.family: Theme.fontUi
                 font.pixelSize: Sizing.fontSize(2.9)

--- a/src/ui/components/BrowseListDetailView.qml
+++ b/src/ui/components/BrowseListDetailView.qml
@@ -12,7 +12,6 @@ Item {
     property alias currentIndex: browseList.currentIndex
     property alias totalItemsOverride: browseList.totalItemsOverride
     property alias targetVisibleRowCount: browseList.targetVisibleRowCount
-    property alias showFileStem: browseList.showFileStem
     property alias currentName: browseList.currentName
     property alias currentCoverKey: browseList.currentCoverKey
     property alias itemCount: browseList.itemCount

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -49,7 +49,6 @@ MediaListScreen {
     loadingText: qsTr("Loading games…")
     totalItemsOverride: Browse.GamesModel.dir_count + Browse.GamesModel.total_files
     targetVisibleRowCount: games._listPageSize
-    showFileStem: true
     detailShowDescription: false
     detailShowTitle: false
     detailLoadingText: qsTr("Loading game…")

--- a/src/ui/screens/MediaListScreen.qml
+++ b/src/ui/screens/MediaListScreen.qml
@@ -26,7 +26,6 @@ Item {
     property string detailPlaceholderKey: "icons/File"
     property int totalItemsOverride: -1
     property int targetVisibleRowCount: 0
-    property bool showFileStem: false
     property bool detailShowDescription: true
     property bool detailShowTitle: true
     property string detailLoadingText: qsTr("Loading…")
@@ -368,7 +367,6 @@ Item {
         model: root.mediaModel
         totalItemsOverride: root.totalItemsOverride
         targetVisibleRowCount: root.targetVisibleRowCount
-        showFileStem: root.showFileStem
         currentIndex: mediaGrid.currentIndex
         detailTitle: listCard.currentName
         detailCoverKey: root.detailRapidScrollActive ? root.detailPlaceholderKey : (root._detailImageKey() !== "" ? root._detailImageKey() : listCard.currentCoverKey)

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -97,100 +97,100 @@ Euskara - devilschile2</source>
         <translation type="unfinished">جارٍ التحميل…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Yr</source>
         <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Gen</source>
         <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Plyr</source>
         <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Dev</source>
         <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Pub</source>
         <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Rtg</source>
         <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Cat</source>
         <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Date</source>
         <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <location filename="../components/BrowseDetailPane.qml" line="156"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <location filename="../components/BrowseDetailPane.qml" line="156"/>
         <source>Mfr</source>
         <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
@@ -425,19 +425,19 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="122"/>
-        <location filename="../screens/GamesScreen.qml" line="157"/>
+        <location filename="../screens/GamesScreen.qml" line="121"/>
+        <location filename="../screens/GamesScreen.qml" line="156"/>
         <source>%1 files</source>
         <translation>%1 ملفات</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="55"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="158"/>
+        <location filename="../screens/GamesScreen.qml" line="130"/>
+        <location filename="../screens/GamesScreen.qml" line="157"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -452,7 +452,7 @@ Euskara - devilschile2</source>
         <translation>جارٍ تحميل الألعاب…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="127"/>
+        <location filename="../screens/GamesScreen.qml" line="126"/>
         <source>Loading more…</source>
         <translation>جارٍ تحميل المزيد…</translation>
     </message>
@@ -699,136 +699,136 @@ Euskara - devilschile2</source>
         <translation type="unfinished">تم لعبها مؤخرًا</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="695"/>
+        <location filename="../app/MainLayout.qml" line="696"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="696"/>
+        <location filename="../app/MainLayout.qml" line="697"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="806"/>
+        <location filename="../app/MainLayout.qml" line="807"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="807"/>
+        <location filename="../app/MainLayout.qml" line="808"/>
         <source>Are you sure you want to exit?</source>
         <translation>هل أنت متأكد أنك تريد الخروج؟</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="886"/>
-        <location filename="../app/MainLayout.qml" line="960"/>
-        <location filename="../app/MainLayout.qml" line="1003"/>
-        <location filename="../app/MainLayout.qml" line="1034"/>
-        <location filename="../app/MainLayout.qml" line="1084"/>
-        <location filename="../app/MainLayout.qml" line="1127"/>
+        <location filename="../app/MainLayout.qml" line="887"/>
+        <location filename="../app/MainLayout.qml" line="961"/>
+        <location filename="../app/MainLayout.qml" line="1004"/>
+        <location filename="../app/MainLayout.qml" line="1035"/>
+        <location filename="../app/MainLayout.qml" line="1085"/>
+        <location filename="../app/MainLayout.qml" line="1128"/>
         <location filename="../app/MainLayout.qml" line="1195"/>
         <source>Move</source>
         <translation>تحريك</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="890"/>
-        <location filename="../app/MainLayout.qml" line="964"/>
+        <location filename="../app/MainLayout.qml" line="891"/>
+        <location filename="../app/MainLayout.qml" line="965"/>
         <source>Select</source>
         <translation>تحديد</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="894"/>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="912"/>
-        <location filename="../app/MainLayout.qml" line="927"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="895"/>
+        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="913"/>
+        <location filename="../app/MainLayout.qml" line="928"/>
+        <location filename="../app/MainLayout.qml" line="939"/>
         <source>Close</source>
         <translation>إغلاق</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="905"/>
-        <location filename="../app/MainLayout.qml" line="945"/>
-        <location filename="../app/MainLayout.qml" line="968"/>
-        <location filename="../app/MainLayout.qml" line="979"/>
+        <location filename="../app/MainLayout.qml" line="906"/>
+        <location filename="../app/MainLayout.qml" line="946"/>
+        <location filename="../app/MainLayout.qml" line="969"/>
+        <location filename="../app/MainLayout.qml" line="980"/>
         <source>Cancel</source>
         <translation>إلغاء</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="923"/>
+        <location filename="../app/MainLayout.qml" line="924"/>
         <source>Done</source>
         <translation>تم</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="934"/>
-        <location filename="../app/MainLayout.qml" line="1057"/>
-        <location filename="../app/MainLayout.qml" line="1110"/>
+        <location filename="../app/MainLayout.qml" line="935"/>
+        <location filename="../app/MainLayout.qml" line="1058"/>
+        <location filename="../app/MainLayout.qml" line="1111"/>
         <location filename="../app/MainLayout.qml" line="1221"/>
         <source>Retry</source>
         <translation>إعادة المحاولة</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="953"/>
+        <location filename="../app/MainLayout.qml" line="954"/>
         <source>I understand</source>
         <translation>أفهم</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="987"/>
+        <location filename="../app/MainLayout.qml" line="988"/>
         <source>Start</source>
         <translation>ابدأ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1007"/>
-        <location filename="../app/MainLayout.qml" line="1044"/>
-        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1008"/>
+        <location filename="../app/MainLayout.qml" line="1045"/>
+        <location filename="../app/MainLayout.qml" line="1095"/>
         <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Open</source>
         <translation>فتح</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1011"/>
+        <location filename="../app/MainLayout.qml" line="1012"/>
         <source>Quit</source>
         <translation>إنهاء</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1050"/>
-        <location filename="../app/MainLayout.qml" line="1061"/>
-        <location filename="../app/MainLayout.qml" line="1076"/>
-        <location filename="../app/MainLayout.qml" line="1103"/>
-        <location filename="../app/MainLayout.qml" line="1114"/>
-        <location filename="../app/MainLayout.qml" line="1151"/>
-        <location filename="../app/MainLayout.qml" line="1169"/>
-        <location filename="../app/MainLayout.qml" line="1178"/>
+        <location filename="../app/MainLayout.qml" line="1021"/>
+        <location filename="../app/MainLayout.qml" line="1051"/>
+        <location filename="../app/MainLayout.qml" line="1062"/>
+        <location filename="../app/MainLayout.qml" line="1077"/>
+        <location filename="../app/MainLayout.qml" line="1104"/>
+        <location filename="../app/MainLayout.qml" line="1115"/>
+        <location filename="../app/MainLayout.qml" line="1152"/>
+        <location filename="../app/MainLayout.qml" line="1170"/>
+        <location filename="../app/MainLayout.qml" line="1179"/>
         <location filename="../app/MainLayout.qml" line="1214"/>
         <location filename="../app/MainLayout.qml" line="1225"/>
         <source>Back</source>
         <translation>رجوع</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1040"/>
-        <location filename="../app/MainLayout.qml" line="1090"/>
+        <location filename="../app/MainLayout.qml" line="1041"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
         <location filename="../app/MainLayout.qml" line="1201"/>
         <source>Page</source>
         <translation>صفحة</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1047"/>
-        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1048"/>
+        <location filename="../app/MainLayout.qml" line="1100"/>
         <location filename="../app/MainLayout.qml" line="1210"/>
         <source>Options</source>
         <translation>الخيارات</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1136"/>
+        <location filename="../app/MainLayout.qml" line="1137"/>
         <source>Change</source>
         <translation>تغيير</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1142"/>
+        <location filename="../app/MainLayout.qml" line="1143"/>
         <source>Toggle</source>
         <translation>تبديل</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1165"/>
+        <location filename="../app/MainLayout.qml" line="1166"/>
         <source>Scroll</source>
         <translation>تمرير</translation>
     </message>
@@ -836,17 +836,17 @@ Euskara - devilschile2</source>
 <context>
     <name>MediaListScreen</name>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="32"/>
+        <location filename="../screens/MediaListScreen.qml" line="31"/>
         <source>Loading…</source>
         <translation type="unfinished">جارٍ التحميل…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="351"/>
+        <location filename="../screens/MediaListScreen.qml" line="350"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 عناصر</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="352"/>
+        <location filename="../screens/MediaListScreen.qml" line="351"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -97,100 +97,100 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Wird geladen…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Yr</source>
         <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Gen</source>
         <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Plyr</source>
         <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Dev</source>
         <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Pub</source>
         <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Rtg</source>
         <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Cat</source>
         <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Date</source>
         <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <location filename="../components/BrowseDetailPane.qml" line="156"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <location filename="../components/BrowseDetailPane.qml" line="156"/>
         <source>Mfr</source>
         <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
@@ -425,19 +425,19 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="122"/>
-        <location filename="../screens/GamesScreen.qml" line="157"/>
+        <location filename="../screens/GamesScreen.qml" line="121"/>
+        <location filename="../screens/GamesScreen.qml" line="156"/>
         <source>%1 files</source>
         <translation>%1 Dateien</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="55"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="158"/>
+        <location filename="../screens/GamesScreen.qml" line="130"/>
+        <location filename="../screens/GamesScreen.qml" line="157"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -447,7 +447,7 @@ Euskara - devilschile2</source>
         <translation>Spiele werden geladen…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="127"/>
+        <location filename="../screens/GamesScreen.qml" line="126"/>
         <source>Loading more…</source>
         <translation>Mehr laden…</translation>
     </message>
@@ -684,60 +684,60 @@ Euskara - devilschile2</source>
         <translation>Beschreibbare Karte an den Leser halten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="807"/>
+        <location filename="../app/MainLayout.qml" line="808"/>
         <source>Are you sure you want to exit?</source>
         <translation>Wirklich beenden?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="890"/>
-        <location filename="../app/MainLayout.qml" line="964"/>
+        <location filename="../app/MainLayout.qml" line="891"/>
+        <location filename="../app/MainLayout.qml" line="965"/>
         <source>Select</source>
         <translation>Auswählen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="894"/>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="912"/>
-        <location filename="../app/MainLayout.qml" line="927"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="895"/>
+        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="913"/>
+        <location filename="../app/MainLayout.qml" line="928"/>
+        <location filename="../app/MainLayout.qml" line="939"/>
         <source>Close</source>
         <translation>Schließen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="905"/>
-        <location filename="../app/MainLayout.qml" line="945"/>
-        <location filename="../app/MainLayout.qml" line="968"/>
-        <location filename="../app/MainLayout.qml" line="979"/>
+        <location filename="../app/MainLayout.qml" line="906"/>
+        <location filename="../app/MainLayout.qml" line="946"/>
+        <location filename="../app/MainLayout.qml" line="969"/>
+        <location filename="../app/MainLayout.qml" line="980"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="923"/>
+        <location filename="../app/MainLayout.qml" line="924"/>
         <source>Done</source>
         <translation>Fertig</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="953"/>
+        <location filename="../app/MainLayout.qml" line="954"/>
         <source>I understand</source>
         <translation>Ich verstehe</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="987"/>
+        <location filename="../app/MainLayout.qml" line="988"/>
         <source>Start</source>
         <translation>Starten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1165"/>
+        <location filename="../app/MainLayout.qml" line="1166"/>
         <source>Scroll</source>
         <translation>Scrollen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="886"/>
-        <location filename="../app/MainLayout.qml" line="960"/>
-        <location filename="../app/MainLayout.qml" line="1003"/>
-        <location filename="../app/MainLayout.qml" line="1034"/>
-        <location filename="../app/MainLayout.qml" line="1084"/>
-        <location filename="../app/MainLayout.qml" line="1127"/>
+        <location filename="../app/MainLayout.qml" line="887"/>
+        <location filename="../app/MainLayout.qml" line="961"/>
+        <location filename="../app/MainLayout.qml" line="1004"/>
+        <location filename="../app/MainLayout.qml" line="1035"/>
+        <location filename="../app/MainLayout.qml" line="1085"/>
+        <location filename="../app/MainLayout.qml" line="1128"/>
         <location filename="../app/MainLayout.qml" line="1195"/>
         <source>Move</source>
         <translation>Bewegen</translation>
@@ -758,77 +758,77 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Zuletzt gespielt</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="695"/>
+        <location filename="../app/MainLayout.qml" line="696"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="696"/>
+        <location filename="../app/MainLayout.qml" line="697"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="806"/>
+        <location filename="../app/MainLayout.qml" line="807"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1007"/>
-        <location filename="../app/MainLayout.qml" line="1044"/>
-        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1008"/>
+        <location filename="../app/MainLayout.qml" line="1045"/>
+        <location filename="../app/MainLayout.qml" line="1095"/>
         <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Open</source>
         <translation>Öffnen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1011"/>
+        <location filename="../app/MainLayout.qml" line="1012"/>
         <source>Quit</source>
         <translation>Beenden</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1050"/>
-        <location filename="../app/MainLayout.qml" line="1061"/>
-        <location filename="../app/MainLayout.qml" line="1076"/>
-        <location filename="../app/MainLayout.qml" line="1103"/>
-        <location filename="../app/MainLayout.qml" line="1114"/>
-        <location filename="../app/MainLayout.qml" line="1151"/>
-        <location filename="../app/MainLayout.qml" line="1169"/>
-        <location filename="../app/MainLayout.qml" line="1178"/>
+        <location filename="../app/MainLayout.qml" line="1021"/>
+        <location filename="../app/MainLayout.qml" line="1051"/>
+        <location filename="../app/MainLayout.qml" line="1062"/>
+        <location filename="../app/MainLayout.qml" line="1077"/>
+        <location filename="../app/MainLayout.qml" line="1104"/>
+        <location filename="../app/MainLayout.qml" line="1115"/>
+        <location filename="../app/MainLayout.qml" line="1152"/>
+        <location filename="../app/MainLayout.qml" line="1170"/>
+        <location filename="../app/MainLayout.qml" line="1179"/>
         <location filename="../app/MainLayout.qml" line="1214"/>
         <location filename="../app/MainLayout.qml" line="1225"/>
         <source>Back</source>
         <translation>Zurück</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1040"/>
-        <location filename="../app/MainLayout.qml" line="1090"/>
+        <location filename="../app/MainLayout.qml" line="1041"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
         <location filename="../app/MainLayout.qml" line="1201"/>
         <source>Page</source>
         <translation>Seite</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1047"/>
-        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1048"/>
+        <location filename="../app/MainLayout.qml" line="1100"/>
         <location filename="../app/MainLayout.qml" line="1210"/>
         <source>Options</source>
         <translation>Optionen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="934"/>
-        <location filename="../app/MainLayout.qml" line="1057"/>
-        <location filename="../app/MainLayout.qml" line="1110"/>
+        <location filename="../app/MainLayout.qml" line="935"/>
+        <location filename="../app/MainLayout.qml" line="1058"/>
+        <location filename="../app/MainLayout.qml" line="1111"/>
         <location filename="../app/MainLayout.qml" line="1221"/>
         <source>Retry</source>
         <translation>Wiederholen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1136"/>
+        <location filename="../app/MainLayout.qml" line="1137"/>
         <source>Change</source>
         <translation>Ändern</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1142"/>
+        <location filename="../app/MainLayout.qml" line="1143"/>
         <source>Toggle</source>
         <translation>Umschalten</translation>
     </message>
@@ -836,17 +836,17 @@ Euskara - devilschile2</source>
 <context>
     <name>MediaListScreen</name>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="32"/>
+        <location filename="../screens/MediaListScreen.qml" line="31"/>
         <source>Loading…</source>
         <translation type="unfinished">Wird geladen…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="351"/>
+        <location filename="../screens/MediaListScreen.qml" line="350"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 Einträge</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="352"/>
+        <location filename="../screens/MediaListScreen.qml" line="351"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -97,100 +97,100 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Φόρτωση…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Yr</source>
         <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Gen</source>
         <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Plyr</source>
         <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Dev</source>
         <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Pub</source>
         <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Rtg</source>
         <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Cat</source>
         <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Date</source>
         <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <location filename="../components/BrowseDetailPane.qml" line="156"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <location filename="../components/BrowseDetailPane.qml" line="156"/>
         <source>Mfr</source>
         <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
@@ -425,19 +425,19 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="122"/>
-        <location filename="../screens/GamesScreen.qml" line="157"/>
+        <location filename="../screens/GamesScreen.qml" line="121"/>
+        <location filename="../screens/GamesScreen.qml" line="156"/>
         <source>%1 files</source>
         <translation>%1 αρχεία</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="55"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="158"/>
+        <location filename="../screens/GamesScreen.qml" line="130"/>
+        <location filename="../screens/GamesScreen.qml" line="157"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -447,7 +447,7 @@ Euskara - devilschile2</source>
         <translation>Φόρτωση παιχνιδιών…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="127"/>
+        <location filename="../screens/GamesScreen.qml" line="126"/>
         <source>Loading more…</source>
         <translation>Φόρτωση περισσότερων…</translation>
     </message>
@@ -684,60 +684,60 @@ Euskara - devilschile2</source>
         <translation>Τοποθετήστε μια εγγράψιμη κάρτα κοντά στον αναγνώστη</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="807"/>
+        <location filename="../app/MainLayout.qml" line="808"/>
         <source>Are you sure you want to exit?</source>
         <translation>Είστε σίγουροι ότι θέλετε να βγείτε;</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="890"/>
-        <location filename="../app/MainLayout.qml" line="964"/>
+        <location filename="../app/MainLayout.qml" line="891"/>
+        <location filename="../app/MainLayout.qml" line="965"/>
         <source>Select</source>
         <translation>Επιλογή</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="894"/>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="912"/>
-        <location filename="../app/MainLayout.qml" line="927"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="895"/>
+        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="913"/>
+        <location filename="../app/MainLayout.qml" line="928"/>
+        <location filename="../app/MainLayout.qml" line="939"/>
         <source>Close</source>
         <translation>Κλείσιμο</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="905"/>
-        <location filename="../app/MainLayout.qml" line="945"/>
-        <location filename="../app/MainLayout.qml" line="968"/>
-        <location filename="../app/MainLayout.qml" line="979"/>
+        <location filename="../app/MainLayout.qml" line="906"/>
+        <location filename="../app/MainLayout.qml" line="946"/>
+        <location filename="../app/MainLayout.qml" line="969"/>
+        <location filename="../app/MainLayout.qml" line="980"/>
         <source>Cancel</source>
         <translation>Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="923"/>
+        <location filename="../app/MainLayout.qml" line="924"/>
         <source>Done</source>
         <translation>Ολοκληρώθηκε</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="953"/>
+        <location filename="../app/MainLayout.qml" line="954"/>
         <source>I understand</source>
         <translation>Κατανοώ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="987"/>
+        <location filename="../app/MainLayout.qml" line="988"/>
         <source>Start</source>
         <translation>Έναρξη</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1165"/>
+        <location filename="../app/MainLayout.qml" line="1166"/>
         <source>Scroll</source>
         <translation>Κύλιση</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="886"/>
-        <location filename="../app/MainLayout.qml" line="960"/>
-        <location filename="../app/MainLayout.qml" line="1003"/>
-        <location filename="../app/MainLayout.qml" line="1034"/>
-        <location filename="../app/MainLayout.qml" line="1084"/>
-        <location filename="../app/MainLayout.qml" line="1127"/>
+        <location filename="../app/MainLayout.qml" line="887"/>
+        <location filename="../app/MainLayout.qml" line="961"/>
+        <location filename="../app/MainLayout.qml" line="1004"/>
+        <location filename="../app/MainLayout.qml" line="1035"/>
+        <location filename="../app/MainLayout.qml" line="1085"/>
+        <location filename="../app/MainLayout.qml" line="1128"/>
         <location filename="../app/MainLayout.qml" line="1195"/>
         <source>Move</source>
         <translation>Μετακίνηση</translation>
@@ -758,77 +758,77 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Πρόσφατα Παιγμένα</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="695"/>
+        <location filename="../app/MainLayout.qml" line="696"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="696"/>
+        <location filename="../app/MainLayout.qml" line="697"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="806"/>
+        <location filename="../app/MainLayout.qml" line="807"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1007"/>
-        <location filename="../app/MainLayout.qml" line="1044"/>
-        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1008"/>
+        <location filename="../app/MainLayout.qml" line="1045"/>
+        <location filename="../app/MainLayout.qml" line="1095"/>
         <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Open</source>
         <translation>Άνοιγμα</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1011"/>
+        <location filename="../app/MainLayout.qml" line="1012"/>
         <source>Quit</source>
         <translation>Έξοδος</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1050"/>
-        <location filename="../app/MainLayout.qml" line="1061"/>
-        <location filename="../app/MainLayout.qml" line="1076"/>
-        <location filename="../app/MainLayout.qml" line="1103"/>
-        <location filename="../app/MainLayout.qml" line="1114"/>
-        <location filename="../app/MainLayout.qml" line="1151"/>
-        <location filename="../app/MainLayout.qml" line="1169"/>
-        <location filename="../app/MainLayout.qml" line="1178"/>
+        <location filename="../app/MainLayout.qml" line="1021"/>
+        <location filename="../app/MainLayout.qml" line="1051"/>
+        <location filename="../app/MainLayout.qml" line="1062"/>
+        <location filename="../app/MainLayout.qml" line="1077"/>
+        <location filename="../app/MainLayout.qml" line="1104"/>
+        <location filename="../app/MainLayout.qml" line="1115"/>
+        <location filename="../app/MainLayout.qml" line="1152"/>
+        <location filename="../app/MainLayout.qml" line="1170"/>
+        <location filename="../app/MainLayout.qml" line="1179"/>
         <location filename="../app/MainLayout.qml" line="1214"/>
         <location filename="../app/MainLayout.qml" line="1225"/>
         <source>Back</source>
         <translation>Πίσω</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1040"/>
-        <location filename="../app/MainLayout.qml" line="1090"/>
+        <location filename="../app/MainLayout.qml" line="1041"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
         <location filename="../app/MainLayout.qml" line="1201"/>
         <source>Page</source>
         <translation>Σελίδα</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1047"/>
-        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1048"/>
+        <location filename="../app/MainLayout.qml" line="1100"/>
         <location filename="../app/MainLayout.qml" line="1210"/>
         <source>Options</source>
         <translation>Επιλογές</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="934"/>
-        <location filename="../app/MainLayout.qml" line="1057"/>
-        <location filename="../app/MainLayout.qml" line="1110"/>
+        <location filename="../app/MainLayout.qml" line="935"/>
+        <location filename="../app/MainLayout.qml" line="1058"/>
+        <location filename="../app/MainLayout.qml" line="1111"/>
         <location filename="../app/MainLayout.qml" line="1221"/>
         <source>Retry</source>
         <translation>Επανάληψη</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1136"/>
+        <location filename="../app/MainLayout.qml" line="1137"/>
         <source>Change</source>
         <translation>Αλλαγή</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1142"/>
+        <location filename="../app/MainLayout.qml" line="1143"/>
         <source>Toggle</source>
         <translation>Εναλλαγή</translation>
     </message>
@@ -836,17 +836,17 @@ Euskara - devilschile2</source>
 <context>
     <name>MediaListScreen</name>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="32"/>
+        <location filename="../screens/MediaListScreen.qml" line="31"/>
         <source>Loading…</source>
         <translation type="unfinished">Φόρτωση…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="351"/>
+        <location filename="../screens/MediaListScreen.qml" line="350"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 εγγραφές</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="352"/>
+        <location filename="../screens/MediaListScreen.qml" line="351"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -97,100 +97,100 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Loading…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Yr</source>
         <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Gen</source>
         <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Plyr</source>
         <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Dev</source>
         <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Pub</source>
         <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Rtg</source>
         <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Cat</source>
         <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Date</source>
         <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <location filename="../components/BrowseDetailPane.qml" line="156"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <location filename="../components/BrowseDetailPane.qml" line="156"/>
         <source>Mfr</source>
         <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
@@ -405,19 +405,19 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="122"/>
-        <location filename="../screens/GamesScreen.qml" line="157"/>
+        <location filename="../screens/GamesScreen.qml" line="121"/>
+        <location filename="../screens/GamesScreen.qml" line="156"/>
         <source>%1 files</source>
         <translation>%1 files</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="55"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="158"/>
+        <location filename="../screens/GamesScreen.qml" line="130"/>
+        <location filename="../screens/GamesScreen.qml" line="157"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -427,7 +427,7 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="127"/>
+        <location filename="../screens/GamesScreen.qml" line="126"/>
         <source>Loading more…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -672,60 +672,60 @@ Euskara - devilschile2</source>
         <translation>Put a writable card near the reader</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="807"/>
+        <location filename="../app/MainLayout.qml" line="808"/>
         <source>Are you sure you want to exit?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="890"/>
-        <location filename="../app/MainLayout.qml" line="964"/>
+        <location filename="../app/MainLayout.qml" line="891"/>
+        <location filename="../app/MainLayout.qml" line="965"/>
         <source>Select</source>
         <translation>Select</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="894"/>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="912"/>
-        <location filename="../app/MainLayout.qml" line="927"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="895"/>
+        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="913"/>
+        <location filename="../app/MainLayout.qml" line="928"/>
+        <location filename="../app/MainLayout.qml" line="939"/>
         <source>Close</source>
         <translation>Close</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="905"/>
-        <location filename="../app/MainLayout.qml" line="945"/>
-        <location filename="../app/MainLayout.qml" line="968"/>
-        <location filename="../app/MainLayout.qml" line="979"/>
+        <location filename="../app/MainLayout.qml" line="906"/>
+        <location filename="../app/MainLayout.qml" line="946"/>
+        <location filename="../app/MainLayout.qml" line="969"/>
+        <location filename="../app/MainLayout.qml" line="980"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="923"/>
+        <location filename="../app/MainLayout.qml" line="924"/>
         <source>Done</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="953"/>
+        <location filename="../app/MainLayout.qml" line="954"/>
         <source>I understand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="987"/>
+        <location filename="../app/MainLayout.qml" line="988"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1165"/>
+        <location filename="../app/MainLayout.qml" line="1166"/>
         <source>Scroll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="886"/>
-        <location filename="../app/MainLayout.qml" line="960"/>
-        <location filename="../app/MainLayout.qml" line="1003"/>
-        <location filename="../app/MainLayout.qml" line="1034"/>
-        <location filename="../app/MainLayout.qml" line="1084"/>
-        <location filename="../app/MainLayout.qml" line="1127"/>
+        <location filename="../app/MainLayout.qml" line="887"/>
+        <location filename="../app/MainLayout.qml" line="961"/>
+        <location filename="../app/MainLayout.qml" line="1004"/>
+        <location filename="../app/MainLayout.qml" line="1035"/>
+        <location filename="../app/MainLayout.qml" line="1085"/>
+        <location filename="../app/MainLayout.qml" line="1128"/>
         <location filename="../app/MainLayout.qml" line="1195"/>
         <source>Move</source>
         <translation>Move</translation>
@@ -746,77 +746,77 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Recently Played</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="695"/>
+        <location filename="../app/MainLayout.qml" line="696"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="696"/>
+        <location filename="../app/MainLayout.qml" line="697"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="806"/>
+        <location filename="../app/MainLayout.qml" line="807"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1007"/>
-        <location filename="../app/MainLayout.qml" line="1044"/>
-        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1008"/>
+        <location filename="../app/MainLayout.qml" line="1045"/>
+        <location filename="../app/MainLayout.qml" line="1095"/>
         <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Open</source>
         <translation>Open</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1011"/>
+        <location filename="../app/MainLayout.qml" line="1012"/>
         <source>Quit</source>
         <translation>Quit</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1050"/>
-        <location filename="../app/MainLayout.qml" line="1061"/>
-        <location filename="../app/MainLayout.qml" line="1076"/>
-        <location filename="../app/MainLayout.qml" line="1103"/>
-        <location filename="../app/MainLayout.qml" line="1114"/>
-        <location filename="../app/MainLayout.qml" line="1151"/>
-        <location filename="../app/MainLayout.qml" line="1169"/>
-        <location filename="../app/MainLayout.qml" line="1178"/>
+        <location filename="../app/MainLayout.qml" line="1021"/>
+        <location filename="../app/MainLayout.qml" line="1051"/>
+        <location filename="../app/MainLayout.qml" line="1062"/>
+        <location filename="../app/MainLayout.qml" line="1077"/>
+        <location filename="../app/MainLayout.qml" line="1104"/>
+        <location filename="../app/MainLayout.qml" line="1115"/>
+        <location filename="../app/MainLayout.qml" line="1152"/>
+        <location filename="../app/MainLayout.qml" line="1170"/>
+        <location filename="../app/MainLayout.qml" line="1179"/>
         <location filename="../app/MainLayout.qml" line="1214"/>
         <location filename="../app/MainLayout.qml" line="1225"/>
         <source>Back</source>
         <translation>Back</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1040"/>
-        <location filename="../app/MainLayout.qml" line="1090"/>
+        <location filename="../app/MainLayout.qml" line="1041"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
         <location filename="../app/MainLayout.qml" line="1201"/>
         <source>Page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1047"/>
-        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1048"/>
+        <location filename="../app/MainLayout.qml" line="1100"/>
         <location filename="../app/MainLayout.qml" line="1210"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="934"/>
-        <location filename="../app/MainLayout.qml" line="1057"/>
-        <location filename="../app/MainLayout.qml" line="1110"/>
+        <location filename="../app/MainLayout.qml" line="935"/>
+        <location filename="../app/MainLayout.qml" line="1058"/>
+        <location filename="../app/MainLayout.qml" line="1111"/>
         <location filename="../app/MainLayout.qml" line="1221"/>
         <source>Retry</source>
         <translation>Retry</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1136"/>
+        <location filename="../app/MainLayout.qml" line="1137"/>
         <source>Change</source>
         <translation>Change</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1142"/>
+        <location filename="../app/MainLayout.qml" line="1143"/>
         <source>Toggle</source>
         <translation>Toggle</translation>
     </message>
@@ -824,17 +824,17 @@ Euskara - devilschile2</source>
 <context>
     <name>MediaListScreen</name>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="32"/>
+        <location filename="../screens/MediaListScreen.qml" line="31"/>
         <source>Loading…</source>
         <translation type="unfinished">Loading…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="351"/>
+        <location filename="../screens/MediaListScreen.qml" line="350"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 entries</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="352"/>
+        <location filename="../screens/MediaListScreen.qml" line="351"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -97,100 +97,100 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Cargando…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Yr</source>
         <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Gen</source>
         <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Plyr</source>
         <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Dev</source>
         <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Pub</source>
         <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Rtg</source>
         <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Cat</source>
         <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Date</source>
         <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <location filename="../components/BrowseDetailPane.qml" line="156"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <location filename="../components/BrowseDetailPane.qml" line="156"/>
         <source>Mfr</source>
         <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
@@ -425,19 +425,19 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="122"/>
-        <location filename="../screens/GamesScreen.qml" line="157"/>
+        <location filename="../screens/GamesScreen.qml" line="121"/>
+        <location filename="../screens/GamesScreen.qml" line="156"/>
         <source>%1 files</source>
         <translation>%1 archivos</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="55"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="158"/>
+        <location filename="../screens/GamesScreen.qml" line="130"/>
+        <location filename="../screens/GamesScreen.qml" line="157"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -447,7 +447,7 @@ Euskara - devilschile2</source>
         <translation>Cargando juegos…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="127"/>
+        <location filename="../screens/GamesScreen.qml" line="126"/>
         <source>Loading more…</source>
         <translation>Cargando más…</translation>
     </message>
@@ -684,60 +684,60 @@ Euskara - devilschile2</source>
         <translation>Pon una tarjeta escribible junto al lector</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="807"/>
+        <location filename="../app/MainLayout.qml" line="808"/>
         <source>Are you sure you want to exit?</source>
         <translation>¿Seguro que quieres salir?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="890"/>
-        <location filename="../app/MainLayout.qml" line="964"/>
+        <location filename="../app/MainLayout.qml" line="891"/>
+        <location filename="../app/MainLayout.qml" line="965"/>
         <source>Select</source>
         <translation>Seleccionar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="894"/>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="912"/>
-        <location filename="../app/MainLayout.qml" line="927"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="895"/>
+        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="913"/>
+        <location filename="../app/MainLayout.qml" line="928"/>
+        <location filename="../app/MainLayout.qml" line="939"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="905"/>
-        <location filename="../app/MainLayout.qml" line="945"/>
-        <location filename="../app/MainLayout.qml" line="968"/>
-        <location filename="../app/MainLayout.qml" line="979"/>
+        <location filename="../app/MainLayout.qml" line="906"/>
+        <location filename="../app/MainLayout.qml" line="946"/>
+        <location filename="../app/MainLayout.qml" line="969"/>
+        <location filename="../app/MainLayout.qml" line="980"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="923"/>
+        <location filename="../app/MainLayout.qml" line="924"/>
         <source>Done</source>
         <translation>Hecho</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="953"/>
+        <location filename="../app/MainLayout.qml" line="954"/>
         <source>I understand</source>
         <translation>Entendido</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="987"/>
+        <location filename="../app/MainLayout.qml" line="988"/>
         <source>Start</source>
         <translation>Iniciar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1165"/>
+        <location filename="../app/MainLayout.qml" line="1166"/>
         <source>Scroll</source>
         <translation>Desplazar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="886"/>
-        <location filename="../app/MainLayout.qml" line="960"/>
-        <location filename="../app/MainLayout.qml" line="1003"/>
-        <location filename="../app/MainLayout.qml" line="1034"/>
-        <location filename="../app/MainLayout.qml" line="1084"/>
-        <location filename="../app/MainLayout.qml" line="1127"/>
+        <location filename="../app/MainLayout.qml" line="887"/>
+        <location filename="../app/MainLayout.qml" line="961"/>
+        <location filename="../app/MainLayout.qml" line="1004"/>
+        <location filename="../app/MainLayout.qml" line="1035"/>
+        <location filename="../app/MainLayout.qml" line="1085"/>
+        <location filename="../app/MainLayout.qml" line="1128"/>
         <location filename="../app/MainLayout.qml" line="1195"/>
         <source>Move</source>
         <translation>Mover</translation>
@@ -758,77 +758,77 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="695"/>
+        <location filename="../app/MainLayout.qml" line="696"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="696"/>
+        <location filename="../app/MainLayout.qml" line="697"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="806"/>
+        <location filename="../app/MainLayout.qml" line="807"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1007"/>
-        <location filename="../app/MainLayout.qml" line="1044"/>
-        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1008"/>
+        <location filename="../app/MainLayout.qml" line="1045"/>
+        <location filename="../app/MainLayout.qml" line="1095"/>
         <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1011"/>
+        <location filename="../app/MainLayout.qml" line="1012"/>
         <source>Quit</source>
         <translation>Salir</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1050"/>
-        <location filename="../app/MainLayout.qml" line="1061"/>
-        <location filename="../app/MainLayout.qml" line="1076"/>
-        <location filename="../app/MainLayout.qml" line="1103"/>
-        <location filename="../app/MainLayout.qml" line="1114"/>
-        <location filename="../app/MainLayout.qml" line="1151"/>
-        <location filename="../app/MainLayout.qml" line="1169"/>
-        <location filename="../app/MainLayout.qml" line="1178"/>
+        <location filename="../app/MainLayout.qml" line="1021"/>
+        <location filename="../app/MainLayout.qml" line="1051"/>
+        <location filename="../app/MainLayout.qml" line="1062"/>
+        <location filename="../app/MainLayout.qml" line="1077"/>
+        <location filename="../app/MainLayout.qml" line="1104"/>
+        <location filename="../app/MainLayout.qml" line="1115"/>
+        <location filename="../app/MainLayout.qml" line="1152"/>
+        <location filename="../app/MainLayout.qml" line="1170"/>
+        <location filename="../app/MainLayout.qml" line="1179"/>
         <location filename="../app/MainLayout.qml" line="1214"/>
         <location filename="../app/MainLayout.qml" line="1225"/>
         <source>Back</source>
         <translation>Atrás</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1040"/>
-        <location filename="../app/MainLayout.qml" line="1090"/>
+        <location filename="../app/MainLayout.qml" line="1041"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
         <location filename="../app/MainLayout.qml" line="1201"/>
         <source>Page</source>
         <translation>Página</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1047"/>
-        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1048"/>
+        <location filename="../app/MainLayout.qml" line="1100"/>
         <location filename="../app/MainLayout.qml" line="1210"/>
         <source>Options</source>
         <translation>Opciones</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="934"/>
-        <location filename="../app/MainLayout.qml" line="1057"/>
-        <location filename="../app/MainLayout.qml" line="1110"/>
+        <location filename="../app/MainLayout.qml" line="935"/>
+        <location filename="../app/MainLayout.qml" line="1058"/>
+        <location filename="../app/MainLayout.qml" line="1111"/>
         <location filename="../app/MainLayout.qml" line="1221"/>
         <source>Retry</source>
         <translation>Reintentar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1136"/>
+        <location filename="../app/MainLayout.qml" line="1137"/>
         <source>Change</source>
         <translation>Cambiar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1142"/>
+        <location filename="../app/MainLayout.qml" line="1143"/>
         <source>Toggle</source>
         <translation>Alternar</translation>
     </message>
@@ -836,17 +836,17 @@ Euskara - devilschile2</source>
 <context>
     <name>MediaListScreen</name>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="32"/>
+        <location filename="../screens/MediaListScreen.qml" line="31"/>
         <source>Loading…</source>
         <translation type="unfinished">Cargando…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="351"/>
+        <location filename="../screens/MediaListScreen.qml" line="350"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 entradas</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="352"/>
+        <location filename="../screens/MediaListScreen.qml" line="351"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -97,100 +97,100 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Kargatzen…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Year</source>
         <translation type="unfinished">Urtea</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Yr</source>
         <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Genre</source>
         <translation type="unfinished">Mota</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Gen</source>
         <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Players</source>
         <translation type="unfinished">Jokalariak</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Plyr</source>
         <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Developer</source>
         <translation type="unfinished">Garatzailea</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Dev</source>
         <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Publisher</source>
         <translation type="unfinished">Argitaratzailea</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Pub</source>
         <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Rating</source>
         <translation type="unfinished">Balorazioa</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Rtg</source>
         <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Category</source>
         <translation type="unfinished">Kategoria</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Cat</source>
         <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Release date</source>
         <translation type="unfinished">Argitaratze data</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Date</source>
         <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <location filename="../components/BrowseDetailPane.qml" line="156"/>
         <source>Manufacturer</source>
         <translation type="unfinished">Fabrikatzailea</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <location filename="../components/BrowseDetailPane.qml" line="156"/>
         <source>Mfr</source>
         <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
@@ -425,19 +425,19 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="122"/>
-        <location filename="../screens/GamesScreen.qml" line="157"/>
+        <location filename="../screens/GamesScreen.qml" line="121"/>
+        <location filename="../screens/GamesScreen.qml" line="156"/>
         <source>%1 files</source>
         <translation>%1 fitxategi</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="55"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading game…</source>
         <translation type="unfinished">Jokua kargatzen...</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="158"/>
+        <location filename="../screens/GamesScreen.qml" line="130"/>
+        <location filename="../screens/GamesScreen.qml" line="157"/>
         <source>%1 / %2</source>
         <translation type="unfinished">%1 / %2</translation>
     </message>
@@ -447,7 +447,7 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Jokuak kargatzen</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="127"/>
+        <location filename="../screens/GamesScreen.qml" line="126"/>
         <source>Loading more…</source>
         <translation type="unfinished">Gehiago kargatzen...</translation>
     </message>
@@ -692,60 +692,60 @@ Euskara - devilschile2</source>
         <translation>Jarri idatzi daitekeen txartel bat irakurlearen ondoan</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="807"/>
+        <location filename="../app/MainLayout.qml" line="808"/>
         <source>Are you sure you want to exit?</source>
         <translation type="unfinished">Ziur zaude irten nahi duzula?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="890"/>
-        <location filename="../app/MainLayout.qml" line="964"/>
+        <location filename="../app/MainLayout.qml" line="891"/>
+        <location filename="../app/MainLayout.qml" line="965"/>
         <source>Select</source>
         <translation>Aukeratu</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="894"/>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="912"/>
-        <location filename="../app/MainLayout.qml" line="927"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="895"/>
+        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="913"/>
+        <location filename="../app/MainLayout.qml" line="928"/>
+        <location filename="../app/MainLayout.qml" line="939"/>
         <source>Close</source>
         <translation>Itxi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="905"/>
-        <location filename="../app/MainLayout.qml" line="945"/>
-        <location filename="../app/MainLayout.qml" line="968"/>
-        <location filename="../app/MainLayout.qml" line="979"/>
+        <location filename="../app/MainLayout.qml" line="906"/>
+        <location filename="../app/MainLayout.qml" line="946"/>
+        <location filename="../app/MainLayout.qml" line="969"/>
+        <location filename="../app/MainLayout.qml" line="980"/>
         <source>Cancel</source>
         <translation>Utzi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="923"/>
+        <location filename="../app/MainLayout.qml" line="924"/>
         <source>Done</source>
         <translation type="unfinished">Eginda</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="953"/>
+        <location filename="../app/MainLayout.qml" line="954"/>
         <source>I understand</source>
         <translation type="unfinished">Ulertzen dut</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="987"/>
+        <location filename="../app/MainLayout.qml" line="988"/>
         <source>Start</source>
         <translation type="unfinished">Hasi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1165"/>
+        <location filename="../app/MainLayout.qml" line="1166"/>
         <source>Scroll</source>
         <translation type="unfinished">Scroll-a egin</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="886"/>
-        <location filename="../app/MainLayout.qml" line="960"/>
-        <location filename="../app/MainLayout.qml" line="1003"/>
-        <location filename="../app/MainLayout.qml" line="1034"/>
-        <location filename="../app/MainLayout.qml" line="1084"/>
-        <location filename="../app/MainLayout.qml" line="1127"/>
+        <location filename="../app/MainLayout.qml" line="887"/>
+        <location filename="../app/MainLayout.qml" line="961"/>
+        <location filename="../app/MainLayout.qml" line="1004"/>
+        <location filename="../app/MainLayout.qml" line="1035"/>
+        <location filename="../app/MainLayout.qml" line="1085"/>
+        <location filename="../app/MainLayout.qml" line="1128"/>
         <location filename="../app/MainLayout.qml" line="1195"/>
         <source>Move</source>
         <translation>Mugitu</translation>
@@ -766,77 +766,77 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Duela gutxi jokatuak</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="695"/>
+        <location filename="../app/MainLayout.qml" line="696"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished">Itxi eta Zaparoo Frontend berabiarazi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="696"/>
+        <location filename="../app/MainLayout.qml" line="697"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished">Ezarpenak indarrean jartzeko frontend-a berrabiarazi behar dugu</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="806"/>
+        <location filename="../app/MainLayout.qml" line="807"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished">Itxi Zaparoo Frontend?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1007"/>
-        <location filename="../app/MainLayout.qml" line="1044"/>
-        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1008"/>
+        <location filename="../app/MainLayout.qml" line="1045"/>
+        <location filename="../app/MainLayout.qml" line="1095"/>
         <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Open</source>
         <translation>Ireki</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1011"/>
+        <location filename="../app/MainLayout.qml" line="1012"/>
         <source>Quit</source>
         <translation>Irten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1050"/>
-        <location filename="../app/MainLayout.qml" line="1061"/>
-        <location filename="../app/MainLayout.qml" line="1076"/>
-        <location filename="../app/MainLayout.qml" line="1103"/>
-        <location filename="../app/MainLayout.qml" line="1114"/>
-        <location filename="../app/MainLayout.qml" line="1151"/>
-        <location filename="../app/MainLayout.qml" line="1169"/>
-        <location filename="../app/MainLayout.qml" line="1178"/>
+        <location filename="../app/MainLayout.qml" line="1021"/>
+        <location filename="../app/MainLayout.qml" line="1051"/>
+        <location filename="../app/MainLayout.qml" line="1062"/>
+        <location filename="../app/MainLayout.qml" line="1077"/>
+        <location filename="../app/MainLayout.qml" line="1104"/>
+        <location filename="../app/MainLayout.qml" line="1115"/>
+        <location filename="../app/MainLayout.qml" line="1152"/>
+        <location filename="../app/MainLayout.qml" line="1170"/>
+        <location filename="../app/MainLayout.qml" line="1179"/>
         <location filename="../app/MainLayout.qml" line="1214"/>
         <location filename="../app/MainLayout.qml" line="1225"/>
         <source>Back</source>
         <translation>Atzera</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1040"/>
-        <location filename="../app/MainLayout.qml" line="1090"/>
+        <location filename="../app/MainLayout.qml" line="1041"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
         <location filename="../app/MainLayout.qml" line="1201"/>
         <source>Page</source>
         <translation type="unfinished">Orria</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1047"/>
-        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1048"/>
+        <location filename="../app/MainLayout.qml" line="1100"/>
         <location filename="../app/MainLayout.qml" line="1210"/>
         <source>Options</source>
         <translation type="unfinished">Aukerak</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="934"/>
-        <location filename="../app/MainLayout.qml" line="1057"/>
-        <location filename="../app/MainLayout.qml" line="1110"/>
+        <location filename="../app/MainLayout.qml" line="935"/>
+        <location filename="../app/MainLayout.qml" line="1058"/>
+        <location filename="../app/MainLayout.qml" line="1111"/>
         <location filename="../app/MainLayout.qml" line="1221"/>
         <source>Retry</source>
         <translation>Berriro saiatu</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1136"/>
+        <location filename="../app/MainLayout.qml" line="1137"/>
         <source>Change</source>
         <translation>Aldatu</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1142"/>
+        <location filename="../app/MainLayout.qml" line="1143"/>
         <source>Toggle</source>
         <translation>Txandakatu</translation>
     </message>
@@ -844,17 +844,17 @@ Euskara - devilschile2</source>
 <context>
     <name>MediaListScreen</name>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="32"/>
+        <location filename="../screens/MediaListScreen.qml" line="31"/>
         <source>Loading…</source>
         <translation type="unfinished">Kargatzen…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="351"/>
+        <location filename="../screens/MediaListScreen.qml" line="350"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 sarrera</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="352"/>
+        <location filename="../screens/MediaListScreen.qml" line="351"/>
         <source>%1 / %2</source>
         <translation type="unfinished">%1 / %2</translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -97,100 +97,100 @@ Euskara - devilschile2</source>
         <translation type="unfinished">טוען…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Yr</source>
         <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Gen</source>
         <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Plyr</source>
         <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Dev</source>
         <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Pub</source>
         <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Rtg</source>
         <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Cat</source>
         <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Date</source>
         <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <location filename="../components/BrowseDetailPane.qml" line="156"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <location filename="../components/BrowseDetailPane.qml" line="156"/>
         <source>Mfr</source>
         <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
@@ -425,19 +425,19 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="122"/>
-        <location filename="../screens/GamesScreen.qml" line="157"/>
+        <location filename="../screens/GamesScreen.qml" line="121"/>
+        <location filename="../screens/GamesScreen.qml" line="156"/>
         <source>%1 files</source>
         <translation>%1 קבצים</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="55"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="158"/>
+        <location filename="../screens/GamesScreen.qml" line="130"/>
+        <location filename="../screens/GamesScreen.qml" line="157"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -452,7 +452,7 @@ Euskara - devilschile2</source>
         <translation>טוען משחקים…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="127"/>
+        <location filename="../screens/GamesScreen.qml" line="126"/>
         <source>Loading more…</source>
         <translation>טוען עוד…</translation>
     </message>
@@ -699,136 +699,136 @@ Euskara - devilschile2</source>
         <translation type="unfinished">שוחקו לאחרונה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="695"/>
+        <location filename="../app/MainLayout.qml" line="696"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="696"/>
+        <location filename="../app/MainLayout.qml" line="697"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="806"/>
+        <location filename="../app/MainLayout.qml" line="807"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="807"/>
+        <location filename="../app/MainLayout.qml" line="808"/>
         <source>Are you sure you want to exit?</source>
         <translation>האם אתה בטוח שברצונך לצאת?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="886"/>
-        <location filename="../app/MainLayout.qml" line="960"/>
-        <location filename="../app/MainLayout.qml" line="1003"/>
-        <location filename="../app/MainLayout.qml" line="1034"/>
-        <location filename="../app/MainLayout.qml" line="1084"/>
-        <location filename="../app/MainLayout.qml" line="1127"/>
+        <location filename="../app/MainLayout.qml" line="887"/>
+        <location filename="../app/MainLayout.qml" line="961"/>
+        <location filename="../app/MainLayout.qml" line="1004"/>
+        <location filename="../app/MainLayout.qml" line="1035"/>
+        <location filename="../app/MainLayout.qml" line="1085"/>
+        <location filename="../app/MainLayout.qml" line="1128"/>
         <location filename="../app/MainLayout.qml" line="1195"/>
         <source>Move</source>
         <translation>הזזה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="890"/>
-        <location filename="../app/MainLayout.qml" line="964"/>
+        <location filename="../app/MainLayout.qml" line="891"/>
+        <location filename="../app/MainLayout.qml" line="965"/>
         <source>Select</source>
         <translation>בחירה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="894"/>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="912"/>
-        <location filename="../app/MainLayout.qml" line="927"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="895"/>
+        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="913"/>
+        <location filename="../app/MainLayout.qml" line="928"/>
+        <location filename="../app/MainLayout.qml" line="939"/>
         <source>Close</source>
         <translation>סגור</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="905"/>
-        <location filename="../app/MainLayout.qml" line="945"/>
-        <location filename="../app/MainLayout.qml" line="968"/>
-        <location filename="../app/MainLayout.qml" line="979"/>
+        <location filename="../app/MainLayout.qml" line="906"/>
+        <location filename="../app/MainLayout.qml" line="946"/>
+        <location filename="../app/MainLayout.qml" line="969"/>
+        <location filename="../app/MainLayout.qml" line="980"/>
         <source>Cancel</source>
         <translation>ביטול</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="923"/>
+        <location filename="../app/MainLayout.qml" line="924"/>
         <source>Done</source>
         <translation>הושלם</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="934"/>
-        <location filename="../app/MainLayout.qml" line="1057"/>
-        <location filename="../app/MainLayout.qml" line="1110"/>
+        <location filename="../app/MainLayout.qml" line="935"/>
+        <location filename="../app/MainLayout.qml" line="1058"/>
+        <location filename="../app/MainLayout.qml" line="1111"/>
         <location filename="../app/MainLayout.qml" line="1221"/>
         <source>Retry</source>
         <translation>נסה שוב</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="953"/>
+        <location filename="../app/MainLayout.qml" line="954"/>
         <source>I understand</source>
         <translation>הבנתי</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="987"/>
+        <location filename="../app/MainLayout.qml" line="988"/>
         <source>Start</source>
         <translation>התחל</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1007"/>
-        <location filename="../app/MainLayout.qml" line="1044"/>
-        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1008"/>
+        <location filename="../app/MainLayout.qml" line="1045"/>
+        <location filename="../app/MainLayout.qml" line="1095"/>
         <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Open</source>
         <translation>פתח</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1011"/>
+        <location filename="../app/MainLayout.qml" line="1012"/>
         <source>Quit</source>
         <translation>יציאה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1050"/>
-        <location filename="../app/MainLayout.qml" line="1061"/>
-        <location filename="../app/MainLayout.qml" line="1076"/>
-        <location filename="../app/MainLayout.qml" line="1103"/>
-        <location filename="../app/MainLayout.qml" line="1114"/>
-        <location filename="../app/MainLayout.qml" line="1151"/>
-        <location filename="../app/MainLayout.qml" line="1169"/>
-        <location filename="../app/MainLayout.qml" line="1178"/>
+        <location filename="../app/MainLayout.qml" line="1021"/>
+        <location filename="../app/MainLayout.qml" line="1051"/>
+        <location filename="../app/MainLayout.qml" line="1062"/>
+        <location filename="../app/MainLayout.qml" line="1077"/>
+        <location filename="../app/MainLayout.qml" line="1104"/>
+        <location filename="../app/MainLayout.qml" line="1115"/>
+        <location filename="../app/MainLayout.qml" line="1152"/>
+        <location filename="../app/MainLayout.qml" line="1170"/>
+        <location filename="../app/MainLayout.qml" line="1179"/>
         <location filename="../app/MainLayout.qml" line="1214"/>
         <location filename="../app/MainLayout.qml" line="1225"/>
         <source>Back</source>
         <translation>חזרה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1040"/>
-        <location filename="../app/MainLayout.qml" line="1090"/>
+        <location filename="../app/MainLayout.qml" line="1041"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
         <location filename="../app/MainLayout.qml" line="1201"/>
         <source>Page</source>
         <translation>עמוד</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1047"/>
-        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1048"/>
+        <location filename="../app/MainLayout.qml" line="1100"/>
         <location filename="../app/MainLayout.qml" line="1210"/>
         <source>Options</source>
         <translation>אפשרויות</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1136"/>
+        <location filename="../app/MainLayout.qml" line="1137"/>
         <source>Change</source>
         <translation>שינוי</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1142"/>
+        <location filename="../app/MainLayout.qml" line="1143"/>
         <source>Toggle</source>
         <translation>החלף</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1165"/>
+        <location filename="../app/MainLayout.qml" line="1166"/>
         <source>Scroll</source>
         <translation>גלילה</translation>
     </message>
@@ -836,17 +836,17 @@ Euskara - devilschile2</source>
 <context>
     <name>MediaListScreen</name>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="32"/>
+        <location filename="../screens/MediaListScreen.qml" line="31"/>
         <source>Loading…</source>
         <translation type="unfinished">טוען…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="351"/>
+        <location filename="../screens/MediaListScreen.qml" line="350"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 פריטים</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="352"/>
+        <location filename="../screens/MediaListScreen.qml" line="351"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -97,100 +97,100 @@ Euskara - devilschile2</source>
         <translation type="unfinished">लोड हो रहा है…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Yr</source>
         <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Gen</source>
         <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Plyr</source>
         <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Dev</source>
         <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Pub</source>
         <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Rtg</source>
         <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Cat</source>
         <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Date</source>
         <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <location filename="../components/BrowseDetailPane.qml" line="156"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <location filename="../components/BrowseDetailPane.qml" line="156"/>
         <source>Mfr</source>
         <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
@@ -425,19 +425,19 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="122"/>
-        <location filename="../screens/GamesScreen.qml" line="157"/>
+        <location filename="../screens/GamesScreen.qml" line="121"/>
+        <location filename="../screens/GamesScreen.qml" line="156"/>
         <source>%1 files</source>
         <translation>%1 फ़ाइलें</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="55"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="158"/>
+        <location filename="../screens/GamesScreen.qml" line="130"/>
+        <location filename="../screens/GamesScreen.qml" line="157"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -452,7 +452,7 @@ Euskara - devilschile2</source>
         <translation>गेम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="127"/>
+        <location filename="../screens/GamesScreen.qml" line="126"/>
         <source>Loading more…</source>
         <translation>और लोड हो रहा है…</translation>
     </message>
@@ -699,136 +699,136 @@ Euskara - devilschile2</source>
         <translation type="unfinished">हाल ही में खेले गए</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="695"/>
+        <location filename="../app/MainLayout.qml" line="696"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="696"/>
+        <location filename="../app/MainLayout.qml" line="697"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="806"/>
+        <location filename="../app/MainLayout.qml" line="807"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="807"/>
+        <location filename="../app/MainLayout.qml" line="808"/>
         <source>Are you sure you want to exit?</source>
         <translation>क्या आप वाकई बाहर निकलना चाहते हैं?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="886"/>
-        <location filename="../app/MainLayout.qml" line="960"/>
-        <location filename="../app/MainLayout.qml" line="1003"/>
-        <location filename="../app/MainLayout.qml" line="1034"/>
-        <location filename="../app/MainLayout.qml" line="1084"/>
-        <location filename="../app/MainLayout.qml" line="1127"/>
+        <location filename="../app/MainLayout.qml" line="887"/>
+        <location filename="../app/MainLayout.qml" line="961"/>
+        <location filename="../app/MainLayout.qml" line="1004"/>
+        <location filename="../app/MainLayout.qml" line="1035"/>
+        <location filename="../app/MainLayout.qml" line="1085"/>
+        <location filename="../app/MainLayout.qml" line="1128"/>
         <location filename="../app/MainLayout.qml" line="1195"/>
         <source>Move</source>
         <translation>स्थानांतरित करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="890"/>
-        <location filename="../app/MainLayout.qml" line="964"/>
+        <location filename="../app/MainLayout.qml" line="891"/>
+        <location filename="../app/MainLayout.qml" line="965"/>
         <source>Select</source>
         <translation>चुनें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="894"/>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="912"/>
-        <location filename="../app/MainLayout.qml" line="927"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="895"/>
+        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="913"/>
+        <location filename="../app/MainLayout.qml" line="928"/>
+        <location filename="../app/MainLayout.qml" line="939"/>
         <source>Close</source>
         <translation>बंद करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="905"/>
-        <location filename="../app/MainLayout.qml" line="945"/>
-        <location filename="../app/MainLayout.qml" line="968"/>
-        <location filename="../app/MainLayout.qml" line="979"/>
+        <location filename="../app/MainLayout.qml" line="906"/>
+        <location filename="../app/MainLayout.qml" line="946"/>
+        <location filename="../app/MainLayout.qml" line="969"/>
+        <location filename="../app/MainLayout.qml" line="980"/>
         <source>Cancel</source>
         <translation>रद्द करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="923"/>
+        <location filename="../app/MainLayout.qml" line="924"/>
         <source>Done</source>
         <translation>पूरा</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="934"/>
-        <location filename="../app/MainLayout.qml" line="1057"/>
-        <location filename="../app/MainLayout.qml" line="1110"/>
+        <location filename="../app/MainLayout.qml" line="935"/>
+        <location filename="../app/MainLayout.qml" line="1058"/>
+        <location filename="../app/MainLayout.qml" line="1111"/>
         <location filename="../app/MainLayout.qml" line="1221"/>
         <source>Retry</source>
         <translation>फिर से प्रयास करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="953"/>
+        <location filename="../app/MainLayout.qml" line="954"/>
         <source>I understand</source>
         <translation>मैं समझ गया</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="987"/>
+        <location filename="../app/MainLayout.qml" line="988"/>
         <source>Start</source>
         <translation>शुरू करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1007"/>
-        <location filename="../app/MainLayout.qml" line="1044"/>
-        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1008"/>
+        <location filename="../app/MainLayout.qml" line="1045"/>
+        <location filename="../app/MainLayout.qml" line="1095"/>
         <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Open</source>
         <translation>खोलें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1011"/>
+        <location filename="../app/MainLayout.qml" line="1012"/>
         <source>Quit</source>
         <translation>बंद करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1050"/>
-        <location filename="../app/MainLayout.qml" line="1061"/>
-        <location filename="../app/MainLayout.qml" line="1076"/>
-        <location filename="../app/MainLayout.qml" line="1103"/>
-        <location filename="../app/MainLayout.qml" line="1114"/>
-        <location filename="../app/MainLayout.qml" line="1151"/>
-        <location filename="../app/MainLayout.qml" line="1169"/>
-        <location filename="../app/MainLayout.qml" line="1178"/>
+        <location filename="../app/MainLayout.qml" line="1021"/>
+        <location filename="../app/MainLayout.qml" line="1051"/>
+        <location filename="../app/MainLayout.qml" line="1062"/>
+        <location filename="../app/MainLayout.qml" line="1077"/>
+        <location filename="../app/MainLayout.qml" line="1104"/>
+        <location filename="../app/MainLayout.qml" line="1115"/>
+        <location filename="../app/MainLayout.qml" line="1152"/>
+        <location filename="../app/MainLayout.qml" line="1170"/>
+        <location filename="../app/MainLayout.qml" line="1179"/>
         <location filename="../app/MainLayout.qml" line="1214"/>
         <location filename="../app/MainLayout.qml" line="1225"/>
         <source>Back</source>
         <translation>वापस</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1040"/>
-        <location filename="../app/MainLayout.qml" line="1090"/>
+        <location filename="../app/MainLayout.qml" line="1041"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
         <location filename="../app/MainLayout.qml" line="1201"/>
         <source>Page</source>
         <translation>पृष्ठ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1047"/>
-        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1048"/>
+        <location filename="../app/MainLayout.qml" line="1100"/>
         <location filename="../app/MainLayout.qml" line="1210"/>
         <source>Options</source>
         <translation>विकल्प</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1136"/>
+        <location filename="../app/MainLayout.qml" line="1137"/>
         <source>Change</source>
         <translation>बदलें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1142"/>
+        <location filename="../app/MainLayout.qml" line="1143"/>
         <source>Toggle</source>
         <translation>टॉगल</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1165"/>
+        <location filename="../app/MainLayout.qml" line="1166"/>
         <source>Scroll</source>
         <translation>स्क्रॉल</translation>
     </message>
@@ -836,17 +836,17 @@ Euskara - devilschile2</source>
 <context>
     <name>MediaListScreen</name>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="32"/>
+        <location filename="../screens/MediaListScreen.qml" line="31"/>
         <source>Loading…</source>
         <translation type="unfinished">लोड हो रहा है…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="351"/>
+        <location filename="../screens/MediaListScreen.qml" line="350"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 प्रविष्टियाँ</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="352"/>
+        <location filename="../screens/MediaListScreen.qml" line="351"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -97,100 +97,100 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Caricamento…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Yr</source>
         <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Gen</source>
         <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Plyr</source>
         <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Dev</source>
         <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Pub</source>
         <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Rtg</source>
         <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Cat</source>
         <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Date</source>
         <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <location filename="../components/BrowseDetailPane.qml" line="156"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <location filename="../components/BrowseDetailPane.qml" line="156"/>
         <source>Mfr</source>
         <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
@@ -425,19 +425,19 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="122"/>
-        <location filename="../screens/GamesScreen.qml" line="157"/>
+        <location filename="../screens/GamesScreen.qml" line="121"/>
+        <location filename="../screens/GamesScreen.qml" line="156"/>
         <source>%1 files</source>
         <translation>%1 file</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="55"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="158"/>
+        <location filename="../screens/GamesScreen.qml" line="130"/>
+        <location filename="../screens/GamesScreen.qml" line="157"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -447,7 +447,7 @@ Euskara - devilschile2</source>
         <translation>Caricamento giochi…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="127"/>
+        <location filename="../screens/GamesScreen.qml" line="126"/>
         <source>Loading more…</source>
         <translation>Caricamento altro…</translation>
     </message>
@@ -684,60 +684,60 @@ Euskara - devilschile2</source>
         <translation>Avvicina una scheda scrivibile al lettore</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="807"/>
+        <location filename="../app/MainLayout.qml" line="808"/>
         <source>Are you sure you want to exit?</source>
         <translation>Sei sicuro di voler uscire?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="890"/>
-        <location filename="../app/MainLayout.qml" line="964"/>
+        <location filename="../app/MainLayout.qml" line="891"/>
+        <location filename="../app/MainLayout.qml" line="965"/>
         <source>Select</source>
         <translation>Seleziona</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="894"/>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="912"/>
-        <location filename="../app/MainLayout.qml" line="927"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="895"/>
+        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="913"/>
+        <location filename="../app/MainLayout.qml" line="928"/>
+        <location filename="../app/MainLayout.qml" line="939"/>
         <source>Close</source>
         <translation>Chiudi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="905"/>
-        <location filename="../app/MainLayout.qml" line="945"/>
-        <location filename="../app/MainLayout.qml" line="968"/>
-        <location filename="../app/MainLayout.qml" line="979"/>
+        <location filename="../app/MainLayout.qml" line="906"/>
+        <location filename="../app/MainLayout.qml" line="946"/>
+        <location filename="../app/MainLayout.qml" line="969"/>
+        <location filename="../app/MainLayout.qml" line="980"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="923"/>
+        <location filename="../app/MainLayout.qml" line="924"/>
         <source>Done</source>
         <translation>Fatto</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="953"/>
+        <location filename="../app/MainLayout.qml" line="954"/>
         <source>I understand</source>
         <translation>Ho capito</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="987"/>
+        <location filename="../app/MainLayout.qml" line="988"/>
         <source>Start</source>
         <translation>Avvia</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1165"/>
+        <location filename="../app/MainLayout.qml" line="1166"/>
         <source>Scroll</source>
         <translation>Scorri</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="886"/>
-        <location filename="../app/MainLayout.qml" line="960"/>
-        <location filename="../app/MainLayout.qml" line="1003"/>
-        <location filename="../app/MainLayout.qml" line="1034"/>
-        <location filename="../app/MainLayout.qml" line="1084"/>
-        <location filename="../app/MainLayout.qml" line="1127"/>
+        <location filename="../app/MainLayout.qml" line="887"/>
+        <location filename="../app/MainLayout.qml" line="961"/>
+        <location filename="../app/MainLayout.qml" line="1004"/>
+        <location filename="../app/MainLayout.qml" line="1035"/>
+        <location filename="../app/MainLayout.qml" line="1085"/>
+        <location filename="../app/MainLayout.qml" line="1128"/>
         <location filename="../app/MainLayout.qml" line="1195"/>
         <source>Move</source>
         <translation>Muovi</translation>
@@ -758,77 +758,77 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Giocati di recente</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="695"/>
+        <location filename="../app/MainLayout.qml" line="696"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="696"/>
+        <location filename="../app/MainLayout.qml" line="697"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="806"/>
+        <location filename="../app/MainLayout.qml" line="807"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1007"/>
-        <location filename="../app/MainLayout.qml" line="1044"/>
-        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1008"/>
+        <location filename="../app/MainLayout.qml" line="1045"/>
+        <location filename="../app/MainLayout.qml" line="1095"/>
         <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Open</source>
         <translation>Apri</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1011"/>
+        <location filename="../app/MainLayout.qml" line="1012"/>
         <source>Quit</source>
         <translation>Esci</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1050"/>
-        <location filename="../app/MainLayout.qml" line="1061"/>
-        <location filename="../app/MainLayout.qml" line="1076"/>
-        <location filename="../app/MainLayout.qml" line="1103"/>
-        <location filename="../app/MainLayout.qml" line="1114"/>
-        <location filename="../app/MainLayout.qml" line="1151"/>
-        <location filename="../app/MainLayout.qml" line="1169"/>
-        <location filename="../app/MainLayout.qml" line="1178"/>
+        <location filename="../app/MainLayout.qml" line="1021"/>
+        <location filename="../app/MainLayout.qml" line="1051"/>
+        <location filename="../app/MainLayout.qml" line="1062"/>
+        <location filename="../app/MainLayout.qml" line="1077"/>
+        <location filename="../app/MainLayout.qml" line="1104"/>
+        <location filename="../app/MainLayout.qml" line="1115"/>
+        <location filename="../app/MainLayout.qml" line="1152"/>
+        <location filename="../app/MainLayout.qml" line="1170"/>
+        <location filename="../app/MainLayout.qml" line="1179"/>
         <location filename="../app/MainLayout.qml" line="1214"/>
         <location filename="../app/MainLayout.qml" line="1225"/>
         <source>Back</source>
         <translation>Indietro</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1040"/>
-        <location filename="../app/MainLayout.qml" line="1090"/>
+        <location filename="../app/MainLayout.qml" line="1041"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
         <location filename="../app/MainLayout.qml" line="1201"/>
         <source>Page</source>
         <translation>Pagina</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1047"/>
-        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1048"/>
+        <location filename="../app/MainLayout.qml" line="1100"/>
         <location filename="../app/MainLayout.qml" line="1210"/>
         <source>Options</source>
         <translation>Opzioni</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="934"/>
-        <location filename="../app/MainLayout.qml" line="1057"/>
-        <location filename="../app/MainLayout.qml" line="1110"/>
+        <location filename="../app/MainLayout.qml" line="935"/>
+        <location filename="../app/MainLayout.qml" line="1058"/>
+        <location filename="../app/MainLayout.qml" line="1111"/>
         <location filename="../app/MainLayout.qml" line="1221"/>
         <source>Retry</source>
         <translation>Riprova</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1136"/>
+        <location filename="../app/MainLayout.qml" line="1137"/>
         <source>Change</source>
         <translation>Cambia</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1142"/>
+        <location filename="../app/MainLayout.qml" line="1143"/>
         <source>Toggle</source>
         <translation>Alterna</translation>
     </message>
@@ -836,17 +836,17 @@ Euskara - devilschile2</source>
 <context>
     <name>MediaListScreen</name>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="32"/>
+        <location filename="../screens/MediaListScreen.qml" line="31"/>
         <source>Loading…</source>
         <translation type="unfinished">Caricamento…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="351"/>
+        <location filename="../screens/MediaListScreen.qml" line="350"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 elementi</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="352"/>
+        <location filename="../screens/MediaListScreen.qml" line="351"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -97,100 +97,100 @@ Euskara - devilschile2</source>
         <translation type="unfinished">読み込み中…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Yr</source>
         <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Gen</source>
         <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Plyr</source>
         <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Dev</source>
         <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Pub</source>
         <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Rtg</source>
         <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Cat</source>
         <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Date</source>
         <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <location filename="../components/BrowseDetailPane.qml" line="156"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <location filename="../components/BrowseDetailPane.qml" line="156"/>
         <source>Mfr</source>
         <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
@@ -425,19 +425,19 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="122"/>
-        <location filename="../screens/GamesScreen.qml" line="157"/>
+        <location filename="../screens/GamesScreen.qml" line="121"/>
+        <location filename="../screens/GamesScreen.qml" line="156"/>
         <source>%1 files</source>
         <translation>%1 ファイル</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="55"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="158"/>
+        <location filename="../screens/GamesScreen.qml" line="130"/>
+        <location filename="../screens/GamesScreen.qml" line="157"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -447,7 +447,7 @@ Euskara - devilschile2</source>
         <translation>ゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="127"/>
+        <location filename="../screens/GamesScreen.qml" line="126"/>
         <source>Loading more…</source>
         <translation>さらに読み込み中…</translation>
     </message>
@@ -684,60 +684,60 @@ Euskara - devilschile2</source>
         <translation>書き込み可能なカードをリーダーに近づけてください</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="807"/>
+        <location filename="../app/MainLayout.qml" line="808"/>
         <source>Are you sure you want to exit?</source>
         <translation>本当に終了しますか？</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="890"/>
-        <location filename="../app/MainLayout.qml" line="964"/>
+        <location filename="../app/MainLayout.qml" line="891"/>
+        <location filename="../app/MainLayout.qml" line="965"/>
         <source>Select</source>
         <translation>選択</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="894"/>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="912"/>
-        <location filename="../app/MainLayout.qml" line="927"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="895"/>
+        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="913"/>
+        <location filename="../app/MainLayout.qml" line="928"/>
+        <location filename="../app/MainLayout.qml" line="939"/>
         <source>Close</source>
         <translation>閉じる</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="905"/>
-        <location filename="../app/MainLayout.qml" line="945"/>
-        <location filename="../app/MainLayout.qml" line="968"/>
-        <location filename="../app/MainLayout.qml" line="979"/>
+        <location filename="../app/MainLayout.qml" line="906"/>
+        <location filename="../app/MainLayout.qml" line="946"/>
+        <location filename="../app/MainLayout.qml" line="969"/>
+        <location filename="../app/MainLayout.qml" line="980"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="923"/>
+        <location filename="../app/MainLayout.qml" line="924"/>
         <source>Done</source>
         <translation>完了</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="953"/>
+        <location filename="../app/MainLayout.qml" line="954"/>
         <source>I understand</source>
         <translation>了解しました</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="987"/>
+        <location filename="../app/MainLayout.qml" line="988"/>
         <source>Start</source>
         <translation>開始</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1165"/>
+        <location filename="../app/MainLayout.qml" line="1166"/>
         <source>Scroll</source>
         <translation>スクロール</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="886"/>
-        <location filename="../app/MainLayout.qml" line="960"/>
-        <location filename="../app/MainLayout.qml" line="1003"/>
-        <location filename="../app/MainLayout.qml" line="1034"/>
-        <location filename="../app/MainLayout.qml" line="1084"/>
-        <location filename="../app/MainLayout.qml" line="1127"/>
+        <location filename="../app/MainLayout.qml" line="887"/>
+        <location filename="../app/MainLayout.qml" line="961"/>
+        <location filename="../app/MainLayout.qml" line="1004"/>
+        <location filename="../app/MainLayout.qml" line="1035"/>
+        <location filename="../app/MainLayout.qml" line="1085"/>
+        <location filename="../app/MainLayout.qml" line="1128"/>
         <location filename="../app/MainLayout.qml" line="1195"/>
         <source>Move</source>
         <translation>移動</translation>
@@ -758,77 +758,77 @@ Euskara - devilschile2</source>
         <translation type="unfinished">最近プレイしたゲーム</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="695"/>
+        <location filename="../app/MainLayout.qml" line="696"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="696"/>
+        <location filename="../app/MainLayout.qml" line="697"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="806"/>
+        <location filename="../app/MainLayout.qml" line="807"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1007"/>
-        <location filename="../app/MainLayout.qml" line="1044"/>
-        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1008"/>
+        <location filename="../app/MainLayout.qml" line="1045"/>
+        <location filename="../app/MainLayout.qml" line="1095"/>
         <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Open</source>
         <translation>開く</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1011"/>
+        <location filename="../app/MainLayout.qml" line="1012"/>
         <source>Quit</source>
         <translation>終了</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1050"/>
-        <location filename="../app/MainLayout.qml" line="1061"/>
-        <location filename="../app/MainLayout.qml" line="1076"/>
-        <location filename="../app/MainLayout.qml" line="1103"/>
-        <location filename="../app/MainLayout.qml" line="1114"/>
-        <location filename="../app/MainLayout.qml" line="1151"/>
-        <location filename="../app/MainLayout.qml" line="1169"/>
-        <location filename="../app/MainLayout.qml" line="1178"/>
+        <location filename="../app/MainLayout.qml" line="1021"/>
+        <location filename="../app/MainLayout.qml" line="1051"/>
+        <location filename="../app/MainLayout.qml" line="1062"/>
+        <location filename="../app/MainLayout.qml" line="1077"/>
+        <location filename="../app/MainLayout.qml" line="1104"/>
+        <location filename="../app/MainLayout.qml" line="1115"/>
+        <location filename="../app/MainLayout.qml" line="1152"/>
+        <location filename="../app/MainLayout.qml" line="1170"/>
+        <location filename="../app/MainLayout.qml" line="1179"/>
         <location filename="../app/MainLayout.qml" line="1214"/>
         <location filename="../app/MainLayout.qml" line="1225"/>
         <source>Back</source>
         <translation>戻る</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1040"/>
-        <location filename="../app/MainLayout.qml" line="1090"/>
+        <location filename="../app/MainLayout.qml" line="1041"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
         <location filename="../app/MainLayout.qml" line="1201"/>
         <source>Page</source>
         <translation>ページ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1047"/>
-        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1048"/>
+        <location filename="../app/MainLayout.qml" line="1100"/>
         <location filename="../app/MainLayout.qml" line="1210"/>
         <source>Options</source>
         <translation>オプション</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="934"/>
-        <location filename="../app/MainLayout.qml" line="1057"/>
-        <location filename="../app/MainLayout.qml" line="1110"/>
+        <location filename="../app/MainLayout.qml" line="935"/>
+        <location filename="../app/MainLayout.qml" line="1058"/>
+        <location filename="../app/MainLayout.qml" line="1111"/>
         <location filename="../app/MainLayout.qml" line="1221"/>
         <source>Retry</source>
         <translation>再試行</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1136"/>
+        <location filename="../app/MainLayout.qml" line="1137"/>
         <source>Change</source>
         <translation>変更</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1142"/>
+        <location filename="../app/MainLayout.qml" line="1143"/>
         <source>Toggle</source>
         <translation>切り替え</translation>
     </message>
@@ -836,17 +836,17 @@ Euskara - devilschile2</source>
 <context>
     <name>MediaListScreen</name>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="32"/>
+        <location filename="../screens/MediaListScreen.qml" line="31"/>
         <source>Loading…</source>
         <translation type="unfinished">読み込み中…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="351"/>
+        <location filename="../screens/MediaListScreen.qml" line="350"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 件</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="352"/>
+        <location filename="../screens/MediaListScreen.qml" line="351"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -97,100 +97,100 @@ Euskara - devilschile2</source>
         <translation type="unfinished">불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Yr</source>
         <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Gen</source>
         <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Plyr</source>
         <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Dev</source>
         <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Pub</source>
         <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Rtg</source>
         <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Cat</source>
         <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Date</source>
         <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <location filename="../components/BrowseDetailPane.qml" line="156"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <location filename="../components/BrowseDetailPane.qml" line="156"/>
         <source>Mfr</source>
         <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
@@ -425,19 +425,19 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="122"/>
-        <location filename="../screens/GamesScreen.qml" line="157"/>
+        <location filename="../screens/GamesScreen.qml" line="121"/>
+        <location filename="../screens/GamesScreen.qml" line="156"/>
         <source>%1 files</source>
         <translation>파일 %1개</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="55"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="158"/>
+        <location filename="../screens/GamesScreen.qml" line="130"/>
+        <location filename="../screens/GamesScreen.qml" line="157"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -452,7 +452,7 @@ Euskara - devilschile2</source>
         <translation>게임 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="127"/>
+        <location filename="../screens/GamesScreen.qml" line="126"/>
         <source>Loading more…</source>
         <translation>더 불러오는 중…</translation>
     </message>
@@ -699,136 +699,136 @@ Euskara - devilschile2</source>
         <translation type="unfinished">최근 플레이</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="695"/>
+        <location filename="../app/MainLayout.qml" line="696"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="696"/>
+        <location filename="../app/MainLayout.qml" line="697"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="806"/>
+        <location filename="../app/MainLayout.qml" line="807"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="807"/>
+        <location filename="../app/MainLayout.qml" line="808"/>
         <source>Are you sure you want to exit?</source>
         <translation>정말 종료하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="886"/>
-        <location filename="../app/MainLayout.qml" line="960"/>
-        <location filename="../app/MainLayout.qml" line="1003"/>
-        <location filename="../app/MainLayout.qml" line="1034"/>
-        <location filename="../app/MainLayout.qml" line="1084"/>
-        <location filename="../app/MainLayout.qml" line="1127"/>
+        <location filename="../app/MainLayout.qml" line="887"/>
+        <location filename="../app/MainLayout.qml" line="961"/>
+        <location filename="../app/MainLayout.qml" line="1004"/>
+        <location filename="../app/MainLayout.qml" line="1035"/>
+        <location filename="../app/MainLayout.qml" line="1085"/>
+        <location filename="../app/MainLayout.qml" line="1128"/>
         <location filename="../app/MainLayout.qml" line="1195"/>
         <source>Move</source>
         <translation>이동</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="890"/>
-        <location filename="../app/MainLayout.qml" line="964"/>
+        <location filename="../app/MainLayout.qml" line="891"/>
+        <location filename="../app/MainLayout.qml" line="965"/>
         <source>Select</source>
         <translation>선택</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="894"/>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="912"/>
-        <location filename="../app/MainLayout.qml" line="927"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="895"/>
+        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="913"/>
+        <location filename="../app/MainLayout.qml" line="928"/>
+        <location filename="../app/MainLayout.qml" line="939"/>
         <source>Close</source>
         <translation>닫기</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="905"/>
-        <location filename="../app/MainLayout.qml" line="945"/>
-        <location filename="../app/MainLayout.qml" line="968"/>
-        <location filename="../app/MainLayout.qml" line="979"/>
+        <location filename="../app/MainLayout.qml" line="906"/>
+        <location filename="../app/MainLayout.qml" line="946"/>
+        <location filename="../app/MainLayout.qml" line="969"/>
+        <location filename="../app/MainLayout.qml" line="980"/>
         <source>Cancel</source>
         <translation>취소</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="923"/>
+        <location filename="../app/MainLayout.qml" line="924"/>
         <source>Done</source>
         <translation>완료</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="934"/>
-        <location filename="../app/MainLayout.qml" line="1057"/>
-        <location filename="../app/MainLayout.qml" line="1110"/>
+        <location filename="../app/MainLayout.qml" line="935"/>
+        <location filename="../app/MainLayout.qml" line="1058"/>
+        <location filename="../app/MainLayout.qml" line="1111"/>
         <location filename="../app/MainLayout.qml" line="1221"/>
         <source>Retry</source>
         <translation>다시 시도</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="953"/>
+        <location filename="../app/MainLayout.qml" line="954"/>
         <source>I understand</source>
         <translation>이해했습니다</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="987"/>
+        <location filename="../app/MainLayout.qml" line="988"/>
         <source>Start</source>
         <translation>시작</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1007"/>
-        <location filename="../app/MainLayout.qml" line="1044"/>
-        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1008"/>
+        <location filename="../app/MainLayout.qml" line="1045"/>
+        <location filename="../app/MainLayout.qml" line="1095"/>
         <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Open</source>
         <translation>열기</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1011"/>
+        <location filename="../app/MainLayout.qml" line="1012"/>
         <source>Quit</source>
         <translation>종료</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1050"/>
-        <location filename="../app/MainLayout.qml" line="1061"/>
-        <location filename="../app/MainLayout.qml" line="1076"/>
-        <location filename="../app/MainLayout.qml" line="1103"/>
-        <location filename="../app/MainLayout.qml" line="1114"/>
-        <location filename="../app/MainLayout.qml" line="1151"/>
-        <location filename="../app/MainLayout.qml" line="1169"/>
-        <location filename="../app/MainLayout.qml" line="1178"/>
+        <location filename="../app/MainLayout.qml" line="1021"/>
+        <location filename="../app/MainLayout.qml" line="1051"/>
+        <location filename="../app/MainLayout.qml" line="1062"/>
+        <location filename="../app/MainLayout.qml" line="1077"/>
+        <location filename="../app/MainLayout.qml" line="1104"/>
+        <location filename="../app/MainLayout.qml" line="1115"/>
+        <location filename="../app/MainLayout.qml" line="1152"/>
+        <location filename="../app/MainLayout.qml" line="1170"/>
+        <location filename="../app/MainLayout.qml" line="1179"/>
         <location filename="../app/MainLayout.qml" line="1214"/>
         <location filename="../app/MainLayout.qml" line="1225"/>
         <source>Back</source>
         <translation>뒤로</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1040"/>
-        <location filename="../app/MainLayout.qml" line="1090"/>
+        <location filename="../app/MainLayout.qml" line="1041"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
         <location filename="../app/MainLayout.qml" line="1201"/>
         <source>Page</source>
         <translation>페이지</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1047"/>
-        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1048"/>
+        <location filename="../app/MainLayout.qml" line="1100"/>
         <location filename="../app/MainLayout.qml" line="1210"/>
         <source>Options</source>
         <translation>옵션</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1136"/>
+        <location filename="../app/MainLayout.qml" line="1137"/>
         <source>Change</source>
         <translation>변경</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1142"/>
+        <location filename="../app/MainLayout.qml" line="1143"/>
         <source>Toggle</source>
         <translation>전환</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1165"/>
+        <location filename="../app/MainLayout.qml" line="1166"/>
         <source>Scroll</source>
         <translation>스크롤</translation>
     </message>
@@ -836,17 +836,17 @@ Euskara - devilschile2</source>
 <context>
     <name>MediaListScreen</name>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="32"/>
+        <location filename="../screens/MediaListScreen.qml" line="31"/>
         <source>Loading…</source>
         <translation type="unfinished">불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="351"/>
+        <location filename="../screens/MediaListScreen.qml" line="350"/>
         <source>%1 entries</source>
         <translation type="unfinished">항목 %1개</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="352"/>
+        <location filename="../screens/MediaListScreen.qml" line="351"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -97,100 +97,100 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Laden…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Yr</source>
         <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Gen</source>
         <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Plyr</source>
         <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Dev</source>
         <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Pub</source>
         <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Rtg</source>
         <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Cat</source>
         <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Date</source>
         <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <location filename="../components/BrowseDetailPane.qml" line="156"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <location filename="../components/BrowseDetailPane.qml" line="156"/>
         <source>Mfr</source>
         <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
@@ -425,19 +425,19 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="122"/>
-        <location filename="../screens/GamesScreen.qml" line="157"/>
+        <location filename="../screens/GamesScreen.qml" line="121"/>
+        <location filename="../screens/GamesScreen.qml" line="156"/>
         <source>%1 files</source>
         <translation>%1 bestanden</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="55"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="158"/>
+        <location filename="../screens/GamesScreen.qml" line="130"/>
+        <location filename="../screens/GamesScreen.qml" line="157"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -447,7 +447,7 @@ Euskara - devilschile2</source>
         <translation>Games laden…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="127"/>
+        <location filename="../screens/GamesScreen.qml" line="126"/>
         <source>Loading more…</source>
         <translation>Meer laden…</translation>
     </message>
@@ -684,60 +684,60 @@ Euskara - devilschile2</source>
         <translation>Houd een beschrijfbare kaart bij de lezer</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="807"/>
+        <location filename="../app/MainLayout.qml" line="808"/>
         <source>Are you sure you want to exit?</source>
         <translation>Weet u zeker dat u wilt afsluiten?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="890"/>
-        <location filename="../app/MainLayout.qml" line="964"/>
+        <location filename="../app/MainLayout.qml" line="891"/>
+        <location filename="../app/MainLayout.qml" line="965"/>
         <source>Select</source>
         <translation>Selecteren</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="894"/>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="912"/>
-        <location filename="../app/MainLayout.qml" line="927"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="895"/>
+        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="913"/>
+        <location filename="../app/MainLayout.qml" line="928"/>
+        <location filename="../app/MainLayout.qml" line="939"/>
         <source>Close</source>
         <translation>Sluiten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="905"/>
-        <location filename="../app/MainLayout.qml" line="945"/>
-        <location filename="../app/MainLayout.qml" line="968"/>
-        <location filename="../app/MainLayout.qml" line="979"/>
+        <location filename="../app/MainLayout.qml" line="906"/>
+        <location filename="../app/MainLayout.qml" line="946"/>
+        <location filename="../app/MainLayout.qml" line="969"/>
+        <location filename="../app/MainLayout.qml" line="980"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="923"/>
+        <location filename="../app/MainLayout.qml" line="924"/>
         <source>Done</source>
         <translation>Klaar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="953"/>
+        <location filename="../app/MainLayout.qml" line="954"/>
         <source>I understand</source>
         <translation>Ik begrijp het</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="987"/>
+        <location filename="../app/MainLayout.qml" line="988"/>
         <source>Start</source>
         <translation>Starten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1165"/>
+        <location filename="../app/MainLayout.qml" line="1166"/>
         <source>Scroll</source>
         <translation>Scrollen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="886"/>
-        <location filename="../app/MainLayout.qml" line="960"/>
-        <location filename="../app/MainLayout.qml" line="1003"/>
-        <location filename="../app/MainLayout.qml" line="1034"/>
-        <location filename="../app/MainLayout.qml" line="1084"/>
-        <location filename="../app/MainLayout.qml" line="1127"/>
+        <location filename="../app/MainLayout.qml" line="887"/>
+        <location filename="../app/MainLayout.qml" line="961"/>
+        <location filename="../app/MainLayout.qml" line="1004"/>
+        <location filename="../app/MainLayout.qml" line="1035"/>
+        <location filename="../app/MainLayout.qml" line="1085"/>
+        <location filename="../app/MainLayout.qml" line="1128"/>
         <location filename="../app/MainLayout.qml" line="1195"/>
         <source>Move</source>
         <translation>Bewegen</translation>
@@ -758,77 +758,77 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Recent gespeeld</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="695"/>
+        <location filename="../app/MainLayout.qml" line="696"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="696"/>
+        <location filename="../app/MainLayout.qml" line="697"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="806"/>
+        <location filename="../app/MainLayout.qml" line="807"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1007"/>
-        <location filename="../app/MainLayout.qml" line="1044"/>
-        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1008"/>
+        <location filename="../app/MainLayout.qml" line="1045"/>
+        <location filename="../app/MainLayout.qml" line="1095"/>
         <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Open</source>
         <translation>Openen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1011"/>
+        <location filename="../app/MainLayout.qml" line="1012"/>
         <source>Quit</source>
         <translation>Afsluiten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1050"/>
-        <location filename="../app/MainLayout.qml" line="1061"/>
-        <location filename="../app/MainLayout.qml" line="1076"/>
-        <location filename="../app/MainLayout.qml" line="1103"/>
-        <location filename="../app/MainLayout.qml" line="1114"/>
-        <location filename="../app/MainLayout.qml" line="1151"/>
-        <location filename="../app/MainLayout.qml" line="1169"/>
-        <location filename="../app/MainLayout.qml" line="1178"/>
+        <location filename="../app/MainLayout.qml" line="1021"/>
+        <location filename="../app/MainLayout.qml" line="1051"/>
+        <location filename="../app/MainLayout.qml" line="1062"/>
+        <location filename="../app/MainLayout.qml" line="1077"/>
+        <location filename="../app/MainLayout.qml" line="1104"/>
+        <location filename="../app/MainLayout.qml" line="1115"/>
+        <location filename="../app/MainLayout.qml" line="1152"/>
+        <location filename="../app/MainLayout.qml" line="1170"/>
+        <location filename="../app/MainLayout.qml" line="1179"/>
         <location filename="../app/MainLayout.qml" line="1214"/>
         <location filename="../app/MainLayout.qml" line="1225"/>
         <source>Back</source>
         <translation>Terug</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1040"/>
-        <location filename="../app/MainLayout.qml" line="1090"/>
+        <location filename="../app/MainLayout.qml" line="1041"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
         <location filename="../app/MainLayout.qml" line="1201"/>
         <source>Page</source>
         <translation>Pagina</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1047"/>
-        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1048"/>
+        <location filename="../app/MainLayout.qml" line="1100"/>
         <location filename="../app/MainLayout.qml" line="1210"/>
         <source>Options</source>
         <translation>Opties</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="934"/>
-        <location filename="../app/MainLayout.qml" line="1057"/>
-        <location filename="../app/MainLayout.qml" line="1110"/>
+        <location filename="../app/MainLayout.qml" line="935"/>
+        <location filename="../app/MainLayout.qml" line="1058"/>
+        <location filename="../app/MainLayout.qml" line="1111"/>
         <location filename="../app/MainLayout.qml" line="1221"/>
         <source>Retry</source>
         <translation>Opnieuw proberen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1136"/>
+        <location filename="../app/MainLayout.qml" line="1137"/>
         <source>Change</source>
         <translation>Wijzigen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1142"/>
+        <location filename="../app/MainLayout.qml" line="1143"/>
         <source>Toggle</source>
         <translation>Schakelen</translation>
     </message>
@@ -836,17 +836,17 @@ Euskara - devilschile2</source>
 <context>
     <name>MediaListScreen</name>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="32"/>
+        <location filename="../screens/MediaListScreen.qml" line="31"/>
         <source>Loading…</source>
         <translation type="unfinished">Laden…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="351"/>
+        <location filename="../screens/MediaListScreen.qml" line="350"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 items</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="352"/>
+        <location filename="../screens/MediaListScreen.qml" line="351"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -97,100 +97,100 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Se încarcă…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Yr</source>
         <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Gen</source>
         <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Plyr</source>
         <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Dev</source>
         <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Pub</source>
         <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Rtg</source>
         <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Cat</source>
         <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Date</source>
         <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <location filename="../components/BrowseDetailPane.qml" line="156"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <location filename="../components/BrowseDetailPane.qml" line="156"/>
         <source>Mfr</source>
         <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
@@ -425,19 +425,19 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="122"/>
-        <location filename="../screens/GamesScreen.qml" line="157"/>
+        <location filename="../screens/GamesScreen.qml" line="121"/>
+        <location filename="../screens/GamesScreen.qml" line="156"/>
         <source>%1 files</source>
         <translation>%1 fișiere</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="55"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="158"/>
+        <location filename="../screens/GamesScreen.qml" line="130"/>
+        <location filename="../screens/GamesScreen.qml" line="157"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -447,7 +447,7 @@ Euskara - devilschile2</source>
         <translation>Se încarcă jocurile…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="127"/>
+        <location filename="../screens/GamesScreen.qml" line="126"/>
         <source>Loading more…</source>
         <translation>Se încarcă mai multe…</translation>
     </message>
@@ -684,60 +684,60 @@ Euskara - devilschile2</source>
         <translation>Apropiați un card inscriptibil de cititor</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="807"/>
+        <location filename="../app/MainLayout.qml" line="808"/>
         <source>Are you sure you want to exit?</source>
         <translation>Sigur doriți să ieșiți?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="890"/>
-        <location filename="../app/MainLayout.qml" line="964"/>
+        <location filename="../app/MainLayout.qml" line="891"/>
+        <location filename="../app/MainLayout.qml" line="965"/>
         <source>Select</source>
         <translation>Selectare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="894"/>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="912"/>
-        <location filename="../app/MainLayout.qml" line="927"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="895"/>
+        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="913"/>
+        <location filename="../app/MainLayout.qml" line="928"/>
+        <location filename="../app/MainLayout.qml" line="939"/>
         <source>Close</source>
         <translation>Închidere</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="905"/>
-        <location filename="../app/MainLayout.qml" line="945"/>
-        <location filename="../app/MainLayout.qml" line="968"/>
-        <location filename="../app/MainLayout.qml" line="979"/>
+        <location filename="../app/MainLayout.qml" line="906"/>
+        <location filename="../app/MainLayout.qml" line="946"/>
+        <location filename="../app/MainLayout.qml" line="969"/>
+        <location filename="../app/MainLayout.qml" line="980"/>
         <source>Cancel</source>
         <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="923"/>
+        <location filename="../app/MainLayout.qml" line="924"/>
         <source>Done</source>
         <translation>Gata</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="953"/>
+        <location filename="../app/MainLayout.qml" line="954"/>
         <source>I understand</source>
         <translation>Am înțeles</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="987"/>
+        <location filename="../app/MainLayout.qml" line="988"/>
         <source>Start</source>
         <translation>Pornire</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1165"/>
+        <location filename="../app/MainLayout.qml" line="1166"/>
         <source>Scroll</source>
         <translation>Derulare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="886"/>
-        <location filename="../app/MainLayout.qml" line="960"/>
-        <location filename="../app/MainLayout.qml" line="1003"/>
-        <location filename="../app/MainLayout.qml" line="1034"/>
-        <location filename="../app/MainLayout.qml" line="1084"/>
-        <location filename="../app/MainLayout.qml" line="1127"/>
+        <location filename="../app/MainLayout.qml" line="887"/>
+        <location filename="../app/MainLayout.qml" line="961"/>
+        <location filename="../app/MainLayout.qml" line="1004"/>
+        <location filename="../app/MainLayout.qml" line="1035"/>
+        <location filename="../app/MainLayout.qml" line="1085"/>
+        <location filename="../app/MainLayout.qml" line="1128"/>
         <location filename="../app/MainLayout.qml" line="1195"/>
         <source>Move</source>
         <translation>Mutare</translation>
@@ -758,77 +758,77 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Recent Jucate</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="695"/>
+        <location filename="../app/MainLayout.qml" line="696"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="696"/>
+        <location filename="../app/MainLayout.qml" line="697"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="806"/>
+        <location filename="../app/MainLayout.qml" line="807"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1007"/>
-        <location filename="../app/MainLayout.qml" line="1044"/>
-        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1008"/>
+        <location filename="../app/MainLayout.qml" line="1045"/>
+        <location filename="../app/MainLayout.qml" line="1095"/>
         <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Open</source>
         <translation>Deschidere</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1011"/>
+        <location filename="../app/MainLayout.qml" line="1012"/>
         <source>Quit</source>
         <translation>Ieșire</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1050"/>
-        <location filename="../app/MainLayout.qml" line="1061"/>
-        <location filename="../app/MainLayout.qml" line="1076"/>
-        <location filename="../app/MainLayout.qml" line="1103"/>
-        <location filename="../app/MainLayout.qml" line="1114"/>
-        <location filename="../app/MainLayout.qml" line="1151"/>
-        <location filename="../app/MainLayout.qml" line="1169"/>
-        <location filename="../app/MainLayout.qml" line="1178"/>
+        <location filename="../app/MainLayout.qml" line="1021"/>
+        <location filename="../app/MainLayout.qml" line="1051"/>
+        <location filename="../app/MainLayout.qml" line="1062"/>
+        <location filename="../app/MainLayout.qml" line="1077"/>
+        <location filename="../app/MainLayout.qml" line="1104"/>
+        <location filename="../app/MainLayout.qml" line="1115"/>
+        <location filename="../app/MainLayout.qml" line="1152"/>
+        <location filename="../app/MainLayout.qml" line="1170"/>
+        <location filename="../app/MainLayout.qml" line="1179"/>
         <location filename="../app/MainLayout.qml" line="1214"/>
         <location filename="../app/MainLayout.qml" line="1225"/>
         <source>Back</source>
         <translation>Înapoi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1040"/>
-        <location filename="../app/MainLayout.qml" line="1090"/>
+        <location filename="../app/MainLayout.qml" line="1041"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
         <location filename="../app/MainLayout.qml" line="1201"/>
         <source>Page</source>
         <translation>Pagină</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1047"/>
-        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1048"/>
+        <location filename="../app/MainLayout.qml" line="1100"/>
         <location filename="../app/MainLayout.qml" line="1210"/>
         <source>Options</source>
         <translation>Opțiuni</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="934"/>
-        <location filename="../app/MainLayout.qml" line="1057"/>
-        <location filename="../app/MainLayout.qml" line="1110"/>
+        <location filename="../app/MainLayout.qml" line="935"/>
+        <location filename="../app/MainLayout.qml" line="1058"/>
+        <location filename="../app/MainLayout.qml" line="1111"/>
         <location filename="../app/MainLayout.qml" line="1221"/>
         <source>Retry</source>
         <translation>Reîncercare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1136"/>
+        <location filename="../app/MainLayout.qml" line="1137"/>
         <source>Change</source>
         <translation>Schimbare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1142"/>
+        <location filename="../app/MainLayout.qml" line="1143"/>
         <source>Toggle</source>
         <translation>Comutare</translation>
     </message>
@@ -836,17 +836,17 @@ Euskara - devilschile2</source>
 <context>
     <name>MediaListScreen</name>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="32"/>
+        <location filename="../screens/MediaListScreen.qml" line="31"/>
         <source>Loading…</source>
         <translation type="unfinished">Se încarcă…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="351"/>
+        <location filename="../screens/MediaListScreen.qml" line="350"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 intrări</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="352"/>
+        <location filename="../screens/MediaListScreen.qml" line="351"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -97,100 +97,100 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Načítanie…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Yr</source>
         <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Gen</source>
         <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Plyr</source>
         <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Dev</source>
         <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Pub</source>
         <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Rtg</source>
         <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Cat</source>
         <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Date</source>
         <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <location filename="../components/BrowseDetailPane.qml" line="156"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <location filename="../components/BrowseDetailPane.qml" line="156"/>
         <source>Mfr</source>
         <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
@@ -425,19 +425,19 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="122"/>
-        <location filename="../screens/GamesScreen.qml" line="157"/>
+        <location filename="../screens/GamesScreen.qml" line="121"/>
+        <location filename="../screens/GamesScreen.qml" line="156"/>
         <source>%1 files</source>
         <translation>%1 súborov</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="55"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="158"/>
+        <location filename="../screens/GamesScreen.qml" line="130"/>
+        <location filename="../screens/GamesScreen.qml" line="157"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -447,7 +447,7 @@ Euskara - devilschile2</source>
         <translation>Načítanie hier…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="127"/>
+        <location filename="../screens/GamesScreen.qml" line="126"/>
         <source>Loading more…</source>
         <translation>Načítava sa viac…</translation>
     </message>
@@ -684,60 +684,60 @@ Euskara - devilschile2</source>
         <translation>Priložte zapisovateľnú kartu k čítačke</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="807"/>
+        <location filename="../app/MainLayout.qml" line="808"/>
         <source>Are you sure you want to exit?</source>
         <translation>Naozaj chcete ukončiť?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="890"/>
-        <location filename="../app/MainLayout.qml" line="964"/>
+        <location filename="../app/MainLayout.qml" line="891"/>
+        <location filename="../app/MainLayout.qml" line="965"/>
         <source>Select</source>
         <translation>Vybrať</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="894"/>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="912"/>
-        <location filename="../app/MainLayout.qml" line="927"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="895"/>
+        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="913"/>
+        <location filename="../app/MainLayout.qml" line="928"/>
+        <location filename="../app/MainLayout.qml" line="939"/>
         <source>Close</source>
         <translation>Zavrieť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="905"/>
-        <location filename="../app/MainLayout.qml" line="945"/>
-        <location filename="../app/MainLayout.qml" line="968"/>
-        <location filename="../app/MainLayout.qml" line="979"/>
+        <location filename="../app/MainLayout.qml" line="906"/>
+        <location filename="../app/MainLayout.qml" line="946"/>
+        <location filename="../app/MainLayout.qml" line="969"/>
+        <location filename="../app/MainLayout.qml" line="980"/>
         <source>Cancel</source>
         <translation>Zrušiť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="923"/>
+        <location filename="../app/MainLayout.qml" line="924"/>
         <source>Done</source>
         <translation>Hotovo</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="953"/>
+        <location filename="../app/MainLayout.qml" line="954"/>
         <source>I understand</source>
         <translation>Rozumiem</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="987"/>
+        <location filename="../app/MainLayout.qml" line="988"/>
         <source>Start</source>
         <translation>Spustiť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1165"/>
+        <location filename="../app/MainLayout.qml" line="1166"/>
         <source>Scroll</source>
         <translation>Posúvať</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="886"/>
-        <location filename="../app/MainLayout.qml" line="960"/>
-        <location filename="../app/MainLayout.qml" line="1003"/>
-        <location filename="../app/MainLayout.qml" line="1034"/>
-        <location filename="../app/MainLayout.qml" line="1084"/>
-        <location filename="../app/MainLayout.qml" line="1127"/>
+        <location filename="../app/MainLayout.qml" line="887"/>
+        <location filename="../app/MainLayout.qml" line="961"/>
+        <location filename="../app/MainLayout.qml" line="1004"/>
+        <location filename="../app/MainLayout.qml" line="1035"/>
+        <location filename="../app/MainLayout.qml" line="1085"/>
+        <location filename="../app/MainLayout.qml" line="1128"/>
         <location filename="../app/MainLayout.qml" line="1195"/>
         <source>Move</source>
         <translation>Presunúť</translation>
@@ -758,77 +758,77 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Nedávno hrané</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="695"/>
+        <location filename="../app/MainLayout.qml" line="696"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="696"/>
+        <location filename="../app/MainLayout.qml" line="697"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="806"/>
+        <location filename="../app/MainLayout.qml" line="807"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1007"/>
-        <location filename="../app/MainLayout.qml" line="1044"/>
-        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1008"/>
+        <location filename="../app/MainLayout.qml" line="1045"/>
+        <location filename="../app/MainLayout.qml" line="1095"/>
         <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Open</source>
         <translation>Otvoriť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1011"/>
+        <location filename="../app/MainLayout.qml" line="1012"/>
         <source>Quit</source>
         <translation>Ukončiť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1050"/>
-        <location filename="../app/MainLayout.qml" line="1061"/>
-        <location filename="../app/MainLayout.qml" line="1076"/>
-        <location filename="../app/MainLayout.qml" line="1103"/>
-        <location filename="../app/MainLayout.qml" line="1114"/>
-        <location filename="../app/MainLayout.qml" line="1151"/>
-        <location filename="../app/MainLayout.qml" line="1169"/>
-        <location filename="../app/MainLayout.qml" line="1178"/>
+        <location filename="../app/MainLayout.qml" line="1021"/>
+        <location filename="../app/MainLayout.qml" line="1051"/>
+        <location filename="../app/MainLayout.qml" line="1062"/>
+        <location filename="../app/MainLayout.qml" line="1077"/>
+        <location filename="../app/MainLayout.qml" line="1104"/>
+        <location filename="../app/MainLayout.qml" line="1115"/>
+        <location filename="../app/MainLayout.qml" line="1152"/>
+        <location filename="../app/MainLayout.qml" line="1170"/>
+        <location filename="../app/MainLayout.qml" line="1179"/>
         <location filename="../app/MainLayout.qml" line="1214"/>
         <location filename="../app/MainLayout.qml" line="1225"/>
         <source>Back</source>
         <translation>Späť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1040"/>
-        <location filename="../app/MainLayout.qml" line="1090"/>
+        <location filename="../app/MainLayout.qml" line="1041"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
         <location filename="../app/MainLayout.qml" line="1201"/>
         <source>Page</source>
         <translation>Stránka</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1047"/>
-        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1048"/>
+        <location filename="../app/MainLayout.qml" line="1100"/>
         <location filename="../app/MainLayout.qml" line="1210"/>
         <source>Options</source>
         <translation>Možnosti</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="934"/>
-        <location filename="../app/MainLayout.qml" line="1057"/>
-        <location filename="../app/MainLayout.qml" line="1110"/>
+        <location filename="../app/MainLayout.qml" line="935"/>
+        <location filename="../app/MainLayout.qml" line="1058"/>
+        <location filename="../app/MainLayout.qml" line="1111"/>
         <location filename="../app/MainLayout.qml" line="1221"/>
         <source>Retry</source>
         <translation>Skúsiť znova</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1136"/>
+        <location filename="../app/MainLayout.qml" line="1137"/>
         <source>Change</source>
         <translation>Zmeniť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1142"/>
+        <location filename="../app/MainLayout.qml" line="1143"/>
         <source>Toggle</source>
         <translation>Prepínať</translation>
     </message>
@@ -836,17 +836,17 @@ Euskara - devilschile2</source>
 <context>
     <name>MediaListScreen</name>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="32"/>
+        <location filename="../screens/MediaListScreen.qml" line="31"/>
         <source>Loading…</source>
         <translation type="unfinished">Načítanie…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="351"/>
+        <location filename="../screens/MediaListScreen.qml" line="350"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 položiek</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="352"/>
+        <location filename="../screens/MediaListScreen.qml" line="351"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -97,100 +97,100 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Завантаження…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Yr</source>
         <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Gen</source>
         <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Plyr</source>
         <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Dev</source>
         <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Pub</source>
         <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Rtg</source>
         <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Cat</source>
         <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Date</source>
         <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <location filename="../components/BrowseDetailPane.qml" line="156"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <location filename="../components/BrowseDetailPane.qml" line="156"/>
         <source>Mfr</source>
         <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
@@ -425,19 +425,19 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="122"/>
-        <location filename="../screens/GamesScreen.qml" line="157"/>
+        <location filename="../screens/GamesScreen.qml" line="121"/>
+        <location filename="../screens/GamesScreen.qml" line="156"/>
         <source>%1 files</source>
         <translation>%1 файлів</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="55"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="158"/>
+        <location filename="../screens/GamesScreen.qml" line="130"/>
+        <location filename="../screens/GamesScreen.qml" line="157"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -447,7 +447,7 @@ Euskara - devilschile2</source>
         <translation>Завантаження ігор…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="127"/>
+        <location filename="../screens/GamesScreen.qml" line="126"/>
         <source>Loading more…</source>
         <translation>Завантаження ще…</translation>
     </message>
@@ -684,60 +684,60 @@ Euskara - devilschile2</source>
         <translation>Прикладіть картку для запису до зчитувача</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="807"/>
+        <location filename="../app/MainLayout.qml" line="808"/>
         <source>Are you sure you want to exit?</source>
         <translation>Ви впевнені, що хочете вийти?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="890"/>
-        <location filename="../app/MainLayout.qml" line="964"/>
+        <location filename="../app/MainLayout.qml" line="891"/>
+        <location filename="../app/MainLayout.qml" line="965"/>
         <source>Select</source>
         <translation>Вибрати</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="894"/>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="912"/>
-        <location filename="../app/MainLayout.qml" line="927"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="895"/>
+        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="913"/>
+        <location filename="../app/MainLayout.qml" line="928"/>
+        <location filename="../app/MainLayout.qml" line="939"/>
         <source>Close</source>
         <translation>Закрити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="905"/>
-        <location filename="../app/MainLayout.qml" line="945"/>
-        <location filename="../app/MainLayout.qml" line="968"/>
-        <location filename="../app/MainLayout.qml" line="979"/>
+        <location filename="../app/MainLayout.qml" line="906"/>
+        <location filename="../app/MainLayout.qml" line="946"/>
+        <location filename="../app/MainLayout.qml" line="969"/>
+        <location filename="../app/MainLayout.qml" line="980"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="923"/>
+        <location filename="../app/MainLayout.qml" line="924"/>
         <source>Done</source>
         <translation>Готово</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="953"/>
+        <location filename="../app/MainLayout.qml" line="954"/>
         <source>I understand</source>
         <translation>Я розумію</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="987"/>
+        <location filename="../app/MainLayout.qml" line="988"/>
         <source>Start</source>
         <translation>Почати</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1165"/>
+        <location filename="../app/MainLayout.qml" line="1166"/>
         <source>Scroll</source>
         <translation>Прокрутка</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="886"/>
-        <location filename="../app/MainLayout.qml" line="960"/>
-        <location filename="../app/MainLayout.qml" line="1003"/>
-        <location filename="../app/MainLayout.qml" line="1034"/>
-        <location filename="../app/MainLayout.qml" line="1084"/>
-        <location filename="../app/MainLayout.qml" line="1127"/>
+        <location filename="../app/MainLayout.qml" line="887"/>
+        <location filename="../app/MainLayout.qml" line="961"/>
+        <location filename="../app/MainLayout.qml" line="1004"/>
+        <location filename="../app/MainLayout.qml" line="1035"/>
+        <location filename="../app/MainLayout.qml" line="1085"/>
+        <location filename="../app/MainLayout.qml" line="1128"/>
         <location filename="../app/MainLayout.qml" line="1195"/>
         <source>Move</source>
         <translation>Переміщення</translation>
@@ -758,77 +758,77 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Нещодавно зіграні</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="695"/>
+        <location filename="../app/MainLayout.qml" line="696"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="696"/>
+        <location filename="../app/MainLayout.qml" line="697"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="806"/>
+        <location filename="../app/MainLayout.qml" line="807"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1007"/>
-        <location filename="../app/MainLayout.qml" line="1044"/>
-        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1008"/>
+        <location filename="../app/MainLayout.qml" line="1045"/>
+        <location filename="../app/MainLayout.qml" line="1095"/>
         <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Open</source>
         <translation>Відкрити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1011"/>
+        <location filename="../app/MainLayout.qml" line="1012"/>
         <source>Quit</source>
         <translation>Вийти</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1050"/>
-        <location filename="../app/MainLayout.qml" line="1061"/>
-        <location filename="../app/MainLayout.qml" line="1076"/>
-        <location filename="../app/MainLayout.qml" line="1103"/>
-        <location filename="../app/MainLayout.qml" line="1114"/>
-        <location filename="../app/MainLayout.qml" line="1151"/>
-        <location filename="../app/MainLayout.qml" line="1169"/>
-        <location filename="../app/MainLayout.qml" line="1178"/>
+        <location filename="../app/MainLayout.qml" line="1021"/>
+        <location filename="../app/MainLayout.qml" line="1051"/>
+        <location filename="../app/MainLayout.qml" line="1062"/>
+        <location filename="../app/MainLayout.qml" line="1077"/>
+        <location filename="../app/MainLayout.qml" line="1104"/>
+        <location filename="../app/MainLayout.qml" line="1115"/>
+        <location filename="../app/MainLayout.qml" line="1152"/>
+        <location filename="../app/MainLayout.qml" line="1170"/>
+        <location filename="../app/MainLayout.qml" line="1179"/>
         <location filename="../app/MainLayout.qml" line="1214"/>
         <location filename="../app/MainLayout.qml" line="1225"/>
         <source>Back</source>
         <translation>Назад</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1040"/>
-        <location filename="../app/MainLayout.qml" line="1090"/>
+        <location filename="../app/MainLayout.qml" line="1041"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
         <location filename="../app/MainLayout.qml" line="1201"/>
         <source>Page</source>
         <translation>Сторінка</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1047"/>
-        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1048"/>
+        <location filename="../app/MainLayout.qml" line="1100"/>
         <location filename="../app/MainLayout.qml" line="1210"/>
         <source>Options</source>
         <translation>Параметри</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="934"/>
-        <location filename="../app/MainLayout.qml" line="1057"/>
-        <location filename="../app/MainLayout.qml" line="1110"/>
+        <location filename="../app/MainLayout.qml" line="935"/>
+        <location filename="../app/MainLayout.qml" line="1058"/>
+        <location filename="../app/MainLayout.qml" line="1111"/>
         <location filename="../app/MainLayout.qml" line="1221"/>
         <source>Retry</source>
         <translation>Повторити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1136"/>
+        <location filename="../app/MainLayout.qml" line="1137"/>
         <source>Change</source>
         <translation>Змінити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1142"/>
+        <location filename="../app/MainLayout.qml" line="1143"/>
         <source>Toggle</source>
         <translation>Перемкнути</translation>
     </message>
@@ -836,17 +836,17 @@ Euskara - devilschile2</source>
 <context>
     <name>MediaListScreen</name>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="32"/>
+        <location filename="../screens/MediaListScreen.qml" line="31"/>
         <source>Loading…</source>
         <translation type="unfinished">Завантаження…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="351"/>
+        <location filename="../screens/MediaListScreen.qml" line="350"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 записів</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="352"/>
+        <location filename="../screens/MediaListScreen.qml" line="351"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -97,100 +97,100 @@ Euskara - devilschile2</source>
         <translation type="unfinished">正在加载…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="138"/>
+        <location filename="../components/BrowseDetailPane.qml" line="140"/>
         <source>Yr</source>
         <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="140"/>
+        <location filename="../components/BrowseDetailPane.qml" line="142"/>
         <source>Gen</source>
         <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="142"/>
+        <location filename="../components/BrowseDetailPane.qml" line="144"/>
         <source>Plyr</source>
         <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="144"/>
+        <location filename="../components/BrowseDetailPane.qml" line="146"/>
         <source>Dev</source>
         <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="146"/>
+        <location filename="../components/BrowseDetailPane.qml" line="148"/>
         <source>Pub</source>
         <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="148"/>
+        <location filename="../components/BrowseDetailPane.qml" line="150"/>
         <source>Rtg</source>
         <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="150"/>
+        <location filename="../components/BrowseDetailPane.qml" line="152"/>
         <source>Cat</source>
         <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="152"/>
+        <location filename="../components/BrowseDetailPane.qml" line="154"/>
         <source>Date</source>
         <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <location filename="../components/BrowseDetailPane.qml" line="156"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="154"/>
+        <location filename="../components/BrowseDetailPane.qml" line="156"/>
         <source>Mfr</source>
         <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
@@ -425,19 +425,19 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="122"/>
-        <location filename="../screens/GamesScreen.qml" line="157"/>
+        <location filename="../screens/GamesScreen.qml" line="121"/>
+        <location filename="../screens/GamesScreen.qml" line="156"/>
         <source>%1 files</source>
         <translation>%1 个文件</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="55"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="158"/>
+        <location filename="../screens/GamesScreen.qml" line="130"/>
+        <location filename="../screens/GamesScreen.qml" line="157"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -452,7 +452,7 @@ Euskara - devilschile2</source>
         <translation>正在加载游戏…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="127"/>
+        <location filename="../screens/GamesScreen.qml" line="126"/>
         <source>Loading more…</source>
         <translation>正在加载更多…</translation>
     </message>
@@ -699,136 +699,136 @@ Euskara - devilschile2</source>
         <translation type="unfinished">最近游玩</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="695"/>
+        <location filename="../app/MainLayout.qml" line="696"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="696"/>
+        <location filename="../app/MainLayout.qml" line="697"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="806"/>
+        <location filename="../app/MainLayout.qml" line="807"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="807"/>
+        <location filename="../app/MainLayout.qml" line="808"/>
         <source>Are you sure you want to exit?</source>
         <translation>确定要退出吗？</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="886"/>
-        <location filename="../app/MainLayout.qml" line="960"/>
-        <location filename="../app/MainLayout.qml" line="1003"/>
-        <location filename="../app/MainLayout.qml" line="1034"/>
-        <location filename="../app/MainLayout.qml" line="1084"/>
-        <location filename="../app/MainLayout.qml" line="1127"/>
+        <location filename="../app/MainLayout.qml" line="887"/>
+        <location filename="../app/MainLayout.qml" line="961"/>
+        <location filename="../app/MainLayout.qml" line="1004"/>
+        <location filename="../app/MainLayout.qml" line="1035"/>
+        <location filename="../app/MainLayout.qml" line="1085"/>
+        <location filename="../app/MainLayout.qml" line="1128"/>
         <location filename="../app/MainLayout.qml" line="1195"/>
         <source>Move</source>
         <translation>移动</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="890"/>
-        <location filename="../app/MainLayout.qml" line="964"/>
+        <location filename="../app/MainLayout.qml" line="891"/>
+        <location filename="../app/MainLayout.qml" line="965"/>
         <source>Select</source>
         <translation>选择</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="894"/>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="912"/>
-        <location filename="../app/MainLayout.qml" line="927"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="895"/>
+        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="913"/>
+        <location filename="../app/MainLayout.qml" line="928"/>
+        <location filename="../app/MainLayout.qml" line="939"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="905"/>
-        <location filename="../app/MainLayout.qml" line="945"/>
-        <location filename="../app/MainLayout.qml" line="968"/>
-        <location filename="../app/MainLayout.qml" line="979"/>
+        <location filename="../app/MainLayout.qml" line="906"/>
+        <location filename="../app/MainLayout.qml" line="946"/>
+        <location filename="../app/MainLayout.qml" line="969"/>
+        <location filename="../app/MainLayout.qml" line="980"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="923"/>
+        <location filename="../app/MainLayout.qml" line="924"/>
         <source>Done</source>
         <translation>完成</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="934"/>
-        <location filename="../app/MainLayout.qml" line="1057"/>
-        <location filename="../app/MainLayout.qml" line="1110"/>
+        <location filename="../app/MainLayout.qml" line="935"/>
+        <location filename="../app/MainLayout.qml" line="1058"/>
+        <location filename="../app/MainLayout.qml" line="1111"/>
         <location filename="../app/MainLayout.qml" line="1221"/>
         <source>Retry</source>
         <translation>重试</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="953"/>
+        <location filename="../app/MainLayout.qml" line="954"/>
         <source>I understand</source>
         <translation>我明白了</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="987"/>
+        <location filename="../app/MainLayout.qml" line="988"/>
         <source>Start</source>
         <translation>开始</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1007"/>
-        <location filename="../app/MainLayout.qml" line="1044"/>
-        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1008"/>
+        <location filename="../app/MainLayout.qml" line="1045"/>
+        <location filename="../app/MainLayout.qml" line="1095"/>
         <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Open</source>
         <translation>打开</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1011"/>
+        <location filename="../app/MainLayout.qml" line="1012"/>
         <source>Quit</source>
         <translation>退出</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1050"/>
-        <location filename="../app/MainLayout.qml" line="1061"/>
-        <location filename="../app/MainLayout.qml" line="1076"/>
-        <location filename="../app/MainLayout.qml" line="1103"/>
-        <location filename="../app/MainLayout.qml" line="1114"/>
-        <location filename="../app/MainLayout.qml" line="1151"/>
-        <location filename="../app/MainLayout.qml" line="1169"/>
-        <location filename="../app/MainLayout.qml" line="1178"/>
+        <location filename="../app/MainLayout.qml" line="1021"/>
+        <location filename="../app/MainLayout.qml" line="1051"/>
+        <location filename="../app/MainLayout.qml" line="1062"/>
+        <location filename="../app/MainLayout.qml" line="1077"/>
+        <location filename="../app/MainLayout.qml" line="1104"/>
+        <location filename="../app/MainLayout.qml" line="1115"/>
+        <location filename="../app/MainLayout.qml" line="1152"/>
+        <location filename="../app/MainLayout.qml" line="1170"/>
+        <location filename="../app/MainLayout.qml" line="1179"/>
         <location filename="../app/MainLayout.qml" line="1214"/>
         <location filename="../app/MainLayout.qml" line="1225"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1040"/>
-        <location filename="../app/MainLayout.qml" line="1090"/>
+        <location filename="../app/MainLayout.qml" line="1041"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
         <location filename="../app/MainLayout.qml" line="1201"/>
         <source>Page</source>
         <translation>页面</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1047"/>
-        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1048"/>
+        <location filename="../app/MainLayout.qml" line="1100"/>
         <location filename="../app/MainLayout.qml" line="1210"/>
         <source>Options</source>
         <translation>选项</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1136"/>
+        <location filename="../app/MainLayout.qml" line="1137"/>
         <source>Change</source>
         <translation>更改</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1142"/>
+        <location filename="../app/MainLayout.qml" line="1143"/>
         <source>Toggle</source>
         <translation>切换</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1165"/>
+        <location filename="../app/MainLayout.qml" line="1166"/>
         <source>Scroll</source>
         <translation>滚动</translation>
     </message>
@@ -836,17 +836,17 @@ Euskara - devilschile2</source>
 <context>
     <name>MediaListScreen</name>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="32"/>
+        <location filename="../screens/MediaListScreen.qml" line="31"/>
         <source>Loading…</source>
         <translation type="unfinished">正在加载…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="351"/>
+        <location filename="../screens/MediaListScreen.qml" line="350"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 个条目</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="352"/>
+        <location filename="../screens/MediaListScreen.qml" line="351"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/tests/ui/CMakeLists.txt
+++ b/tests/ui/CMakeLists.txt
@@ -17,6 +17,7 @@ qt_add_qml_module(
         tst_paged_grid.qml
         tst_focused_media_detail_controller.qml
         tst_browse_detail_pane.qml
+        tst_media_list_titles.qml
         tst_list_picker_modal.qml
     IMPORTS
         Zaparoo.App

--- a/tests/ui/tst_media_list_titles.qml
+++ b/tests/ui/tst_media_list_titles.qml
@@ -1,0 +1,119 @@
+// Zaparoo Frontend
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+import QtQuick
+import QtTest
+import Zaparoo.Browse as Browse
+import Zaparoo.Screens
+import Zaparoo.Theme
+
+TestCase {
+    id: testCase
+
+    name: "UiMediaListTitles"
+    when: windowShown
+    width: 1280
+    height: 720
+    visible: true
+
+    property string _originalBrowseLayout: "grid"
+
+    Component.onCompleted: {
+        _originalBrowseLayout = Browse.Settings.current_browse_layout;
+        Sizing.screenWidth = testCase.width;
+        Sizing.screenHeight = testCase.height;
+    }
+
+    ListModel {
+        id: mediaModel
+    }
+
+    MediaListScreen {
+        id: screen
+
+        anchors.fill: parent
+        mediaModel: mediaModel
+        emptyText: "No entries"
+        loadingText: "Loading entries"
+        showTopStrip: false
+        detailShowTitle: false
+        suppressSelectionPersist: true
+        gridColumnsOverride: 2
+        gridRowsOverride: 2
+        totalItemsOverride: mediaModel.count
+        activeLabelTextProvider: () => testCase.displayTitleAt(screen.mediaGrid.currentIndex)
+    }
+
+    function init(): void {
+        Sizing.screenWidth = testCase.width;
+        Sizing.screenHeight = testCase.height;
+        Browse.Settings.current_browse_layout = "grid";
+        mediaModel.clear();
+        mediaModel.append({
+            "name": "D (Disc 1)",
+            "fileStem": "D",
+            "coverKey": "",
+            "favorite": 0
+        });
+        mediaModel.append({
+            "name": "D (Disc 2)",
+            "fileStem": "D",
+            "coverKey": "",
+            "favorite": 0
+        });
+        mediaModel.append({
+            "name": "Friendly Alias",
+            "fileStem": "InternalContainer",
+            "coverKey": "",
+            "favorite": 0
+        });
+        tryCompare(screen.mediaGrid, "itemCount", mediaModel.count);
+        screen.mediaGrid.setCurrentIndexImmediate(0);
+    }
+
+    function cleanup(): void {
+        Browse.Settings.current_browse_layout = _originalBrowseLayout;
+    }
+
+    function displayTitleAt(index: int): string {
+        if (index < 0 || index >= mediaModel.count)
+            return "";
+        const row = mediaModel.get(index);
+        return row.name !== "" ? row.name : row.fileStem;
+    }
+
+    function hasVisibleText(item: var, expected: string): bool {
+        if (item === null || item.visible === false || item.opacity === 0)
+            return false;
+        if (typeof item.text === "string" && item.text === expected && item.width > 0 && item.height > 0)
+            return true;
+        const children = item.children;
+        for (let i = 0; i < children.length; i++) {
+            if (hasVisibleText(children[i], expected))
+                return true;
+        }
+        return false;
+    }
+
+    function assertGridAndListTitle(index: int, expected: string): void {
+        Browse.Settings.current_browse_layout = "grid";
+        screen.mediaGrid.setCurrentIndexImmediate(index);
+        tryCompare(screen.activeLabel, "text", expected);
+        tryVerify(() => hasVisibleText(screen.mediaGrid, expected), 1000, "grid title should render " + expected);
+
+        Browse.Settings.current_browse_layout = "list";
+        screen.mediaGrid.setCurrentIndexImmediate(index);
+        tryCompare(screen.listCard, "visible", true);
+        tryVerify(() => hasVisibleText(screen.listCard, expected), 1000, "list title should render " + expected);
+    }
+
+    function test_multi_disc_titles_match_between_grid_and_list(): void {
+        assertGridAndListTitle(0, "D (Disc 1)");
+        assertGridAndListTitle(1, "D (Disc 2)");
+    }
+
+    function test_singleton_directory_alias_title_matches_between_grid_and_list(): void {
+        assertGridAndListTitle(2, "Friendly Alias");
+    }
+}

--- a/tests/ui/tst_smoke.qml
+++ b/tests/ui/tst_smoke.qml
@@ -49,5 +49,4 @@ TestCase {
         width: 1280
         height: 720
     }
-
 }


### PR DESCRIPTION
## Summary
- use Core browse `name` as the Games display title, falling back to file stem only when `name` is empty
- remove `showFileStem` plumbing so grid, active label, and list/detail views render the same title
- add Rust/QML coverage for disc markers and singleton directory aliases

## Tests
- `just test-qml`
- `just test`
- `just lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Game title display now intelligently uses available entry metadata, falling back to file names when needed.

* **Tests**
  * Added comprehensive tests for title display consistency across different layout modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->