### PR TITLE
Bump version to 1.1.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.22)
 
 project(
     zaparoo-frontend
-    VERSION 1.1.0
+    VERSION 1.1.1
     DESCRIPTION "Zaparoo Core frontend"
     HOMEPAGE_URL "https://zaparoo.org"
     LANGUAGES CXX

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -679,7 +679,7 @@ dependencies = [
 
 [[package]]
 name = "mock-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "futures-util",
  "serde",
@@ -1629,7 +1629,7 @@ dependencies = [
 
 [[package]]
 name = "zaparoo-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "dirs-next",
  "futures-util",
@@ -1649,7 +1649,7 @@ dependencies = [
 
 [[package]]
 name = "zaparoo-frontend-rs"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "base64",
  "cxx",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ members = ["frontend", "mock-core", "zaparoo-core"]
 resolver = "2"
 
 [workspace.package]
-version      = "1.1.0"
+version      = "1.1.1"
 edition      = "2021"
 rust-version = "1.90"
 license      = "LicenseRef-PolyForm-Noncommercial-1.0.0"


### PR DESCRIPTION
## Summary
- bump CMake project version to 1.1.1
- bump Rust workspace and lockfile package versions to 1.1.1

## Tests
- just lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 1.1.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->