### PR TITLE
Improve browse navigation responsiveness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,8 @@ jobs:
         run: ctest --preset desktop-debug
       - name: Lint (clang-format + clang-tidy + qmllint)
         run: cmake --build build --target lint
+      - name: Check translations are up to date
+        run: bash scripts/check-translations-updated.sh build
       - name: Upload frontend binary
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/justfile
+++ b/justfile
@@ -137,13 +137,20 @@ _lint-cpp-target: _build-in-image
 _lint-qml-target: _build-in-image
     cmake --build build-docker --target all_qmllint
 
+# Container-internal: refresh Qt Linguist catalogs and fail if checked-in
+# translations are stale. `lupdate` updates source locations as well as strings,
+# so this catches missing line-number/catalog churn from QML/C++ edits.
+_lint-translations-internal:
+    test -f build-docker/build.ninja || cmake --preset desktop-docker-debug
+    bash scripts/check-translations-updated.sh build-docker
+
 # Container-internal: the rust lint surface (fmt --check + clippy + deny).
 _lint-rust-internal:
     cd rust && cargo fmt --all --check
     cd rust && cargo clippy --workspace --all-targets -- -D warnings
     cd rust && cargo deny check
 
-_lint-all-internal: _lint-rust-internal _lint-cpp-target
+_lint-all-internal: _lint-rust-internal _lint-cpp-target _lint-translations-internal
 
 # Container-internal: format-and-autofix surface. xargs -r skips the
 # invocation when the file list is empty.
@@ -174,6 +181,9 @@ lint-cpp:
 
 lint-qml:
     just _lint just _lint-qml-target
+
+lint-translations:
+    just _lint just _lint-translations-internal
 
 fmt:
     just _lint just _fmt-internal

--- a/rust/frontend/src/media_image_cache.rs
+++ b/rust/frontend/src/media_image_cache.rs
@@ -36,6 +36,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::ffi::{c_char, c_void};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex, OnceLock, RwLock};
+use std::time::{Duration, Instant};
 
 use base64::engine::general_purpose::{STANDARD as BASE64_STANDARD, URL_SAFE_NO_PAD};
 use base64::Engine as _;
@@ -444,6 +445,7 @@ struct QueueEntry {
     key: MediaKey,
     page_size: u32,
     no_image_policy: NoImagePolicy,
+    enqueued_at: Instant,
 }
 
 #[derive(Debug)]
@@ -799,6 +801,7 @@ impl MediaImageCache {
                     key,
                     page_size,
                     no_image_policy: NoImagePolicy::Memoize,
+                    enqueued_at: Instant::now(),
                 });
             }
         }
@@ -908,6 +911,7 @@ impl MediaImageCache {
                 key,
                 page_size,
                 no_image_policy,
+                enqueued_at: Instant::now(),
             });
             // Keep only the freshest MAX_QUEUE_LEN entries; the rest
             // (oldest enqueues at the front) get dropped. The dropped
@@ -1014,7 +1018,7 @@ fn process_batch_outcomes(
     queue_notify: &Arc<Notify>,
     outcomes: Vec<(QueueEntry, FetchOutcome)>,
 ) {
-    for (entry, outcome) in outcomes {
+    for (mut entry, outcome) in outcomes {
         let key = entry.key.clone();
         let is_transient = matches!(outcome, FetchOutcome::Transient);
         let is_connection_down = matches!(outcome, FetchOutcome::ConnectionDown);
@@ -1044,6 +1048,7 @@ fn process_batch_outcomes(
                 let dropped = {
                     #[allow(clippy::unwrap_used, reason = "Mutex poisoning is unrecoverable")]
                     let mut q = queue.lock().unwrap();
+                    entry.enqueued_at = Instant::now();
                     q.push_front(entry);
                     // Mirror the `enqueue_with_media_id` cap: a
                     // long-running burst of transient failures can
@@ -1154,6 +1159,15 @@ enum FetchOutcome {
     ConnectionDown,
 }
 
+fn fetch_outcome_label(outcome: &FetchOutcome) -> &'static str {
+    match outcome {
+        FetchOutcome::Success { .. } => "success",
+        FetchOutcome::NoImage => "no_image",
+        FetchOutcome::Transient => "transient",
+        FetchOutcome::ConnectionDown => "connection_down",
+    }
+}
+
 /// Fetch one media image with one `media.image` JSON-RPC call. Core no
 /// longer accepts batched `items`, so queue fan-out happens entirely in
 /// this single-flight driver.
@@ -1164,6 +1178,7 @@ async fn fetch_one(
     entry: QueueEntry,
 ) -> (QueueEntry, FetchOutcome) {
     let key = entry.key.clone();
+    let queue_wait = entry.enqueued_at.elapsed();
     let (mut params, had_id_hint) = {
         #[allow(clippy::unwrap_used, reason = "RwLock poisoning is unrecoverable")]
         let guard = state.read().unwrap();
@@ -1194,17 +1209,30 @@ async fn fetch_one(
         max_size,
         "media_image_cache: media.image request"
     );
-    match store.client().media_image(params).await {
-        Ok(image) => (entry, classify_media_image_result(&key, &image)),
+    let fetch_started = Instant::now();
+    let result = store.client().media_image(params).await;
+    let fetch_duration = fetch_started.elapsed();
+    let (outcome, decode_duration) = match result {
+        Ok(image) => classify_media_image_result(&key, &image),
         Err(e) => {
             let outcome = classify_single_media_image_error(&key, &e.message, had_id_hint);
             if matches!(outcome, FetchOutcome::Transient) && had_id_hint {
                 #[allow(clippy::unwrap_used, reason = "RwLock poisoning is unrecoverable")]
                 state.write().unwrap().media_ids.remove(&key);
             }
-            (entry, outcome)
+            (outcome, Duration::ZERO)
         }
-    }
+    };
+    debug!(
+        system_id = %key.system_id,
+        path = %key.path,
+        outcome = fetch_outcome_label(&outcome),
+        queue_wait_ms = queue_wait.as_millis(),
+        fetch_ms = fetch_duration.as_millis(),
+        decode_ms = decode_duration.as_millis(),
+        "media_image_cache: cover timing",
+    );
+    (entry, outcome)
 }
 
 fn classify_single_media_image_error(
@@ -1255,25 +1283,31 @@ fn is_stable_media_image_miss(message: &str) -> bool {
         || (message.contains("media binary") && message.contains("is too large"))
 }
 
-fn classify_media_image_result(key: &MediaKey, image: &MediaImageResult) -> FetchOutcome {
+fn classify_media_image_result(
+    key: &MediaKey,
+    image: &MediaImageResult,
+) -> (FetchOutcome, Duration) {
+    let decode_started = Instant::now();
     let bytes = match BASE64_STANDARD.decode(image.data.as_bytes()) {
         Ok(b) => b,
         Err(e) => {
+            let decode_duration = decode_started.elapsed();
             warn!(
                 system_id = %key.system_id,
                 path = %key.path,
                 "media_image_cache: base64 decode failed: {e} (transient, will retry on next enqueue)",
             );
-            return FetchOutcome::Transient;
+            return (FetchOutcome::Transient, decode_duration);
         }
     };
+    let decode_duration = decode_started.elapsed();
     if bytes.is_empty() {
         warn!(
             system_id = %key.system_id,
             path = %key.path,
             "media_image_cache: media.image returned 0 bytes after base64 decode, treating as no image",
         );
-        return FetchOutcome::NoImage;
+        return (FetchOutcome::NoImage, decode_duration);
     }
     let ext = image
         .extension
@@ -1289,9 +1323,9 @@ fn classify_media_image_result(key: &MediaKey, image: &MediaImageResult) -> Fetc
             bytes_len = bytes.len(),
             "media_image_cache: unsupported extension/content_type, skipping cache",
         );
-        return FetchOutcome::NoImage;
+        return (FetchOutcome::NoImage, decode_duration);
     };
-    FetchOutcome::Success { bytes, ext }
+    (FetchOutcome::Success { bytes, ext }, decode_duration)
 }
 
 fn finish_fetch(
@@ -1486,6 +1520,7 @@ mod tests {
     use std::collections::VecDeque;
     use std::sync::atomic::AtomicU32;
     use std::sync::{Arc, Mutex, RwLock};
+    use std::time::Instant;
     use tokio::sync::{broadcast, Notify};
 
     /// Build a `MediaImageCache` without spawning the fetch driver.
@@ -2170,6 +2205,7 @@ mod tests {
             key: key("NES", "/retry"),
             page_size: 15,
             no_image_policy: NoImagePolicy::Memoize,
+            enqueued_at: Instant::now(),
         };
         {
             let mut q = queue.lock().unwrap();
@@ -2177,11 +2213,13 @@ mod tests {
                 key: second.clone(),
                 page_size: 15,
                 no_image_policy: NoImagePolicy::Memoize,
+                enqueued_at: Instant::now(),
             });
             q.push_back(QueueEntry {
                 key: first.clone(),
                 page_size: 15,
                 no_image_policy: NoImagePolicy::Memoize,
+                enqueued_at: Instant::now(),
             });
         }
         state.write().unwrap().pending.insert(retry.key.clone());
@@ -2215,16 +2253,19 @@ mod tests {
             key: a.clone(),
             page_size: 15,
             no_image_policy: NoImagePolicy::Memoize,
+            enqueued_at: Instant::now(),
         });
         q.push_back(QueueEntry {
             key: b.clone(),
             page_size: 15,
             no_image_policy: NoImagePolicy::Memoize,
+            enqueued_at: Instant::now(),
         });
         q.push_back(QueueEntry {
             key: c.clone(),
             page_size: 15,
             no_image_policy: NoImagePolicy::Memoize,
+            enqueued_at: Instant::now(),
         });
         assert_eq!(q.pop_back().map(|e| e.key), Some(c));
         assert_eq!(q.pop_back().map(|e| e.key), Some(b));

--- a/rust/frontend/src/models/favorites.rs
+++ b/rust/frontend/src/models/favorites.rs
@@ -322,8 +322,8 @@ fn apply_state(
             disarm_cover_gate(model.as_mut());
             if model.loading {
                 model.as_mut().set_loading(false);
-                finish_nav_timing(model.as_mut(), "covers-paused", 0);
             }
+            finish_nav_timing(model.as_mut(), "covers-paused", 0);
         } else {
             // Decide whether to release `loading` immediately or hold it until
             // covers are cached. `arm_cover_gate` flips loading off itself when
@@ -1062,8 +1062,8 @@ fn notify_cover_update(mut model: Pin<&mut ffi::FavoritesModel>, key: &MediaKey)
                 if model.loading {
                     info!("favorites: cover gate released after decode-settle window");
                     model.as_mut().set_loading(false);
-                    finish_nav_timing(model.as_mut(), "covers-ready", 0);
                 }
+                finish_nav_timing(model.as_mut(), "covers-ready", 0);
             });
         });
         model.as_mut().rust_mut().cover_gate_timer = Some(handle);
@@ -1125,8 +1125,8 @@ fn arm_cover_gate(mut model: Pin<&mut ffi::FavoritesModel>) {
         model.as_mut().rust_mut().pending_first_paint_keys.clear();
         if model.loading {
             model.as_mut().set_loading(false);
-            finish_nav_timing(model.as_mut(), "covers-ready", 0);
         }
+        finish_nav_timing(model.as_mut(), "covers-ready", 0);
         return;
     }
     info!(
@@ -1170,8 +1170,8 @@ fn release_cover_gate_after_timeout(mut model: Pin<&mut ffi::FavoritesModel>) {
     model.as_mut().rust_mut().cover_gate_timer = None;
     if model.loading {
         model.as_mut().set_loading(false);
-        finish_nav_timing(model.as_mut(), "timeout", pending);
     }
+    finish_nav_timing(model.as_mut(), "timeout", pending);
 }
 
 /// Build the `text` payload sent to Core's `run` for a search entry.

--- a/rust/frontend/src/models/favorites.rs
+++ b/rust/frontend/src/models/favorites.rs
@@ -23,6 +23,7 @@
 // QR/card-write payloads prefer Core's portable ZapScript.
 
 use crate::media_image_cache::{global_media_image_cache, MediaImageCache, MediaKey};
+use crate::models::nav_timing::NavTiming;
 use crate::models::tag_utils::tag_display_value;
 use crate::models::{global_handle, global_store};
 use cxx_qt::{CxxQtType, Threading};
@@ -33,7 +34,7 @@ use std::collections::HashSet;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::broadcast::error::RecvError;
 use tokio::task::JoinHandle;
 use tracing::{info, warn};
@@ -113,6 +114,7 @@ pub struct FavoritesModelRust {
     // JoinHandle doesn't cancel a callback already queued onto the Qt
     // thread between sleep-completion and abort.
     cover_gate_seq: Arc<AtomicU64>,
+    nav_timing: Option<NavTiming>,
 }
 
 #[cxx_qt::bridge]
@@ -280,7 +282,14 @@ fn apply_state(
     mut model: Pin<&mut ffi::FavoritesModel>,
     (data, err): (Option<PageSnapshot>, String),
 ) {
+    let apply_started = Instant::now();
     if let Some((entries, has_next_page, next_cursor)) = data {
+        if model.nav_timing.is_none() {
+            model.as_mut().rust_mut().nav_timing = Some(NavTiming::new("cache"));
+        }
+        if let Some(timing) = model.as_mut().rust_mut().nav_timing.as_mut() {
+            timing.mark_request_done();
+        }
         // A fresh initial page resets the cursor chain — bump `seq` so
         // any in-flight `fetch_more` sees a stale ticket and bails.
         model.as_mut().rust_mut().seq.fetch_add(1, Ordering::SeqCst);
@@ -296,6 +305,13 @@ fn apply_state(
         model.as_mut().rust_mut().next_cursor = next_cursor;
         model.as_mut().end_reset_model();
         model.as_mut().count_changed();
+        if let Some(timing) = model.as_mut().rust_mut().nav_timing.as_mut() {
+            timing.mark_apply_done();
+        }
+        info!(
+            apply_ms = apply_started.elapsed().as_millis(),
+            "favorites: apply_state timing",
+        );
         if model.has_next_page != has_next_page {
             model.as_mut().set_has_next_page(has_next_page);
         }
@@ -306,6 +322,7 @@ fn apply_state(
             disarm_cover_gate(model.as_mut());
             if model.loading {
                 model.as_mut().set_loading(false);
+                finish_nav_timing(model.as_mut(), "covers-paused", 0);
             }
         } else {
             // Decide whether to release `loading` immediately or hold it until
@@ -324,6 +341,11 @@ fn apply_state(
             model.as_mut().fetch_more();
         }
     } else if err.is_empty() {
+        if model.nav_timing.is_none() {
+            model.as_mut().rust_mut().nav_timing = Some(NavTiming::new("network"));
+        } else if let Some(timing) = model.as_mut().rust_mut().nav_timing.as_mut() {
+            timing.set_source("network");
+        }
         // Pending (Idle/Loading): show the spinner; don't touch results.
         // Disarm pagination so a grid scroll during a refetch doesn't
         // fire `fetch_more` against a stale cursor — `has_next_page`
@@ -354,6 +376,7 @@ fn apply_state(
         if model.loading {
             model.as_mut().set_loading(false);
         }
+        finish_nav_timing(model.as_mut(), "error", 0);
         if model.has_next_page {
             model.as_mut().set_has_next_page(false);
         }
@@ -953,6 +976,16 @@ fn enqueue_favorites_covers(results: &[MediaItem]) {
     }
 }
 
+fn finish_nav_timing(
+    mut model: Pin<&mut ffi::FavoritesModel>,
+    reason: &'static str,
+    pending_remaining: usize,
+) {
+    if let Some(timing) = model.as_mut().rust_mut().nav_timing.take() {
+        timing.log_release("favorites", reason, pending_remaining);
+    }
+}
+
 /// Emit `dataChanged(coverKey)` for every row whose entry's
 /// `(systemId, mediaPath)` matches `key`. Cheap walk of the current
 /// `entries` vec — favorites pages top out at a few hundred rows after
@@ -1029,6 +1062,7 @@ fn notify_cover_update(mut model: Pin<&mut ffi::FavoritesModel>, key: &MediaKey)
                 if model.loading {
                     info!("favorites: cover gate released after decode-settle window");
                     model.as_mut().set_loading(false);
+                    finish_nav_timing(model.as_mut(), "covers-ready", 0);
                 }
             });
         });
@@ -1072,15 +1106,26 @@ fn arm_cover_gate(mut model: Pin<&mut ffi::FavoritesModel>) {
         handle.abort();
     }
     let cache = global_media_image_cache();
+    let cover_keys = model
+        .entries
+        .iter()
+        .filter_map(|entry| media_key_for(entry).map(MediaKey::with_current_cover_preference))
+        .collect::<Vec<_>>();
+    let cover_total = cover_keys.len();
+    let cover_cache_hits = cover_keys.iter().filter(|k| cache.is_cached(k)).count();
     let unresolved = compute_unresolved_keys(
         &model.entries,
         |k| cache.is_cached(k),
         |k| cache.is_negative(k) || cache.is_soft_no_image(k),
     );
+    if let Some(timing) = model.as_mut().rust_mut().nav_timing.as_mut() {
+        timing.start_gate(cover_total, cover_cache_hits, unresolved.len());
+    }
     if unresolved.is_empty() {
         model.as_mut().rust_mut().pending_first_paint_keys.clear();
         if model.loading {
             model.as_mut().set_loading(false);
+            finish_nav_timing(model.as_mut(), "covers-ready", 0);
         }
         return;
     }
@@ -1125,6 +1170,7 @@ fn release_cover_gate_after_timeout(mut model: Pin<&mut ffi::FavoritesModel>) {
     model.as_mut().rust_mut().cover_gate_timer = None;
     if model.loading {
         model.as_mut().set_loading(false);
+        finish_nav_timing(model.as_mut(), "timeout", pending);
     }
 }
 

--- a/rust/frontend/src/models/games.rs
+++ b/rust/frontend/src/models/games.rs
@@ -31,6 +31,7 @@
 // when the user spams direction-arrow + Accept across a model swap.
 
 use crate::media_image_cache::{global_media_image_cache, MediaImageCache, MediaKey};
+use crate::models::nav_timing::NavTiming;
 use crate::models::tag_utils::tag_display_value;
 use crate::models::{global_handle, global_store};
 use cxx_qt::{CxxQtType, Threading};
@@ -41,7 +42,7 @@ use std::collections::{BTreeSet, HashSet};
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::broadcast::error::RecvError;
 use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
@@ -233,6 +234,7 @@ pub struct GamesModelRust {
     // window for whatever row the user is currently looking at.
     visible_first_row: i32,
     cover_max_size: i32,
+    nav_timing: Option<NavTiming>,
 }
 
 impl Default for GamesModelRust {
@@ -277,6 +279,7 @@ impl Default for GamesModelRust {
             pending_initial_lookahead: false,
             visible_first_row: 0,
             cover_max_size: 0,
+            nav_timing: None,
         }
     }
 }
@@ -994,6 +997,7 @@ impl ffi::GamesModel {
             page_size = self.page_size,
             "games: start_initial_browse",
         );
+        self.as_mut().rust_mut().nav_timing = Some(NavTiming::new("network"));
         self.as_mut().ensure_cover_subscription();
         self.as_mut().set_current_path(QString::from(path.as_str()));
         self.as_mut().set_loading(true);
@@ -1071,6 +1075,12 @@ impl ffi::GamesModel {
         // the outer call later overwrites `self.watcher`.
         let qt_thread = self.qt_thread();
         let snapshot = status_rx.borrow_and_update().clone();
+        if let Some(timing) = self.as_mut().rust_mut().nav_timing.as_mut() {
+            if matches!(snapshot, ResourceStatus::Ready(_)) {
+                timing.set_source("cache");
+                timing.mark_request_done();
+            }
+        }
         let seq_for_loop = seq.clone();
         let handle = global_handle().spawn(async move {
             while status_rx.changed().await.is_ok() {
@@ -1694,6 +1704,28 @@ fn cover_key_for_with(
     }
 }
 
+fn finish_nav_timing(
+    mut model: Pin<&mut ffi::GamesModel>,
+    reason: &'static str,
+    pending_remaining: usize,
+) {
+    if let Some(timing) = model.as_mut().rust_mut().nav_timing.take() {
+        timing.log_release("games", reason, pending_remaining);
+    }
+}
+
+fn mark_nav_source(mut model: Pin<&mut ffi::GamesModel>, source: &'static str) {
+    if let Some(timing) = model.as_mut().rust_mut().nav_timing.as_mut() {
+        timing.set_source(source);
+    }
+}
+
+fn mark_nav_request_done(mut model: Pin<&mut ffi::GamesModel>) {
+    if let Some(timing) = model.as_mut().rust_mut().nav_timing.as_mut() {
+        timing.mark_request_done();
+    }
+}
+
 /// Emit `dataChanged(coverKey)` for every row whose entry's
 /// `(systemId, path)` matches `key`. Cheap walk of the current
 /// `entries` vec — pages top out at a few hundred rows after look-
@@ -1792,6 +1824,7 @@ fn notify_cover_update(mut model: Pin<&mut ffi::GamesModel>, key: &MediaKey) {
                 if model.loading {
                     info!("games: cover gate released after decode-settle window");
                     model.as_mut().set_loading(false);
+                    finish_nav_timing(model.as_mut(), "covers-ready", 0);
                 }
             });
         });
@@ -1867,11 +1900,21 @@ fn arm_cover_gate(mut model: Pin<&mut ffi::GamesModel>) {
     let first = model.rust().visible_first_row.max(0) as usize;
     let window_end = (first + page_size).min(model.entries.len());
     let visible_entries = &model.entries[first..window_end];
+    let cover_keys = visible_entries
+        .iter()
+        .filter(|entry| entry.has_cover)
+        .filter_map(|entry| media_key_for(entry).map(MediaKey::with_current_cover_preference))
+        .collect::<Vec<_>>();
+    let cover_total = cover_keys.len();
+    let cover_cache_hits = cover_keys.iter().filter(|k| cache.is_cached(k)).count();
     let unresolved = compute_unresolved_keys(
         visible_entries,
         |k| cache.is_cached(k),
         |k| cache.is_negative(k),
     );
+    if let Some(timing) = model.as_mut().rust_mut().nav_timing.as_mut() {
+        timing.start_gate(cover_total, cover_cache_hits, unresolved.len());
+    }
     if unresolved.is_empty() {
         model.as_mut().rust_mut().pending_first_paint_keys.clear();
         // If the initial look-ahead is still in flight, keep loading=true
@@ -1884,6 +1927,7 @@ fn arm_cover_gate(mut model: Pin<&mut ffi::GamesModel>) {
                 arm_cover_gate_timeout(model);
             } else {
                 model.as_mut().set_loading(false);
+                finish_nav_timing(model.as_mut(), "covers-ready", 0);
             }
         }
         return;
@@ -1931,6 +1975,7 @@ fn release_initial_lookahead_gate(mut model: Pin<&mut ffi::GamesModel>) {
         }
         if model.loading {
             model.as_mut().set_loading(false);
+            finish_nav_timing(model.as_mut(), "lookahead-ready", 0);
         }
     }
 }
@@ -1950,6 +1995,7 @@ fn release_cover_gate_after_timeout(mut model: Pin<&mut ffi::GamesModel>) {
     model.as_mut().rust_mut().pending_initial_lookahead = false;
     if model.loading {
         model.as_mut().set_loading(false);
+        finish_nav_timing(model.as_mut(), "timeout", pending);
     }
 }
 
@@ -2103,6 +2149,7 @@ fn is_strict_ancestor_path(parent: &str, child: &str) -> bool {
 fn apply_status(mut model: Pin<&mut ffi::GamesModel>, status: ResourceStatus<MediaBrowseResult>) {
     match project_status(status) {
         Projection::Pending => {
+            mark_nav_source(model.as_mut(), "network");
             // A new browse round started (or a Ready→Pending refetch
             // is in flight). Abort any cover gate left from the
             // previous Ready so its safety-timer callback can't race
@@ -2126,6 +2173,7 @@ fn apply_status(mut model: Pin<&mut ffi::GamesModel>, status: ResourceStatus<Med
             }
         }
         Projection::Ready(mut result) => {
+            mark_nav_request_done(model.as_mut());
             let eligible = model.rust().auto_nav_eligible;
             // Eligibility is consumed by the first Ready that follows
             // an eligible load. A subsequent refetch (mutation
@@ -2214,6 +2262,7 @@ fn apply_status(mut model: Pin<&mut ffi::GamesModel>, status: ResourceStatus<Med
             if model.loading {
                 model.as_mut().set_loading(false);
             }
+            finish_nav_timing(model.as_mut(), "error", 0);
             if model.has_next_page {
                 model.as_mut().set_has_next_page(false);
             }
@@ -2222,6 +2271,7 @@ fn apply_status(mut model: Pin<&mut ffi::GamesModel>, status: ResourceStatus<Med
 }
 
 fn apply_initial_page(mut model: Pin<&mut ffi::GamesModel>, result: MediaBrowseResult) {
+    let apply_started = Instant::now();
     // Already seeded: this Ready is a cache invalidation refetch on
     // the same browse target (e.g. `MediaTagsUpdateMutation`'s
     // `MediaBrowseEndpoint` invalidation after a favorite toggle, or
@@ -2236,6 +2286,7 @@ fn apply_initial_page(mut model: Pin<&mut ffi::GamesModel>, result: MediaBrowseR
         if model.loading {
             model.as_mut().set_loading(false);
         }
+        finish_nav_timing(model.as_mut(), "already-seeded", 0);
         return;
     }
     let has_next_page = result.has_next_page();
@@ -2277,6 +2328,13 @@ fn apply_initial_page(mut model: Pin<&mut ffi::GamesModel>, result: MediaBrowseR
     // re-issues this through `onCurrentPageChanged` in QML.
     model.as_mut().rust_mut().visible_first_row = 0;
     model.as_mut().prefetch_around(0);
+    if let Some(timing) = model.as_mut().rust_mut().nav_timing.as_mut() {
+        timing.mark_apply_done();
+    }
+    debug!(
+        apply_ms = apply_started.elapsed().as_millis(),
+        "games: apply_initial_page timing",
+    );
     // Metadata look-ahead runs in the background. Track it only so
     // stale follow-up completions can clear their own bookkeeping; do
     // not let it hold the first visible page behind the full-screen

--- a/rust/frontend/src/models/games.rs
+++ b/rust/frontend/src/models/games.rs
@@ -101,6 +101,11 @@ const FETCH_MORE_RAPID_CHUNK_SIZE: i32 = 300;
 const COLLAPSED_DIRECTORY_BROWSE_PAGE_SIZE: u32 = 1000;
 const COVER_PREFETCH_NEXT_PAGES: i32 = 2;
 const COVER_PREFETCH_PREVIOUS_PAGES: i32 = 1;
+// Bound how long navigation waits for cold visible covers. After this,
+// the page becomes interactive and any remaining covers pop in via the
+// normal update path. Keeps cold pages from waiting on the slowest
+// `media.image` request while preserving no-pop-in for warm/cache-hit pages.
+const COVER_GATE_TIMEOUT_MS: u64 = 300;
 
 // `apply_append_page` sub-batches the model insert into chunks of this
 // many rows so the Repeater's per-delegate `createObject` cost (the
@@ -220,11 +225,11 @@ pub struct GamesModelRust {
     // the new one. Same race shape as `cover_gate_seq`, just for the
     // sub-batch fan-out.
     append_seq: Arc<AtomicU64>,
-    // True from the moment `apply_initial_page` queues its metadata
-    // look-ahead `fetch_more` until the matching `apply_append_page`
-    // lands. This is informational only: background look-ahead must
-    // not hold the full-screen loading gate after the visible page is
-    // ready.
+    // True when `apply_initial_page` wants to start the metadata
+    // look-ahead `fetch_more` after the visible page is interactive.
+    // Starting it before the cover gate releases can splice rows and
+    // create delegates during a screen transition, which is exactly
+    // the UI-thread stall the loading overlay is trying to hide.
     pending_initial_lookahead: bool,
     // First visible row in the grid. Bound from QML to
     // `gamesGrid.currentPage * gamesGrid.pageSize` so the model knows
@@ -1775,60 +1780,16 @@ fn notify_cover_update(mut model: Pin<&mut ffi::GamesModel>, key: &MediaKey) {
         .rust_mut()
         .pending_first_paint_keys
         .remove(key);
-    // Hold the overlay while the initial look-ahead is still in flight so
-    // the Loading screen covers both cover resolution AND the background
-    // chunk's materialization. `release_initial_lookahead_gate` below will
-    // trigger the release once both conditions are satisfied.
-    if was_pending
-        && model.pending_first_paint_keys.is_empty()
-        && !model.pending_initial_lookahead
-        && model.loading
-    {
+    if was_pending && model.pending_first_paint_keys.is_empty() && model.loading {
         if let Some(handle) = model.as_mut().rust_mut().cover_gate_timer.take() {
             handle.abort();
         }
-        // Bytes are cached, but QML's `MediaImageProvider` still has to
-        // decode them. PagedGrid now feeds real coverKey values to the
-        // current and next page while the loading overlay is still up,
-        // but MiSTer's software-rendered frame loop can lag behind the
-        // last cache broadcast. Keep a bounded MiSTer-only settle window
-        // long enough for the first-page provider/decode lag seen there
-        // so the first visible grid frame is less likely to paint
-        // fallbacks or hourglasses. Desktop/non-MiSTer releases
-        // immediately so restores are not globally delayed.
-        // TODO: Replace this heuristic with a QML decode-ready handshake
-        // from the first visible page (Ready/Error per Image plus a
-        // timeout fallback), so the gate releases on real decode state
-        // instead of runtime-specific sleep.
-        let settle_delay = if matches!(platform::current(), Some(Platform::Mister)) {
-            Duration::from_millis(1000)
-        } else {
-            Duration::ZERO
-        };
-        info!(
-            settle_ms = settle_delay.as_millis(),
-            "games: cover gate bytes settled — entering decode-settle window"
-        );
-        let seq = model.rust().cover_gate_seq.clone();
-        let ticket = seq.fetch_add(1, Ordering::SeqCst) + 1;
-        let qt_thread = model.qt_thread();
-        let handle = global_handle().spawn(async move {
-            if !settle_delay.is_zero() {
-                tokio::time::sleep(settle_delay).await;
-            }
-            let _ = qt_thread.queue(move |mut model: Pin<&mut ffi::GamesModel>| {
-                if seq.load(Ordering::SeqCst) != ticket {
-                    return;
-                }
-                model.as_mut().rust_mut().cover_gate_timer = None;
-                if model.loading {
-                    info!("games: cover gate released after decode-settle window");
-                    model.as_mut().set_loading(false);
-                    finish_nav_timing(model.as_mut(), "covers-ready", 0);
-                }
-            });
-        });
-        model.as_mut().rust_mut().cover_gate_timer = Some(handle);
+        if model.loading {
+            info!("games: cover gate released after visible covers cached");
+            model.as_mut().set_loading(false);
+            finish_nav_timing(model.as_mut(), "covers-ready", 0);
+            maybe_start_initial_lookahead(model.as_mut());
+        }
     }
 }
 
@@ -1877,14 +1838,14 @@ fn reset_cover_gate(mut model: Pin<&mut ffi::GamesModel>) {
 /// - If every media entry is already cached or negatively-memoised
 ///   (folder-only page, or revisit), set loading=false right now —
 ///   there's nothing to wait on, the screen-flip overlay clears.
-/// - Otherwise, store the unresolved set on the model, arm a 1.5 s
+/// - Otherwise, store the unresolved set on the model, arm a short
 ///   safety timer, and leave loading=true. `notify_cover_update` will
 ///   drain the set as covers land; whichever happens first (set empties
 ///   or timer fires) releases the gate.
 ///
-/// The 1.5 s timeout is the fall-through: if the bulk RPC or initial
-/// look-ahead stalls, the user sees `Loading…` for at most 1.5 s before
-/// the existing "list with placeholders → covers pop in" behavior resumes.
+/// The timeout is the fall-through: if visible cover fetches are cold,
+/// the user sees `Loading…` only briefly before the existing "list with
+/// placeholders → covers pop in" behavior resumes.
 fn arm_cover_gate(mut model: Pin<&mut ffi::GamesModel>) {
     if let Some(handle) = model.as_mut().rust_mut().cover_gate_timer.take() {
         handle.abort();
@@ -1917,18 +1878,10 @@ fn arm_cover_gate(mut model: Pin<&mut ffi::GamesModel>) {
     }
     if unresolved.is_empty() {
         model.as_mut().rust_mut().pending_first_paint_keys.clear();
-        // If the initial look-ahead is still in flight, keep loading=true
-        // so the overlay covers the materialization of the first background
-        // chunk. `release_initial_lookahead_gate` will release it once
-        // the sub-batches have finished splicing onto the Qt thread.
         if model.loading {
-            if model.pending_initial_lookahead {
-                info!("games: arm cover gate (holding loading until look-ahead lands)");
-                arm_cover_gate_timeout(model);
-            } else {
-                model.as_mut().set_loading(false);
-                finish_nav_timing(model.as_mut(), "covers-ready", 0);
-            }
+            model.as_mut().set_loading(false);
+            finish_nav_timing(model.as_mut(), "covers-ready", 0);
+            maybe_start_initial_lookahead(model.as_mut());
         }
         return;
     }
@@ -1945,14 +1898,12 @@ fn arm_cover_gate_timeout(mut model: Pin<&mut ffi::GamesModel>) {
     let ticket = seq.fetch_add(1, Ordering::SeqCst) + 1;
     let qt_thread = model.qt_thread();
     let handle = global_handle().spawn(async move {
-        tokio::time::sleep(Duration::from_millis(1500)).await;
+        tokio::time::sleep(Duration::from_millis(COVER_GATE_TIMEOUT_MS)).await;
         let _ = qt_thread.queue(move |mut model: Pin<&mut ffi::GamesModel>| {
             if seq.load(Ordering::SeqCst) != ticket {
                 return;
             }
-            if model.loading
-                && (model.pending_initial_lookahead || !model.pending_first_paint_keys.is_empty())
-            {
+            if model.loading && !model.pending_first_paint_keys.is_empty() {
                 release_cover_gate_after_timeout(model);
             } else {
                 model.as_mut().rust_mut().cover_gate_timer = None;
@@ -1962,22 +1913,21 @@ fn arm_cover_gate_timeout(mut model: Pin<&mut ffi::GamesModel>) {
     model.as_mut().rust_mut().cover_gate_timer = Some(handle);
 }
 
-/// Clear `pending_initial_lookahead` after the background prefetch lands.
-/// If the cover gate already drained before look-ahead finished (e.g. a
-/// system with no covers whose pending keys resolved to empty immediately),
-/// release the loading overlay now that both conditions are met.
+fn maybe_start_initial_lookahead(mut model: Pin<&mut ffi::GamesModel>) {
+    if !model.pending_initial_lookahead
+        || model.loading
+        || model.loading_more
+        || !model.has_next_page
+    {
+        return;
+    }
+    model.as_mut().rust_mut().pending_initial_lookahead = false;
+    model.as_mut().fetch_more();
+}
+
+/// Clear stale look-ahead state after the background prefetch lands or fails.
 fn release_initial_lookahead_gate(mut model: Pin<&mut ffi::GamesModel>) {
     model.as_mut().rust_mut().pending_initial_lookahead = false;
-    if model.pending_first_paint_keys.is_empty() {
-        if let Some(handle) = model.as_mut().rust_mut().cover_gate_timer.take() {
-            handle.abort();
-            model.rust().cover_gate_seq.fetch_add(1, Ordering::SeqCst);
-        }
-        if model.loading {
-            model.as_mut().set_loading(false);
-            finish_nav_timing(model.as_mut(), "lookahead-ready", 0);
-        }
-    }
 }
 
 /// Force-release the cover gate from the safety timer. Called only via
@@ -1988,14 +1938,11 @@ fn release_cover_gate_after_timeout(mut model: Pin<&mut ffi::GamesModel>) {
     info!(pending, "games: cover gate timed out, releasing");
     model.as_mut().rust_mut().pending_first_paint_keys.clear();
     model.as_mut().rust_mut().cover_gate_timer = None;
-    // Safety timer is the hard upper bound — release regardless of
-    // whether the look-ahead prefetch has landed. Clear the flag too
-    // so a late `apply_append_page` doesn't try to flip loading off a
-    // second time.
-    model.as_mut().rust_mut().pending_initial_lookahead = false;
+    // Safety timer is the hard upper bound for visible covers.
     if model.loading {
         model.as_mut().set_loading(false);
         finish_nav_timing(model.as_mut(), "timeout", pending);
+        maybe_start_initial_lookahead(model.as_mut());
     }
 }
 
@@ -2293,13 +2240,16 @@ fn apply_initial_page(mut model: Pin<&mut ffi::GamesModel>, result: MediaBrowseR
     let next_cursor = result.next_cursor();
     let total = i32::try_from(result.total_files).unwrap_or(i32::MAX);
     let platform = platform::current();
+    let transform_started = Instant::now();
     let entries = transform_entries(result.entries, platform.as_ref());
+    let transform_ms = transform_started.elapsed().as_millis();
     let dir_count = leading_dir_count(&entries);
     let count = i32::try_from(entries.len()).unwrap_or(i32::MAX);
     info!(
         count,
         dir_count, total, has_next_page, "games: apply_initial_page"
     );
+    let reset_started = Instant::now();
     model.as_mut().begin_reset_model();
     model.as_mut().rust_mut().entries = entries;
     model.as_mut().rust_mut().count = count;
@@ -2322,12 +2272,15 @@ fn apply_initial_page(mut model: Pin<&mut ffi::GamesModel>, result: MediaBrowseR
     model.as_mut().set_has_next_page(has_next_page);
     model.as_mut().end_reset_model();
     model.as_mut().count_changed();
+    let reset_ms = reset_started.elapsed().as_millis();
     // Seed the cover queue from the visible row outwards instead of
     // bulk-enqueuing every entry. The grid resets to row 0 on a fresh
     // browse, so anchor the first prefetch there. Any later page turn
     // re-issues this through `onCurrentPageChanged` in QML.
     model.as_mut().rust_mut().visible_first_row = 0;
+    let prefetch_started = Instant::now();
     model.as_mut().prefetch_around(0);
+    let prefetch_ms = prefetch_started.elapsed().as_millis();
     if let Some(timing) = model.as_mut().rust_mut().nav_timing.as_mut() {
         timing.mark_apply_done();
     }
@@ -2335,10 +2288,9 @@ fn apply_initial_page(mut model: Pin<&mut ffi::GamesModel>, result: MediaBrowseR
         apply_ms = apply_started.elapsed().as_millis(),
         "games: apply_initial_page timing",
     );
-    // Metadata look-ahead runs in the background. Track it only so
-    // stale follow-up completions can clear their own bookkeeping; do
-    // not let it hold the first visible page behind the full-screen
-    // loading overlay.
+    // Metadata look-ahead starts only after the visible page is
+    // interactive. Otherwise the follow-up append can create delegates
+    // during the transition and extend the perceived navigation stall.
     let will_lookahead = has_next_page && !model.loading_more;
     if will_lookahead {
         model.as_mut().rust_mut().pending_initial_lookahead = true;
@@ -2346,18 +2298,25 @@ fn apply_initial_page(mut model: Pin<&mut ffi::GamesModel>, result: MediaBrowseR
     // Decide whether to release `loading` immediately or hold it until
     // visible-page covers are cached. Background metadata look-ahead
     // does not participate in this gate.
+    let gate_arm_started = Instant::now();
     arm_cover_gate(model.as_mut());
+    let gate_arm_ms = gate_arm_started.elapsed().as_millis();
+    debug!(
+        count,
+        transform_ms,
+        reset_ms,
+        prefetch_ms,
+        gate_arm_ms,
+        total_ms = apply_started.elapsed().as_millis(),
+        "games: apply_initial_page detail timing",
+    );
     if !model.error_message.is_empty() {
         model.as_mut().set_error_message(QString::default());
     }
-    // Metadata look-ahead: keep rows one chunk ahead of the highlight
-    // so a page advance does not pause on "Loading more…". Cover
-    // prefetch is separate: `prefetch_around` rebuilds the queue in
-    // current → next → previous order whenever rows land or the page
-    // changes.
-    if will_lookahead {
-        model.as_mut().fetch_more();
-    }
+    // If the visible page released synchronously (all covers cached or
+    // no media covers), start look-ahead now. Otherwise the release path
+    // calls `maybe_start_initial_lookahead` after loading flips false.
+    maybe_start_initial_lookahead(model.as_mut());
     // Mark seeded last so any early-return from this function leaves
     // the flag in its previous state. Subsequent Ready transitions
     // on the same browse target now skip the reset above.

--- a/rust/frontend/src/models/games.rs
+++ b/rust/frontend/src/models/games.rs
@@ -346,6 +346,9 @@ pub mod ffi {
         fn set_path(self: Pin<&mut GamesModel>, path: &QString);
 
         #[qinvokable]
+        fn browse_cached_for_path(self: &GamesModel, path: &QString) -> bool;
+
+        #[qinvokable]
         fn fetch_more(self: Pin<&mut GamesModel>);
 
         #[qinvokable]
@@ -546,6 +549,21 @@ impl ffi::GamesModel {
             vec![sid]
         };
         self.start_initial_browse(p, systems, false);
+    }
+
+    fn browse_cached_for_path(&self, path: &QString) -> bool {
+        let sid = self.current_system_id.to_string();
+        let systems = if sid.is_empty() {
+            Vec::new()
+        } else {
+            vec![sid]
+        };
+        let max_results = u32::try_from(self.page_size.max(1)).unwrap_or(u32::from(u16::MAX));
+        global_store().is_ready::<MediaBrowseEndpoint>(&BrowseArgs::new(
+            path.to_string(),
+            systems,
+            max_results,
+        ))
     }
 
     fn fetch_more(self: Pin<&mut Self>) {

--- a/rust/frontend/src/models/games.rs
+++ b/rust/frontend/src/models/games.rs
@@ -1889,7 +1889,7 @@ fn arm_cover_gate(mut model: Pin<&mut ffi::GamesModel>) {
     let unresolved = compute_unresolved_keys(
         visible_entries,
         |k| cache.is_cached(k),
-        |k| cache.is_negative(k),
+        |k| cache.is_negative(k) || cache.is_soft_no_image(k),
     );
     if let Some(timing) = model.as_mut().rust_mut().nav_timing.as_mut() {
         timing.start_gate(cover_total, cover_cache_hits, unresolved.len());
@@ -2248,6 +2248,16 @@ fn apply_initial_page(mut model: Pin<&mut ffi::GamesModel>, result: MediaBrowseR
     // transient blip doesn't leave the spinner stuck on after the
     // refetch lands.
     if model.is_seeded {
+        let has_next_page = result.has_next_page();
+        let next_cursor = result.next_cursor();
+        let total = i32::try_from(result.total_files).unwrap_or(i32::MAX);
+        model.as_mut().rust_mut().next_cursor = next_cursor;
+        if model.has_next_page != has_next_page {
+            model.as_mut().set_has_next_page(has_next_page);
+        }
+        if model.total_files != total {
+            model.as_mut().set_total_files(total);
+        }
         if model.loading {
             model.as_mut().set_loading(false);
         }

--- a/rust/frontend/src/models/mod.rs
+++ b/rust/frontend/src/models/mod.rs
@@ -38,6 +38,7 @@ pub mod hub_state;
 pub mod input;
 pub mod log_upload;
 pub mod media_status;
+pub mod nav_timing;
 pub mod notice;
 pub mod platform;
 pub mod qr_code;

--- a/rust/frontend/src/models/nav_timing.rs
+++ b/rust/frontend/src/models/nav_timing.rs
@@ -1,0 +1,82 @@
+// Zaparoo Frontend
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+use std::time::Instant;
+
+use tracing::info;
+
+#[derive(Debug)]
+pub struct NavTiming {
+    source: &'static str,
+    started: Instant,
+    request_done: Option<Instant>,
+    apply_done: Option<Instant>,
+    gate_started: Option<Instant>,
+    cover_total: usize,
+    cover_cache_hits: usize,
+    cover_initial_pending: usize,
+}
+
+impl NavTiming {
+    pub fn new(source: &'static str) -> Self {
+        Self {
+            source,
+            started: Instant::now(),
+            request_done: None,
+            apply_done: None,
+            gate_started: None,
+            cover_total: 0,
+            cover_cache_hits: 0,
+            cover_initial_pending: 0,
+        }
+    }
+
+    pub fn set_source(&mut self, source: &'static str) {
+        self.source = source;
+    }
+
+    pub fn mark_request_done(&mut self) {
+        if self.request_done.is_none() {
+            self.request_done = Some(Instant::now());
+        }
+    }
+
+    pub fn mark_apply_done(&mut self) {
+        self.apply_done = Some(Instant::now());
+    }
+
+    pub fn start_gate(&mut self, total: usize, cache_hits: usize, initial_pending: usize) {
+        self.gate_started = Some(Instant::now());
+        self.cover_total = total;
+        self.cover_cache_hits = cache_hits;
+        self.cover_initial_pending = initial_pending;
+    }
+
+    pub fn log_release(self, screen: &'static str, reason: &'static str, pending_remaining: usize) {
+        let now = Instant::now();
+        let request_anchor = self.request_done.unwrap_or(self.started);
+        let apply_anchor = self.apply_done.unwrap_or(request_anchor);
+        let request_ms = request_anchor.duration_since(self.started).as_millis();
+        let apply_ms = apply_anchor.duration_since(request_anchor).as_millis();
+        let gate_ms = self.gate_started.map_or(0, |gate_started| {
+            now.duration_since(gate_started).as_millis()
+        });
+        let total_ms = now.duration_since(self.started).as_millis();
+        let fetched = self.cover_initial_pending.saturating_sub(pending_remaining);
+        info!(
+            screen,
+            source = self.source,
+            reason,
+            request_ms,
+            apply_ms,
+            gate_ms,
+            total_ms,
+            cover_total = self.cover_total,
+            cover_cache_hits = self.cover_cache_hits,
+            cover_fetched = fetched,
+            cover_pending = pending_remaining,
+            "nav timing",
+        );
+    }
+}

--- a/rust/frontend/src/models/recents.rs
+++ b/rust/frontend/src/models/recents.rs
@@ -23,6 +23,7 @@
 // recents launches by `run`-ing the entry's launcher route.
 
 use crate::media_image_cache::{global_media_image_cache, MediaImageCache, MediaKey};
+use crate::models::nav_timing::NavTiming;
 use crate::models::tag_utils::tag_display_value;
 use crate::models::{global_handle, global_store};
 use cxx_qt::{CxxQtType, Initialize, Threading};
@@ -33,7 +34,7 @@ use std::collections::HashSet;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use time::{format_description::well_known::Rfc3339, Duration as TimeDuration, OffsetDateTime};
 use tokio::sync::broadcast::error::RecvError;
 use tokio::task::JoinHandle;
@@ -120,6 +121,7 @@ pub struct RecentsModelRust {
     // JoinHandle doesn't cancel a callback already queued onto the Qt
     // thread between sleep-completion and abort.
     cover_gate_seq: Arc<AtomicU64>,
+    nav_timing: Option<NavTiming>,
 }
 
 #[cxx_qt::bridge]
@@ -267,7 +269,11 @@ fn apply_state(
     mut model: Pin<&mut ffi::RecentsModel>,
     (data, err): (Option<PageSnapshot>, String),
 ) {
+    let apply_started = Instant::now();
     if let Some((entries, has_next_page, next_cursor)) = data {
+        if let Some(timing) = model.as_mut().rust_mut().nav_timing.as_mut() {
+            timing.mark_request_done();
+        }
         model.as_mut().rust_mut().history_requested = true;
         model.as_mut().rust_mut().history_fetching = false;
         model.as_mut().rust_mut().history_subscription = None;
@@ -288,6 +294,13 @@ fn apply_state(
         model.as_mut().end_reset_model();
         model.as_mut().count_changed();
         sync_resume_state(model.as_mut());
+        if let Some(timing) = model.as_mut().rust_mut().nav_timing.as_mut() {
+            timing.mark_apply_done();
+        }
+        debug!(
+            apply_ms = apply_started.elapsed().as_millis(),
+            "recents: apply_state timing",
+        );
         if model.has_next_page != has_next_page {
             model.as_mut().set_has_next_page(has_next_page);
         }
@@ -298,6 +311,7 @@ fn apply_state(
             disarm_cover_gate(model.as_mut());
             if model.loading {
                 model.as_mut().set_loading(false);
+                finish_nav_timing(model.as_mut(), "covers-paused", 0);
             }
         } else {
             // Decide whether to release `loading` immediately or hold it until
@@ -329,6 +343,9 @@ fn apply_state(
         model.as_mut().rust_mut().seq.fetch_add(1, Ordering::SeqCst);
         model.as_mut().rust_mut().next_cursor = None;
         sync_resume_state(model.as_mut());
+        if let Some(timing) = model.as_mut().rust_mut().nav_timing.as_mut() {
+            timing.set_source("network");
+        }
         if !model.loading {
             model.as_mut().set_loading(true);
         }
@@ -351,6 +368,7 @@ fn apply_state(
         if model.loading {
             model.as_mut().set_loading(false);
         }
+        finish_nav_timing(model.as_mut(), "error", 0);
         if model.has_next_page {
             model.as_mut().set_has_next_page(false);
         }
@@ -418,7 +436,11 @@ impl ffi::RecentsModel {
     }
 
     fn ensure_loaded(mut self: Pin<&mut Self>) {
-        if self.history_requested || self.history_fetching {
+        if self.history_requested {
+            NavTiming::new("cache").log_release("recents", "already-loaded", 0);
+            return;
+        }
+        if self.history_fetching {
             return;
         }
         self.as_mut().rust_mut().history_fetching = true;
@@ -479,6 +501,7 @@ impl ffi::RecentsModel {
     }
 
     fn start_initial_history_fetch(mut self: Pin<&mut Self>) {
+        self.as_mut().rust_mut().nav_timing = Some(NavTiming::new("network"));
         self.as_mut().rust_mut().history_subscription = None;
         if !self.loading {
             self.as_mut().set_loading(true);
@@ -999,6 +1022,16 @@ fn enqueue_recents_covers(entries: &[MediaHistoryEntry]) {
     }
 }
 
+fn finish_nav_timing(
+    mut model: Pin<&mut ffi::RecentsModel>,
+    reason: &'static str,
+    pending_remaining: usize,
+) {
+    if let Some(timing) = model.as_mut().rust_mut().nav_timing.take() {
+        timing.log_release("recents", reason, pending_remaining);
+    }
+}
+
 /// Emit `dataChanged(coverKey)` for every row whose entry's
 /// `(systemId, mediaPath)` matches `key`. Cheap walk of the current
 /// `entries` vec — recents pages top out at a few hundred rows after
@@ -1083,6 +1116,7 @@ fn notify_cover_update(mut model: Pin<&mut ffi::RecentsModel>, key: &MediaKey) {
                 if model.loading {
                     info!("recents: cover gate released after decode-settle window");
                     model.as_mut().set_loading(false);
+                    finish_nav_timing(model.as_mut(), "covers-ready", 0);
                 }
             });
         });
@@ -1126,15 +1160,26 @@ fn arm_cover_gate(mut model: Pin<&mut ffi::RecentsModel>) {
         handle.abort();
     }
     let cache = global_media_image_cache();
+    let cover_keys = model
+        .entries
+        .iter()
+        .filter_map(|entry| media_key_for(entry).map(MediaKey::with_current_cover_preference))
+        .collect::<Vec<_>>();
+    let cover_total = cover_keys.len();
+    let cover_cache_hits = cover_keys.iter().filter(|k| cache.is_cached(k)).count();
     let unresolved = compute_unresolved_keys(
         &model.entries,
         |k| cache.is_cached(k),
         |k| cache.is_negative(k) || cache.is_soft_no_image(k),
     );
+    if let Some(timing) = model.as_mut().rust_mut().nav_timing.as_mut() {
+        timing.start_gate(cover_total, cover_cache_hits, unresolved.len());
+    }
     if unresolved.is_empty() {
         model.as_mut().rust_mut().pending_first_paint_keys.clear();
         if model.loading {
             model.as_mut().set_loading(false);
+            finish_nav_timing(model.as_mut(), "covers-ready", 0);
         }
         return;
     }
@@ -1179,6 +1224,7 @@ fn release_cover_gate_after_timeout(mut model: Pin<&mut ffi::RecentsModel>) {
     model.as_mut().rust_mut().cover_gate_timer = None;
     if model.loading {
         model.as_mut().set_loading(false);
+        finish_nav_timing(model.as_mut(), "timeout", pending);
     }
 }
 

--- a/rust/frontend/src/models/recents.rs
+++ b/rust/frontend/src/models/recents.rs
@@ -311,8 +311,8 @@ fn apply_state(
             disarm_cover_gate(model.as_mut());
             if model.loading {
                 model.as_mut().set_loading(false);
-                finish_nav_timing(model.as_mut(), "covers-paused", 0);
             }
+            finish_nav_timing(model.as_mut(), "covers-paused", 0);
         } else {
             // Decide whether to release `loading` immediately or hold it until
             // covers are cached. `arm_cover_gate` flips loading off itself when
@@ -1116,8 +1116,8 @@ fn notify_cover_update(mut model: Pin<&mut ffi::RecentsModel>, key: &MediaKey) {
                 if model.loading {
                     info!("recents: cover gate released after decode-settle window");
                     model.as_mut().set_loading(false);
-                    finish_nav_timing(model.as_mut(), "covers-ready", 0);
                 }
+                finish_nav_timing(model.as_mut(), "covers-ready", 0);
             });
         });
         model.as_mut().rust_mut().cover_gate_timer = Some(handle);
@@ -1179,8 +1179,8 @@ fn arm_cover_gate(mut model: Pin<&mut ffi::RecentsModel>) {
         model.as_mut().rust_mut().pending_first_paint_keys.clear();
         if model.loading {
             model.as_mut().set_loading(false);
-            finish_nav_timing(model.as_mut(), "covers-ready", 0);
         }
+        finish_nav_timing(model.as_mut(), "covers-ready", 0);
         return;
     }
     info!(
@@ -1224,8 +1224,8 @@ fn release_cover_gate_after_timeout(mut model: Pin<&mut ffi::RecentsModel>) {
     model.as_mut().rust_mut().cover_gate_timer = None;
     if model.loading {
         model.as_mut().set_loading(false);
-        finish_nav_timing(model.as_mut(), "timeout", pending);
     }
+    finish_nav_timing(model.as_mut(), "timeout", pending);
 }
 
 fn launch_entry(entry: &MediaHistoryEntry) {

--- a/rust/zaparoo-core/src/client.rs
+++ b/rust/zaparoo-core/src/client.rs
@@ -24,11 +24,11 @@ use crate::media_types::{
     TokensResult, UpdateSettingsParams, VersionResult,
 };
 use futures_util::{SinkExt, StreamExt};
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::{broadcast, mpsc, oneshot, watch};
 use tokio_tungstenite::{
     connect_async_with_config,
@@ -158,6 +158,23 @@ impl std::fmt::Display for ClientError {
 impl std::error::Error for ClientError {}
 
 type PendingMap = Arc<Mutex<HashMap<String, oneshot::Sender<Result<Value, ClientError>>>>>;
+
+fn deserialize_timed<T: DeserializeOwned>(
+    method: &'static str,
+    val: Value,
+) -> Result<T, ClientError> {
+    let started = Instant::now();
+    let result = serde_json::from_value(val).map_err(|e| ClientError {
+        message: e.to_string(),
+    });
+    debug!(
+        method,
+        duration_ms = started.elapsed().as_millis(),
+        ok = result.is_ok(),
+        "rpc deserialize",
+    );
+    result
+}
 
 /// Session-scoped outbound sender. `None` means no live ws session, so
 /// `call()` fails fast with `not connected` instead of queueing into a
@@ -304,7 +321,7 @@ impl Client {
 
         runtime.spawn(async move {
             let mut fsm = ConnectionFsm::default();
-            let process_start = std::time::Instant::now();
+            let process_start = Instant::now();
 
             loop {
                 // Cold-boot fast-retry window: while we have never
@@ -437,6 +454,7 @@ impl Client {
         let text = serde_json::to_string(&req).map_err(|e| ClientError {
             message: e.to_string(),
         })?;
+        let started = Instant::now();
 
         // Snapshot the current session's sender. If `None`, no live link —
         // fail immediately rather than queueing into a channel that will
@@ -461,14 +479,41 @@ impl Client {
             {
                 self.pending.lock().unwrap().remove(&id);
             }
+            debug!(
+                method,
+                duration_ms = started.elapsed().as_millis(),
+                error = "not connected",
+                "rpc round trip",
+            );
             return Err(ClientError {
                 message: "not connected".into(),
             });
         }
 
-        resp_rx.await.map_err(|_| ClientError {
+        let result = resp_rx.await.map_err(|_| ClientError {
             message: "channel closed".into(),
-        })?
+        })?;
+        match result {
+            Ok(val) => {
+                let payload_bytes = serde_json::to_vec(&val).map_or(0, |bytes| bytes.len());
+                debug!(
+                    method,
+                    duration_ms = started.elapsed().as_millis(),
+                    payload_bytes,
+                    "rpc round trip",
+                );
+                Ok(val)
+            }
+            Err(e) => {
+                debug!(
+                    method,
+                    duration_ms = started.elapsed().as_millis(),
+                    error = %e.message,
+                    "rpc round trip",
+                );
+                Err(e)
+            }
+        }
     }
 
     pub async fn systems(&self, params: SystemsParams) -> Result<SystemsResult, ClientError> {
@@ -554,9 +599,7 @@ impl Client {
         params: MediaSearchParams,
     ) -> Result<MediaSearchResult, ClientError> {
         let val = self.call("media.search", &params).await?;
-        serde_json::from_value(val).map_err(|e| ClientError {
-            message: e.to_string(),
-        })
+        deserialize_timed("media.search", val)
     }
 
     pub async fn media_browse(
@@ -579,9 +622,7 @@ impl Client {
             .map_or(0, Vec::len);
         let total_files = val.get("totalFiles").and_then(Value::as_u64).unwrap_or(0);
         debug!(entries_len, total_files, "media.browse response");
-        serde_json::from_value(val).map_err(|e| ClientError {
-            message: e.to_string(),
-        })
+        deserialize_timed("media.browse", val)
     }
 
     /// Fetches a single best-match cover image for the given media row.
@@ -613,9 +654,7 @@ impl Client {
         params: MediaMetaParams,
     ) -> Result<MediaMetaResult, ClientError> {
         let val = self.call("media.meta", &params).await?;
-        serde_json::from_value(val).map_err(|e| ClientError {
-            message: e.to_string(),
-        })
+        deserialize_timed("media.meta", val)
     }
 
     pub async fn media_history(
@@ -634,9 +673,7 @@ impl Client {
             .and_then(Value::as_array)
             .map_or(0, Vec::len);
         debug!(entries_len, "media.history response");
-        serde_json::from_value(val).map_err(|e| ClientError {
-            message: e.to_string(),
-        })
+        deserialize_timed("media.history", val)
     }
 
     /// Fetches the latest play-history row without media DB enrichment.

--- a/rust/zaparoo-core/src/remote_resource.rs
+++ b/rust/zaparoo-core/src/remote_resource.rs
@@ -81,6 +81,10 @@ impl<T: Clone + Send + Sync + 'static> RemoteResource<T> {
         self.status.subscribe()
     }
 
+    pub fn is_ready(&self) -> bool {
+        matches!(&*self.status.borrow(), ResourceStatus::Ready(_))
+    }
+
     /// Trigger a refetch outside the natural connection-change cadence.
     /// While connected, this cancels any in-flight fetch and starts a
     /// new one; otherwise the notification queues and fires on the

--- a/rust/zaparoo-core/src/store/mod.rs
+++ b/rust/zaparoo-core/src/store/mod.rs
@@ -157,6 +157,26 @@ impl Store {
         self.client.clone()
     }
 
+    #[allow(
+        clippy::unwrap_used,
+        reason = "mutex poisoning signals another thread panicked with the lock held; state is unrecoverable"
+    )]
+    pub fn is_ready<E: Endpoint>(&self, args: &E::Args) -> bool {
+        let key = CacheKey::new::<E>(args);
+        let inner = self.inner.lock().unwrap();
+        inner
+            .cache
+            .get(&key)
+            .and_then(|entry| {
+                entry
+                    .resource
+                    .clone()
+                    .downcast::<RemoteResource<E::Output>>()
+                    .ok()
+            })
+            .is_some_and(|resource| resource.is_ready())
+    }
+
     /// Get (or create) the shared `RemoteResource` for endpoint `E`
     /// with `args`. Subsequent calls with equal args return the same
     /// `Arc`, so multiple QML singletons binding the same endpoint

--- a/scripts/check-translations-updated.sh
+++ b/scripts/check-translations-updated.sh
@@ -8,7 +8,7 @@ for candidate in "$script_dir/.." "${GITHUB_WORKSPACE:-}" "$PWD"; do
     if [[ -z "$candidate" ]]; then
         continue
     fi
-    if top="$(git -C "$candidate" rev-parse --show-toplevel 2>/dev/null)"; then
+    if top="$(git -c safe.directory="$candidate" -C "$candidate" rev-parse --show-toplevel 2>/dev/null)"; then
         repo_root="$top"
         break
     fi
@@ -24,9 +24,9 @@ before="$(mktemp)"
 after="$(mktemp)"
 trap 'rm -f "$before" "$after"' EXIT
 
-git -C "$repo_root" diff -- src/ui/translations >"$before"
+git -c safe.directory="$repo_root" -C "$repo_root" diff -- src/ui/translations >"$before"
 cmake --build "$repo_root/$build_dir" --target update_translations
-git -C "$repo_root" diff -- src/ui/translations >"$after"
+git -c safe.directory="$repo_root" -C "$repo_root" diff -- src/ui/translations >"$after"
 
 if cmp -s "$before" "$after"; then
     exit 0
@@ -38,5 +38,5 @@ else
     echo "Qt translation catalogs are stale. Run cmake --build $build_dir --target update_translations and commit the src/ui/translations changes." >&2
 fi
 
-git -C "$repo_root" diff -- src/ui/translations
+git -c safe.directory="$repo_root" -C "$repo_root" diff -- src/ui/translations
 exit 1

--- a/scripts/check-translations-updated.sh
+++ b/scripts/check-translations-updated.sh
@@ -2,15 +2,31 @@
 set -euo pipefail
 
 build_dir="${1:-build}"
-repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-cd "$repo_root"
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+repo_root=""
+for candidate in "$script_dir/.." "${GITHUB_WORKSPACE:-}" "$PWD"; do
+    if [[ -z "$candidate" ]]; then
+        continue
+    fi
+    if top="$(git -C "$candidate" rev-parse --show-toplevel 2>/dev/null)"; then
+        repo_root="$top"
+        break
+    fi
+done
+if [[ -z "$repo_root" ]]; then
+    echo "Unable to find git repository root for translation check." >&2
+    echo "script_dir=$script_dir" >&2
+    echo "GITHUB_WORKSPACE=${GITHUB_WORKSPACE:-}" >&2
+    echo "PWD=$PWD" >&2
+    exit 1
+fi
 before="$(mktemp)"
 after="$(mktemp)"
 trap 'rm -f "$before" "$after"' EXIT
 
-git diff -- src/ui/translations >"$before"
-cmake --build "$build_dir" --target update_translations
-git diff -- src/ui/translations >"$after"
+git -C "$repo_root" diff -- src/ui/translations >"$before"
+cmake --build "$repo_root/$build_dir" --target update_translations
+git -C "$repo_root" diff -- src/ui/translations >"$after"
 
 if cmp -s "$before" "$after"; then
     exit 0
@@ -22,5 +38,5 @@ else
     echo "Qt translation catalogs are stale. Run cmake --build $build_dir --target update_translations and commit the src/ui/translations changes." >&2
 fi
 
-git diff -- src/ui/translations
+git -C "$repo_root" diff -- src/ui/translations
 exit 1

--- a/scripts/check-translations-updated.sh
+++ b/scripts/check-translations-updated.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 build_dir="${1:-build}"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
 before="$(mktemp)"
 after="$(mktemp)"
 trap 'rm -f "$before" "$after"' EXIT

--- a/scripts/check-translations-updated.sh
+++ b/scripts/check-translations-updated.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+build_dir="${1:-build}"
+before="$(mktemp)"
+after="$(mktemp)"
+trap 'rm -f "$before" "$after"' EXIT
+
+git diff -- src/ui/translations >"$before"
+cmake --build "$build_dir" --target update_translations
+git diff -- src/ui/translations >"$after"
+
+if cmp -s "$before" "$after"; then
+    exit 0
+fi
+
+if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+    echo "::error::Qt translation catalogs are stale. Run cmake --build $build_dir --target update_translations and commit the src/ui/translations changes."
+else
+    echo "Qt translation catalogs are stale. Run cmake --build $build_dir --target update_translations and commit the src/ui/translations changes." >&2
+fi
+
+git diff -- src/ui/translations
+exit 1

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -374,19 +374,56 @@ MainLayout {
         Browse.AppState.active_screen = screen;
     }
 
-    // Back transitions need the same delayed loading cue as forward
-    // model fills. Request the destination first so lazy Loaders can
-    // mount behind the cue, then cut after the cue has had one frame to
-    // paint.
+    function _backTargetReady(screen: string): bool {
+        const item = root._screenItem(screen);
+        if (item === null || item === undefined)
+            return false;
+        if (screen === root.screenHub)
+            return true;
+        if (screen === root.screenSystems)
+            return !root.catalogStillBooting && !Browse.SystemsModel.loading;
+        if (screen === root.screenGames)
+            return !root.catalogStillBooting && !Browse.GamesModel.loading;
+        if (screen === root.screenFavorites)
+            return !root.catalogStillBooting && !Browse.FavoritesModel.loading;
+        if (screen === root.screenRecents)
+            return !root.catalogStillBooting && !Browse.RecentsModel.loading;
+        return true;
+    }
+
+    function _maybeCompleteBackTransition(): void {
+        if (root.pendingTransition !== "back")
+            return;
+        const target = root._backTransitionTarget;
+        if (target === "" || !root._backTargetReady(target))
+            return;
+        root._backTransitionTarget = "";
+        backTransitionTimer.stop();
+        root._completeTransition(target);
+    }
+
+    // Back navigation is usually a return to an already-mounted, already-filled
+    // screen. Cut immediately in that case. Keep the delayed Loading cue only
+    // when real work is pending: lazy screen mount, catalog boot, or a model
+    // fill still in flight.
     function _navigateBackToScreen(screen: string): void {
         if (screen === root.activeScreen)
             return;
+        root._backTransitionTarget = "";
+        backTransitionTimer.stop();
+        if (root._backTargetReady(screen)) {
+            root._goto(screen);
+            root._resetIdle();
+            return;
+        }
         root._backTransitionTarget = screen;
         root.pendingTransition = "back";
         root._whenScreenReady(screen, function () {
             if (root.pendingTransition !== "back" || root._backTransitionTarget !== screen)
                 return;
-            backTransitionTimer.restart();
+            root._maybeCompleteBackTransition();
+            if (root.pendingTransition === "back")
+                backTransitionTimer.restart();
         });
     }
 
@@ -487,6 +524,7 @@ MainLayout {
                 if (root.pendingTransition === "settings")
                     root._completeTransition(root.screenSettings);
             });
+        root._maybeCompleteBackTransition();
     }
 
     // Listen for SystemsModel fills owned by an in-flight transition.
@@ -516,10 +554,13 @@ MainLayout {
             if (root._catalogWaitCategory !== "" && root._catalogStillBooting())
                 return;
             const cb = root._categoryReadyCallback;
-            if (cb === null)
+            if (cb === null) {
+                root._maybeCompleteBackTransition();
                 return;
+            }
             root._categoryReadyCallback = null;
             cb();
+            root._maybeCompleteBackTransition();
         }
     }
     Connections {
@@ -537,6 +578,7 @@ MainLayout {
                 cb();
             }
             root._completeFolderBackRebrowseIfReady();
+            root._maybeCompleteBackTransition();
         }
     }
     Connections {
@@ -546,10 +588,13 @@ MainLayout {
                 return;
             root._maybeCompletePendingResumeLaunch();
             const cb = root._recentsReadyCallback;
-            if (cb === null)
+            if (cb === null) {
+                root._maybeCompleteBackTransition();
                 return;
+            }
             root._recentsReadyCallback = null;
             cb();
+            root._maybeCompleteBackTransition();
         }
 
         function onResume_availableChanged(): void {
@@ -562,10 +607,13 @@ MainLayout {
             if (Browse.FavoritesModel.loading)
                 return;
             const cb = root._favoritesReadyCallback;
-            if (cb === null)
+            if (cb === null) {
+                root._maybeCompleteBackTransition();
                 return;
+            }
             root._favoritesReadyCallback = null;
             cb();
+            root._maybeCompleteBackTransition();
         }
     }
 
@@ -2436,9 +2484,11 @@ MainLayout {
     // background and circuit-trace texture stay visible underneath; never
     // paint a full-screen fill. The delayed indicator suppresses flashes
     // for quick loads; once it appears, screen `transitioning` bindings hide
-    // primary content so the centred "Loading…" reads alone in the cleared
-    // band. Sized to the full window so anchors.centerIn parks the row in
-    // the geometric centre regardless of which screen is the source.
+    // primary content so the centered "Loading…" reads alone in the cleared
+    // band. Do not apply a minimum-visible tail here: when the work completes
+    // near the delay threshold, the destination must not paint underneath a
+    // stale loading label. Sized to the full window so anchors.centerIn parks
+    // the row in the geometric center regardless of which screen is the source.
     Item {
         anchors.fill: parent
         visible: transitionCueActive || transitionCue.showing
@@ -2451,7 +2501,7 @@ MainLayout {
             id: transitionCue
             active: parent.transitionCueActive
             delayMs: root.loadingIndicatorDelayMs
-            minimumVisibleMs: root.minimumLoadingVisibleMs
+            minimumVisibleMs: 0
             x: Sizing.center(parent.width, width)
             y: Sizing.center(parent.height, height)
             onShowingChanged: root.transitionCueVisible = showing
@@ -2600,18 +2650,7 @@ MainLayout {
         id: backTransitionTimer
         interval: root.loadingIndicatorDelayMs + 50
         repeat: false
-        onTriggered: {
-            const target = root._backTransitionTarget;
-            root._backTransitionTarget = "";
-            if (target === "") {
-                if (root.pendingTransition === "back")
-                    root.pendingTransition = "";
-                return;
-            }
-            if (root.pendingTransition !== "back")
-                return;
-            root._completeTransition(target);
-        }
+        onTriggered: root._maybeCompleteBackTransition()
     }
 
     Timer {

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -381,13 +381,13 @@ MainLayout {
         if (screen === root.screenHub)
             return true;
         if (screen === root.screenSystems)
-            return !root.catalogStillBooting && !Browse.SystemsModel.loading;
+            return !Browse.SystemsModel.loading;
         if (screen === root.screenGames)
-            return !root.catalogStillBooting && !Browse.GamesModel.loading;
+            return !Browse.GamesModel.loading;
         if (screen === root.screenFavorites)
-            return !root.catalogStillBooting && !Browse.FavoritesModel.loading;
+            return !Browse.FavoritesModel.loading;
         if (screen === root.screenRecents)
-            return !root.catalogStillBooting && !Browse.RecentsModel.loading;
+            return !Browse.RecentsModel.loading;
         return true;
     }
 
@@ -940,22 +940,38 @@ MainLayout {
         Browse.GamesModel.set_path(path);
     }
 
-    // Folder pop-up inside the games screen. Pop persistence immediately
-    // so kill-resume observes the back intent, then defer the model rebrowse
-    // until LoadingIndicator has painted. If we pop to the root level
-    // (path_stack[0] is always "") the call goes through `set_system` so
-    // the model re-runs single-root auto-nav rather than browsing the
-    // literal empty path with no system filter.
+    function _rebrowseGamesFolderTarget(path: string, systemId: string): void {
+        if (path === "") {
+            if (systemId !== "")
+                Browse.GamesModel.set_system(systemId);
+        } else {
+            Browse.GamesModel.set_path(path);
+        }
+    }
+
+    // Folder pop-up inside the games screen. Cached parents take the same direct
+    // path as folder drill-down, so Back does not show fake global Loading for a
+    // browse result we can seed synchronously. Cold parents keep the delayed cue
+    // before rebrowse so the UI does not look dead if the reset/RPC stalls.
     function _navigateOutOfFolder(): void {
         const stack = Browse.GamesState.path_stack;
         if (stack.length <= 1)
             return;
-        root.pendingTransition = "folder_back";
         Browse.GamesState.pop_level();
         const newStack = Browse.GamesState.path_stack;
         const target = newStack[newStack.length - 1];
+        const systemId = target === "" ? Browse.GamesState.system_id : "";
+        root._pendingFolderBackTargetPath = "";
+        root._pendingFolderBackSystemId = "";
+        folderBackTransitionTimer.stop();
+        if (Browse.GamesModel.browse_cached_for_path(target)) {
+            root._rebrowseGamesFolderTarget(target, systemId);
+            root._resetIdle();
+            return;
+        }
+        root.pendingTransition = "folder_back";
         root._pendingFolderBackTargetPath = target;
-        root._pendingFolderBackSystemId = target === "" ? Browse.GamesState.system_id : "";
+        root._pendingFolderBackSystemId = systemId;
         folderBackTransitionTimer.restart();
     }
 
@@ -967,12 +983,7 @@ MainLayout {
         if (root.pendingTransition !== "folder_back")
             return;
         root._folderBackReadyCallback = root._finishFolderBackTransition;
-        if (target === "") {
-            if (systemId !== "")
-                Browse.GamesModel.set_system(systemId);
-        } else {
-            Browse.GamesModel.set_path(target);
-        }
+        root._rebrowseGamesFolderTarget(target, systemId);
         root._completeFolderBackRebrowseIfReady();
     }
 

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -549,124 +549,124 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1217"/>
+        <location filename="../app/Main.qml" line="1353"/>
         <source>Launch core</source>
         <translation>تشغيل النواة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1223"/>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1359"/>
+        <location filename="../app/Main.qml" line="1567"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1230"/>
+        <location filename="../app/Main.qml" line="1366"/>
         <source>Update media database</source>
         <translation type="unfinished">تحديث قاعدة بيانات الوسائط</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1233"/>
+        <location filename="../app/Main.qml" line="1369"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">استخراج البيانات الوصفية</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1242"/>
-        <location filename="../app/Main.qml" line="1277"/>
+        <location filename="../app/Main.qml" line="1378"/>
+        <location filename="../app/Main.qml" line="1413"/>
         <source>Launch game</source>
         <translation>تشغيل اللعبة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1258"/>
+        <location filename="../app/Main.qml" line="1394"/>
         <source>Remove from favorites</source>
         <translation>إزالة من المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1258"/>
+        <location filename="../app/Main.qml" line="1394"/>
         <source>Add to favorites</source>
         <translation>أضف إلى المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1263"/>
+        <location filename="../app/Main.qml" line="1399"/>
         <source>Write to NFC token</source>
         <translation>الكتابة إلى رمز NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1267"/>
+        <location filename="../app/Main.qml" line="1403"/>
         <source>QR code</source>
         <translation>رمز QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1427"/>
+        <location filename="../app/Main.qml" line="1563"/>
         <source>Default</source>
         <translation type="unfinished">افتراضي</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1427"/>
+        <location filename="../app/Main.qml" line="1563"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1719"/>
+        <location filename="../app/Main.qml" line="1855"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1723"/>
+        <location filename="../app/Main.qml" line="1859"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1737"/>
+        <location filename="../app/Main.qml" line="1873"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1741"/>
+        <location filename="../app/Main.qml" line="1877"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1745"/>
+        <location filename="../app/Main.qml" line="1881"/>
         <source>Retry</source>
         <translation type="unfinished">إعادة المحاولة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1749"/>
+        <location filename="../app/Main.qml" line="1885"/>
         <source>Cancel</source>
         <translation type="unfinished">إلغاء</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2379"/>
+        <location filename="../app/Main.qml" line="2523"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2381"/>
+        <location filename="../app/Main.qml" line="2525"/>
         <source>Loading games…</source>
         <translation>جارٍ تحميل الألعاب…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2383"/>
+        <location filename="../app/Main.qml" line="2527"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2385"/>
+        <location filename="../app/Main.qml" line="2529"/>
         <source>Loading favorites…</source>
         <translation>جارٍ تحميل المفضلة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2387"/>
+        <location filename="../app/Main.qml" line="2531"/>
         <source>Loading recently played…</source>
         <translation>جارٍ تحميل آخر ما تم لعبه…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2389"/>
+        <location filename="../app/Main.qml" line="2533"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2391"/>
+        <location filename="../app/Main.qml" line="2535"/>
         <source>Loading…</source>
         <translation>جارٍ التحميل…</translation>
     </message>
@@ -674,12 +674,12 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="680"/>
+        <location filename="../app/MainLayout.qml" line="682"/>
         <source>Writing failed</source>
         <translation>فشلت الكتابة</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="680"/>
+        <location filename="../app/MainLayout.qml" line="682"/>
         <source>Put a writable card near the reader</source>
         <translation>ضع بطاقة قابلة للكتابة بالقرب من القارئ</translation>
     </message>
@@ -689,146 +689,146 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="364"/>
+        <location filename="../app/MainLayout.qml" line="367"/>
         <source>Favorites</source>
         <translation type="unfinished">المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="366"/>
+        <location filename="../app/MainLayout.qml" line="369"/>
         <source>Recently Played</source>
         <translation type="unfinished">تم لعبها مؤخرًا</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="696"/>
+        <location filename="../app/MainLayout.qml" line="698"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="697"/>
+        <location filename="../app/MainLayout.qml" line="699"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="807"/>
+        <location filename="../app/MainLayout.qml" line="809"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="808"/>
+        <location filename="../app/MainLayout.qml" line="810"/>
         <source>Are you sure you want to exit?</source>
         <translation>هل أنت متأكد أنك تريد الخروج؟</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="887"/>
-        <location filename="../app/MainLayout.qml" line="961"/>
-        <location filename="../app/MainLayout.qml" line="1004"/>
-        <location filename="../app/MainLayout.qml" line="1035"/>
-        <location filename="../app/MainLayout.qml" line="1085"/>
-        <location filename="../app/MainLayout.qml" line="1128"/>
-        <location filename="../app/MainLayout.qml" line="1195"/>
+        <location filename="../app/MainLayout.qml" line="889"/>
+        <location filename="../app/MainLayout.qml" line="963"/>
+        <location filename="../app/MainLayout.qml" line="1006"/>
+        <location filename="../app/MainLayout.qml" line="1037"/>
+        <location filename="../app/MainLayout.qml" line="1087"/>
+        <location filename="../app/MainLayout.qml" line="1130"/>
+        <location filename="../app/MainLayout.qml" line="1197"/>
         <source>Move</source>
         <translation>تحريك</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="891"/>
-        <location filename="../app/MainLayout.qml" line="965"/>
+        <location filename="../app/MainLayout.qml" line="893"/>
+        <location filename="../app/MainLayout.qml" line="967"/>
         <source>Select</source>
         <translation>تحديد</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="895"/>
-        <location filename="../app/MainLayout.qml" line="899"/>
-        <location filename="../app/MainLayout.qml" line="913"/>
-        <location filename="../app/MainLayout.qml" line="928"/>
-        <location filename="../app/MainLayout.qml" line="939"/>
+        <location filename="../app/MainLayout.qml" line="897"/>
+        <location filename="../app/MainLayout.qml" line="901"/>
+        <location filename="../app/MainLayout.qml" line="915"/>
+        <location filename="../app/MainLayout.qml" line="930"/>
+        <location filename="../app/MainLayout.qml" line="941"/>
         <source>Close</source>
         <translation>إغلاق</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="906"/>
-        <location filename="../app/MainLayout.qml" line="946"/>
-        <location filename="../app/MainLayout.qml" line="969"/>
-        <location filename="../app/MainLayout.qml" line="980"/>
+        <location filename="../app/MainLayout.qml" line="908"/>
+        <location filename="../app/MainLayout.qml" line="948"/>
+        <location filename="../app/MainLayout.qml" line="971"/>
+        <location filename="../app/MainLayout.qml" line="982"/>
         <source>Cancel</source>
         <translation>إلغاء</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="924"/>
+        <location filename="../app/MainLayout.qml" line="926"/>
         <source>Done</source>
         <translation>تم</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="935"/>
-        <location filename="../app/MainLayout.qml" line="1058"/>
-        <location filename="../app/MainLayout.qml" line="1111"/>
-        <location filename="../app/MainLayout.qml" line="1221"/>
+        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="1060"/>
+        <location filename="../app/MainLayout.qml" line="1113"/>
+        <location filename="../app/MainLayout.qml" line="1223"/>
         <source>Retry</source>
         <translation>إعادة المحاولة</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="954"/>
+        <location filename="../app/MainLayout.qml" line="956"/>
         <source>I understand</source>
         <translation>أفهم</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="988"/>
+        <location filename="../app/MainLayout.qml" line="990"/>
         <source>Start</source>
         <translation>ابدأ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1008"/>
-        <location filename="../app/MainLayout.qml" line="1045"/>
-        <location filename="../app/MainLayout.qml" line="1095"/>
-        <location filename="../app/MainLayout.qml" line="1205"/>
+        <location filename="../app/MainLayout.qml" line="1010"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1097"/>
+        <location filename="../app/MainLayout.qml" line="1207"/>
         <source>Open</source>
         <translation>فتح</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1012"/>
+        <location filename="../app/MainLayout.qml" line="1014"/>
         <source>Quit</source>
         <translation>إنهاء</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1021"/>
-        <location filename="../app/MainLayout.qml" line="1051"/>
-        <location filename="../app/MainLayout.qml" line="1062"/>
-        <location filename="../app/MainLayout.qml" line="1077"/>
-        <location filename="../app/MainLayout.qml" line="1104"/>
-        <location filename="../app/MainLayout.qml" line="1115"/>
-        <location filename="../app/MainLayout.qml" line="1152"/>
-        <location filename="../app/MainLayout.qml" line="1170"/>
-        <location filename="../app/MainLayout.qml" line="1179"/>
-        <location filename="../app/MainLayout.qml" line="1214"/>
-        <location filename="../app/MainLayout.qml" line="1225"/>
+        <location filename="../app/MainLayout.qml" line="1023"/>
+        <location filename="../app/MainLayout.qml" line="1053"/>
+        <location filename="../app/MainLayout.qml" line="1064"/>
+        <location filename="../app/MainLayout.qml" line="1079"/>
+        <location filename="../app/MainLayout.qml" line="1106"/>
+        <location filename="../app/MainLayout.qml" line="1117"/>
+        <location filename="../app/MainLayout.qml" line="1154"/>
+        <location filename="../app/MainLayout.qml" line="1172"/>
+        <location filename="../app/MainLayout.qml" line="1181"/>
+        <location filename="../app/MainLayout.qml" line="1216"/>
+        <location filename="../app/MainLayout.qml" line="1227"/>
         <source>Back</source>
         <translation>رجوع</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1041"/>
-        <location filename="../app/MainLayout.qml" line="1091"/>
-        <location filename="../app/MainLayout.qml" line="1201"/>
+        <location filename="../app/MainLayout.qml" line="1043"/>
+        <location filename="../app/MainLayout.qml" line="1093"/>
+        <location filename="../app/MainLayout.qml" line="1203"/>
         <source>Page</source>
         <translation>صفحة</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1048"/>
-        <location filename="../app/MainLayout.qml" line="1100"/>
-        <location filename="../app/MainLayout.qml" line="1210"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1102"/>
+        <location filename="../app/MainLayout.qml" line="1212"/>
         <source>Options</source>
         <translation>الخيارات</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1137"/>
+        <location filename="../app/MainLayout.qml" line="1139"/>
         <source>Change</source>
         <translation>تغيير</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1143"/>
+        <location filename="../app/MainLayout.qml" line="1145"/>
         <source>Toggle</source>
         <translation>تبديل</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1166"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
         <source>Scroll</source>
         <translation>تمرير</translation>
     </message>
@@ -841,12 +841,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">جارٍ التحميل…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="350"/>
+        <location filename="../screens/MediaListScreen.qml" line="354"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 عناصر</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="351"/>
+        <location filename="../screens/MediaListScreen.qml" line="355"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -905,7 +905,7 @@ Euskara - devilschile2</source>
         <translation>جارٍ التحميل…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="58"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="65"/>
         <source>Failed to load</source>
         <translation>فشل التحميل</translation>
     </message>
@@ -1338,24 +1338,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="197"/>
-        <location filename="../screens/SystemsScreen.qml" line="295"/>
+        <location filename="../screens/SystemsScreen.qml" line="199"/>
+        <location filename="../screens/SystemsScreen.qml" line="297"/>
         <source>%1 systems</source>
         <translation>%1 أنظمة</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="198"/>
-        <location filename="../screens/SystemsScreen.qml" line="312"/>
+        <location filename="../screens/SystemsScreen.qml" line="200"/>
+        <location filename="../screens/SystemsScreen.qml" line="314"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="328"/>
+        <location filename="../screens/SystemsScreen.qml" line="330"/>
         <source>No systems in this category</source>
         <translation>لا توجد أنظمة في هذه الفئة</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="329"/>
+        <location filename="../screens/SystemsScreen.qml" line="331"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -549,124 +549,124 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1217"/>
+        <location filename="../app/Main.qml" line="1353"/>
         <source>Launch core</source>
         <translation>Core starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1223"/>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1359"/>
+        <location filename="../app/Main.qml" line="1567"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1258"/>
+        <location filename="../app/Main.qml" line="1394"/>
         <source>Remove from favorites</source>
         <translation>Aus Favoriten entfernen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1258"/>
+        <location filename="../app/Main.qml" line="1394"/>
         <source>Add to favorites</source>
         <translation>Zu Favoriten hinzufügen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1263"/>
+        <location filename="../app/Main.qml" line="1399"/>
         <source>Write to NFC token</source>
         <translation>Auf NFC-Token schreiben</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1267"/>
+        <location filename="../app/Main.qml" line="1403"/>
         <source>QR code</source>
         <translation>QR-Code</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1242"/>
-        <location filename="../app/Main.qml" line="1277"/>
+        <location filename="../app/Main.qml" line="1378"/>
+        <location filename="../app/Main.qml" line="1413"/>
         <source>Launch game</source>
         <translation>Spiel starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2379"/>
+        <location filename="../app/Main.qml" line="2523"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2385"/>
+        <location filename="../app/Main.qml" line="2529"/>
         <source>Loading favorites…</source>
         <translation>Favoriten werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2381"/>
+        <location filename="../app/Main.qml" line="2525"/>
         <source>Loading games…</source>
         <translation>Spiele werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1230"/>
+        <location filename="../app/Main.qml" line="1366"/>
         <source>Update media database</source>
         <translation type="unfinished">Mediendatenbank aktualisieren</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1233"/>
+        <location filename="../app/Main.qml" line="1369"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadaten abrufen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1427"/>
+        <location filename="../app/Main.qml" line="1563"/>
         <source>Default</source>
         <translation type="unfinished">Standard</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1427"/>
+        <location filename="../app/Main.qml" line="1563"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1719"/>
+        <location filename="../app/Main.qml" line="1855"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1723"/>
+        <location filename="../app/Main.qml" line="1859"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1737"/>
+        <location filename="../app/Main.qml" line="1873"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1741"/>
+        <location filename="../app/Main.qml" line="1877"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1745"/>
+        <location filename="../app/Main.qml" line="1881"/>
         <source>Retry</source>
         <translation type="unfinished">Wiederholen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1749"/>
+        <location filename="../app/Main.qml" line="1885"/>
         <source>Cancel</source>
         <translation type="unfinished">Abbrechen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2383"/>
+        <location filename="../app/Main.qml" line="2527"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2387"/>
+        <location filename="../app/Main.qml" line="2531"/>
         <source>Loading recently played…</source>
         <translation>Zuletzt gespielte werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2389"/>
+        <location filename="../app/Main.qml" line="2533"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2391"/>
+        <location filename="../app/Main.qml" line="2535"/>
         <source>Loading…</source>
         <translation>Wird geladen…</translation>
     </message>
@@ -674,71 +674,71 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="680"/>
+        <location filename="../app/MainLayout.qml" line="682"/>
         <source>Writing failed</source>
         <translation>Schreiben fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="680"/>
+        <location filename="../app/MainLayout.qml" line="682"/>
         <source>Put a writable card near the reader</source>
         <translation>Beschreibbare Karte an den Leser halten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="808"/>
+        <location filename="../app/MainLayout.qml" line="810"/>
         <source>Are you sure you want to exit?</source>
         <translation>Wirklich beenden?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="891"/>
-        <location filename="../app/MainLayout.qml" line="965"/>
+        <location filename="../app/MainLayout.qml" line="893"/>
+        <location filename="../app/MainLayout.qml" line="967"/>
         <source>Select</source>
         <translation>Auswählen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="895"/>
-        <location filename="../app/MainLayout.qml" line="899"/>
-        <location filename="../app/MainLayout.qml" line="913"/>
-        <location filename="../app/MainLayout.qml" line="928"/>
-        <location filename="../app/MainLayout.qml" line="939"/>
+        <location filename="../app/MainLayout.qml" line="897"/>
+        <location filename="../app/MainLayout.qml" line="901"/>
+        <location filename="../app/MainLayout.qml" line="915"/>
+        <location filename="../app/MainLayout.qml" line="930"/>
+        <location filename="../app/MainLayout.qml" line="941"/>
         <source>Close</source>
         <translation>Schließen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="906"/>
-        <location filename="../app/MainLayout.qml" line="946"/>
-        <location filename="../app/MainLayout.qml" line="969"/>
-        <location filename="../app/MainLayout.qml" line="980"/>
+        <location filename="../app/MainLayout.qml" line="908"/>
+        <location filename="../app/MainLayout.qml" line="948"/>
+        <location filename="../app/MainLayout.qml" line="971"/>
+        <location filename="../app/MainLayout.qml" line="982"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="924"/>
+        <location filename="../app/MainLayout.qml" line="926"/>
         <source>Done</source>
         <translation>Fertig</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="954"/>
+        <location filename="../app/MainLayout.qml" line="956"/>
         <source>I understand</source>
         <translation>Ich verstehe</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="988"/>
+        <location filename="../app/MainLayout.qml" line="990"/>
         <source>Start</source>
         <translation>Starten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1166"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
         <source>Scroll</source>
         <translation>Scrollen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="887"/>
-        <location filename="../app/MainLayout.qml" line="961"/>
-        <location filename="../app/MainLayout.qml" line="1004"/>
-        <location filename="../app/MainLayout.qml" line="1035"/>
-        <location filename="../app/MainLayout.qml" line="1085"/>
-        <location filename="../app/MainLayout.qml" line="1128"/>
-        <location filename="../app/MainLayout.qml" line="1195"/>
+        <location filename="../app/MainLayout.qml" line="889"/>
+        <location filename="../app/MainLayout.qml" line="963"/>
+        <location filename="../app/MainLayout.qml" line="1006"/>
+        <location filename="../app/MainLayout.qml" line="1037"/>
+        <location filename="../app/MainLayout.qml" line="1087"/>
+        <location filename="../app/MainLayout.qml" line="1130"/>
+        <location filename="../app/MainLayout.qml" line="1197"/>
         <source>Move</source>
         <translation>Bewegen</translation>
     </message>
@@ -748,87 +748,87 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="364"/>
+        <location filename="../app/MainLayout.qml" line="367"/>
         <source>Favorites</source>
         <translation type="unfinished">Favoriten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="366"/>
+        <location filename="../app/MainLayout.qml" line="369"/>
         <source>Recently Played</source>
         <translation type="unfinished">Zuletzt gespielt</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="696"/>
+        <location filename="../app/MainLayout.qml" line="698"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="697"/>
+        <location filename="../app/MainLayout.qml" line="699"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="807"/>
+        <location filename="../app/MainLayout.qml" line="809"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1008"/>
-        <location filename="../app/MainLayout.qml" line="1045"/>
-        <location filename="../app/MainLayout.qml" line="1095"/>
-        <location filename="../app/MainLayout.qml" line="1205"/>
+        <location filename="../app/MainLayout.qml" line="1010"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1097"/>
+        <location filename="../app/MainLayout.qml" line="1207"/>
         <source>Open</source>
         <translation>Öffnen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1012"/>
+        <location filename="../app/MainLayout.qml" line="1014"/>
         <source>Quit</source>
         <translation>Beenden</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1021"/>
-        <location filename="../app/MainLayout.qml" line="1051"/>
-        <location filename="../app/MainLayout.qml" line="1062"/>
-        <location filename="../app/MainLayout.qml" line="1077"/>
-        <location filename="../app/MainLayout.qml" line="1104"/>
-        <location filename="../app/MainLayout.qml" line="1115"/>
-        <location filename="../app/MainLayout.qml" line="1152"/>
-        <location filename="../app/MainLayout.qml" line="1170"/>
-        <location filename="../app/MainLayout.qml" line="1179"/>
-        <location filename="../app/MainLayout.qml" line="1214"/>
-        <location filename="../app/MainLayout.qml" line="1225"/>
+        <location filename="../app/MainLayout.qml" line="1023"/>
+        <location filename="../app/MainLayout.qml" line="1053"/>
+        <location filename="../app/MainLayout.qml" line="1064"/>
+        <location filename="../app/MainLayout.qml" line="1079"/>
+        <location filename="../app/MainLayout.qml" line="1106"/>
+        <location filename="../app/MainLayout.qml" line="1117"/>
+        <location filename="../app/MainLayout.qml" line="1154"/>
+        <location filename="../app/MainLayout.qml" line="1172"/>
+        <location filename="../app/MainLayout.qml" line="1181"/>
+        <location filename="../app/MainLayout.qml" line="1216"/>
+        <location filename="../app/MainLayout.qml" line="1227"/>
         <source>Back</source>
         <translation>Zurück</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1041"/>
-        <location filename="../app/MainLayout.qml" line="1091"/>
-        <location filename="../app/MainLayout.qml" line="1201"/>
+        <location filename="../app/MainLayout.qml" line="1043"/>
+        <location filename="../app/MainLayout.qml" line="1093"/>
+        <location filename="../app/MainLayout.qml" line="1203"/>
         <source>Page</source>
         <translation>Seite</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1048"/>
-        <location filename="../app/MainLayout.qml" line="1100"/>
-        <location filename="../app/MainLayout.qml" line="1210"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1102"/>
+        <location filename="../app/MainLayout.qml" line="1212"/>
         <source>Options</source>
         <translation>Optionen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="935"/>
-        <location filename="../app/MainLayout.qml" line="1058"/>
-        <location filename="../app/MainLayout.qml" line="1111"/>
-        <location filename="../app/MainLayout.qml" line="1221"/>
+        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="1060"/>
+        <location filename="../app/MainLayout.qml" line="1113"/>
+        <location filename="../app/MainLayout.qml" line="1223"/>
         <source>Retry</source>
         <translation>Wiederholen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1137"/>
+        <location filename="../app/MainLayout.qml" line="1139"/>
         <source>Change</source>
         <translation>Ändern</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1143"/>
+        <location filename="../app/MainLayout.qml" line="1145"/>
         <source>Toggle</source>
         <translation>Umschalten</translation>
     </message>
@@ -841,12 +841,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Wird geladen…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="350"/>
+        <location filename="../screens/MediaListScreen.qml" line="354"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 Einträge</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="351"/>
+        <location filename="../screens/MediaListScreen.qml" line="355"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -905,7 +905,7 @@ Euskara - devilschile2</source>
         <translation>Wird geladen…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="58"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="65"/>
         <source>Failed to load</source>
         <translation>Laden fehlgeschlagen</translation>
     </message>
@@ -1338,24 +1338,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="197"/>
-        <location filename="../screens/SystemsScreen.qml" line="295"/>
+        <location filename="../screens/SystemsScreen.qml" line="199"/>
+        <location filename="../screens/SystemsScreen.qml" line="297"/>
         <source>%1 systems</source>
         <translation>%1 Systeme</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="198"/>
-        <location filename="../screens/SystemsScreen.qml" line="312"/>
+        <location filename="../screens/SystemsScreen.qml" line="200"/>
+        <location filename="../screens/SystemsScreen.qml" line="314"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="328"/>
+        <location filename="../screens/SystemsScreen.qml" line="330"/>
         <source>No systems in this category</source>
         <translation>Keine Systeme in dieser Kategorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="329"/>
+        <location filename="../screens/SystemsScreen.qml" line="331"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -549,124 +549,124 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1217"/>
+        <location filename="../app/Main.qml" line="1353"/>
         <source>Launch core</source>
         <translation>Εκκίνηση Core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1223"/>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1359"/>
+        <location filename="../app/Main.qml" line="1567"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1258"/>
+        <location filename="../app/Main.qml" line="1394"/>
         <source>Remove from favorites</source>
         <translation>Αφαίρεση από αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1258"/>
+        <location filename="../app/Main.qml" line="1394"/>
         <source>Add to favorites</source>
         <translation>Προσθήκη στα αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1263"/>
+        <location filename="../app/Main.qml" line="1399"/>
         <source>Write to NFC token</source>
         <translation>Εγγραφή σε NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1267"/>
+        <location filename="../app/Main.qml" line="1403"/>
         <source>QR code</source>
         <translation>Κωδικός QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1242"/>
-        <location filename="../app/Main.qml" line="1277"/>
+        <location filename="../app/Main.qml" line="1378"/>
+        <location filename="../app/Main.qml" line="1413"/>
         <source>Launch game</source>
         <translation>Εκκίνηση παιχνιδιού</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2379"/>
+        <location filename="../app/Main.qml" line="2523"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2385"/>
+        <location filename="../app/Main.qml" line="2529"/>
         <source>Loading favorites…</source>
         <translation>Φόρτωση αγαπημένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2381"/>
+        <location filename="../app/Main.qml" line="2525"/>
         <source>Loading games…</source>
         <translation>Φόρτωση παιχνιδιών…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1230"/>
+        <location filename="../app/Main.qml" line="1366"/>
         <source>Update media database</source>
         <translation type="unfinished">Ενημέρωση βάσης δεδομένων</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1233"/>
+        <location filename="../app/Main.qml" line="1369"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Ανάκτηση μεταδεδομένων</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1427"/>
+        <location filename="../app/Main.qml" line="1563"/>
         <source>Default</source>
         <translation type="unfinished">Προεπιλογή</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1427"/>
+        <location filename="../app/Main.qml" line="1563"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1719"/>
+        <location filename="../app/Main.qml" line="1855"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1723"/>
+        <location filename="../app/Main.qml" line="1859"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1737"/>
+        <location filename="../app/Main.qml" line="1873"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1741"/>
+        <location filename="../app/Main.qml" line="1877"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1745"/>
+        <location filename="../app/Main.qml" line="1881"/>
         <source>Retry</source>
         <translation type="unfinished">Επανάληψη</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1749"/>
+        <location filename="../app/Main.qml" line="1885"/>
         <source>Cancel</source>
         <translation type="unfinished">Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2383"/>
+        <location filename="../app/Main.qml" line="2527"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2387"/>
+        <location filename="../app/Main.qml" line="2531"/>
         <source>Loading recently played…</source>
         <translation>Φόρτωση πρόσφατα παιγμένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2389"/>
+        <location filename="../app/Main.qml" line="2533"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2391"/>
+        <location filename="../app/Main.qml" line="2535"/>
         <source>Loading…</source>
         <translation>Φόρτωση…</translation>
     </message>
@@ -674,71 +674,71 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="680"/>
+        <location filename="../app/MainLayout.qml" line="682"/>
         <source>Writing failed</source>
         <translation>Αποτυχία εγγραφής</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="680"/>
+        <location filename="../app/MainLayout.qml" line="682"/>
         <source>Put a writable card near the reader</source>
         <translation>Τοποθετήστε μια εγγράψιμη κάρτα κοντά στον αναγνώστη</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="808"/>
+        <location filename="../app/MainLayout.qml" line="810"/>
         <source>Are you sure you want to exit?</source>
         <translation>Είστε σίγουροι ότι θέλετε να βγείτε;</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="891"/>
-        <location filename="../app/MainLayout.qml" line="965"/>
+        <location filename="../app/MainLayout.qml" line="893"/>
+        <location filename="../app/MainLayout.qml" line="967"/>
         <source>Select</source>
         <translation>Επιλογή</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="895"/>
-        <location filename="../app/MainLayout.qml" line="899"/>
-        <location filename="../app/MainLayout.qml" line="913"/>
-        <location filename="../app/MainLayout.qml" line="928"/>
-        <location filename="../app/MainLayout.qml" line="939"/>
+        <location filename="../app/MainLayout.qml" line="897"/>
+        <location filename="../app/MainLayout.qml" line="901"/>
+        <location filename="../app/MainLayout.qml" line="915"/>
+        <location filename="../app/MainLayout.qml" line="930"/>
+        <location filename="../app/MainLayout.qml" line="941"/>
         <source>Close</source>
         <translation>Κλείσιμο</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="906"/>
-        <location filename="../app/MainLayout.qml" line="946"/>
-        <location filename="../app/MainLayout.qml" line="969"/>
-        <location filename="../app/MainLayout.qml" line="980"/>
+        <location filename="../app/MainLayout.qml" line="908"/>
+        <location filename="../app/MainLayout.qml" line="948"/>
+        <location filename="../app/MainLayout.qml" line="971"/>
+        <location filename="../app/MainLayout.qml" line="982"/>
         <source>Cancel</source>
         <translation>Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="924"/>
+        <location filename="../app/MainLayout.qml" line="926"/>
         <source>Done</source>
         <translation>Ολοκληρώθηκε</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="954"/>
+        <location filename="../app/MainLayout.qml" line="956"/>
         <source>I understand</source>
         <translation>Κατανοώ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="988"/>
+        <location filename="../app/MainLayout.qml" line="990"/>
         <source>Start</source>
         <translation>Έναρξη</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1166"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
         <source>Scroll</source>
         <translation>Κύλιση</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="887"/>
-        <location filename="../app/MainLayout.qml" line="961"/>
-        <location filename="../app/MainLayout.qml" line="1004"/>
-        <location filename="../app/MainLayout.qml" line="1035"/>
-        <location filename="../app/MainLayout.qml" line="1085"/>
-        <location filename="../app/MainLayout.qml" line="1128"/>
-        <location filename="../app/MainLayout.qml" line="1195"/>
+        <location filename="../app/MainLayout.qml" line="889"/>
+        <location filename="../app/MainLayout.qml" line="963"/>
+        <location filename="../app/MainLayout.qml" line="1006"/>
+        <location filename="../app/MainLayout.qml" line="1037"/>
+        <location filename="../app/MainLayout.qml" line="1087"/>
+        <location filename="../app/MainLayout.qml" line="1130"/>
+        <location filename="../app/MainLayout.qml" line="1197"/>
         <source>Move</source>
         <translation>Μετακίνηση</translation>
     </message>
@@ -748,87 +748,87 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="364"/>
+        <location filename="../app/MainLayout.qml" line="367"/>
         <source>Favorites</source>
         <translation type="unfinished">Αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="366"/>
+        <location filename="../app/MainLayout.qml" line="369"/>
         <source>Recently Played</source>
         <translation type="unfinished">Πρόσφατα Παιγμένα</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="696"/>
+        <location filename="../app/MainLayout.qml" line="698"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="697"/>
+        <location filename="../app/MainLayout.qml" line="699"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="807"/>
+        <location filename="../app/MainLayout.qml" line="809"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1008"/>
-        <location filename="../app/MainLayout.qml" line="1045"/>
-        <location filename="../app/MainLayout.qml" line="1095"/>
-        <location filename="../app/MainLayout.qml" line="1205"/>
+        <location filename="../app/MainLayout.qml" line="1010"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1097"/>
+        <location filename="../app/MainLayout.qml" line="1207"/>
         <source>Open</source>
         <translation>Άνοιγμα</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1012"/>
+        <location filename="../app/MainLayout.qml" line="1014"/>
         <source>Quit</source>
         <translation>Έξοδος</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1021"/>
-        <location filename="../app/MainLayout.qml" line="1051"/>
-        <location filename="../app/MainLayout.qml" line="1062"/>
-        <location filename="../app/MainLayout.qml" line="1077"/>
-        <location filename="../app/MainLayout.qml" line="1104"/>
-        <location filename="../app/MainLayout.qml" line="1115"/>
-        <location filename="../app/MainLayout.qml" line="1152"/>
-        <location filename="../app/MainLayout.qml" line="1170"/>
-        <location filename="../app/MainLayout.qml" line="1179"/>
-        <location filename="../app/MainLayout.qml" line="1214"/>
-        <location filename="../app/MainLayout.qml" line="1225"/>
+        <location filename="../app/MainLayout.qml" line="1023"/>
+        <location filename="../app/MainLayout.qml" line="1053"/>
+        <location filename="../app/MainLayout.qml" line="1064"/>
+        <location filename="../app/MainLayout.qml" line="1079"/>
+        <location filename="../app/MainLayout.qml" line="1106"/>
+        <location filename="../app/MainLayout.qml" line="1117"/>
+        <location filename="../app/MainLayout.qml" line="1154"/>
+        <location filename="../app/MainLayout.qml" line="1172"/>
+        <location filename="../app/MainLayout.qml" line="1181"/>
+        <location filename="../app/MainLayout.qml" line="1216"/>
+        <location filename="../app/MainLayout.qml" line="1227"/>
         <source>Back</source>
         <translation>Πίσω</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1041"/>
-        <location filename="../app/MainLayout.qml" line="1091"/>
-        <location filename="../app/MainLayout.qml" line="1201"/>
+        <location filename="../app/MainLayout.qml" line="1043"/>
+        <location filename="../app/MainLayout.qml" line="1093"/>
+        <location filename="../app/MainLayout.qml" line="1203"/>
         <source>Page</source>
         <translation>Σελίδα</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1048"/>
-        <location filename="../app/MainLayout.qml" line="1100"/>
-        <location filename="../app/MainLayout.qml" line="1210"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1102"/>
+        <location filename="../app/MainLayout.qml" line="1212"/>
         <source>Options</source>
         <translation>Επιλογές</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="935"/>
-        <location filename="../app/MainLayout.qml" line="1058"/>
-        <location filename="../app/MainLayout.qml" line="1111"/>
-        <location filename="../app/MainLayout.qml" line="1221"/>
+        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="1060"/>
+        <location filename="../app/MainLayout.qml" line="1113"/>
+        <location filename="../app/MainLayout.qml" line="1223"/>
         <source>Retry</source>
         <translation>Επανάληψη</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1137"/>
+        <location filename="../app/MainLayout.qml" line="1139"/>
         <source>Change</source>
         <translation>Αλλαγή</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1143"/>
+        <location filename="../app/MainLayout.qml" line="1145"/>
         <source>Toggle</source>
         <translation>Εναλλαγή</translation>
     </message>
@@ -841,12 +841,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Φόρτωση…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="350"/>
+        <location filename="../screens/MediaListScreen.qml" line="354"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 εγγραφές</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="351"/>
+        <location filename="../screens/MediaListScreen.qml" line="355"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -905,7 +905,7 @@ Euskara - devilschile2</source>
         <translation>Φόρτωση…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="58"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="65"/>
         <source>Failed to load</source>
         <translation>Αποτυχία φόρτωσης</translation>
     </message>
@@ -1338,24 +1338,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="197"/>
-        <location filename="../screens/SystemsScreen.qml" line="295"/>
+        <location filename="../screens/SystemsScreen.qml" line="199"/>
+        <location filename="../screens/SystemsScreen.qml" line="297"/>
         <source>%1 systems</source>
         <translation>%1 συστήματα</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="198"/>
-        <location filename="../screens/SystemsScreen.qml" line="312"/>
+        <location filename="../screens/SystemsScreen.qml" line="200"/>
+        <location filename="../screens/SystemsScreen.qml" line="314"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="328"/>
+        <location filename="../screens/SystemsScreen.qml" line="330"/>
         <source>No systems in this category</source>
         <translation>Δεν υπάρχουν συστήματα σε αυτή την κατηγορία</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="329"/>
+        <location filename="../screens/SystemsScreen.qml" line="331"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -537,124 +537,124 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1217"/>
+        <location filename="../app/Main.qml" line="1353"/>
         <source>Launch core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1223"/>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1359"/>
+        <location filename="../app/Main.qml" line="1567"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1258"/>
+        <location filename="../app/Main.qml" line="1394"/>
         <source>Remove from favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1258"/>
+        <location filename="../app/Main.qml" line="1394"/>
         <source>Add to favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1263"/>
+        <location filename="../app/Main.qml" line="1399"/>
         <source>Write to NFC token</source>
         <translation type="unfinished">Write to NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1267"/>
+        <location filename="../app/Main.qml" line="1403"/>
         <source>QR code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1242"/>
-        <location filename="../app/Main.qml" line="1277"/>
+        <location filename="../app/Main.qml" line="1378"/>
+        <location filename="../app/Main.qml" line="1413"/>
         <source>Launch game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2379"/>
+        <location filename="../app/Main.qml" line="2523"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2385"/>
+        <location filename="../app/Main.qml" line="2529"/>
         <source>Loading favorites…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2381"/>
+        <location filename="../app/Main.qml" line="2525"/>
         <source>Loading games…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1230"/>
+        <location filename="../app/Main.qml" line="1366"/>
         <source>Update media database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1233"/>
+        <location filename="../app/Main.qml" line="1369"/>
         <source>Scrape metadata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1427"/>
+        <location filename="../app/Main.qml" line="1563"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1427"/>
+        <location filename="../app/Main.qml" line="1563"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1719"/>
+        <location filename="../app/Main.qml" line="1855"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1723"/>
+        <location filename="../app/Main.qml" line="1859"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1737"/>
+        <location filename="../app/Main.qml" line="1873"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1741"/>
+        <location filename="../app/Main.qml" line="1877"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1745"/>
+        <location filename="../app/Main.qml" line="1881"/>
         <source>Retry</source>
         <translation type="unfinished">Retry</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1749"/>
+        <location filename="../app/Main.qml" line="1885"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2383"/>
+        <location filename="../app/Main.qml" line="2527"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2387"/>
+        <location filename="../app/Main.qml" line="2531"/>
         <source>Loading recently played…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2389"/>
+        <location filename="../app/Main.qml" line="2533"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2391"/>
+        <location filename="../app/Main.qml" line="2535"/>
         <source>Loading…</source>
         <translation type="unfinished">Loading…</translation>
     </message>
@@ -662,71 +662,71 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="680"/>
+        <location filename="../app/MainLayout.qml" line="682"/>
         <source>Writing failed</source>
         <translation>Writing failed</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="680"/>
+        <location filename="../app/MainLayout.qml" line="682"/>
         <source>Put a writable card near the reader</source>
         <translation>Put a writable card near the reader</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="808"/>
+        <location filename="../app/MainLayout.qml" line="810"/>
         <source>Are you sure you want to exit?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="891"/>
-        <location filename="../app/MainLayout.qml" line="965"/>
+        <location filename="../app/MainLayout.qml" line="893"/>
+        <location filename="../app/MainLayout.qml" line="967"/>
         <source>Select</source>
         <translation>Select</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="895"/>
-        <location filename="../app/MainLayout.qml" line="899"/>
-        <location filename="../app/MainLayout.qml" line="913"/>
-        <location filename="../app/MainLayout.qml" line="928"/>
-        <location filename="../app/MainLayout.qml" line="939"/>
+        <location filename="../app/MainLayout.qml" line="897"/>
+        <location filename="../app/MainLayout.qml" line="901"/>
+        <location filename="../app/MainLayout.qml" line="915"/>
+        <location filename="../app/MainLayout.qml" line="930"/>
+        <location filename="../app/MainLayout.qml" line="941"/>
         <source>Close</source>
         <translation>Close</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="906"/>
-        <location filename="../app/MainLayout.qml" line="946"/>
-        <location filename="../app/MainLayout.qml" line="969"/>
-        <location filename="../app/MainLayout.qml" line="980"/>
+        <location filename="../app/MainLayout.qml" line="908"/>
+        <location filename="../app/MainLayout.qml" line="948"/>
+        <location filename="../app/MainLayout.qml" line="971"/>
+        <location filename="../app/MainLayout.qml" line="982"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="924"/>
+        <location filename="../app/MainLayout.qml" line="926"/>
         <source>Done</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="954"/>
+        <location filename="../app/MainLayout.qml" line="956"/>
         <source>I understand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="988"/>
+        <location filename="../app/MainLayout.qml" line="990"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1166"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
         <source>Scroll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="887"/>
-        <location filename="../app/MainLayout.qml" line="961"/>
-        <location filename="../app/MainLayout.qml" line="1004"/>
-        <location filename="../app/MainLayout.qml" line="1035"/>
-        <location filename="../app/MainLayout.qml" line="1085"/>
-        <location filename="../app/MainLayout.qml" line="1128"/>
-        <location filename="../app/MainLayout.qml" line="1195"/>
+        <location filename="../app/MainLayout.qml" line="889"/>
+        <location filename="../app/MainLayout.qml" line="963"/>
+        <location filename="../app/MainLayout.qml" line="1006"/>
+        <location filename="../app/MainLayout.qml" line="1037"/>
+        <location filename="../app/MainLayout.qml" line="1087"/>
+        <location filename="../app/MainLayout.qml" line="1130"/>
+        <location filename="../app/MainLayout.qml" line="1197"/>
         <source>Move</source>
         <translation>Move</translation>
     </message>
@@ -736,87 +736,87 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="364"/>
+        <location filename="../app/MainLayout.qml" line="367"/>
         <source>Favorites</source>
         <translation type="unfinished">Favorites</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="366"/>
+        <location filename="../app/MainLayout.qml" line="369"/>
         <source>Recently Played</source>
         <translation type="unfinished">Recently Played</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="696"/>
+        <location filename="../app/MainLayout.qml" line="698"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="697"/>
+        <location filename="../app/MainLayout.qml" line="699"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="807"/>
+        <location filename="../app/MainLayout.qml" line="809"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1008"/>
-        <location filename="../app/MainLayout.qml" line="1045"/>
-        <location filename="../app/MainLayout.qml" line="1095"/>
-        <location filename="../app/MainLayout.qml" line="1205"/>
+        <location filename="../app/MainLayout.qml" line="1010"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1097"/>
+        <location filename="../app/MainLayout.qml" line="1207"/>
         <source>Open</source>
         <translation>Open</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1012"/>
+        <location filename="../app/MainLayout.qml" line="1014"/>
         <source>Quit</source>
         <translation>Quit</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1021"/>
-        <location filename="../app/MainLayout.qml" line="1051"/>
-        <location filename="../app/MainLayout.qml" line="1062"/>
-        <location filename="../app/MainLayout.qml" line="1077"/>
-        <location filename="../app/MainLayout.qml" line="1104"/>
-        <location filename="../app/MainLayout.qml" line="1115"/>
-        <location filename="../app/MainLayout.qml" line="1152"/>
-        <location filename="../app/MainLayout.qml" line="1170"/>
-        <location filename="../app/MainLayout.qml" line="1179"/>
-        <location filename="../app/MainLayout.qml" line="1214"/>
-        <location filename="../app/MainLayout.qml" line="1225"/>
+        <location filename="../app/MainLayout.qml" line="1023"/>
+        <location filename="../app/MainLayout.qml" line="1053"/>
+        <location filename="../app/MainLayout.qml" line="1064"/>
+        <location filename="../app/MainLayout.qml" line="1079"/>
+        <location filename="../app/MainLayout.qml" line="1106"/>
+        <location filename="../app/MainLayout.qml" line="1117"/>
+        <location filename="../app/MainLayout.qml" line="1154"/>
+        <location filename="../app/MainLayout.qml" line="1172"/>
+        <location filename="../app/MainLayout.qml" line="1181"/>
+        <location filename="../app/MainLayout.qml" line="1216"/>
+        <location filename="../app/MainLayout.qml" line="1227"/>
         <source>Back</source>
         <translation>Back</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1041"/>
-        <location filename="../app/MainLayout.qml" line="1091"/>
-        <location filename="../app/MainLayout.qml" line="1201"/>
+        <location filename="../app/MainLayout.qml" line="1043"/>
+        <location filename="../app/MainLayout.qml" line="1093"/>
+        <location filename="../app/MainLayout.qml" line="1203"/>
         <source>Page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1048"/>
-        <location filename="../app/MainLayout.qml" line="1100"/>
-        <location filename="../app/MainLayout.qml" line="1210"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1102"/>
+        <location filename="../app/MainLayout.qml" line="1212"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="935"/>
-        <location filename="../app/MainLayout.qml" line="1058"/>
-        <location filename="../app/MainLayout.qml" line="1111"/>
-        <location filename="../app/MainLayout.qml" line="1221"/>
+        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="1060"/>
+        <location filename="../app/MainLayout.qml" line="1113"/>
+        <location filename="../app/MainLayout.qml" line="1223"/>
         <source>Retry</source>
         <translation>Retry</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1137"/>
+        <location filename="../app/MainLayout.qml" line="1139"/>
         <source>Change</source>
         <translation>Change</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1143"/>
+        <location filename="../app/MainLayout.qml" line="1145"/>
         <source>Toggle</source>
         <translation>Toggle</translation>
     </message>
@@ -829,12 +829,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Loading…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="350"/>
+        <location filename="../screens/MediaListScreen.qml" line="354"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 entries</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="351"/>
+        <location filename="../screens/MediaListScreen.qml" line="355"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -893,7 +893,7 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Loading…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="58"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="65"/>
         <source>Failed to load</source>
         <translation>Failed to load</translation>
     </message>
@@ -1318,24 +1318,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="197"/>
-        <location filename="../screens/SystemsScreen.qml" line="295"/>
+        <location filename="../screens/SystemsScreen.qml" line="199"/>
+        <location filename="../screens/SystemsScreen.qml" line="297"/>
         <source>%1 systems</source>
         <translation>%1 systems</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="198"/>
-        <location filename="../screens/SystemsScreen.qml" line="312"/>
+        <location filename="../screens/SystemsScreen.qml" line="200"/>
+        <location filename="../screens/SystemsScreen.qml" line="314"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="328"/>
+        <location filename="../screens/SystemsScreen.qml" line="330"/>
         <source>No systems in this category</source>
         <translation>No systems in this category</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="329"/>
+        <location filename="../screens/SystemsScreen.qml" line="331"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -549,124 +549,124 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1217"/>
+        <location filename="../app/Main.qml" line="1353"/>
         <source>Launch core</source>
         <translation>Lanzar core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1223"/>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1359"/>
+        <location filename="../app/Main.qml" line="1567"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1258"/>
+        <location filename="../app/Main.qml" line="1394"/>
         <source>Remove from favorites</source>
         <translation>Eliminar de favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1258"/>
+        <location filename="../app/Main.qml" line="1394"/>
         <source>Add to favorites</source>
         <translation>Agregar a favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1263"/>
+        <location filename="../app/Main.qml" line="1399"/>
         <source>Write to NFC token</source>
         <translation>Escribir en token NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1267"/>
+        <location filename="../app/Main.qml" line="1403"/>
         <source>QR code</source>
         <translation>Código QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1242"/>
-        <location filename="../app/Main.qml" line="1277"/>
+        <location filename="../app/Main.qml" line="1378"/>
+        <location filename="../app/Main.qml" line="1413"/>
         <source>Launch game</source>
         <translation>Iniciar juego</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2379"/>
+        <location filename="../app/Main.qml" line="2523"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2385"/>
+        <location filename="../app/Main.qml" line="2529"/>
         <source>Loading favorites…</source>
         <translation>Cargando favoritos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2381"/>
+        <location filename="../app/Main.qml" line="2525"/>
         <source>Loading games…</source>
         <translation>Cargando juegos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1230"/>
+        <location filename="../app/Main.qml" line="1366"/>
         <source>Update media database</source>
         <translation type="unfinished">Actualizar base de datos de medios</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1233"/>
+        <location filename="../app/Main.qml" line="1369"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Extraer metadatos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1427"/>
+        <location filename="../app/Main.qml" line="1563"/>
         <source>Default</source>
         <translation type="unfinished">Por defecto</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1427"/>
+        <location filename="../app/Main.qml" line="1563"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1719"/>
+        <location filename="../app/Main.qml" line="1855"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1723"/>
+        <location filename="../app/Main.qml" line="1859"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1737"/>
+        <location filename="../app/Main.qml" line="1873"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1741"/>
+        <location filename="../app/Main.qml" line="1877"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1745"/>
+        <location filename="../app/Main.qml" line="1881"/>
         <source>Retry</source>
         <translation type="unfinished">Reintentar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1749"/>
+        <location filename="../app/Main.qml" line="1885"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2383"/>
+        <location filename="../app/Main.qml" line="2527"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2387"/>
+        <location filename="../app/Main.qml" line="2531"/>
         <source>Loading recently played…</source>
         <translation>Cargando jugados recientemente…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2389"/>
+        <location filename="../app/Main.qml" line="2533"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2391"/>
+        <location filename="../app/Main.qml" line="2535"/>
         <source>Loading…</source>
         <translation>Cargando…</translation>
     </message>
@@ -674,71 +674,71 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="680"/>
+        <location filename="../app/MainLayout.qml" line="682"/>
         <source>Writing failed</source>
         <translation>Error de escritura</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="680"/>
+        <location filename="../app/MainLayout.qml" line="682"/>
         <source>Put a writable card near the reader</source>
         <translation>Pon una tarjeta escribible junto al lector</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="808"/>
+        <location filename="../app/MainLayout.qml" line="810"/>
         <source>Are you sure you want to exit?</source>
         <translation>¿Seguro que quieres salir?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="891"/>
-        <location filename="../app/MainLayout.qml" line="965"/>
+        <location filename="../app/MainLayout.qml" line="893"/>
+        <location filename="../app/MainLayout.qml" line="967"/>
         <source>Select</source>
         <translation>Seleccionar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="895"/>
-        <location filename="../app/MainLayout.qml" line="899"/>
-        <location filename="../app/MainLayout.qml" line="913"/>
-        <location filename="../app/MainLayout.qml" line="928"/>
-        <location filename="../app/MainLayout.qml" line="939"/>
+        <location filename="../app/MainLayout.qml" line="897"/>
+        <location filename="../app/MainLayout.qml" line="901"/>
+        <location filename="../app/MainLayout.qml" line="915"/>
+        <location filename="../app/MainLayout.qml" line="930"/>
+        <location filename="../app/MainLayout.qml" line="941"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="906"/>
-        <location filename="../app/MainLayout.qml" line="946"/>
-        <location filename="../app/MainLayout.qml" line="969"/>
-        <location filename="../app/MainLayout.qml" line="980"/>
+        <location filename="../app/MainLayout.qml" line="908"/>
+        <location filename="../app/MainLayout.qml" line="948"/>
+        <location filename="../app/MainLayout.qml" line="971"/>
+        <location filename="../app/MainLayout.qml" line="982"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="924"/>
+        <location filename="../app/MainLayout.qml" line="926"/>
         <source>Done</source>
         <translation>Hecho</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="954"/>
+        <location filename="../app/MainLayout.qml" line="956"/>
         <source>I understand</source>
         <translation>Entendido</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="988"/>
+        <location filename="../app/MainLayout.qml" line="990"/>
         <source>Start</source>
         <translation>Iniciar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1166"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
         <source>Scroll</source>
         <translation>Desplazar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="887"/>
-        <location filename="../app/MainLayout.qml" line="961"/>
-        <location filename="../app/MainLayout.qml" line="1004"/>
-        <location filename="../app/MainLayout.qml" line="1035"/>
-        <location filename="../app/MainLayout.qml" line="1085"/>
-        <location filename="../app/MainLayout.qml" line="1128"/>
-        <location filename="../app/MainLayout.qml" line="1195"/>
+        <location filename="../app/MainLayout.qml" line="889"/>
+        <location filename="../app/MainLayout.qml" line="963"/>
+        <location filename="../app/MainLayout.qml" line="1006"/>
+        <location filename="../app/MainLayout.qml" line="1037"/>
+        <location filename="../app/MainLayout.qml" line="1087"/>
+        <location filename="../app/MainLayout.qml" line="1130"/>
+        <location filename="../app/MainLayout.qml" line="1197"/>
         <source>Move</source>
         <translation>Mover</translation>
     </message>
@@ -748,87 +748,87 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="364"/>
+        <location filename="../app/MainLayout.qml" line="367"/>
         <source>Favorites</source>
         <translation type="unfinished">Favoritos</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="366"/>
+        <location filename="../app/MainLayout.qml" line="369"/>
         <source>Recently Played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="696"/>
+        <location filename="../app/MainLayout.qml" line="698"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="697"/>
+        <location filename="../app/MainLayout.qml" line="699"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="807"/>
+        <location filename="../app/MainLayout.qml" line="809"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1008"/>
-        <location filename="../app/MainLayout.qml" line="1045"/>
-        <location filename="../app/MainLayout.qml" line="1095"/>
-        <location filename="../app/MainLayout.qml" line="1205"/>
+        <location filename="../app/MainLayout.qml" line="1010"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1097"/>
+        <location filename="../app/MainLayout.qml" line="1207"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1012"/>
+        <location filename="../app/MainLayout.qml" line="1014"/>
         <source>Quit</source>
         <translation>Salir</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1021"/>
-        <location filename="../app/MainLayout.qml" line="1051"/>
-        <location filename="../app/MainLayout.qml" line="1062"/>
-        <location filename="../app/MainLayout.qml" line="1077"/>
-        <location filename="../app/MainLayout.qml" line="1104"/>
-        <location filename="../app/MainLayout.qml" line="1115"/>
-        <location filename="../app/MainLayout.qml" line="1152"/>
-        <location filename="../app/MainLayout.qml" line="1170"/>
-        <location filename="../app/MainLayout.qml" line="1179"/>
-        <location filename="../app/MainLayout.qml" line="1214"/>
-        <location filename="../app/MainLayout.qml" line="1225"/>
+        <location filename="../app/MainLayout.qml" line="1023"/>
+        <location filename="../app/MainLayout.qml" line="1053"/>
+        <location filename="../app/MainLayout.qml" line="1064"/>
+        <location filename="../app/MainLayout.qml" line="1079"/>
+        <location filename="../app/MainLayout.qml" line="1106"/>
+        <location filename="../app/MainLayout.qml" line="1117"/>
+        <location filename="../app/MainLayout.qml" line="1154"/>
+        <location filename="../app/MainLayout.qml" line="1172"/>
+        <location filename="../app/MainLayout.qml" line="1181"/>
+        <location filename="../app/MainLayout.qml" line="1216"/>
+        <location filename="../app/MainLayout.qml" line="1227"/>
         <source>Back</source>
         <translation>Atrás</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1041"/>
-        <location filename="../app/MainLayout.qml" line="1091"/>
-        <location filename="../app/MainLayout.qml" line="1201"/>
+        <location filename="../app/MainLayout.qml" line="1043"/>
+        <location filename="../app/MainLayout.qml" line="1093"/>
+        <location filename="../app/MainLayout.qml" line="1203"/>
         <source>Page</source>
         <translation>Página</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1048"/>
-        <location filename="../app/MainLayout.qml" line="1100"/>
-        <location filename="../app/MainLayout.qml" line="1210"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1102"/>
+        <location filename="../app/MainLayout.qml" line="1212"/>
         <source>Options</source>
         <translation>Opciones</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="935"/>
-        <location filename="../app/MainLayout.qml" line="1058"/>
-        <location filename="../app/MainLayout.qml" line="1111"/>
-        <location filename="../app/MainLayout.qml" line="1221"/>
+        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="1060"/>
+        <location filename="../app/MainLayout.qml" line="1113"/>
+        <location filename="../app/MainLayout.qml" line="1223"/>
         <source>Retry</source>
         <translation>Reintentar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1137"/>
+        <location filename="../app/MainLayout.qml" line="1139"/>
         <source>Change</source>
         <translation>Cambiar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1143"/>
+        <location filename="../app/MainLayout.qml" line="1145"/>
         <source>Toggle</source>
         <translation>Alternar</translation>
     </message>
@@ -841,12 +841,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Cargando…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="350"/>
+        <location filename="../screens/MediaListScreen.qml" line="354"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 entradas</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="351"/>
+        <location filename="../screens/MediaListScreen.qml" line="355"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -905,7 +905,7 @@ Euskara - devilschile2</source>
         <translation>Cargando…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="58"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="65"/>
         <source>Failed to load</source>
         <translation>Fallo al cargar</translation>
     </message>
@@ -1338,24 +1338,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="197"/>
-        <location filename="../screens/SystemsScreen.qml" line="295"/>
+        <location filename="../screens/SystemsScreen.qml" line="199"/>
+        <location filename="../screens/SystemsScreen.qml" line="297"/>
         <source>%1 systems</source>
         <translation>%1 sistemas</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="198"/>
-        <location filename="../screens/SystemsScreen.qml" line="312"/>
+        <location filename="../screens/SystemsScreen.qml" line="200"/>
+        <location filename="../screens/SystemsScreen.qml" line="314"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="328"/>
+        <location filename="../screens/SystemsScreen.qml" line="330"/>
         <source>No systems in this category</source>
         <translation>No hay sistemas en esta categoría</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="329"/>
+        <location filename="../screens/SystemsScreen.qml" line="331"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -557,124 +557,124 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1217"/>
+        <location filename="../app/Main.qml" line="1353"/>
         <source>Launch core</source>
         <translation type="unfinished">Exekutatu nukleoa</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1223"/>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1359"/>
+        <location filename="../app/Main.qml" line="1567"/>
         <source>Change launcher</source>
         <translation type="unfinished">Aldatu abiarazlea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1258"/>
+        <location filename="../app/Main.qml" line="1394"/>
         <source>Remove from favorites</source>
         <translation type="unfinished">Kendu gogokoetatik</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1258"/>
+        <location filename="../app/Main.qml" line="1394"/>
         <source>Add to favorites</source>
         <translation type="unfinished">Gehitu gogokoetan</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1263"/>
+        <location filename="../app/Main.qml" line="1399"/>
         <source>Write to NFC token</source>
         <translation type="unfinished">Idatzi NFC token-a</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1267"/>
+        <location filename="../app/Main.qml" line="1403"/>
         <source>QR code</source>
         <translation type="unfinished">QR kodea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1242"/>
-        <location filename="../app/Main.qml" line="1277"/>
+        <location filename="../app/Main.qml" line="1378"/>
+        <location filename="../app/Main.qml" line="1413"/>
         <source>Launch game</source>
         <translation type="unfinished">Abiarazi jokua</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2379"/>
+        <location filename="../app/Main.qml" line="2523"/>
         <source>Loading systems…</source>
         <translation type="unfinished">Sistemak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2385"/>
+        <location filename="../app/Main.qml" line="2529"/>
         <source>Loading favorites…</source>
         <translation type="unfinished">Gogokoak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2381"/>
+        <location filename="../app/Main.qml" line="2525"/>
         <source>Loading games…</source>
         <translation type="unfinished">Jokoak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1230"/>
+        <location filename="../app/Main.qml" line="1366"/>
         <source>Update media database</source>
         <translation type="unfinished">Eguneratu multimedia datu-basea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1233"/>
+        <location filename="../app/Main.qml" line="1369"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadatuak scrapeatu</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1427"/>
+        <location filename="../app/Main.qml" line="1563"/>
         <source>Default</source>
         <translation type="unfinished">Lehenetsia</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1427"/>
+        <location filename="../app/Main.qml" line="1563"/>
         <source>Current: %1</source>
         <translation type="unfinished">Unekoa: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1719"/>
+        <location filename="../app/Main.qml" line="1855"/>
         <source>Saving launcher</source>
         <translation type="unfinished">Abiarazlea gordetzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1723"/>
+        <location filename="../app/Main.qml" line="1859"/>
         <source>Saving…</source>
         <translation type="unfinished">Gordetzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1737"/>
+        <location filename="../app/Main.qml" line="1873"/>
         <source>Launcher update failed</source>
         <translation type="unfinished">Abiarazle egukeraketak huts egin du</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1741"/>
+        <location filename="../app/Main.qml" line="1877"/>
         <source>Error: %1</source>
         <translation type="unfinished">Errorea: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1745"/>
+        <location filename="../app/Main.qml" line="1881"/>
         <source>Retry</source>
         <translation type="unfinished">Berriro saiatu</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1749"/>
+        <location filename="../app/Main.qml" line="1885"/>
         <source>Cancel</source>
         <translation type="unfinished">Utzi</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2383"/>
+        <location filename="../app/Main.qml" line="2527"/>
         <source>Loading game…</source>
         <translation type="unfinished">Jokua kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2387"/>
+        <location filename="../app/Main.qml" line="2531"/>
         <source>Loading recently played…</source>
         <translation type="unfinished">Duela gutxi jokatutakoak kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2389"/>
+        <location filename="../app/Main.qml" line="2533"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2391"/>
+        <location filename="../app/Main.qml" line="2535"/>
         <source>Loading…</source>
         <translation type="unfinished">Kargatzen…</translation>
     </message>
@@ -682,71 +682,71 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="680"/>
+        <location filename="../app/MainLayout.qml" line="682"/>
         <source>Writing failed</source>
         <translation>Idazketak huts egin du</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="680"/>
+        <location filename="../app/MainLayout.qml" line="682"/>
         <source>Put a writable card near the reader</source>
         <translation>Jarri idatzi daitekeen txartel bat irakurlearen ondoan</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="808"/>
+        <location filename="../app/MainLayout.qml" line="810"/>
         <source>Are you sure you want to exit?</source>
         <translation type="unfinished">Ziur zaude irten nahi duzula?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="891"/>
-        <location filename="../app/MainLayout.qml" line="965"/>
+        <location filename="../app/MainLayout.qml" line="893"/>
+        <location filename="../app/MainLayout.qml" line="967"/>
         <source>Select</source>
         <translation>Aukeratu</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="895"/>
-        <location filename="../app/MainLayout.qml" line="899"/>
-        <location filename="../app/MainLayout.qml" line="913"/>
-        <location filename="../app/MainLayout.qml" line="928"/>
-        <location filename="../app/MainLayout.qml" line="939"/>
+        <location filename="../app/MainLayout.qml" line="897"/>
+        <location filename="../app/MainLayout.qml" line="901"/>
+        <location filename="../app/MainLayout.qml" line="915"/>
+        <location filename="../app/MainLayout.qml" line="930"/>
+        <location filename="../app/MainLayout.qml" line="941"/>
         <source>Close</source>
         <translation>Itxi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="906"/>
-        <location filename="../app/MainLayout.qml" line="946"/>
-        <location filename="../app/MainLayout.qml" line="969"/>
-        <location filename="../app/MainLayout.qml" line="980"/>
+        <location filename="../app/MainLayout.qml" line="908"/>
+        <location filename="../app/MainLayout.qml" line="948"/>
+        <location filename="../app/MainLayout.qml" line="971"/>
+        <location filename="../app/MainLayout.qml" line="982"/>
         <source>Cancel</source>
         <translation>Utzi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="924"/>
+        <location filename="../app/MainLayout.qml" line="926"/>
         <source>Done</source>
         <translation type="unfinished">Eginda</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="954"/>
+        <location filename="../app/MainLayout.qml" line="956"/>
         <source>I understand</source>
         <translation type="unfinished">Ulertzen dut</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="988"/>
+        <location filename="../app/MainLayout.qml" line="990"/>
         <source>Start</source>
         <translation type="unfinished">Hasi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1166"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
         <source>Scroll</source>
         <translation type="unfinished">Scroll-a egin</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="887"/>
-        <location filename="../app/MainLayout.qml" line="961"/>
-        <location filename="../app/MainLayout.qml" line="1004"/>
-        <location filename="../app/MainLayout.qml" line="1035"/>
-        <location filename="../app/MainLayout.qml" line="1085"/>
-        <location filename="../app/MainLayout.qml" line="1128"/>
-        <location filename="../app/MainLayout.qml" line="1195"/>
+        <location filename="../app/MainLayout.qml" line="889"/>
+        <location filename="../app/MainLayout.qml" line="963"/>
+        <location filename="../app/MainLayout.qml" line="1006"/>
+        <location filename="../app/MainLayout.qml" line="1037"/>
+        <location filename="../app/MainLayout.qml" line="1087"/>
+        <location filename="../app/MainLayout.qml" line="1130"/>
+        <location filename="../app/MainLayout.qml" line="1197"/>
         <source>Move</source>
         <translation>Mugitu</translation>
     </message>
@@ -756,87 +756,87 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Zaparoo Frontend</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="364"/>
+        <location filename="../app/MainLayout.qml" line="367"/>
         <source>Favorites</source>
         <translation type="unfinished">Gogokoak</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="366"/>
+        <location filename="../app/MainLayout.qml" line="369"/>
         <source>Recently Played</source>
         <translation type="unfinished">Duela gutxi jokatuak</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="696"/>
+        <location filename="../app/MainLayout.qml" line="698"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished">Itxi eta Zaparoo Frontend berabiarazi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="697"/>
+        <location filename="../app/MainLayout.qml" line="699"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished">Ezarpenak indarrean jartzeko frontend-a berrabiarazi behar dugu</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="807"/>
+        <location filename="../app/MainLayout.qml" line="809"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished">Itxi Zaparoo Frontend?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1008"/>
-        <location filename="../app/MainLayout.qml" line="1045"/>
-        <location filename="../app/MainLayout.qml" line="1095"/>
-        <location filename="../app/MainLayout.qml" line="1205"/>
+        <location filename="../app/MainLayout.qml" line="1010"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1097"/>
+        <location filename="../app/MainLayout.qml" line="1207"/>
         <source>Open</source>
         <translation>Ireki</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1012"/>
+        <location filename="../app/MainLayout.qml" line="1014"/>
         <source>Quit</source>
         <translation>Irten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1021"/>
-        <location filename="../app/MainLayout.qml" line="1051"/>
-        <location filename="../app/MainLayout.qml" line="1062"/>
-        <location filename="../app/MainLayout.qml" line="1077"/>
-        <location filename="../app/MainLayout.qml" line="1104"/>
-        <location filename="../app/MainLayout.qml" line="1115"/>
-        <location filename="../app/MainLayout.qml" line="1152"/>
-        <location filename="../app/MainLayout.qml" line="1170"/>
-        <location filename="../app/MainLayout.qml" line="1179"/>
-        <location filename="../app/MainLayout.qml" line="1214"/>
-        <location filename="../app/MainLayout.qml" line="1225"/>
+        <location filename="../app/MainLayout.qml" line="1023"/>
+        <location filename="../app/MainLayout.qml" line="1053"/>
+        <location filename="../app/MainLayout.qml" line="1064"/>
+        <location filename="../app/MainLayout.qml" line="1079"/>
+        <location filename="../app/MainLayout.qml" line="1106"/>
+        <location filename="../app/MainLayout.qml" line="1117"/>
+        <location filename="../app/MainLayout.qml" line="1154"/>
+        <location filename="../app/MainLayout.qml" line="1172"/>
+        <location filename="../app/MainLayout.qml" line="1181"/>
+        <location filename="../app/MainLayout.qml" line="1216"/>
+        <location filename="../app/MainLayout.qml" line="1227"/>
         <source>Back</source>
         <translation>Atzera</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1041"/>
-        <location filename="../app/MainLayout.qml" line="1091"/>
-        <location filename="../app/MainLayout.qml" line="1201"/>
+        <location filename="../app/MainLayout.qml" line="1043"/>
+        <location filename="../app/MainLayout.qml" line="1093"/>
+        <location filename="../app/MainLayout.qml" line="1203"/>
         <source>Page</source>
         <translation type="unfinished">Orria</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1048"/>
-        <location filename="../app/MainLayout.qml" line="1100"/>
-        <location filename="../app/MainLayout.qml" line="1210"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1102"/>
+        <location filename="../app/MainLayout.qml" line="1212"/>
         <source>Options</source>
         <translation type="unfinished">Aukerak</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="935"/>
-        <location filename="../app/MainLayout.qml" line="1058"/>
-        <location filename="../app/MainLayout.qml" line="1111"/>
-        <location filename="../app/MainLayout.qml" line="1221"/>
+        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="1060"/>
+        <location filename="../app/MainLayout.qml" line="1113"/>
+        <location filename="../app/MainLayout.qml" line="1223"/>
         <source>Retry</source>
         <translation>Berriro saiatu</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1137"/>
+        <location filename="../app/MainLayout.qml" line="1139"/>
         <source>Change</source>
         <translation>Aldatu</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1143"/>
+        <location filename="../app/MainLayout.qml" line="1145"/>
         <source>Toggle</source>
         <translation>Txandakatu</translation>
     </message>
@@ -849,12 +849,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Kargatzen…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="350"/>
+        <location filename="../screens/MediaListScreen.qml" line="354"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 sarrera</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="351"/>
+        <location filename="../screens/MediaListScreen.qml" line="355"/>
         <source>%1 / %2</source>
         <translation type="unfinished">%1 / %2</translation>
     </message>
@@ -913,7 +913,7 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Kargatzen…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="58"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="65"/>
         <source>Failed to load</source>
         <translation>Ezin izan da kargatu</translation>
     </message>
@@ -1346,24 +1346,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="197"/>
-        <location filename="../screens/SystemsScreen.qml" line="295"/>
+        <location filename="../screens/SystemsScreen.qml" line="199"/>
+        <location filename="../screens/SystemsScreen.qml" line="297"/>
         <source>%1 systems</source>
         <translation>%1 sistema</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="198"/>
-        <location filename="../screens/SystemsScreen.qml" line="312"/>
+        <location filename="../screens/SystemsScreen.qml" line="200"/>
+        <location filename="../screens/SystemsScreen.qml" line="314"/>
         <source>%1 / %2</source>
         <translation type="unfinished">%1 / %2</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="328"/>
+        <location filename="../screens/SystemsScreen.qml" line="330"/>
         <source>No systems in this category</source>
         <translation>Ez dago sistemarik kategoria honetan</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="329"/>
+        <location filename="../screens/SystemsScreen.qml" line="331"/>
         <source>Loading systems…</source>
         <translation type="unfinished">Sistemak kargatzen</translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -549,124 +549,124 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1217"/>
+        <location filename="../app/Main.qml" line="1353"/>
         <source>Launch core</source>
         <translation>הפעל את הליבה</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1223"/>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1359"/>
+        <location filename="../app/Main.qml" line="1567"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1230"/>
+        <location filename="../app/Main.qml" line="1366"/>
         <source>Update media database</source>
         <translation type="unfinished">עדכון מסד נתוני המדיה</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1233"/>
+        <location filename="../app/Main.qml" line="1369"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">איסוף מטא-נתונים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1242"/>
-        <location filename="../app/Main.qml" line="1277"/>
+        <location filename="../app/Main.qml" line="1378"/>
+        <location filename="../app/Main.qml" line="1413"/>
         <source>Launch game</source>
         <translation>הפעל משחק</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1258"/>
+        <location filename="../app/Main.qml" line="1394"/>
         <source>Remove from favorites</source>
         <translation>הסר מהמועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1258"/>
+        <location filename="../app/Main.qml" line="1394"/>
         <source>Add to favorites</source>
         <translation>הוסף למועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1263"/>
+        <location filename="../app/Main.qml" line="1399"/>
         <source>Write to NFC token</source>
         <translation>כתוב לטוקן NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1267"/>
+        <location filename="../app/Main.qml" line="1403"/>
         <source>QR code</source>
         <translation>קוד QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1427"/>
+        <location filename="../app/Main.qml" line="1563"/>
         <source>Default</source>
         <translation type="unfinished">ברירת מחדל</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1427"/>
+        <location filename="../app/Main.qml" line="1563"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1719"/>
+        <location filename="../app/Main.qml" line="1855"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1723"/>
+        <location filename="../app/Main.qml" line="1859"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1737"/>
+        <location filename="../app/Main.qml" line="1873"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1741"/>
+        <location filename="../app/Main.qml" line="1877"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1745"/>
+        <location filename="../app/Main.qml" line="1881"/>
         <source>Retry</source>
         <translation type="unfinished">נסה שוב</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1749"/>
+        <location filename="../app/Main.qml" line="1885"/>
         <source>Cancel</source>
         <translation type="unfinished">ביטול</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2379"/>
+        <location filename="../app/Main.qml" line="2523"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2381"/>
+        <location filename="../app/Main.qml" line="2525"/>
         <source>Loading games…</source>
         <translation>טוען משחקים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2383"/>
+        <location filename="../app/Main.qml" line="2527"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2385"/>
+        <location filename="../app/Main.qml" line="2529"/>
         <source>Loading favorites…</source>
         <translation>טוען מועדפים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2387"/>
+        <location filename="../app/Main.qml" line="2531"/>
         <source>Loading recently played…</source>
         <translation>טוען את הפריטים ששוחקו לאחרונה…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2389"/>
+        <location filename="../app/Main.qml" line="2533"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2391"/>
+        <location filename="../app/Main.qml" line="2535"/>
         <source>Loading…</source>
         <translation>טוען…</translation>
     </message>
@@ -674,12 +674,12 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="680"/>
+        <location filename="../app/MainLayout.qml" line="682"/>
         <source>Writing failed</source>
         <translation>הכתיבה נכשלה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="680"/>
+        <location filename="../app/MainLayout.qml" line="682"/>
         <source>Put a writable card near the reader</source>
         <translation>הניחו כרטיס הניתן לכתיבה ליד הקורא</translation>
     </message>
@@ -689,146 +689,146 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="364"/>
+        <location filename="../app/MainLayout.qml" line="367"/>
         <source>Favorites</source>
         <translation type="unfinished">מועדפים</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="366"/>
+        <location filename="../app/MainLayout.qml" line="369"/>
         <source>Recently Played</source>
         <translation type="unfinished">שוחקו לאחרונה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="696"/>
+        <location filename="../app/MainLayout.qml" line="698"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="697"/>
+        <location filename="../app/MainLayout.qml" line="699"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="807"/>
+        <location filename="../app/MainLayout.qml" line="809"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="808"/>
+        <location filename="../app/MainLayout.qml" line="810"/>
         <source>Are you sure you want to exit?</source>
         <translation>האם אתה בטוח שברצונך לצאת?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="887"/>
-        <location filename="../app/MainLayout.qml" line="961"/>
-        <location filename="../app/MainLayout.qml" line="1004"/>
-        <location filename="../app/MainLayout.qml" line="1035"/>
-        <location filename="../app/MainLayout.qml" line="1085"/>
-        <location filename="../app/MainLayout.qml" line="1128"/>
-        <location filename="../app/MainLayout.qml" line="1195"/>
+        <location filename="../app/MainLayout.qml" line="889"/>
+        <location filename="../app/MainLayout.qml" line="963"/>
+        <location filename="../app/MainLayout.qml" line="1006"/>
+        <location filename="../app/MainLayout.qml" line="1037"/>
+        <location filename="../app/MainLayout.qml" line="1087"/>
+        <location filename="../app/MainLayout.qml" line="1130"/>
+        <location filename="../app/MainLayout.qml" line="1197"/>
         <source>Move</source>
         <translation>הזזה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="891"/>
-        <location filename="../app/MainLayout.qml" line="965"/>
+        <location filename="../app/MainLayout.qml" line="893"/>
+        <location filename="../app/MainLayout.qml" line="967"/>
         <source>Select</source>
         <translation>בחירה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="895"/>
-        <location filename="../app/MainLayout.qml" line="899"/>
-        <location filename="../app/MainLayout.qml" line="913"/>
-        <location filename="../app/MainLayout.qml" line="928"/>
-        <location filename="../app/MainLayout.qml" line="939"/>
+        <location filename="../app/MainLayout.qml" line="897"/>
+        <location filename="../app/MainLayout.qml" line="901"/>
+        <location filename="../app/MainLayout.qml" line="915"/>
+        <location filename="../app/MainLayout.qml" line="930"/>
+        <location filename="../app/MainLayout.qml" line="941"/>
         <source>Close</source>
         <translation>סגור</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="906"/>
-        <location filename="../app/MainLayout.qml" line="946"/>
-        <location filename="../app/MainLayout.qml" line="969"/>
-        <location filename="../app/MainLayout.qml" line="980"/>
+        <location filename="../app/MainLayout.qml" line="908"/>
+        <location filename="../app/MainLayout.qml" line="948"/>
+        <location filename="../app/MainLayout.qml" line="971"/>
+        <location filename="../app/MainLayout.qml" line="982"/>
         <source>Cancel</source>
         <translation>ביטול</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="924"/>
+        <location filename="../app/MainLayout.qml" line="926"/>
         <source>Done</source>
         <translation>הושלם</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="935"/>
-        <location filename="../app/MainLayout.qml" line="1058"/>
-        <location filename="../app/MainLayout.qml" line="1111"/>
-        <location filename="../app/MainLayout.qml" line="1221"/>
+        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="1060"/>
+        <location filename="../app/MainLayout.qml" line="1113"/>
+        <location filename="../app/MainLayout.qml" line="1223"/>
         <source>Retry</source>
         <translation>נסה שוב</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="954"/>
+        <location filename="../app/MainLayout.qml" line="956"/>
         <source>I understand</source>
         <translation>הבנתי</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="988"/>
+        <location filename="../app/MainLayout.qml" line="990"/>
         <source>Start</source>
         <translation>התחל</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1008"/>
-        <location filename="../app/MainLayout.qml" line="1045"/>
-        <location filename="../app/MainLayout.qml" line="1095"/>
-        <location filename="../app/MainLayout.qml" line="1205"/>
+        <location filename="../app/MainLayout.qml" line="1010"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1097"/>
+        <location filename="../app/MainLayout.qml" line="1207"/>
         <source>Open</source>
         <translation>פתח</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1012"/>
+        <location filename="../app/MainLayout.qml" line="1014"/>
         <source>Quit</source>
         <translation>יציאה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1021"/>
-        <location filename="../app/MainLayout.qml" line="1051"/>
-        <location filename="../app/MainLayout.qml" line="1062"/>
-        <location filename="../app/MainLayout.qml" line="1077"/>
-        <location filename="../app/MainLayout.qml" line="1104"/>
-        <location filename="../app/MainLayout.qml" line="1115"/>
-        <location filename="../app/MainLayout.qml" line="1152"/>
-        <location filename="../app/MainLayout.qml" line="1170"/>
-        <location filename="../app/MainLayout.qml" line="1179"/>
-        <location filename="../app/MainLayout.qml" line="1214"/>
-        <location filename="../app/MainLayout.qml" line="1225"/>
+        <location filename="../app/MainLayout.qml" line="1023"/>
+        <location filename="../app/MainLayout.qml" line="1053"/>
+        <location filename="../app/MainLayout.qml" line="1064"/>
+        <location filename="../app/MainLayout.qml" line="1079"/>
+        <location filename="../app/MainLayout.qml" line="1106"/>
+        <location filename="../app/MainLayout.qml" line="1117"/>
+        <location filename="../app/MainLayout.qml" line="1154"/>
+        <location filename="../app/MainLayout.qml" line="1172"/>
+        <location filename="../app/MainLayout.qml" line="1181"/>
+        <location filename="../app/MainLayout.qml" line="1216"/>
+        <location filename="../app/MainLayout.qml" line="1227"/>
         <source>Back</source>
         <translation>חזרה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1041"/>
-        <location filename="../app/MainLayout.qml" line="1091"/>
-        <location filename="../app/MainLayout.qml" line="1201"/>
+        <location filename="../app/MainLayout.qml" line="1043"/>
+        <location filename="../app/MainLayout.qml" line="1093"/>
+        <location filename="../app/MainLayout.qml" line="1203"/>
         <source>Page</source>
         <translation>עמוד</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1048"/>
-        <location filename="../app/MainLayout.qml" line="1100"/>
-        <location filename="../app/MainLayout.qml" line="1210"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1102"/>
+        <location filename="../app/MainLayout.qml" line="1212"/>
         <source>Options</source>
         <translation>אפשרויות</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1137"/>
+        <location filename="../app/MainLayout.qml" line="1139"/>
         <source>Change</source>
         <translation>שינוי</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1143"/>
+        <location filename="../app/MainLayout.qml" line="1145"/>
         <source>Toggle</source>
         <translation>החלף</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1166"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
         <source>Scroll</source>
         <translation>גלילה</translation>
     </message>
@@ -841,12 +841,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">טוען…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="350"/>
+        <location filename="../screens/MediaListScreen.qml" line="354"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 פריטים</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="351"/>
+        <location filename="../screens/MediaListScreen.qml" line="355"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -905,7 +905,7 @@ Euskara - devilschile2</source>
         <translation>טוען…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="58"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="65"/>
         <source>Failed to load</source>
         <translation>הטעינה נכשלה</translation>
     </message>
@@ -1338,24 +1338,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="197"/>
-        <location filename="../screens/SystemsScreen.qml" line="295"/>
+        <location filename="../screens/SystemsScreen.qml" line="199"/>
+        <location filename="../screens/SystemsScreen.qml" line="297"/>
         <source>%1 systems</source>
         <translation>%1 מערכות</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="198"/>
-        <location filename="../screens/SystemsScreen.qml" line="312"/>
+        <location filename="../screens/SystemsScreen.qml" line="200"/>
+        <location filename="../screens/SystemsScreen.qml" line="314"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="328"/>
+        <location filename="../screens/SystemsScreen.qml" line="330"/>
         <source>No systems in this category</source>
         <translation>אין מערכות בקטגוריה זו</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="329"/>
+        <location filename="../screens/SystemsScreen.qml" line="331"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -549,124 +549,124 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1217"/>
+        <location filename="../app/Main.qml" line="1353"/>
         <source>Launch core</source>
         <translation>कोर चलाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1223"/>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1359"/>
+        <location filename="../app/Main.qml" line="1567"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1230"/>
+        <location filename="../app/Main.qml" line="1366"/>
         <source>Update media database</source>
         <translation type="unfinished">मीडिया डेटाबेस अपडेट करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1233"/>
+        <location filename="../app/Main.qml" line="1369"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">मेटाडेटा स्क्रैप करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1242"/>
-        <location filename="../app/Main.qml" line="1277"/>
+        <location filename="../app/Main.qml" line="1378"/>
+        <location filename="../app/Main.qml" line="1413"/>
         <source>Launch game</source>
         <translation>गेम चलाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1258"/>
+        <location filename="../app/Main.qml" line="1394"/>
         <source>Remove from favorites</source>
         <translation>पसंदीदा से हटाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1258"/>
+        <location filename="../app/Main.qml" line="1394"/>
         <source>Add to favorites</source>
         <translation>पसंदीदा में जोड़ें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1263"/>
+        <location filename="../app/Main.qml" line="1399"/>
         <source>Write to NFC token</source>
         <translation>NFC टोकन पर लिखें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1267"/>
+        <location filename="../app/Main.qml" line="1403"/>
         <source>QR code</source>
         <translation>QR कोड</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1427"/>
+        <location filename="../app/Main.qml" line="1563"/>
         <source>Default</source>
         <translation type="unfinished">डिफ़ॉल्ट</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1427"/>
+        <location filename="../app/Main.qml" line="1563"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1719"/>
+        <location filename="../app/Main.qml" line="1855"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1723"/>
+        <location filename="../app/Main.qml" line="1859"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1737"/>
+        <location filename="../app/Main.qml" line="1873"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1741"/>
+        <location filename="../app/Main.qml" line="1877"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1745"/>
+        <location filename="../app/Main.qml" line="1881"/>
         <source>Retry</source>
         <translation type="unfinished">फिर से प्रयास करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1749"/>
+        <location filename="../app/Main.qml" line="1885"/>
         <source>Cancel</source>
         <translation type="unfinished">रद्द करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2379"/>
+        <location filename="../app/Main.qml" line="2523"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2381"/>
+        <location filename="../app/Main.qml" line="2525"/>
         <source>Loading games…</source>
         <translation>गेम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2383"/>
+        <location filename="../app/Main.qml" line="2527"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2385"/>
+        <location filename="../app/Main.qml" line="2529"/>
         <source>Loading favorites…</source>
         <translation>पसंदीदा लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2387"/>
+        <location filename="../app/Main.qml" line="2531"/>
         <source>Loading recently played…</source>
         <translation>हाल ही में खेले गए लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2389"/>
+        <location filename="../app/Main.qml" line="2533"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2391"/>
+        <location filename="../app/Main.qml" line="2535"/>
         <source>Loading…</source>
         <translation>लोड हो रहा है…</translation>
     </message>
@@ -674,12 +674,12 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="680"/>
+        <location filename="../app/MainLayout.qml" line="682"/>
         <source>Writing failed</source>
         <translation>लिखना विफल हुआ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="680"/>
+        <location filename="../app/MainLayout.qml" line="682"/>
         <source>Put a writable card near the reader</source>
         <translation>रीडर के पास लिखने योग्य कार्ड रखें</translation>
     </message>
@@ -689,146 +689,146 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="364"/>
+        <location filename="../app/MainLayout.qml" line="367"/>
         <source>Favorites</source>
         <translation type="unfinished">पसंदीदा</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="366"/>
+        <location filename="../app/MainLayout.qml" line="369"/>
         <source>Recently Played</source>
         <translation type="unfinished">हाल ही में खेले गए</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="696"/>
+        <location filename="../app/MainLayout.qml" line="698"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="697"/>
+        <location filename="../app/MainLayout.qml" line="699"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="807"/>
+        <location filename="../app/MainLayout.qml" line="809"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="808"/>
+        <location filename="../app/MainLayout.qml" line="810"/>
         <source>Are you sure you want to exit?</source>
         <translation>क्या आप वाकई बाहर निकलना चाहते हैं?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="887"/>
-        <location filename="../app/MainLayout.qml" line="961"/>
-        <location filename="../app/MainLayout.qml" line="1004"/>
-        <location filename="../app/MainLayout.qml" line="1035"/>
-        <location filename="../app/MainLayout.qml" line="1085"/>
-        <location filename="../app/MainLayout.qml" line="1128"/>
-        <location filename="../app/MainLayout.qml" line="1195"/>
+        <location filename="../app/MainLayout.qml" line="889"/>
+        <location filename="../app/MainLayout.qml" line="963"/>
+        <location filename="../app/MainLayout.qml" line="1006"/>
+        <location filename="../app/MainLayout.qml" line="1037"/>
+        <location filename="../app/MainLayout.qml" line="1087"/>
+        <location filename="../app/MainLayout.qml" line="1130"/>
+        <location filename="../app/MainLayout.qml" line="1197"/>
         <source>Move</source>
         <translation>स्थानांतरित करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="891"/>
-        <location filename="../app/MainLayout.qml" line="965"/>
+        <location filename="../app/MainLayout.qml" line="893"/>
+        <location filename="../app/MainLayout.qml" line="967"/>
         <source>Select</source>
         <translation>चुनें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="895"/>
-        <location filename="../app/MainLayout.qml" line="899"/>
-        <location filename="../app/MainLayout.qml" line="913"/>
-        <location filename="../app/MainLayout.qml" line="928"/>
-        <location filename="../app/MainLayout.qml" line="939"/>
+        <location filename="../app/MainLayout.qml" line="897"/>
+        <location filename="../app/MainLayout.qml" line="901"/>
+        <location filename="../app/MainLayout.qml" line="915"/>
+        <location filename="../app/MainLayout.qml" line="930"/>
+        <location filename="../app/MainLayout.qml" line="941"/>
         <source>Close</source>
         <translation>बंद करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="906"/>
-        <location filename="../app/MainLayout.qml" line="946"/>
-        <location filename="../app/MainLayout.qml" line="969"/>
-        <location filename="../app/MainLayout.qml" line="980"/>
+        <location filename="../app/MainLayout.qml" line="908"/>
+        <location filename="../app/MainLayout.qml" line="948"/>
+        <location filename="../app/MainLayout.qml" line="971"/>
+        <location filename="../app/MainLayout.qml" line="982"/>
         <source>Cancel</source>
         <translation>रद्द करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="924"/>
+        <location filename="../app/MainLayout.qml" line="926"/>
         <source>Done</source>
         <translation>पूरा</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="935"/>
-        <location filename="../app/MainLayout.qml" line="1058"/>
-        <location filename="../app/MainLayout.qml" line="1111"/>
-        <location filename="../app/MainLayout.qml" line="1221"/>
+        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="1060"/>
+        <location filename="../app/MainLayout.qml" line="1113"/>
+        <location filename="../app/MainLayout.qml" line="1223"/>
         <source>Retry</source>
         <translation>फिर से प्रयास करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="954"/>
+        <location filename="../app/MainLayout.qml" line="956"/>
         <source>I understand</source>
         <translation>मैं समझ गया</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="988"/>
+        <location filename="../app/MainLayout.qml" line="990"/>
         <source>Start</source>
         <translation>शुरू करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1008"/>
-        <location filename="../app/MainLayout.qml" line="1045"/>
-        <location filename="../app/MainLayout.qml" line="1095"/>
-        <location filename="../app/MainLayout.qml" line="1205"/>
+        <location filename="../app/MainLayout.qml" line="1010"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1097"/>
+        <location filename="../app/MainLayout.qml" line="1207"/>
         <source>Open</source>
         <translation>खोलें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1012"/>
+        <location filename="../app/MainLayout.qml" line="1014"/>
         <source>Quit</source>
         <translation>बंद करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1021"/>
-        <location filename="../app/MainLayout.qml" line="1051"/>
-        <location filename="../app/MainLayout.qml" line="1062"/>
-        <location filename="../app/MainLayout.qml" line="1077"/>
-        <location filename="../app/MainLayout.qml" line="1104"/>
-        <location filename="../app/MainLayout.qml" line="1115"/>
-        <location filename="../app/MainLayout.qml" line="1152"/>
-        <location filename="../app/MainLayout.qml" line="1170"/>
-        <location filename="../app/MainLayout.qml" line="1179"/>
-        <location filename="../app/MainLayout.qml" line="1214"/>
-        <location filename="../app/MainLayout.qml" line="1225"/>
+        <location filename="../app/MainLayout.qml" line="1023"/>
+        <location filename="../app/MainLayout.qml" line="1053"/>
+        <location filename="../app/MainLayout.qml" line="1064"/>
+        <location filename="../app/MainLayout.qml" line="1079"/>
+        <location filename="../app/MainLayout.qml" line="1106"/>
+        <location filename="../app/MainLayout.qml" line="1117"/>
+        <location filename="../app/MainLayout.qml" line="1154"/>
+        <location filename="../app/MainLayout.qml" line="1172"/>
+        <location filename="../app/MainLayout.qml" line="1181"/>
+        <location filename="../app/MainLayout.qml" line="1216"/>
+        <location filename="../app/MainLayout.qml" line="1227"/>
         <source>Back</source>
         <translation>वापस</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1041"/>
-        <location filename="../app/MainLayout.qml" line="1091"/>
-        <location filename="../app/MainLayout.qml" line="1201"/>
+        <location filename="../app/MainLayout.qml" line="1043"/>
+        <location filename="../app/MainLayout.qml" line="1093"/>
+        <location filename="../app/MainLayout.qml" line="1203"/>
         <source>Page</source>
         <translation>पृष्ठ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1048"/>
-        <location filename="../app/MainLayout.qml" line="1100"/>
-        <location filename="../app/MainLayout.qml" line="1210"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1102"/>
+        <location filename="../app/MainLayout.qml" line="1212"/>
         <source>Options</source>
         <translation>विकल्प</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1137"/>
+        <location filename="../app/MainLayout.qml" line="1139"/>
         <source>Change</source>
         <translation>बदलें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1143"/>
+        <location filename="../app/MainLayout.qml" line="1145"/>
         <source>Toggle</source>
         <translation>टॉगल</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1166"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
         <source>Scroll</source>
         <translation>स्क्रॉल</translation>
     </message>
@@ -841,12 +841,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">लोड हो रहा है…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="350"/>
+        <location filename="../screens/MediaListScreen.qml" line="354"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 प्रविष्टियाँ</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="351"/>
+        <location filename="../screens/MediaListScreen.qml" line="355"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -905,7 +905,7 @@ Euskara - devilschile2</source>
         <translation>लोड हो रहा है…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="58"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="65"/>
         <source>Failed to load</source>
         <translation>लोड करने में विफल</translation>
     </message>
@@ -1338,24 +1338,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="197"/>
-        <location filename="../screens/SystemsScreen.qml" line="295"/>
+        <location filename="../screens/SystemsScreen.qml" line="199"/>
+        <location filename="../screens/SystemsScreen.qml" line="297"/>
         <source>%1 systems</source>
         <translation>%1 सिस्टम</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="198"/>
-        <location filename="../screens/SystemsScreen.qml" line="312"/>
+        <location filename="../screens/SystemsScreen.qml" line="200"/>
+        <location filename="../screens/SystemsScreen.qml" line="314"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="328"/>
+        <location filename="../screens/SystemsScreen.qml" line="330"/>
         <source>No systems in this category</source>
         <translation>इस श्रेणी में कोई सिस्टम नहीं है</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="329"/>
+        <location filename="../screens/SystemsScreen.qml" line="331"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -549,124 +549,124 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1217"/>
+        <location filename="../app/Main.qml" line="1353"/>
         <source>Launch core</source>
         <translation>Avvia core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1223"/>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1359"/>
+        <location filename="../app/Main.qml" line="1567"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1258"/>
+        <location filename="../app/Main.qml" line="1394"/>
         <source>Remove from favorites</source>
         <translation>Rimuovi dai preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1258"/>
+        <location filename="../app/Main.qml" line="1394"/>
         <source>Add to favorites</source>
         <translation>Aggiungi ai preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1263"/>
+        <location filename="../app/Main.qml" line="1399"/>
         <source>Write to NFC token</source>
         <translation>Scrivi sul token NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1267"/>
+        <location filename="../app/Main.qml" line="1403"/>
         <source>QR code</source>
         <translation>Codice QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1242"/>
-        <location filename="../app/Main.qml" line="1277"/>
+        <location filename="../app/Main.qml" line="1378"/>
+        <location filename="../app/Main.qml" line="1413"/>
         <source>Launch game</source>
         <translation>Avvia gioco</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2379"/>
+        <location filename="../app/Main.qml" line="2523"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2385"/>
+        <location filename="../app/Main.qml" line="2529"/>
         <source>Loading favorites…</source>
         <translation>Caricamento preferiti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2381"/>
+        <location filename="../app/Main.qml" line="2525"/>
         <source>Loading games…</source>
         <translation>Caricamento giochi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1230"/>
+        <location filename="../app/Main.qml" line="1366"/>
         <source>Update media database</source>
         <translation type="unfinished">Aggiorna database multimediale</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1233"/>
+        <location filename="../app/Main.qml" line="1369"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Recupera metadati</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1427"/>
+        <location filename="../app/Main.qml" line="1563"/>
         <source>Default</source>
         <translation type="unfinished">Predefinito</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1427"/>
+        <location filename="../app/Main.qml" line="1563"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1719"/>
+        <location filename="../app/Main.qml" line="1855"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1723"/>
+        <location filename="../app/Main.qml" line="1859"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1737"/>
+        <location filename="../app/Main.qml" line="1873"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1741"/>
+        <location filename="../app/Main.qml" line="1877"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1745"/>
+        <location filename="../app/Main.qml" line="1881"/>
         <source>Retry</source>
         <translation type="unfinished">Riprova</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1749"/>
+        <location filename="../app/Main.qml" line="1885"/>
         <source>Cancel</source>
         <translation type="unfinished">Annulla</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2383"/>
+        <location filename="../app/Main.qml" line="2527"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2387"/>
+        <location filename="../app/Main.qml" line="2531"/>
         <source>Loading recently played…</source>
         <translation>Caricamento recenti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2389"/>
+        <location filename="../app/Main.qml" line="2533"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2391"/>
+        <location filename="../app/Main.qml" line="2535"/>
         <source>Loading…</source>
         <translation>Caricamento…</translation>
     </message>
@@ -674,71 +674,71 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="680"/>
+        <location filename="../app/MainLayout.qml" line="682"/>
         <source>Writing failed</source>
         <translation>Scrittura non riuscita</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="680"/>
+        <location filename="../app/MainLayout.qml" line="682"/>
         <source>Put a writable card near the reader</source>
         <translation>Avvicina una scheda scrivibile al lettore</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="808"/>
+        <location filename="../app/MainLayout.qml" line="810"/>
         <source>Are you sure you want to exit?</source>
         <translation>Sei sicuro di voler uscire?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="891"/>
-        <location filename="../app/MainLayout.qml" line="965"/>
+        <location filename="../app/MainLayout.qml" line="893"/>
+        <location filename="../app/MainLayout.qml" line="967"/>
         <source>Select</source>
         <translation>Seleziona</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="895"/>
-        <location filename="../app/MainLayout.qml" line="899"/>
-        <location filename="../app/MainLayout.qml" line="913"/>
-        <location filename="../app/MainLayout.qml" line="928"/>
-        <location filename="../app/MainLayout.qml" line="939"/>
+        <location filename="../app/MainLayout.qml" line="897"/>
+        <location filename="../app/MainLayout.qml" line="901"/>
+        <location filename="../app/MainLayout.qml" line="915"/>
+        <location filename="../app/MainLayout.qml" line="930"/>
+        <location filename="../app/MainLayout.qml" line="941"/>
         <source>Close</source>
         <translation>Chiudi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="906"/>
-        <location filename="../app/MainLayout.qml" line="946"/>
-        <location filename="../app/MainLayout.qml" line="969"/>
-        <location filename="../app/MainLayout.qml" line="980"/>
+        <location filename="../app/MainLayout.qml" line="908"/>
+        <location filename="../app/MainLayout.qml" line="948"/>
+        <location filename="../app/MainLayout.qml" line="971"/>
+        <location filename="../app/MainLayout.qml" line="982"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="924"/>
+        <location filename="../app/MainLayout.qml" line="926"/>
         <source>Done</source>
         <translation>Fatto</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="954"/>
+        <location filename="../app/MainLayout.qml" line="956"/>
         <source>I understand</source>
         <translation>Ho capito</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="988"/>
+        <location filename="../app/MainLayout.qml" line="990"/>
         <source>Start</source>
         <translation>Avvia</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1166"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
         <source>Scroll</source>
         <translation>Scorri</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="887"/>
-        <location filename="../app/MainLayout.qml" line="961"/>
-        <location filename="../app/MainLayout.qml" line="1004"/>
-        <location filename="../app/MainLayout.qml" line="1035"/>
-        <location filename="../app/MainLayout.qml" line="1085"/>
-        <location filename="../app/MainLayout.qml" line="1128"/>
-        <location filename="../app/MainLayout.qml" line="1195"/>
+        <location filename="../app/MainLayout.qml" line="889"/>
+        <location filename="../app/MainLayout.qml" line="963"/>
+        <location filename="../app/MainLayout.qml" line="1006"/>
+        <location filename="../app/MainLayout.qml" line="1037"/>
+        <location filename="../app/MainLayout.qml" line="1087"/>
+        <location filename="../app/MainLayout.qml" line="1130"/>
+        <location filename="../app/MainLayout.qml" line="1197"/>
         <source>Move</source>
         <translation>Muovi</translation>
     </message>
@@ -748,87 +748,87 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="364"/>
+        <location filename="../app/MainLayout.qml" line="367"/>
         <source>Favorites</source>
         <translation type="unfinished">Preferiti</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="366"/>
+        <location filename="../app/MainLayout.qml" line="369"/>
         <source>Recently Played</source>
         <translation type="unfinished">Giocati di recente</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="696"/>
+        <location filename="../app/MainLayout.qml" line="698"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="697"/>
+        <location filename="../app/MainLayout.qml" line="699"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="807"/>
+        <location filename="../app/MainLayout.qml" line="809"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1008"/>
-        <location filename="../app/MainLayout.qml" line="1045"/>
-        <location filename="../app/MainLayout.qml" line="1095"/>
-        <location filename="../app/MainLayout.qml" line="1205"/>
+        <location filename="../app/MainLayout.qml" line="1010"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1097"/>
+        <location filename="../app/MainLayout.qml" line="1207"/>
         <source>Open</source>
         <translation>Apri</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1012"/>
+        <location filename="../app/MainLayout.qml" line="1014"/>
         <source>Quit</source>
         <translation>Esci</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1021"/>
-        <location filename="../app/MainLayout.qml" line="1051"/>
-        <location filename="../app/MainLayout.qml" line="1062"/>
-        <location filename="../app/MainLayout.qml" line="1077"/>
-        <location filename="../app/MainLayout.qml" line="1104"/>
-        <location filename="../app/MainLayout.qml" line="1115"/>
-        <location filename="../app/MainLayout.qml" line="1152"/>
-        <location filename="../app/MainLayout.qml" line="1170"/>
-        <location filename="../app/MainLayout.qml" line="1179"/>
-        <location filename="../app/MainLayout.qml" line="1214"/>
-        <location filename="../app/MainLayout.qml" line="1225"/>
+        <location filename="../app/MainLayout.qml" line="1023"/>
+        <location filename="../app/MainLayout.qml" line="1053"/>
+        <location filename="../app/MainLayout.qml" line="1064"/>
+        <location filename="../app/MainLayout.qml" line="1079"/>
+        <location filename="../app/MainLayout.qml" line="1106"/>
+        <location filename="../app/MainLayout.qml" line="1117"/>
+        <location filename="../app/MainLayout.qml" line="1154"/>
+        <location filename="../app/MainLayout.qml" line="1172"/>
+        <location filename="../app/MainLayout.qml" line="1181"/>
+        <location filename="../app/MainLayout.qml" line="1216"/>
+        <location filename="../app/MainLayout.qml" line="1227"/>
         <source>Back</source>
         <translation>Indietro</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1041"/>
-        <location filename="../app/MainLayout.qml" line="1091"/>
-        <location filename="../app/MainLayout.qml" line="1201"/>
+        <location filename="../app/MainLayout.qml" line="1043"/>
+        <location filename="../app/MainLayout.qml" line="1093"/>
+        <location filename="../app/MainLayout.qml" line="1203"/>
         <source>Page</source>
         <translation>Pagina</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1048"/>
-        <location filename="../app/MainLayout.qml" line="1100"/>
-        <location filename="../app/MainLayout.qml" line="1210"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1102"/>
+        <location filename="../app/MainLayout.qml" line="1212"/>
         <source>Options</source>
         <translation>Opzioni</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="935"/>
-        <location filename="../app/MainLayout.qml" line="1058"/>
-        <location filename="../app/MainLayout.qml" line="1111"/>
-        <location filename="../app/MainLayout.qml" line="1221"/>
+        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="1060"/>
+        <location filename="../app/MainLayout.qml" line="1113"/>
+        <location filename="../app/MainLayout.qml" line="1223"/>
         <source>Retry</source>
         <translation>Riprova</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1137"/>
+        <location filename="../app/MainLayout.qml" line="1139"/>
         <source>Change</source>
         <translation>Cambia</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1143"/>
+        <location filename="../app/MainLayout.qml" line="1145"/>
         <source>Toggle</source>
         <translation>Alterna</translation>
     </message>
@@ -841,12 +841,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Caricamento…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="350"/>
+        <location filename="../screens/MediaListScreen.qml" line="354"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 elementi</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="351"/>
+        <location filename="../screens/MediaListScreen.qml" line="355"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -905,7 +905,7 @@ Euskara - devilschile2</source>
         <translation>Caricamento…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="58"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="65"/>
         <source>Failed to load</source>
         <translation>Caricamento non riuscito</translation>
     </message>
@@ -1338,24 +1338,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="197"/>
-        <location filename="../screens/SystemsScreen.qml" line="295"/>
+        <location filename="../screens/SystemsScreen.qml" line="199"/>
+        <location filename="../screens/SystemsScreen.qml" line="297"/>
         <source>%1 systems</source>
         <translation>%1 sistemi</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="198"/>
-        <location filename="../screens/SystemsScreen.qml" line="312"/>
+        <location filename="../screens/SystemsScreen.qml" line="200"/>
+        <location filename="../screens/SystemsScreen.qml" line="314"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="328"/>
+        <location filename="../screens/SystemsScreen.qml" line="330"/>
         <source>No systems in this category</source>
         <translation>Nessun sistema in questa categoria</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="329"/>
+        <location filename="../screens/SystemsScreen.qml" line="331"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -549,124 +549,124 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1217"/>
+        <location filename="../app/Main.qml" line="1353"/>
         <source>Launch core</source>
         <translation>コアを起動</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1223"/>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1359"/>
+        <location filename="../app/Main.qml" line="1567"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1258"/>
+        <location filename="../app/Main.qml" line="1394"/>
         <source>Remove from favorites</source>
         <translation>お気に入りから削除</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1258"/>
+        <location filename="../app/Main.qml" line="1394"/>
         <source>Add to favorites</source>
         <translation>お気に入りに追加</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1263"/>
+        <location filename="../app/Main.qml" line="1399"/>
         <source>Write to NFC token</source>
         <translation>NFC トークンに書き込む</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1267"/>
+        <location filename="../app/Main.qml" line="1403"/>
         <source>QR code</source>
         <translation>QR コード</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1242"/>
-        <location filename="../app/Main.qml" line="1277"/>
+        <location filename="../app/Main.qml" line="1378"/>
+        <location filename="../app/Main.qml" line="1413"/>
         <source>Launch game</source>
         <translation>ゲームを起動</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2379"/>
+        <location filename="../app/Main.qml" line="2523"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2385"/>
+        <location filename="../app/Main.qml" line="2529"/>
         <source>Loading favorites…</source>
         <translation>お気に入りを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2381"/>
+        <location filename="../app/Main.qml" line="2525"/>
         <source>Loading games…</source>
         <translation>ゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1230"/>
+        <location filename="../app/Main.qml" line="1366"/>
         <source>Update media database</source>
         <translation type="unfinished">メディアデータベースを更新</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1233"/>
+        <location filename="../app/Main.qml" line="1369"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">メタデータをスクレイピング</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1427"/>
+        <location filename="../app/Main.qml" line="1563"/>
         <source>Default</source>
         <translation type="unfinished">デフォルト</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1427"/>
+        <location filename="../app/Main.qml" line="1563"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1719"/>
+        <location filename="../app/Main.qml" line="1855"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1723"/>
+        <location filename="../app/Main.qml" line="1859"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1737"/>
+        <location filename="../app/Main.qml" line="1873"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1741"/>
+        <location filename="../app/Main.qml" line="1877"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1745"/>
+        <location filename="../app/Main.qml" line="1881"/>
         <source>Retry</source>
         <translation type="unfinished">再試行</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1749"/>
+        <location filename="../app/Main.qml" line="1885"/>
         <source>Cancel</source>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2383"/>
+        <location filename="../app/Main.qml" line="2527"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2387"/>
+        <location filename="../app/Main.qml" line="2531"/>
         <source>Loading recently played…</source>
         <translation>最近プレイしたゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2389"/>
+        <location filename="../app/Main.qml" line="2533"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2391"/>
+        <location filename="../app/Main.qml" line="2535"/>
         <source>Loading…</source>
         <translation>読み込み中…</translation>
     </message>
@@ -674,71 +674,71 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="680"/>
+        <location filename="../app/MainLayout.qml" line="682"/>
         <source>Writing failed</source>
         <translation>書き込み失敗</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="680"/>
+        <location filename="../app/MainLayout.qml" line="682"/>
         <source>Put a writable card near the reader</source>
         <translation>書き込み可能なカードをリーダーに近づけてください</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="808"/>
+        <location filename="../app/MainLayout.qml" line="810"/>
         <source>Are you sure you want to exit?</source>
         <translation>本当に終了しますか？</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="891"/>
-        <location filename="../app/MainLayout.qml" line="965"/>
+        <location filename="../app/MainLayout.qml" line="893"/>
+        <location filename="../app/MainLayout.qml" line="967"/>
         <source>Select</source>
         <translation>選択</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="895"/>
-        <location filename="../app/MainLayout.qml" line="899"/>
-        <location filename="../app/MainLayout.qml" line="913"/>
-        <location filename="../app/MainLayout.qml" line="928"/>
-        <location filename="../app/MainLayout.qml" line="939"/>
+        <location filename="../app/MainLayout.qml" line="897"/>
+        <location filename="../app/MainLayout.qml" line="901"/>
+        <location filename="../app/MainLayout.qml" line="915"/>
+        <location filename="../app/MainLayout.qml" line="930"/>
+        <location filename="../app/MainLayout.qml" line="941"/>
         <source>Close</source>
         <translation>閉じる</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="906"/>
-        <location filename="../app/MainLayout.qml" line="946"/>
-        <location filename="../app/MainLayout.qml" line="969"/>
-        <location filename="../app/MainLayout.qml" line="980"/>
+        <location filename="../app/MainLayout.qml" line="908"/>
+        <location filename="../app/MainLayout.qml" line="948"/>
+        <location filename="../app/MainLayout.qml" line="971"/>
+        <location filename="../app/MainLayout.qml" line="982"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="924"/>
+        <location filename="../app/MainLayout.qml" line="926"/>
         <source>Done</source>
         <translation>完了</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="954"/>
+        <location filename="../app/MainLayout.qml" line="956"/>
         <source>I understand</source>
         <translation>了解しました</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="988"/>
+        <location filename="../app/MainLayout.qml" line="990"/>
         <source>Start</source>
         <translation>開始</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1166"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
         <source>Scroll</source>
         <translation>スクロール</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="887"/>
-        <location filename="../app/MainLayout.qml" line="961"/>
-        <location filename="../app/MainLayout.qml" line="1004"/>
-        <location filename="../app/MainLayout.qml" line="1035"/>
-        <location filename="../app/MainLayout.qml" line="1085"/>
-        <location filename="../app/MainLayout.qml" line="1128"/>
-        <location filename="../app/MainLayout.qml" line="1195"/>
+        <location filename="../app/MainLayout.qml" line="889"/>
+        <location filename="../app/MainLayout.qml" line="963"/>
+        <location filename="../app/MainLayout.qml" line="1006"/>
+        <location filename="../app/MainLayout.qml" line="1037"/>
+        <location filename="../app/MainLayout.qml" line="1087"/>
+        <location filename="../app/MainLayout.qml" line="1130"/>
+        <location filename="../app/MainLayout.qml" line="1197"/>
         <source>Move</source>
         <translation>移動</translation>
     </message>
@@ -748,87 +748,87 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="364"/>
+        <location filename="../app/MainLayout.qml" line="367"/>
         <source>Favorites</source>
         <translation type="unfinished">お気に入り</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="366"/>
+        <location filename="../app/MainLayout.qml" line="369"/>
         <source>Recently Played</source>
         <translation type="unfinished">最近プレイしたゲーム</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="696"/>
+        <location filename="../app/MainLayout.qml" line="698"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="697"/>
+        <location filename="../app/MainLayout.qml" line="699"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="807"/>
+        <location filename="../app/MainLayout.qml" line="809"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1008"/>
-        <location filename="../app/MainLayout.qml" line="1045"/>
-        <location filename="../app/MainLayout.qml" line="1095"/>
-        <location filename="../app/MainLayout.qml" line="1205"/>
+        <location filename="../app/MainLayout.qml" line="1010"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1097"/>
+        <location filename="../app/MainLayout.qml" line="1207"/>
         <source>Open</source>
         <translation>開く</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1012"/>
+        <location filename="../app/MainLayout.qml" line="1014"/>
         <source>Quit</source>
         <translation>終了</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1021"/>
-        <location filename="../app/MainLayout.qml" line="1051"/>
-        <location filename="../app/MainLayout.qml" line="1062"/>
-        <location filename="../app/MainLayout.qml" line="1077"/>
-        <location filename="../app/MainLayout.qml" line="1104"/>
-        <location filename="../app/MainLayout.qml" line="1115"/>
-        <location filename="../app/MainLayout.qml" line="1152"/>
-        <location filename="../app/MainLayout.qml" line="1170"/>
-        <location filename="../app/MainLayout.qml" line="1179"/>
-        <location filename="../app/MainLayout.qml" line="1214"/>
-        <location filename="../app/MainLayout.qml" line="1225"/>
+        <location filename="../app/MainLayout.qml" line="1023"/>
+        <location filename="../app/MainLayout.qml" line="1053"/>
+        <location filename="../app/MainLayout.qml" line="1064"/>
+        <location filename="../app/MainLayout.qml" line="1079"/>
+        <location filename="../app/MainLayout.qml" line="1106"/>
+        <location filename="../app/MainLayout.qml" line="1117"/>
+        <location filename="../app/MainLayout.qml" line="1154"/>
+        <location filename="../app/MainLayout.qml" line="1172"/>
+        <location filename="../app/MainLayout.qml" line="1181"/>
+        <location filename="../app/MainLayout.qml" line="1216"/>
+        <location filename="../app/MainLayout.qml" line="1227"/>
         <source>Back</source>
         <translation>戻る</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1041"/>
-        <location filename="../app/MainLayout.qml" line="1091"/>
-        <location filename="../app/MainLayout.qml" line="1201"/>
+        <location filename="../app/MainLayout.qml" line="1043"/>
+        <location filename="../app/MainLayout.qml" line="1093"/>
+        <location filename="../app/MainLayout.qml" line="1203"/>
         <source>Page</source>
         <translation>ページ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1048"/>
-        <location filename="../app/MainLayout.qml" line="1100"/>
-        <location filename="../app/MainLayout.qml" line="1210"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1102"/>
+        <location filename="../app/MainLayout.qml" line="1212"/>
         <source>Options</source>
         <translation>オプション</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="935"/>
-        <location filename="../app/MainLayout.qml" line="1058"/>
-        <location filename="../app/MainLayout.qml" line="1111"/>
-        <location filename="../app/MainLayout.qml" line="1221"/>
+        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="1060"/>
+        <location filename="../app/MainLayout.qml" line="1113"/>
+        <location filename="../app/MainLayout.qml" line="1223"/>
         <source>Retry</source>
         <translation>再試行</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1137"/>
+        <location filename="../app/MainLayout.qml" line="1139"/>
         <source>Change</source>
         <translation>変更</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1143"/>
+        <location filename="../app/MainLayout.qml" line="1145"/>
         <source>Toggle</source>
         <translation>切り替え</translation>
     </message>
@@ -841,12 +841,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">読み込み中…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="350"/>
+        <location filename="../screens/MediaListScreen.qml" line="354"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 件</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="351"/>
+        <location filename="../screens/MediaListScreen.qml" line="355"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -905,7 +905,7 @@ Euskara - devilschile2</source>
         <translation>読み込み中…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="58"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="65"/>
         <source>Failed to load</source>
         <translation>読み込みに失敗しました</translation>
     </message>
@@ -1338,24 +1338,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="197"/>
-        <location filename="../screens/SystemsScreen.qml" line="295"/>
+        <location filename="../screens/SystemsScreen.qml" line="199"/>
+        <location filename="../screens/SystemsScreen.qml" line="297"/>
         <source>%1 systems</source>
         <translation>%1 システム</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="198"/>
-        <location filename="../screens/SystemsScreen.qml" line="312"/>
+        <location filename="../screens/SystemsScreen.qml" line="200"/>
+        <location filename="../screens/SystemsScreen.qml" line="314"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="328"/>
+        <location filename="../screens/SystemsScreen.qml" line="330"/>
         <source>No systems in this category</source>
         <translation>このカテゴリにシステムはありません</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="329"/>
+        <location filename="../screens/SystemsScreen.qml" line="331"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -549,124 +549,124 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1217"/>
+        <location filename="../app/Main.qml" line="1353"/>
         <source>Launch core</source>
         <translation>코어 실행</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1223"/>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1359"/>
+        <location filename="../app/Main.qml" line="1567"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1230"/>
+        <location filename="../app/Main.qml" line="1366"/>
         <source>Update media database</source>
         <translation type="unfinished">미디어 데이터베이스 업데이트</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1233"/>
+        <location filename="../app/Main.qml" line="1369"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">메타데이터 수집</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1242"/>
-        <location filename="../app/Main.qml" line="1277"/>
+        <location filename="../app/Main.qml" line="1378"/>
+        <location filename="../app/Main.qml" line="1413"/>
         <source>Launch game</source>
         <translation>게임 실행</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1258"/>
+        <location filename="../app/Main.qml" line="1394"/>
         <source>Remove from favorites</source>
         <translation>즐겨찾기에서 제거</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1258"/>
+        <location filename="../app/Main.qml" line="1394"/>
         <source>Add to favorites</source>
         <translation>즐겨찾기에 추가</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1263"/>
+        <location filename="../app/Main.qml" line="1399"/>
         <source>Write to NFC token</source>
         <translation>NFC 토큰에 쓰기</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1267"/>
+        <location filename="../app/Main.qml" line="1403"/>
         <source>QR code</source>
         <translation>QR 코드</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1427"/>
+        <location filename="../app/Main.qml" line="1563"/>
         <source>Default</source>
         <translation type="unfinished">기본값</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1427"/>
+        <location filename="../app/Main.qml" line="1563"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1719"/>
+        <location filename="../app/Main.qml" line="1855"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1723"/>
+        <location filename="../app/Main.qml" line="1859"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1737"/>
+        <location filename="../app/Main.qml" line="1873"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1741"/>
+        <location filename="../app/Main.qml" line="1877"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1745"/>
+        <location filename="../app/Main.qml" line="1881"/>
         <source>Retry</source>
         <translation type="unfinished">다시 시도</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1749"/>
+        <location filename="../app/Main.qml" line="1885"/>
         <source>Cancel</source>
         <translation type="unfinished">취소</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2379"/>
+        <location filename="../app/Main.qml" line="2523"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2381"/>
+        <location filename="../app/Main.qml" line="2525"/>
         <source>Loading games…</source>
         <translation>게임 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2383"/>
+        <location filename="../app/Main.qml" line="2527"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2385"/>
+        <location filename="../app/Main.qml" line="2529"/>
         <source>Loading favorites…</source>
         <translation>즐겨찾기 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2387"/>
+        <location filename="../app/Main.qml" line="2531"/>
         <source>Loading recently played…</source>
         <translation>최근 플레이 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2389"/>
+        <location filename="../app/Main.qml" line="2533"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2391"/>
+        <location filename="../app/Main.qml" line="2535"/>
         <source>Loading…</source>
         <translation>불러오는 중…</translation>
     </message>
@@ -674,12 +674,12 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="680"/>
+        <location filename="../app/MainLayout.qml" line="682"/>
         <source>Writing failed</source>
         <translation>쓰기 실패</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="680"/>
+        <location filename="../app/MainLayout.qml" line="682"/>
         <source>Put a writable card near the reader</source>
         <translation>기록 가능한 카드를 리더 근처에 놓으세요</translation>
     </message>
@@ -689,146 +689,146 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="364"/>
+        <location filename="../app/MainLayout.qml" line="367"/>
         <source>Favorites</source>
         <translation type="unfinished">즐겨찾기</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="366"/>
+        <location filename="../app/MainLayout.qml" line="369"/>
         <source>Recently Played</source>
         <translation type="unfinished">최근 플레이</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="696"/>
+        <location filename="../app/MainLayout.qml" line="698"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="697"/>
+        <location filename="../app/MainLayout.qml" line="699"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="807"/>
+        <location filename="../app/MainLayout.qml" line="809"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="808"/>
+        <location filename="../app/MainLayout.qml" line="810"/>
         <source>Are you sure you want to exit?</source>
         <translation>정말 종료하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="887"/>
-        <location filename="../app/MainLayout.qml" line="961"/>
-        <location filename="../app/MainLayout.qml" line="1004"/>
-        <location filename="../app/MainLayout.qml" line="1035"/>
-        <location filename="../app/MainLayout.qml" line="1085"/>
-        <location filename="../app/MainLayout.qml" line="1128"/>
-        <location filename="../app/MainLayout.qml" line="1195"/>
+        <location filename="../app/MainLayout.qml" line="889"/>
+        <location filename="../app/MainLayout.qml" line="963"/>
+        <location filename="../app/MainLayout.qml" line="1006"/>
+        <location filename="../app/MainLayout.qml" line="1037"/>
+        <location filename="../app/MainLayout.qml" line="1087"/>
+        <location filename="../app/MainLayout.qml" line="1130"/>
+        <location filename="../app/MainLayout.qml" line="1197"/>
         <source>Move</source>
         <translation>이동</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="891"/>
-        <location filename="../app/MainLayout.qml" line="965"/>
+        <location filename="../app/MainLayout.qml" line="893"/>
+        <location filename="../app/MainLayout.qml" line="967"/>
         <source>Select</source>
         <translation>선택</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="895"/>
-        <location filename="../app/MainLayout.qml" line="899"/>
-        <location filename="../app/MainLayout.qml" line="913"/>
-        <location filename="../app/MainLayout.qml" line="928"/>
-        <location filename="../app/MainLayout.qml" line="939"/>
+        <location filename="../app/MainLayout.qml" line="897"/>
+        <location filename="../app/MainLayout.qml" line="901"/>
+        <location filename="../app/MainLayout.qml" line="915"/>
+        <location filename="../app/MainLayout.qml" line="930"/>
+        <location filename="../app/MainLayout.qml" line="941"/>
         <source>Close</source>
         <translation>닫기</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="906"/>
-        <location filename="../app/MainLayout.qml" line="946"/>
-        <location filename="../app/MainLayout.qml" line="969"/>
-        <location filename="../app/MainLayout.qml" line="980"/>
+        <location filename="../app/MainLayout.qml" line="908"/>
+        <location filename="../app/MainLayout.qml" line="948"/>
+        <location filename="../app/MainLayout.qml" line="971"/>
+        <location filename="../app/MainLayout.qml" line="982"/>
         <source>Cancel</source>
         <translation>취소</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="924"/>
+        <location filename="../app/MainLayout.qml" line="926"/>
         <source>Done</source>
         <translation>완료</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="935"/>
-        <location filename="../app/MainLayout.qml" line="1058"/>
-        <location filename="../app/MainLayout.qml" line="1111"/>
-        <location filename="../app/MainLayout.qml" line="1221"/>
+        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="1060"/>
+        <location filename="../app/MainLayout.qml" line="1113"/>
+        <location filename="../app/MainLayout.qml" line="1223"/>
         <source>Retry</source>
         <translation>다시 시도</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="954"/>
+        <location filename="../app/MainLayout.qml" line="956"/>
         <source>I understand</source>
         <translation>이해했습니다</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="988"/>
+        <location filename="../app/MainLayout.qml" line="990"/>
         <source>Start</source>
         <translation>시작</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1008"/>
-        <location filename="../app/MainLayout.qml" line="1045"/>
-        <location filename="../app/MainLayout.qml" line="1095"/>
-        <location filename="../app/MainLayout.qml" line="1205"/>
+        <location filename="../app/MainLayout.qml" line="1010"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1097"/>
+        <location filename="../app/MainLayout.qml" line="1207"/>
         <source>Open</source>
         <translation>열기</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1012"/>
+        <location filename="../app/MainLayout.qml" line="1014"/>
         <source>Quit</source>
         <translation>종료</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1021"/>
-        <location filename="../app/MainLayout.qml" line="1051"/>
-        <location filename="../app/MainLayout.qml" line="1062"/>
-        <location filename="../app/MainLayout.qml" line="1077"/>
-        <location filename="../app/MainLayout.qml" line="1104"/>
-        <location filename="../app/MainLayout.qml" line="1115"/>
-        <location filename="../app/MainLayout.qml" line="1152"/>
-        <location filename="../app/MainLayout.qml" line="1170"/>
-        <location filename="../app/MainLayout.qml" line="1179"/>
-        <location filename="../app/MainLayout.qml" line="1214"/>
-        <location filename="../app/MainLayout.qml" line="1225"/>
+        <location filename="../app/MainLayout.qml" line="1023"/>
+        <location filename="../app/MainLayout.qml" line="1053"/>
+        <location filename="../app/MainLayout.qml" line="1064"/>
+        <location filename="../app/MainLayout.qml" line="1079"/>
+        <location filename="../app/MainLayout.qml" line="1106"/>
+        <location filename="../app/MainLayout.qml" line="1117"/>
+        <location filename="../app/MainLayout.qml" line="1154"/>
+        <location filename="../app/MainLayout.qml" line="1172"/>
+        <location filename="../app/MainLayout.qml" line="1181"/>
+        <location filename="../app/MainLayout.qml" line="1216"/>
+        <location filename="../app/MainLayout.qml" line="1227"/>
         <source>Back</source>
         <translation>뒤로</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1041"/>
-        <location filename="../app/MainLayout.qml" line="1091"/>
-        <location filename="../app/MainLayout.qml" line="1201"/>
+        <location filename="../app/MainLayout.qml" line="1043"/>
+        <location filename="../app/MainLayout.qml" line="1093"/>
+        <location filename="../app/MainLayout.qml" line="1203"/>
         <source>Page</source>
         <translation>페이지</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1048"/>
-        <location filename="../app/MainLayout.qml" line="1100"/>
-        <location filename="../app/MainLayout.qml" line="1210"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1102"/>
+        <location filename="../app/MainLayout.qml" line="1212"/>
         <source>Options</source>
         <translation>옵션</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1137"/>
+        <location filename="../app/MainLayout.qml" line="1139"/>
         <source>Change</source>
         <translation>변경</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1143"/>
+        <location filename="../app/MainLayout.qml" line="1145"/>
         <source>Toggle</source>
         <translation>전환</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1166"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
         <source>Scroll</source>
         <translation>스크롤</translation>
     </message>
@@ -841,12 +841,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="350"/>
+        <location filename="../screens/MediaListScreen.qml" line="354"/>
         <source>%1 entries</source>
         <translation type="unfinished">항목 %1개</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="351"/>
+        <location filename="../screens/MediaListScreen.qml" line="355"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -905,7 +905,7 @@ Euskara - devilschile2</source>
         <translation>불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="58"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="65"/>
         <source>Failed to load</source>
         <translation>불러오지 못했습니다</translation>
     </message>
@@ -1338,24 +1338,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="197"/>
-        <location filename="../screens/SystemsScreen.qml" line="295"/>
+        <location filename="../screens/SystemsScreen.qml" line="199"/>
+        <location filename="../screens/SystemsScreen.qml" line="297"/>
         <source>%1 systems</source>
         <translation>시스템 %1개</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="198"/>
-        <location filename="../screens/SystemsScreen.qml" line="312"/>
+        <location filename="../screens/SystemsScreen.qml" line="200"/>
+        <location filename="../screens/SystemsScreen.qml" line="314"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="328"/>
+        <location filename="../screens/SystemsScreen.qml" line="330"/>
         <source>No systems in this category</source>
         <translation>이 카테고리에는 시스템이 없습니다</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="329"/>
+        <location filename="../screens/SystemsScreen.qml" line="331"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -549,124 +549,124 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1217"/>
+        <location filename="../app/Main.qml" line="1353"/>
         <source>Launch core</source>
         <translation>Core starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1223"/>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1359"/>
+        <location filename="../app/Main.qml" line="1567"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1258"/>
+        <location filename="../app/Main.qml" line="1394"/>
         <source>Remove from favorites</source>
         <translation>Uit favorieten verwijderen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1258"/>
+        <location filename="../app/Main.qml" line="1394"/>
         <source>Add to favorites</source>
         <translation>Aan favorieten toevoegen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1263"/>
+        <location filename="../app/Main.qml" line="1399"/>
         <source>Write to NFC token</source>
         <translation>Naar NFC-token schrijven</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1267"/>
+        <location filename="../app/Main.qml" line="1403"/>
         <source>QR code</source>
         <translation>QR-code</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1242"/>
-        <location filename="../app/Main.qml" line="1277"/>
+        <location filename="../app/Main.qml" line="1378"/>
+        <location filename="../app/Main.qml" line="1413"/>
         <source>Launch game</source>
         <translation>Game starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2379"/>
+        <location filename="../app/Main.qml" line="2523"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2385"/>
+        <location filename="../app/Main.qml" line="2529"/>
         <source>Loading favorites…</source>
         <translation>Favorieten laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2381"/>
+        <location filename="../app/Main.qml" line="2525"/>
         <source>Loading games…</source>
         <translation>Games laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1230"/>
+        <location filename="../app/Main.qml" line="1366"/>
         <source>Update media database</source>
         <translation type="unfinished">Mediadatabase bijwerken</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1233"/>
+        <location filename="../app/Main.qml" line="1369"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadata ophalen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1427"/>
+        <location filename="../app/Main.qml" line="1563"/>
         <source>Default</source>
         <translation type="unfinished">Standaard</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1427"/>
+        <location filename="../app/Main.qml" line="1563"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1719"/>
+        <location filename="../app/Main.qml" line="1855"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1723"/>
+        <location filename="../app/Main.qml" line="1859"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1737"/>
+        <location filename="../app/Main.qml" line="1873"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1741"/>
+        <location filename="../app/Main.qml" line="1877"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1745"/>
+        <location filename="../app/Main.qml" line="1881"/>
         <source>Retry</source>
         <translation type="unfinished">Opnieuw proberen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1749"/>
+        <location filename="../app/Main.qml" line="1885"/>
         <source>Cancel</source>
         <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2383"/>
+        <location filename="../app/Main.qml" line="2527"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2387"/>
+        <location filename="../app/Main.qml" line="2531"/>
         <source>Loading recently played…</source>
         <translation>Recent gespeeld laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2389"/>
+        <location filename="../app/Main.qml" line="2533"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2391"/>
+        <location filename="../app/Main.qml" line="2535"/>
         <source>Loading…</source>
         <translation>Laden…</translation>
     </message>
@@ -674,71 +674,71 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="680"/>
+        <location filename="../app/MainLayout.qml" line="682"/>
         <source>Writing failed</source>
         <translation>Schrijven mislukt</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="680"/>
+        <location filename="../app/MainLayout.qml" line="682"/>
         <source>Put a writable card near the reader</source>
         <translation>Houd een beschrijfbare kaart bij de lezer</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="808"/>
+        <location filename="../app/MainLayout.qml" line="810"/>
         <source>Are you sure you want to exit?</source>
         <translation>Weet u zeker dat u wilt afsluiten?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="891"/>
-        <location filename="../app/MainLayout.qml" line="965"/>
+        <location filename="../app/MainLayout.qml" line="893"/>
+        <location filename="../app/MainLayout.qml" line="967"/>
         <source>Select</source>
         <translation>Selecteren</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="895"/>
-        <location filename="../app/MainLayout.qml" line="899"/>
-        <location filename="../app/MainLayout.qml" line="913"/>
-        <location filename="../app/MainLayout.qml" line="928"/>
-        <location filename="../app/MainLayout.qml" line="939"/>
+        <location filename="../app/MainLayout.qml" line="897"/>
+        <location filename="../app/MainLayout.qml" line="901"/>
+        <location filename="../app/MainLayout.qml" line="915"/>
+        <location filename="../app/MainLayout.qml" line="930"/>
+        <location filename="../app/MainLayout.qml" line="941"/>
         <source>Close</source>
         <translation>Sluiten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="906"/>
-        <location filename="../app/MainLayout.qml" line="946"/>
-        <location filename="../app/MainLayout.qml" line="969"/>
-        <location filename="../app/MainLayout.qml" line="980"/>
+        <location filename="../app/MainLayout.qml" line="908"/>
+        <location filename="../app/MainLayout.qml" line="948"/>
+        <location filename="../app/MainLayout.qml" line="971"/>
+        <location filename="../app/MainLayout.qml" line="982"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="924"/>
+        <location filename="../app/MainLayout.qml" line="926"/>
         <source>Done</source>
         <translation>Klaar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="954"/>
+        <location filename="../app/MainLayout.qml" line="956"/>
         <source>I understand</source>
         <translation>Ik begrijp het</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="988"/>
+        <location filename="../app/MainLayout.qml" line="990"/>
         <source>Start</source>
         <translation>Starten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1166"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
         <source>Scroll</source>
         <translation>Scrollen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="887"/>
-        <location filename="../app/MainLayout.qml" line="961"/>
-        <location filename="../app/MainLayout.qml" line="1004"/>
-        <location filename="../app/MainLayout.qml" line="1035"/>
-        <location filename="../app/MainLayout.qml" line="1085"/>
-        <location filename="../app/MainLayout.qml" line="1128"/>
-        <location filename="../app/MainLayout.qml" line="1195"/>
+        <location filename="../app/MainLayout.qml" line="889"/>
+        <location filename="../app/MainLayout.qml" line="963"/>
+        <location filename="../app/MainLayout.qml" line="1006"/>
+        <location filename="../app/MainLayout.qml" line="1037"/>
+        <location filename="../app/MainLayout.qml" line="1087"/>
+        <location filename="../app/MainLayout.qml" line="1130"/>
+        <location filename="../app/MainLayout.qml" line="1197"/>
         <source>Move</source>
         <translation>Bewegen</translation>
     </message>
@@ -748,87 +748,87 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="364"/>
+        <location filename="../app/MainLayout.qml" line="367"/>
         <source>Favorites</source>
         <translation type="unfinished">Favorieten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="366"/>
+        <location filename="../app/MainLayout.qml" line="369"/>
         <source>Recently Played</source>
         <translation type="unfinished">Recent gespeeld</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="696"/>
+        <location filename="../app/MainLayout.qml" line="698"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="697"/>
+        <location filename="../app/MainLayout.qml" line="699"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="807"/>
+        <location filename="../app/MainLayout.qml" line="809"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1008"/>
-        <location filename="../app/MainLayout.qml" line="1045"/>
-        <location filename="../app/MainLayout.qml" line="1095"/>
-        <location filename="../app/MainLayout.qml" line="1205"/>
+        <location filename="../app/MainLayout.qml" line="1010"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1097"/>
+        <location filename="../app/MainLayout.qml" line="1207"/>
         <source>Open</source>
         <translation>Openen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1012"/>
+        <location filename="../app/MainLayout.qml" line="1014"/>
         <source>Quit</source>
         <translation>Afsluiten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1021"/>
-        <location filename="../app/MainLayout.qml" line="1051"/>
-        <location filename="../app/MainLayout.qml" line="1062"/>
-        <location filename="../app/MainLayout.qml" line="1077"/>
-        <location filename="../app/MainLayout.qml" line="1104"/>
-        <location filename="../app/MainLayout.qml" line="1115"/>
-        <location filename="../app/MainLayout.qml" line="1152"/>
-        <location filename="../app/MainLayout.qml" line="1170"/>
-        <location filename="../app/MainLayout.qml" line="1179"/>
-        <location filename="../app/MainLayout.qml" line="1214"/>
-        <location filename="../app/MainLayout.qml" line="1225"/>
+        <location filename="../app/MainLayout.qml" line="1023"/>
+        <location filename="../app/MainLayout.qml" line="1053"/>
+        <location filename="../app/MainLayout.qml" line="1064"/>
+        <location filename="../app/MainLayout.qml" line="1079"/>
+        <location filename="../app/MainLayout.qml" line="1106"/>
+        <location filename="../app/MainLayout.qml" line="1117"/>
+        <location filename="../app/MainLayout.qml" line="1154"/>
+        <location filename="../app/MainLayout.qml" line="1172"/>
+        <location filename="../app/MainLayout.qml" line="1181"/>
+        <location filename="../app/MainLayout.qml" line="1216"/>
+        <location filename="../app/MainLayout.qml" line="1227"/>
         <source>Back</source>
         <translation>Terug</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1041"/>
-        <location filename="../app/MainLayout.qml" line="1091"/>
-        <location filename="../app/MainLayout.qml" line="1201"/>
+        <location filename="../app/MainLayout.qml" line="1043"/>
+        <location filename="../app/MainLayout.qml" line="1093"/>
+        <location filename="../app/MainLayout.qml" line="1203"/>
         <source>Page</source>
         <translation>Pagina</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1048"/>
-        <location filename="../app/MainLayout.qml" line="1100"/>
-        <location filename="../app/MainLayout.qml" line="1210"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1102"/>
+        <location filename="../app/MainLayout.qml" line="1212"/>
         <source>Options</source>
         <translation>Opties</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="935"/>
-        <location filename="../app/MainLayout.qml" line="1058"/>
-        <location filename="../app/MainLayout.qml" line="1111"/>
-        <location filename="../app/MainLayout.qml" line="1221"/>
+        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="1060"/>
+        <location filename="../app/MainLayout.qml" line="1113"/>
+        <location filename="../app/MainLayout.qml" line="1223"/>
         <source>Retry</source>
         <translation>Opnieuw proberen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1137"/>
+        <location filename="../app/MainLayout.qml" line="1139"/>
         <source>Change</source>
         <translation>Wijzigen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1143"/>
+        <location filename="../app/MainLayout.qml" line="1145"/>
         <source>Toggle</source>
         <translation>Schakelen</translation>
     </message>
@@ -841,12 +841,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Laden…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="350"/>
+        <location filename="../screens/MediaListScreen.qml" line="354"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 items</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="351"/>
+        <location filename="../screens/MediaListScreen.qml" line="355"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -905,7 +905,7 @@ Euskara - devilschile2</source>
         <translation>Laden…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="58"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="65"/>
         <source>Failed to load</source>
         <translation>Laden mislukt</translation>
     </message>
@@ -1338,24 +1338,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="197"/>
-        <location filename="../screens/SystemsScreen.qml" line="295"/>
+        <location filename="../screens/SystemsScreen.qml" line="199"/>
+        <location filename="../screens/SystemsScreen.qml" line="297"/>
         <source>%1 systems</source>
         <translation>%1 systemen</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="198"/>
-        <location filename="../screens/SystemsScreen.qml" line="312"/>
+        <location filename="../screens/SystemsScreen.qml" line="200"/>
+        <location filename="../screens/SystemsScreen.qml" line="314"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="328"/>
+        <location filename="../screens/SystemsScreen.qml" line="330"/>
         <source>No systems in this category</source>
         <translation>Geen systemen in deze categorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="329"/>
+        <location filename="../screens/SystemsScreen.qml" line="331"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -549,124 +549,124 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1217"/>
+        <location filename="../app/Main.qml" line="1353"/>
         <source>Launch core</source>
         <translation>Lansare core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1223"/>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1359"/>
+        <location filename="../app/Main.qml" line="1567"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1258"/>
+        <location filename="../app/Main.qml" line="1394"/>
         <source>Remove from favorites</source>
         <translation>Elimină din favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1258"/>
+        <location filename="../app/Main.qml" line="1394"/>
         <source>Add to favorites</source>
         <translation>Adaugă la favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1263"/>
+        <location filename="../app/Main.qml" line="1399"/>
         <source>Write to NFC token</source>
         <translation>Scriere pe token NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1267"/>
+        <location filename="../app/Main.qml" line="1403"/>
         <source>QR code</source>
         <translation>Cod QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1242"/>
-        <location filename="../app/Main.qml" line="1277"/>
+        <location filename="../app/Main.qml" line="1378"/>
+        <location filename="../app/Main.qml" line="1413"/>
         <source>Launch game</source>
         <translation>Lansare joc</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2379"/>
+        <location filename="../app/Main.qml" line="2523"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2385"/>
+        <location filename="../app/Main.qml" line="2529"/>
         <source>Loading favorites…</source>
         <translation>Se încarcă favoritele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2381"/>
+        <location filename="../app/Main.qml" line="2525"/>
         <source>Loading games…</source>
         <translation>Se încarcă jocurile…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1230"/>
+        <location filename="../app/Main.qml" line="1366"/>
         <source>Update media database</source>
         <translation type="unfinished">Actualizare bază de date media</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1233"/>
+        <location filename="../app/Main.qml" line="1369"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Extragere metadate</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1427"/>
+        <location filename="../app/Main.qml" line="1563"/>
         <source>Default</source>
         <translation type="unfinished">Implicit</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1427"/>
+        <location filename="../app/Main.qml" line="1563"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1719"/>
+        <location filename="../app/Main.qml" line="1855"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1723"/>
+        <location filename="../app/Main.qml" line="1859"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1737"/>
+        <location filename="../app/Main.qml" line="1873"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1741"/>
+        <location filename="../app/Main.qml" line="1877"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1745"/>
+        <location filename="../app/Main.qml" line="1881"/>
         <source>Retry</source>
         <translation type="unfinished">Reîncercare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1749"/>
+        <location filename="../app/Main.qml" line="1885"/>
         <source>Cancel</source>
         <translation type="unfinished">Anulare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2383"/>
+        <location filename="../app/Main.qml" line="2527"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2387"/>
+        <location filename="../app/Main.qml" line="2531"/>
         <source>Loading recently played…</source>
         <translation>Se încarcă recent jucatele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2389"/>
+        <location filename="../app/Main.qml" line="2533"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2391"/>
+        <location filename="../app/Main.qml" line="2535"/>
         <source>Loading…</source>
         <translation>Se încarcă…</translation>
     </message>
@@ -674,71 +674,71 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="680"/>
+        <location filename="../app/MainLayout.qml" line="682"/>
         <source>Writing failed</source>
         <translation>Scriere eșuată</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="680"/>
+        <location filename="../app/MainLayout.qml" line="682"/>
         <source>Put a writable card near the reader</source>
         <translation>Apropiați un card inscriptibil de cititor</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="808"/>
+        <location filename="../app/MainLayout.qml" line="810"/>
         <source>Are you sure you want to exit?</source>
         <translation>Sigur doriți să ieșiți?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="891"/>
-        <location filename="../app/MainLayout.qml" line="965"/>
+        <location filename="../app/MainLayout.qml" line="893"/>
+        <location filename="../app/MainLayout.qml" line="967"/>
         <source>Select</source>
         <translation>Selectare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="895"/>
-        <location filename="../app/MainLayout.qml" line="899"/>
-        <location filename="../app/MainLayout.qml" line="913"/>
-        <location filename="../app/MainLayout.qml" line="928"/>
-        <location filename="../app/MainLayout.qml" line="939"/>
+        <location filename="../app/MainLayout.qml" line="897"/>
+        <location filename="../app/MainLayout.qml" line="901"/>
+        <location filename="../app/MainLayout.qml" line="915"/>
+        <location filename="../app/MainLayout.qml" line="930"/>
+        <location filename="../app/MainLayout.qml" line="941"/>
         <source>Close</source>
         <translation>Închidere</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="906"/>
-        <location filename="../app/MainLayout.qml" line="946"/>
-        <location filename="../app/MainLayout.qml" line="969"/>
-        <location filename="../app/MainLayout.qml" line="980"/>
+        <location filename="../app/MainLayout.qml" line="908"/>
+        <location filename="../app/MainLayout.qml" line="948"/>
+        <location filename="../app/MainLayout.qml" line="971"/>
+        <location filename="../app/MainLayout.qml" line="982"/>
         <source>Cancel</source>
         <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="924"/>
+        <location filename="../app/MainLayout.qml" line="926"/>
         <source>Done</source>
         <translation>Gata</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="954"/>
+        <location filename="../app/MainLayout.qml" line="956"/>
         <source>I understand</source>
         <translation>Am înțeles</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="988"/>
+        <location filename="../app/MainLayout.qml" line="990"/>
         <source>Start</source>
         <translation>Pornire</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1166"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
         <source>Scroll</source>
         <translation>Derulare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="887"/>
-        <location filename="../app/MainLayout.qml" line="961"/>
-        <location filename="../app/MainLayout.qml" line="1004"/>
-        <location filename="../app/MainLayout.qml" line="1035"/>
-        <location filename="../app/MainLayout.qml" line="1085"/>
-        <location filename="../app/MainLayout.qml" line="1128"/>
-        <location filename="../app/MainLayout.qml" line="1195"/>
+        <location filename="../app/MainLayout.qml" line="889"/>
+        <location filename="../app/MainLayout.qml" line="963"/>
+        <location filename="../app/MainLayout.qml" line="1006"/>
+        <location filename="../app/MainLayout.qml" line="1037"/>
+        <location filename="../app/MainLayout.qml" line="1087"/>
+        <location filename="../app/MainLayout.qml" line="1130"/>
+        <location filename="../app/MainLayout.qml" line="1197"/>
         <source>Move</source>
         <translation>Mutare</translation>
     </message>
@@ -748,87 +748,87 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="364"/>
+        <location filename="../app/MainLayout.qml" line="367"/>
         <source>Favorites</source>
         <translation type="unfinished">Favorite</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="366"/>
+        <location filename="../app/MainLayout.qml" line="369"/>
         <source>Recently Played</source>
         <translation type="unfinished">Recent Jucate</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="696"/>
+        <location filename="../app/MainLayout.qml" line="698"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="697"/>
+        <location filename="../app/MainLayout.qml" line="699"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="807"/>
+        <location filename="../app/MainLayout.qml" line="809"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1008"/>
-        <location filename="../app/MainLayout.qml" line="1045"/>
-        <location filename="../app/MainLayout.qml" line="1095"/>
-        <location filename="../app/MainLayout.qml" line="1205"/>
+        <location filename="../app/MainLayout.qml" line="1010"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1097"/>
+        <location filename="../app/MainLayout.qml" line="1207"/>
         <source>Open</source>
         <translation>Deschidere</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1012"/>
+        <location filename="../app/MainLayout.qml" line="1014"/>
         <source>Quit</source>
         <translation>Ieșire</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1021"/>
-        <location filename="../app/MainLayout.qml" line="1051"/>
-        <location filename="../app/MainLayout.qml" line="1062"/>
-        <location filename="../app/MainLayout.qml" line="1077"/>
-        <location filename="../app/MainLayout.qml" line="1104"/>
-        <location filename="../app/MainLayout.qml" line="1115"/>
-        <location filename="../app/MainLayout.qml" line="1152"/>
-        <location filename="../app/MainLayout.qml" line="1170"/>
-        <location filename="../app/MainLayout.qml" line="1179"/>
-        <location filename="../app/MainLayout.qml" line="1214"/>
-        <location filename="../app/MainLayout.qml" line="1225"/>
+        <location filename="../app/MainLayout.qml" line="1023"/>
+        <location filename="../app/MainLayout.qml" line="1053"/>
+        <location filename="../app/MainLayout.qml" line="1064"/>
+        <location filename="../app/MainLayout.qml" line="1079"/>
+        <location filename="../app/MainLayout.qml" line="1106"/>
+        <location filename="../app/MainLayout.qml" line="1117"/>
+        <location filename="../app/MainLayout.qml" line="1154"/>
+        <location filename="../app/MainLayout.qml" line="1172"/>
+        <location filename="../app/MainLayout.qml" line="1181"/>
+        <location filename="../app/MainLayout.qml" line="1216"/>
+        <location filename="../app/MainLayout.qml" line="1227"/>
         <source>Back</source>
         <translation>Înapoi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1041"/>
-        <location filename="../app/MainLayout.qml" line="1091"/>
-        <location filename="../app/MainLayout.qml" line="1201"/>
+        <location filename="../app/MainLayout.qml" line="1043"/>
+        <location filename="../app/MainLayout.qml" line="1093"/>
+        <location filename="../app/MainLayout.qml" line="1203"/>
         <source>Page</source>
         <translation>Pagină</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1048"/>
-        <location filename="../app/MainLayout.qml" line="1100"/>
-        <location filename="../app/MainLayout.qml" line="1210"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1102"/>
+        <location filename="../app/MainLayout.qml" line="1212"/>
         <source>Options</source>
         <translation>Opțiuni</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="935"/>
-        <location filename="../app/MainLayout.qml" line="1058"/>
-        <location filename="../app/MainLayout.qml" line="1111"/>
-        <location filename="../app/MainLayout.qml" line="1221"/>
+        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="1060"/>
+        <location filename="../app/MainLayout.qml" line="1113"/>
+        <location filename="../app/MainLayout.qml" line="1223"/>
         <source>Retry</source>
         <translation>Reîncercare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1137"/>
+        <location filename="../app/MainLayout.qml" line="1139"/>
         <source>Change</source>
         <translation>Schimbare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1143"/>
+        <location filename="../app/MainLayout.qml" line="1145"/>
         <source>Toggle</source>
         <translation>Comutare</translation>
     </message>
@@ -841,12 +841,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Se încarcă…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="350"/>
+        <location filename="../screens/MediaListScreen.qml" line="354"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 intrări</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="351"/>
+        <location filename="../screens/MediaListScreen.qml" line="355"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -905,7 +905,7 @@ Euskara - devilschile2</source>
         <translation>Se încarcă…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="58"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="65"/>
         <source>Failed to load</source>
         <translation>Încărcare eșuată</translation>
     </message>
@@ -1338,24 +1338,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="197"/>
-        <location filename="../screens/SystemsScreen.qml" line="295"/>
+        <location filename="../screens/SystemsScreen.qml" line="199"/>
+        <location filename="../screens/SystemsScreen.qml" line="297"/>
         <source>%1 systems</source>
         <translation>%1 sisteme</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="198"/>
-        <location filename="../screens/SystemsScreen.qml" line="312"/>
+        <location filename="../screens/SystemsScreen.qml" line="200"/>
+        <location filename="../screens/SystemsScreen.qml" line="314"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="328"/>
+        <location filename="../screens/SystemsScreen.qml" line="330"/>
         <source>No systems in this category</source>
         <translation>Niciun sistem în această categorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="329"/>
+        <location filename="../screens/SystemsScreen.qml" line="331"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -549,124 +549,124 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1217"/>
+        <location filename="../app/Main.qml" line="1353"/>
         <source>Launch core</source>
         <translation>Spustiť core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1223"/>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1359"/>
+        <location filename="../app/Main.qml" line="1567"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1258"/>
+        <location filename="../app/Main.qml" line="1394"/>
         <source>Remove from favorites</source>
         <translation>Odstrániť z obľúbených</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1258"/>
+        <location filename="../app/Main.qml" line="1394"/>
         <source>Add to favorites</source>
         <translation>Pridať do obľúbených</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1263"/>
+        <location filename="../app/Main.qml" line="1399"/>
         <source>Write to NFC token</source>
         <translation>Zapísať na NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1267"/>
+        <location filename="../app/Main.qml" line="1403"/>
         <source>QR code</source>
         <translation>QR kód</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1242"/>
-        <location filename="../app/Main.qml" line="1277"/>
+        <location filename="../app/Main.qml" line="1378"/>
+        <location filename="../app/Main.qml" line="1413"/>
         <source>Launch game</source>
         <translation>Spustiť hru</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2379"/>
+        <location filename="../app/Main.qml" line="2523"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2385"/>
+        <location filename="../app/Main.qml" line="2529"/>
         <source>Loading favorites…</source>
         <translation>Načítanie obľúbených…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2381"/>
+        <location filename="../app/Main.qml" line="2525"/>
         <source>Loading games…</source>
         <translation>Načítanie hier…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1230"/>
+        <location filename="../app/Main.qml" line="1366"/>
         <source>Update media database</source>
         <translation type="unfinished">Aktualizovať databázu médií</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1233"/>
+        <location filename="../app/Main.qml" line="1369"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Získať metadáta</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1427"/>
+        <location filename="../app/Main.qml" line="1563"/>
         <source>Default</source>
         <translation type="unfinished">Predvolené</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1427"/>
+        <location filename="../app/Main.qml" line="1563"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1719"/>
+        <location filename="../app/Main.qml" line="1855"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1723"/>
+        <location filename="../app/Main.qml" line="1859"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1737"/>
+        <location filename="../app/Main.qml" line="1873"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1741"/>
+        <location filename="../app/Main.qml" line="1877"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1745"/>
+        <location filename="../app/Main.qml" line="1881"/>
         <source>Retry</source>
         <translation type="unfinished">Skúsiť znova</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1749"/>
+        <location filename="../app/Main.qml" line="1885"/>
         <source>Cancel</source>
         <translation type="unfinished">Zrušiť</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2383"/>
+        <location filename="../app/Main.qml" line="2527"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2387"/>
+        <location filename="../app/Main.qml" line="2531"/>
         <source>Loading recently played…</source>
         <translation>Načítanie nedávno hraných…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2389"/>
+        <location filename="../app/Main.qml" line="2533"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2391"/>
+        <location filename="../app/Main.qml" line="2535"/>
         <source>Loading…</source>
         <translation>Načítanie…</translation>
     </message>
@@ -674,71 +674,71 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="680"/>
+        <location filename="../app/MainLayout.qml" line="682"/>
         <source>Writing failed</source>
         <translation>Zápis zlyhal</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="680"/>
+        <location filename="../app/MainLayout.qml" line="682"/>
         <source>Put a writable card near the reader</source>
         <translation>Priložte zapisovateľnú kartu k čítačke</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="808"/>
+        <location filename="../app/MainLayout.qml" line="810"/>
         <source>Are you sure you want to exit?</source>
         <translation>Naozaj chcete ukončiť?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="891"/>
-        <location filename="../app/MainLayout.qml" line="965"/>
+        <location filename="../app/MainLayout.qml" line="893"/>
+        <location filename="../app/MainLayout.qml" line="967"/>
         <source>Select</source>
         <translation>Vybrať</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="895"/>
-        <location filename="../app/MainLayout.qml" line="899"/>
-        <location filename="../app/MainLayout.qml" line="913"/>
-        <location filename="../app/MainLayout.qml" line="928"/>
-        <location filename="../app/MainLayout.qml" line="939"/>
+        <location filename="../app/MainLayout.qml" line="897"/>
+        <location filename="../app/MainLayout.qml" line="901"/>
+        <location filename="../app/MainLayout.qml" line="915"/>
+        <location filename="../app/MainLayout.qml" line="930"/>
+        <location filename="../app/MainLayout.qml" line="941"/>
         <source>Close</source>
         <translation>Zavrieť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="906"/>
-        <location filename="../app/MainLayout.qml" line="946"/>
-        <location filename="../app/MainLayout.qml" line="969"/>
-        <location filename="../app/MainLayout.qml" line="980"/>
+        <location filename="../app/MainLayout.qml" line="908"/>
+        <location filename="../app/MainLayout.qml" line="948"/>
+        <location filename="../app/MainLayout.qml" line="971"/>
+        <location filename="../app/MainLayout.qml" line="982"/>
         <source>Cancel</source>
         <translation>Zrušiť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="924"/>
+        <location filename="../app/MainLayout.qml" line="926"/>
         <source>Done</source>
         <translation>Hotovo</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="954"/>
+        <location filename="../app/MainLayout.qml" line="956"/>
         <source>I understand</source>
         <translation>Rozumiem</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="988"/>
+        <location filename="../app/MainLayout.qml" line="990"/>
         <source>Start</source>
         <translation>Spustiť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1166"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
         <source>Scroll</source>
         <translation>Posúvať</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="887"/>
-        <location filename="../app/MainLayout.qml" line="961"/>
-        <location filename="../app/MainLayout.qml" line="1004"/>
-        <location filename="../app/MainLayout.qml" line="1035"/>
-        <location filename="../app/MainLayout.qml" line="1085"/>
-        <location filename="../app/MainLayout.qml" line="1128"/>
-        <location filename="../app/MainLayout.qml" line="1195"/>
+        <location filename="../app/MainLayout.qml" line="889"/>
+        <location filename="../app/MainLayout.qml" line="963"/>
+        <location filename="../app/MainLayout.qml" line="1006"/>
+        <location filename="../app/MainLayout.qml" line="1037"/>
+        <location filename="../app/MainLayout.qml" line="1087"/>
+        <location filename="../app/MainLayout.qml" line="1130"/>
+        <location filename="../app/MainLayout.qml" line="1197"/>
         <source>Move</source>
         <translation>Presunúť</translation>
     </message>
@@ -748,87 +748,87 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="364"/>
+        <location filename="../app/MainLayout.qml" line="367"/>
         <source>Favorites</source>
         <translation type="unfinished">Obľúbené</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="366"/>
+        <location filename="../app/MainLayout.qml" line="369"/>
         <source>Recently Played</source>
         <translation type="unfinished">Nedávno hrané</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="696"/>
+        <location filename="../app/MainLayout.qml" line="698"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="697"/>
+        <location filename="../app/MainLayout.qml" line="699"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="807"/>
+        <location filename="../app/MainLayout.qml" line="809"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1008"/>
-        <location filename="../app/MainLayout.qml" line="1045"/>
-        <location filename="../app/MainLayout.qml" line="1095"/>
-        <location filename="../app/MainLayout.qml" line="1205"/>
+        <location filename="../app/MainLayout.qml" line="1010"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1097"/>
+        <location filename="../app/MainLayout.qml" line="1207"/>
         <source>Open</source>
         <translation>Otvoriť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1012"/>
+        <location filename="../app/MainLayout.qml" line="1014"/>
         <source>Quit</source>
         <translation>Ukončiť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1021"/>
-        <location filename="../app/MainLayout.qml" line="1051"/>
-        <location filename="../app/MainLayout.qml" line="1062"/>
-        <location filename="../app/MainLayout.qml" line="1077"/>
-        <location filename="../app/MainLayout.qml" line="1104"/>
-        <location filename="../app/MainLayout.qml" line="1115"/>
-        <location filename="../app/MainLayout.qml" line="1152"/>
-        <location filename="../app/MainLayout.qml" line="1170"/>
-        <location filename="../app/MainLayout.qml" line="1179"/>
-        <location filename="../app/MainLayout.qml" line="1214"/>
-        <location filename="../app/MainLayout.qml" line="1225"/>
+        <location filename="../app/MainLayout.qml" line="1023"/>
+        <location filename="../app/MainLayout.qml" line="1053"/>
+        <location filename="../app/MainLayout.qml" line="1064"/>
+        <location filename="../app/MainLayout.qml" line="1079"/>
+        <location filename="../app/MainLayout.qml" line="1106"/>
+        <location filename="../app/MainLayout.qml" line="1117"/>
+        <location filename="../app/MainLayout.qml" line="1154"/>
+        <location filename="../app/MainLayout.qml" line="1172"/>
+        <location filename="../app/MainLayout.qml" line="1181"/>
+        <location filename="../app/MainLayout.qml" line="1216"/>
+        <location filename="../app/MainLayout.qml" line="1227"/>
         <source>Back</source>
         <translation>Späť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1041"/>
-        <location filename="../app/MainLayout.qml" line="1091"/>
-        <location filename="../app/MainLayout.qml" line="1201"/>
+        <location filename="../app/MainLayout.qml" line="1043"/>
+        <location filename="../app/MainLayout.qml" line="1093"/>
+        <location filename="../app/MainLayout.qml" line="1203"/>
         <source>Page</source>
         <translation>Stránka</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1048"/>
-        <location filename="../app/MainLayout.qml" line="1100"/>
-        <location filename="../app/MainLayout.qml" line="1210"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1102"/>
+        <location filename="../app/MainLayout.qml" line="1212"/>
         <source>Options</source>
         <translation>Možnosti</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="935"/>
-        <location filename="../app/MainLayout.qml" line="1058"/>
-        <location filename="../app/MainLayout.qml" line="1111"/>
-        <location filename="../app/MainLayout.qml" line="1221"/>
+        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="1060"/>
+        <location filename="../app/MainLayout.qml" line="1113"/>
+        <location filename="../app/MainLayout.qml" line="1223"/>
         <source>Retry</source>
         <translation>Skúsiť znova</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1137"/>
+        <location filename="../app/MainLayout.qml" line="1139"/>
         <source>Change</source>
         <translation>Zmeniť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1143"/>
+        <location filename="../app/MainLayout.qml" line="1145"/>
         <source>Toggle</source>
         <translation>Prepínať</translation>
     </message>
@@ -841,12 +841,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Načítanie…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="350"/>
+        <location filename="../screens/MediaListScreen.qml" line="354"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 položiek</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="351"/>
+        <location filename="../screens/MediaListScreen.qml" line="355"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -905,7 +905,7 @@ Euskara - devilschile2</source>
         <translation>Načítanie…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="58"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="65"/>
         <source>Failed to load</source>
         <translation>Načítanie zlyhalo</translation>
     </message>
@@ -1338,24 +1338,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="197"/>
-        <location filename="../screens/SystemsScreen.qml" line="295"/>
+        <location filename="../screens/SystemsScreen.qml" line="199"/>
+        <location filename="../screens/SystemsScreen.qml" line="297"/>
         <source>%1 systems</source>
         <translation>%1 systémov</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="198"/>
-        <location filename="../screens/SystemsScreen.qml" line="312"/>
+        <location filename="../screens/SystemsScreen.qml" line="200"/>
+        <location filename="../screens/SystemsScreen.qml" line="314"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="328"/>
+        <location filename="../screens/SystemsScreen.qml" line="330"/>
         <source>No systems in this category</source>
         <translation>V tejto kategórii nie sú žiadne systémy</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="329"/>
+        <location filename="../screens/SystemsScreen.qml" line="331"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -549,124 +549,124 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1217"/>
+        <location filename="../app/Main.qml" line="1353"/>
         <source>Launch core</source>
         <translation>Запустити core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1223"/>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1359"/>
+        <location filename="../app/Main.qml" line="1567"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1258"/>
+        <location filename="../app/Main.qml" line="1394"/>
         <source>Remove from favorites</source>
         <translation>Видалити з вибраного</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1258"/>
+        <location filename="../app/Main.qml" line="1394"/>
         <source>Add to favorites</source>
         <translation>Додати до вибраного</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1263"/>
+        <location filename="../app/Main.qml" line="1399"/>
         <source>Write to NFC token</source>
         <translation>Записати на NFC-токен</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1267"/>
+        <location filename="../app/Main.qml" line="1403"/>
         <source>QR code</source>
         <translation>QR-код</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1242"/>
-        <location filename="../app/Main.qml" line="1277"/>
+        <location filename="../app/Main.qml" line="1378"/>
+        <location filename="../app/Main.qml" line="1413"/>
         <source>Launch game</source>
         <translation>Запустити гру</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2379"/>
+        <location filename="../app/Main.qml" line="2523"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2385"/>
+        <location filename="../app/Main.qml" line="2529"/>
         <source>Loading favorites…</source>
         <translation>Завантаження вибраного…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2381"/>
+        <location filename="../app/Main.qml" line="2525"/>
         <source>Loading games…</source>
         <translation>Завантаження ігор…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1230"/>
+        <location filename="../app/Main.qml" line="1366"/>
         <source>Update media database</source>
         <translation type="unfinished">Оновити базу медіа</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1233"/>
+        <location filename="../app/Main.qml" line="1369"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Отримати метадані</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1427"/>
+        <location filename="../app/Main.qml" line="1563"/>
         <source>Default</source>
         <translation type="unfinished">Типовий</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1427"/>
+        <location filename="../app/Main.qml" line="1563"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1719"/>
+        <location filename="../app/Main.qml" line="1855"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1723"/>
+        <location filename="../app/Main.qml" line="1859"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1737"/>
+        <location filename="../app/Main.qml" line="1873"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1741"/>
+        <location filename="../app/Main.qml" line="1877"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1745"/>
+        <location filename="../app/Main.qml" line="1881"/>
         <source>Retry</source>
         <translation type="unfinished">Повторити</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1749"/>
+        <location filename="../app/Main.qml" line="1885"/>
         <source>Cancel</source>
         <translation type="unfinished">Скасувати</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2383"/>
+        <location filename="../app/Main.qml" line="2527"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2387"/>
+        <location filename="../app/Main.qml" line="2531"/>
         <source>Loading recently played…</source>
         <translation>Завантаження нещодавніх…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2389"/>
+        <location filename="../app/Main.qml" line="2533"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2391"/>
+        <location filename="../app/Main.qml" line="2535"/>
         <source>Loading…</source>
         <translation>Завантаження…</translation>
     </message>
@@ -674,71 +674,71 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="680"/>
+        <location filename="../app/MainLayout.qml" line="682"/>
         <source>Writing failed</source>
         <translation>Помилка запису</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="680"/>
+        <location filename="../app/MainLayout.qml" line="682"/>
         <source>Put a writable card near the reader</source>
         <translation>Прикладіть картку для запису до зчитувача</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="808"/>
+        <location filename="../app/MainLayout.qml" line="810"/>
         <source>Are you sure you want to exit?</source>
         <translation>Ви впевнені, що хочете вийти?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="891"/>
-        <location filename="../app/MainLayout.qml" line="965"/>
+        <location filename="../app/MainLayout.qml" line="893"/>
+        <location filename="../app/MainLayout.qml" line="967"/>
         <source>Select</source>
         <translation>Вибрати</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="895"/>
-        <location filename="../app/MainLayout.qml" line="899"/>
-        <location filename="../app/MainLayout.qml" line="913"/>
-        <location filename="../app/MainLayout.qml" line="928"/>
-        <location filename="../app/MainLayout.qml" line="939"/>
+        <location filename="../app/MainLayout.qml" line="897"/>
+        <location filename="../app/MainLayout.qml" line="901"/>
+        <location filename="../app/MainLayout.qml" line="915"/>
+        <location filename="../app/MainLayout.qml" line="930"/>
+        <location filename="../app/MainLayout.qml" line="941"/>
         <source>Close</source>
         <translation>Закрити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="906"/>
-        <location filename="../app/MainLayout.qml" line="946"/>
-        <location filename="../app/MainLayout.qml" line="969"/>
-        <location filename="../app/MainLayout.qml" line="980"/>
+        <location filename="../app/MainLayout.qml" line="908"/>
+        <location filename="../app/MainLayout.qml" line="948"/>
+        <location filename="../app/MainLayout.qml" line="971"/>
+        <location filename="../app/MainLayout.qml" line="982"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="924"/>
+        <location filename="../app/MainLayout.qml" line="926"/>
         <source>Done</source>
         <translation>Готово</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="954"/>
+        <location filename="../app/MainLayout.qml" line="956"/>
         <source>I understand</source>
         <translation>Я розумію</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="988"/>
+        <location filename="../app/MainLayout.qml" line="990"/>
         <source>Start</source>
         <translation>Почати</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1166"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
         <source>Scroll</source>
         <translation>Прокрутка</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="887"/>
-        <location filename="../app/MainLayout.qml" line="961"/>
-        <location filename="../app/MainLayout.qml" line="1004"/>
-        <location filename="../app/MainLayout.qml" line="1035"/>
-        <location filename="../app/MainLayout.qml" line="1085"/>
-        <location filename="../app/MainLayout.qml" line="1128"/>
-        <location filename="../app/MainLayout.qml" line="1195"/>
+        <location filename="../app/MainLayout.qml" line="889"/>
+        <location filename="../app/MainLayout.qml" line="963"/>
+        <location filename="../app/MainLayout.qml" line="1006"/>
+        <location filename="../app/MainLayout.qml" line="1037"/>
+        <location filename="../app/MainLayout.qml" line="1087"/>
+        <location filename="../app/MainLayout.qml" line="1130"/>
+        <location filename="../app/MainLayout.qml" line="1197"/>
         <source>Move</source>
         <translation>Переміщення</translation>
     </message>
@@ -748,87 +748,87 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="364"/>
+        <location filename="../app/MainLayout.qml" line="367"/>
         <source>Favorites</source>
         <translation type="unfinished">Вибране</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="366"/>
+        <location filename="../app/MainLayout.qml" line="369"/>
         <source>Recently Played</source>
         <translation type="unfinished">Нещодавно зіграні</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="696"/>
+        <location filename="../app/MainLayout.qml" line="698"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="697"/>
+        <location filename="../app/MainLayout.qml" line="699"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="807"/>
+        <location filename="../app/MainLayout.qml" line="809"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1008"/>
-        <location filename="../app/MainLayout.qml" line="1045"/>
-        <location filename="../app/MainLayout.qml" line="1095"/>
-        <location filename="../app/MainLayout.qml" line="1205"/>
+        <location filename="../app/MainLayout.qml" line="1010"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1097"/>
+        <location filename="../app/MainLayout.qml" line="1207"/>
         <source>Open</source>
         <translation>Відкрити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1012"/>
+        <location filename="../app/MainLayout.qml" line="1014"/>
         <source>Quit</source>
         <translation>Вийти</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1021"/>
-        <location filename="../app/MainLayout.qml" line="1051"/>
-        <location filename="../app/MainLayout.qml" line="1062"/>
-        <location filename="../app/MainLayout.qml" line="1077"/>
-        <location filename="../app/MainLayout.qml" line="1104"/>
-        <location filename="../app/MainLayout.qml" line="1115"/>
-        <location filename="../app/MainLayout.qml" line="1152"/>
-        <location filename="../app/MainLayout.qml" line="1170"/>
-        <location filename="../app/MainLayout.qml" line="1179"/>
-        <location filename="../app/MainLayout.qml" line="1214"/>
-        <location filename="../app/MainLayout.qml" line="1225"/>
+        <location filename="../app/MainLayout.qml" line="1023"/>
+        <location filename="../app/MainLayout.qml" line="1053"/>
+        <location filename="../app/MainLayout.qml" line="1064"/>
+        <location filename="../app/MainLayout.qml" line="1079"/>
+        <location filename="../app/MainLayout.qml" line="1106"/>
+        <location filename="../app/MainLayout.qml" line="1117"/>
+        <location filename="../app/MainLayout.qml" line="1154"/>
+        <location filename="../app/MainLayout.qml" line="1172"/>
+        <location filename="../app/MainLayout.qml" line="1181"/>
+        <location filename="../app/MainLayout.qml" line="1216"/>
+        <location filename="../app/MainLayout.qml" line="1227"/>
         <source>Back</source>
         <translation>Назад</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1041"/>
-        <location filename="../app/MainLayout.qml" line="1091"/>
-        <location filename="../app/MainLayout.qml" line="1201"/>
+        <location filename="../app/MainLayout.qml" line="1043"/>
+        <location filename="../app/MainLayout.qml" line="1093"/>
+        <location filename="../app/MainLayout.qml" line="1203"/>
         <source>Page</source>
         <translation>Сторінка</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1048"/>
-        <location filename="../app/MainLayout.qml" line="1100"/>
-        <location filename="../app/MainLayout.qml" line="1210"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1102"/>
+        <location filename="../app/MainLayout.qml" line="1212"/>
         <source>Options</source>
         <translation>Параметри</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="935"/>
-        <location filename="../app/MainLayout.qml" line="1058"/>
-        <location filename="../app/MainLayout.qml" line="1111"/>
-        <location filename="../app/MainLayout.qml" line="1221"/>
+        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="1060"/>
+        <location filename="../app/MainLayout.qml" line="1113"/>
+        <location filename="../app/MainLayout.qml" line="1223"/>
         <source>Retry</source>
         <translation>Повторити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1137"/>
+        <location filename="../app/MainLayout.qml" line="1139"/>
         <source>Change</source>
         <translation>Змінити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1143"/>
+        <location filename="../app/MainLayout.qml" line="1145"/>
         <source>Toggle</source>
         <translation>Перемкнути</translation>
     </message>
@@ -841,12 +841,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Завантаження…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="350"/>
+        <location filename="../screens/MediaListScreen.qml" line="354"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 записів</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="351"/>
+        <location filename="../screens/MediaListScreen.qml" line="355"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -905,7 +905,7 @@ Euskara - devilschile2</source>
         <translation>Завантаження…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="58"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="65"/>
         <source>Failed to load</source>
         <translation>Не вдалося завантажити</translation>
     </message>
@@ -1338,24 +1338,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="197"/>
-        <location filename="../screens/SystemsScreen.qml" line="295"/>
+        <location filename="../screens/SystemsScreen.qml" line="199"/>
+        <location filename="../screens/SystemsScreen.qml" line="297"/>
         <source>%1 systems</source>
         <translation>%1 систем</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="198"/>
-        <location filename="../screens/SystemsScreen.qml" line="312"/>
+        <location filename="../screens/SystemsScreen.qml" line="200"/>
+        <location filename="../screens/SystemsScreen.qml" line="314"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="328"/>
+        <location filename="../screens/SystemsScreen.qml" line="330"/>
         <source>No systems in this category</source>
         <translation>У цій категорії немає систем</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="329"/>
+        <location filename="../screens/SystemsScreen.qml" line="331"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -549,124 +549,124 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1217"/>
+        <location filename="../app/Main.qml" line="1353"/>
         <source>Launch core</source>
         <translation>启动核心</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1223"/>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1359"/>
+        <location filename="../app/Main.qml" line="1567"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1230"/>
+        <location filename="../app/Main.qml" line="1366"/>
         <source>Update media database</source>
         <translation type="unfinished">更新媒体数据库</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1233"/>
+        <location filename="../app/Main.qml" line="1369"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">抓取元数据</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1242"/>
-        <location filename="../app/Main.qml" line="1277"/>
+        <location filename="../app/Main.qml" line="1378"/>
+        <location filename="../app/Main.qml" line="1413"/>
         <source>Launch game</source>
         <translation>启动游戏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1258"/>
+        <location filename="../app/Main.qml" line="1394"/>
         <source>Remove from favorites</source>
         <translation>从收藏中移除</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1258"/>
+        <location filename="../app/Main.qml" line="1394"/>
         <source>Add to favorites</source>
         <translation>添加到收藏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1263"/>
+        <location filename="../app/Main.qml" line="1399"/>
         <source>Write to NFC token</source>
         <translation>写入 NFC 令牌</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1267"/>
+        <location filename="../app/Main.qml" line="1403"/>
         <source>QR code</source>
         <translation>二维码</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1427"/>
+        <location filename="../app/Main.qml" line="1563"/>
         <source>Default</source>
         <translation type="unfinished">默认</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1427"/>
+        <location filename="../app/Main.qml" line="1563"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1719"/>
+        <location filename="../app/Main.qml" line="1855"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1723"/>
+        <location filename="../app/Main.qml" line="1859"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1737"/>
+        <location filename="../app/Main.qml" line="1873"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1741"/>
+        <location filename="../app/Main.qml" line="1877"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1745"/>
+        <location filename="../app/Main.qml" line="1881"/>
         <source>Retry</source>
         <translation type="unfinished">重试</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1749"/>
+        <location filename="../app/Main.qml" line="1885"/>
         <source>Cancel</source>
         <translation type="unfinished">取消</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2379"/>
+        <location filename="../app/Main.qml" line="2523"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2381"/>
+        <location filename="../app/Main.qml" line="2525"/>
         <source>Loading games…</source>
         <translation>正在加载游戏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2383"/>
+        <location filename="../app/Main.qml" line="2527"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2385"/>
+        <location filename="../app/Main.qml" line="2529"/>
         <source>Loading favorites…</source>
         <translation>正在加载收藏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2387"/>
+        <location filename="../app/Main.qml" line="2531"/>
         <source>Loading recently played…</source>
         <translation>正在加载最近游玩…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2389"/>
+        <location filename="../app/Main.qml" line="2533"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2391"/>
+        <location filename="../app/Main.qml" line="2535"/>
         <source>Loading…</source>
         <translation>正在加载…</translation>
     </message>
@@ -674,12 +674,12 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="680"/>
+        <location filename="../app/MainLayout.qml" line="682"/>
         <source>Writing failed</source>
         <translation>写入失败</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="680"/>
+        <location filename="../app/MainLayout.qml" line="682"/>
         <source>Put a writable card near the reader</source>
         <translation>将可写卡片放在读卡器附近</translation>
     </message>
@@ -689,146 +689,146 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="364"/>
+        <location filename="../app/MainLayout.qml" line="367"/>
         <source>Favorites</source>
         <translation type="unfinished">收藏</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="366"/>
+        <location filename="../app/MainLayout.qml" line="369"/>
         <source>Recently Played</source>
         <translation type="unfinished">最近游玩</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="696"/>
+        <location filename="../app/MainLayout.qml" line="698"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="697"/>
+        <location filename="../app/MainLayout.qml" line="699"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="807"/>
+        <location filename="../app/MainLayout.qml" line="809"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="808"/>
+        <location filename="../app/MainLayout.qml" line="810"/>
         <source>Are you sure you want to exit?</source>
         <translation>确定要退出吗？</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="887"/>
-        <location filename="../app/MainLayout.qml" line="961"/>
-        <location filename="../app/MainLayout.qml" line="1004"/>
-        <location filename="../app/MainLayout.qml" line="1035"/>
-        <location filename="../app/MainLayout.qml" line="1085"/>
-        <location filename="../app/MainLayout.qml" line="1128"/>
-        <location filename="../app/MainLayout.qml" line="1195"/>
+        <location filename="../app/MainLayout.qml" line="889"/>
+        <location filename="../app/MainLayout.qml" line="963"/>
+        <location filename="../app/MainLayout.qml" line="1006"/>
+        <location filename="../app/MainLayout.qml" line="1037"/>
+        <location filename="../app/MainLayout.qml" line="1087"/>
+        <location filename="../app/MainLayout.qml" line="1130"/>
+        <location filename="../app/MainLayout.qml" line="1197"/>
         <source>Move</source>
         <translation>移动</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="891"/>
-        <location filename="../app/MainLayout.qml" line="965"/>
+        <location filename="../app/MainLayout.qml" line="893"/>
+        <location filename="../app/MainLayout.qml" line="967"/>
         <source>Select</source>
         <translation>选择</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="895"/>
-        <location filename="../app/MainLayout.qml" line="899"/>
-        <location filename="../app/MainLayout.qml" line="913"/>
-        <location filename="../app/MainLayout.qml" line="928"/>
-        <location filename="../app/MainLayout.qml" line="939"/>
+        <location filename="../app/MainLayout.qml" line="897"/>
+        <location filename="../app/MainLayout.qml" line="901"/>
+        <location filename="../app/MainLayout.qml" line="915"/>
+        <location filename="../app/MainLayout.qml" line="930"/>
+        <location filename="../app/MainLayout.qml" line="941"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="906"/>
-        <location filename="../app/MainLayout.qml" line="946"/>
-        <location filename="../app/MainLayout.qml" line="969"/>
-        <location filename="../app/MainLayout.qml" line="980"/>
+        <location filename="../app/MainLayout.qml" line="908"/>
+        <location filename="../app/MainLayout.qml" line="948"/>
+        <location filename="../app/MainLayout.qml" line="971"/>
+        <location filename="../app/MainLayout.qml" line="982"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="924"/>
+        <location filename="../app/MainLayout.qml" line="926"/>
         <source>Done</source>
         <translation>完成</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="935"/>
-        <location filename="../app/MainLayout.qml" line="1058"/>
-        <location filename="../app/MainLayout.qml" line="1111"/>
-        <location filename="../app/MainLayout.qml" line="1221"/>
+        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="1060"/>
+        <location filename="../app/MainLayout.qml" line="1113"/>
+        <location filename="../app/MainLayout.qml" line="1223"/>
         <source>Retry</source>
         <translation>重试</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="954"/>
+        <location filename="../app/MainLayout.qml" line="956"/>
         <source>I understand</source>
         <translation>我明白了</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="988"/>
+        <location filename="../app/MainLayout.qml" line="990"/>
         <source>Start</source>
         <translation>开始</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1008"/>
-        <location filename="../app/MainLayout.qml" line="1045"/>
-        <location filename="../app/MainLayout.qml" line="1095"/>
-        <location filename="../app/MainLayout.qml" line="1205"/>
+        <location filename="../app/MainLayout.qml" line="1010"/>
+        <location filename="../app/MainLayout.qml" line="1047"/>
+        <location filename="../app/MainLayout.qml" line="1097"/>
+        <location filename="../app/MainLayout.qml" line="1207"/>
         <source>Open</source>
         <translation>打开</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1012"/>
+        <location filename="../app/MainLayout.qml" line="1014"/>
         <source>Quit</source>
         <translation>退出</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1021"/>
-        <location filename="../app/MainLayout.qml" line="1051"/>
-        <location filename="../app/MainLayout.qml" line="1062"/>
-        <location filename="../app/MainLayout.qml" line="1077"/>
-        <location filename="../app/MainLayout.qml" line="1104"/>
-        <location filename="../app/MainLayout.qml" line="1115"/>
-        <location filename="../app/MainLayout.qml" line="1152"/>
-        <location filename="../app/MainLayout.qml" line="1170"/>
-        <location filename="../app/MainLayout.qml" line="1179"/>
-        <location filename="../app/MainLayout.qml" line="1214"/>
-        <location filename="../app/MainLayout.qml" line="1225"/>
+        <location filename="../app/MainLayout.qml" line="1023"/>
+        <location filename="../app/MainLayout.qml" line="1053"/>
+        <location filename="../app/MainLayout.qml" line="1064"/>
+        <location filename="../app/MainLayout.qml" line="1079"/>
+        <location filename="../app/MainLayout.qml" line="1106"/>
+        <location filename="../app/MainLayout.qml" line="1117"/>
+        <location filename="../app/MainLayout.qml" line="1154"/>
+        <location filename="../app/MainLayout.qml" line="1172"/>
+        <location filename="../app/MainLayout.qml" line="1181"/>
+        <location filename="../app/MainLayout.qml" line="1216"/>
+        <location filename="../app/MainLayout.qml" line="1227"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1041"/>
-        <location filename="../app/MainLayout.qml" line="1091"/>
-        <location filename="../app/MainLayout.qml" line="1201"/>
+        <location filename="../app/MainLayout.qml" line="1043"/>
+        <location filename="../app/MainLayout.qml" line="1093"/>
+        <location filename="../app/MainLayout.qml" line="1203"/>
         <source>Page</source>
         <translation>页面</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1048"/>
-        <location filename="../app/MainLayout.qml" line="1100"/>
-        <location filename="../app/MainLayout.qml" line="1210"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1102"/>
+        <location filename="../app/MainLayout.qml" line="1212"/>
         <source>Options</source>
         <translation>选项</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1137"/>
+        <location filename="../app/MainLayout.qml" line="1139"/>
         <source>Change</source>
         <translation>更改</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1143"/>
+        <location filename="../app/MainLayout.qml" line="1145"/>
         <source>Toggle</source>
         <translation>切换</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1166"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
         <source>Scroll</source>
         <translation>滚动</translation>
     </message>
@@ -841,12 +841,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">正在加载…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="350"/>
+        <location filename="../screens/MediaListScreen.qml" line="354"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 个条目</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="351"/>
+        <location filename="../screens/MediaListScreen.qml" line="355"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -905,7 +905,7 @@ Euskara - devilschile2</source>
         <translation>正在加载…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="58"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="65"/>
         <source>Failed to load</source>
         <translation>加载失败</translation>
     </message>
@@ -1338,24 +1338,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="197"/>
-        <location filename="../screens/SystemsScreen.qml" line="295"/>
+        <location filename="../screens/SystemsScreen.qml" line="199"/>
+        <location filename="../screens/SystemsScreen.qml" line="297"/>
         <source>%1 systems</source>
         <translation>%1 个系统</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="198"/>
-        <location filename="../screens/SystemsScreen.qml" line="312"/>
+        <location filename="../screens/SystemsScreen.qml" line="200"/>
+        <location filename="../screens/SystemsScreen.qml" line="314"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="328"/>
+        <location filename="../screens/SystemsScreen.qml" line="330"/>
         <source>No systems in this category</source>
         <translation>此类别中没有系统</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="329"/>
+        <location filename="../screens/SystemsScreen.qml" line="331"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>

--- a/tests/ui/tst_navigation.qml
+++ b/tests/ui/tst_navigation.qml
@@ -108,26 +108,22 @@ TestCase {
         compare(main.activeScreen, main.screenSystems, "Enter on an empty systems screen must retry, not flip to games");
     }
 
-    // Escape on games goes back to systems (one peer up the stack) after
-    // a one-frame Loading cue, matching heavy forward transitions.
+    // Escape on games goes straight back to systems when the destination
+    // screen is already mounted and its model is idle.
     function test_escape_on_games_returns_to_systems(): void {
         main.activeScreen = main.screenGames;
         main.handleKey(Qt.Key_Escape);
-        compare(main.pendingTransition, "back");
-        compare(main.activeScreen, main.screenGames);
-        tryCompare(main, "activeScreen", main.screenSystems);
         compare(main.pendingTransition, "");
+        compare(main.activeScreen, main.screenSystems);
         tryCompare(main, "transitionCueVisible", false);
     }
 
-    // Escape on systems goes back to hub after the same Loading cue.
+    // Escape on systems goes straight back to Hub; Hub has no model fill to wait on.
     function test_escape_on_systems_returns_to_hub(): void {
         main.activeScreen = main.screenSystems;
         main.handleKey(Qt.Key_Escape);
-        compare(main.pendingTransition, "back");
-        compare(main.activeScreen, main.screenSystems);
-        tryCompare(main, "activeScreen", main.screenHub);
         compare(main.pendingTransition, "");
+        compare(main.activeScreen, main.screenHub);
         tryCompare(main, "transitionCueVisible", false);
     }
 
@@ -144,9 +140,8 @@ TestCase {
     function test_backspace_behaves_like_escape_on_games(): void {
         main.activeScreen = main.screenGames;
         main.handleKey(Qt.Key_Backspace);
-        compare(main.pendingTransition, "back");
-        tryCompare(main, "activeScreen", main.screenSystems);
         compare(main.pendingTransition, "");
+        compare(main.activeScreen, main.screenSystems);
         tryCompare(main, "transitionCueVisible", false);
     }
 


### PR DESCRIPTION
## Summary
- add browse/navigation timing instrumentation for RPCs, model apply, cover gates, and image cache work
- improve games navigation by releasing warm cover gates faster and deferring initial lookahead until the visible page is interactive
- make back navigation cache-aware so ready screens and cached folder parents skip fake global Loading cues while cold paths still show feedback

## Tests
- just fmt
- just lint
- just test-qml
- just test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browse cache check available via model API
  * Navigation-timing telemetry surfaced for multiple screens

* **Improvements**
  * Back navigation completes immediately when target is already loaded
  * Added detailed timing logs for image fetches and RPCs for better observability
  * Loading indicator no longer enforces a minimum visible time

* **Tests**
  * Updated navigation tests to expect immediate back transitions

* **Chores**
  * CI and lint added to validate translation files; translation catalogs refreshed across locales
<!-- end of auto-generated comment: release notes by coderabbit.ai -->