### PR TITLE
Fix loading overlay content overlap

### DIFF
--- a/rust/zaparoo-core/src/input_actions.rs
+++ b/rust/zaparoo-core/src/input_actions.rs
@@ -16,7 +16,7 @@ pub mod actions {
     pub const RIGHT: &str = "right";
     pub const ACCEPT: &str = "accept";
     pub const CANCEL: &str = "cancel";
-    pub const WRITE_CARD: &str = "write_card";
+    pub const CONTEXT_MENU: &str = "context_menu";
     pub const DETAILS: &str = "details";
     pub const PAGE_PREV: &str = "page_prev";
     pub const PAGE_NEXT: &str = "page_next";
@@ -65,7 +65,7 @@ pub fn default_bindings() -> HashMap<String, Vec<String>> {
         actions::CANCEL.into(),
         vec!["Escape".into(), "Backspace".into()],
     );
-    map.insert(actions::WRITE_CARD.into(), vec!["Tab".into()]);
+    map.insert(actions::CONTEXT_MENU.into(), vec!["Tab".into()]);
     map.insert(actions::PAGE_PREV.into(), vec!["PageUp".into()]);
     map.insert(actions::PAGE_NEXT.into(), vec!["PageDown".into()]);
     map
@@ -139,7 +139,7 @@ mod tests {
         );
         assert_eq!(
             map.get(&qt_key_code("Tab").unwrap()).map(String::as_str),
-            Some(actions::WRITE_CARD),
+            Some(actions::CONTEXT_MENU),
         );
     }
 

--- a/src/ui/components/ContextMenu.qml
+++ b/src/ui/components/ContextMenu.qml
@@ -101,7 +101,7 @@ Item {
         else if (action === "accept") {
             if (menu.currentIndex >= 0 && menu.currentIndex < menu.entries.length)
                 menu.accepted(menu.entries[menu.currentIndex].id);
-        } else if (action === "cancel" || action === "write_card")
+        } else if (action === "cancel" || action === "context_menu")
             menu.closeRequested();
     }
 

--- a/src/ui/screens/MediaListScreen.qml
+++ b/src/ui/screens/MediaListScreen.qml
@@ -261,7 +261,7 @@ Item {
     }
 
     function handleAction(action: string): void {
-        if ((action === "left" || action === "right" || action === "up" || action === "down") && root._gateHide)
+        if ((action === "left" || action === "right" || action === "up" || action === "down" || action === "context_menu") && root._gateHide)
             return;
 
         if (action === "left") {
@@ -313,7 +313,7 @@ Item {
                 root.acceptAction(mediaGrid.currentIndex);
             else
                 root.mediaModel.launch_at(mediaGrid.currentIndex);
-        } else if (action === "write_card") {
+        } else if (action === "context_menu") {
             if (mediaGrid.itemCount > 0) {
                 const idx = mediaGrid.currentIndex;
                 if (typeof root.contextMenuEnabledAt === "function" && !root.contextMenuEnabledAt(idx))
@@ -393,7 +393,7 @@ Item {
         }
         onItemRightClicked: index => {
             root._focusIndex(index);
-            root.handleAction("write_card");
+            root.handleAction("context_menu");
         }
         onEmptyRightClicked: root.handleAction("cancel")
         onPageWheelRequested: delta => root.handleAction(delta > 0 ? "page_next" : "page_prev")
@@ -443,7 +443,7 @@ Item {
         }
         onItemRightClicked: index => {
             root._focusIndex(index);
-            root.handleAction("write_card");
+            root.handleAction("context_menu");
         }
         onEmptyRightClicked: root.handleAction("cancel")
         onPageWheelRequested: delta => root.handleAction(delta > 0 ? "page_next" : "page_prev")

--- a/src/ui/screens/MediaListScreen.qml
+++ b/src/ui/screens/MediaListScreen.qml
@@ -261,6 +261,9 @@ Item {
     }
 
     function handleAction(action: string): void {
+        if ((action === "left" || action === "right" || action === "up" || action === "down") && root._gateHide)
+            return;
+
         if (action === "left") {
             if (root._listLayout && typeof root.listLeftAction === "function")
                 root.listLeftAction();

--- a/src/ui/screens/MediaListScreen.qml
+++ b/src/ui/screens/MediaListScreen.qml
@@ -104,10 +104,11 @@ Item {
     readonly property bool _crtListStrip: Theme.crtNativePath && root._listLayout
     readonly property int _listOverlayBottomMargin: root._listLayoutProfile && root._listLayoutProfile.list ? root._listLayoutProfile.list.overlayBottomMargin : Sizing.pctH(15)
     // Hide list/grid content as soon as the model enters Loading, but
-    // let ScreenStateOverlay keep delaying the centered cue. Tying the
-    // content gate to `loadingVisible` leaves a frame window where the
-    // model has cleared/reseeded rows and the user sees loading tiles.
-    readonly property bool _gateHide: root.transitioning || root._loading()
+    // let ScreenStateOverlay keep delaying the centered cue. Keep the
+    // content hidden through the cue's minimum-visible tail so newly
+    // loaded rows cannot paint underneath lingering loading text.
+    readonly property bool _overlayLoadingVisible: stateOverlay.loadingVisible
+    readonly property bool _gateHide: root.transitioning || root._loading() || root._overlayLoadingVisible
 
     signal requestHubScreen
     signal requestContextMenu(int index, var anchorRect)
@@ -250,7 +251,7 @@ Item {
     }
 
     function _state(): string {
-        if (root._loading())
+        if (root._loading() || root._overlayLoadingVisible)
             return "loading";
         if (root._errorMessage() !== "")
             return "error";
@@ -508,6 +509,8 @@ Item {
     }
 
     ScreenStateOverlay {
+        id: stateOverlay
+
         x: root._listLayout ? listCard.x : mediaGrid.x
         y: root._listLayout ? listCard.y : mediaGrid.y
         width: root._listLayout ? listCard.width : mediaGrid.width

--- a/src/ui/screens/SystemsScreen.qml
+++ b/src/ui/screens/SystemsScreen.qml
@@ -123,6 +123,9 @@ Item {
     }
 
     function handleAction(action: string): void {
+        if (action === "context_menu" && systems._gateHide)
+            return;
+
         if (action === "left") {
             systems._performMove(-1, 0);
         } else if (action === "right") {
@@ -159,7 +162,7 @@ Item {
             }
             const chosen = Browse.SystemsModel.system_id_at(systems.systemsGrid.currentIndex);
             systems.requestAccept(chosen);
-        } else if (action === "write_card") {
+        } else if (action === "context_menu") {
             if (systems.systemsGrid.itemCount > 0) {
                 const idx = systems.systemsGrid.currentIndex;
                 Browse.SystemsState.system_id = Browse.SystemsModel.system_id_at(idx);
@@ -227,7 +230,7 @@ Item {
         }
         onItemRightClicked: index => {
             systems._focusIndex(index);
-            systems.handleAction("write_card");
+            systems.handleAction("context_menu");
         }
         onEmptyRightClicked: systems.handleAction("cancel")
         onPageWheelRequested: delta => systems.handleAction(delta > 0 ? "page_next" : "page_prev")
@@ -259,7 +262,7 @@ Item {
         }
         onItemRightClicked: index => {
             systems._focusIndex(index);
-            systems.handleAction("write_card");
+            systems.handleAction("context_menu");
         }
         onEmptyRightClicked: systems.handleAction("cancel")
         onPageWheelRequested: delta => systems.handleAction(delta > 0 ? "page_next" : "page_prev")

--- a/src/ui/screens/SystemsScreen.qml
+++ b/src/ui/screens/SystemsScreen.qml
@@ -52,7 +52,8 @@ Item {
     readonly property int _listOverlayBottomMargin: systems._listProfile ? systems._listProfile.overlayBottomMargin : Sizing.pctH(15)
     readonly property var _gridShape: Sizing.systemsGridShape(Sizing.screenWidth, Sizing.screenHeight)
     readonly property bool _loading: Browse.SystemsModel.loading || systems.optimisticLoading
-    readonly property bool _gateHide: systems.transitioning || systems._loading
+    readonly property bool _overlayLoadingVisible: stateOverlay.loadingVisible
+    readonly property bool _gateHide: systems.transitioning || systems._loading || systems._overlayLoadingVisible
 
     signal requestAccept(systemId: string)
     signal requestHubScreen
@@ -112,7 +113,7 @@ Item {
     // Mirrors ScreenStateOverlay's `state` ternary so accept routing and
     // the in-screen overlay agree on which state we're in.
     function _state(): string {
-        if (systems._loading)
+        if (systems._loading || systems._overlayLoadingVisible)
             return "loading";
         if ((Browse.SystemsModel.error_message ?? "") !== "")
             return "error";
@@ -319,6 +320,8 @@ Item {
     }
 
     ScreenStateOverlay {
+        id: stateOverlay
+
         x: systems._listLayout ? 0 : systemsGrid.x
         y: systems._listLayout ? listCard.y : systemsGrid.y
         width: systems._listLayout ? systems.width : systemsGrid.width

--- a/src/ui/screens/SystemsScreen.qml
+++ b/src/ui/screens/SystemsScreen.qml
@@ -123,6 +123,8 @@ Item {
     }
 
     function handleAction(action: string): void {
+        if ((action === "left" || action === "right" || action === "up" || action === "down" || action === "page_prev" || action === "page_next") && systems._overlayLoadingVisible)
+            return;
         if (action === "context_menu" && systems._gateHide)
             return;
 

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="203"/>
-        <location filename="../screens/SystemsScreen.qml" line="301"/>
+        <location filename="../screens/SystemsScreen.qml" line="205"/>
+        <location filename="../screens/SystemsScreen.qml" line="303"/>
         <source>%1 systems</source>
         <translation>%1 أنظمة</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="204"/>
-        <location filename="../screens/SystemsScreen.qml" line="318"/>
+        <location filename="../screens/SystemsScreen.qml" line="206"/>
+        <location filename="../screens/SystemsScreen.qml" line="320"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="336"/>
+        <location filename="../screens/SystemsScreen.qml" line="338"/>
         <source>No systems in this category</source>
         <translation>لا توجد أنظمة في هذه الفئة</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="337"/>
+        <location filename="../screens/SystemsScreen.qml" line="339"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -849,12 +849,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">جارٍ التحميل…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="355"/>
+        <location filename="../screens/MediaListScreen.qml" line="358"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 عناصر</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="356"/>
+        <location filename="../screens/MediaListScreen.qml" line="359"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -849,12 +849,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">جارٍ التحميل…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="354"/>
+        <location filename="../screens/MediaListScreen.qml" line="355"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 عناصر</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="355"/>
+        <location filename="../screens/MediaListScreen.qml" line="356"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="199"/>
-        <location filename="../screens/SystemsScreen.qml" line="297"/>
+        <location filename="../screens/SystemsScreen.qml" line="200"/>
+        <location filename="../screens/SystemsScreen.qml" line="298"/>
         <source>%1 systems</source>
         <translation>%1 أنظمة</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="200"/>
-        <location filename="../screens/SystemsScreen.qml" line="314"/>
+        <location filename="../screens/SystemsScreen.qml" line="201"/>
+        <location filename="../screens/SystemsScreen.qml" line="315"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <location filename="../screens/SystemsScreen.qml" line="333"/>
         <source>No systems in this category</source>
         <translation>لا توجد أنظمة في هذه الفئة</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="331"/>
+        <location filename="../screens/SystemsScreen.qml" line="334"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="200"/>
-        <location filename="../screens/SystemsScreen.qml" line="298"/>
+        <location filename="../screens/SystemsScreen.qml" line="203"/>
+        <location filename="../screens/SystemsScreen.qml" line="301"/>
         <source>%1 systems</source>
         <translation>%1 أنظمة</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="201"/>
-        <location filename="../screens/SystemsScreen.qml" line="315"/>
+        <location filename="../screens/SystemsScreen.qml" line="204"/>
+        <location filename="../screens/SystemsScreen.qml" line="318"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="333"/>
+        <location filename="../screens/SystemsScreen.qml" line="336"/>
         <source>No systems in this category</source>
         <translation>لا توجد أنظمة في هذه الفئة</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="334"/>
+        <location filename="../screens/SystemsScreen.qml" line="337"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -849,12 +849,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Wird geladen…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="355"/>
+        <location filename="../screens/MediaListScreen.qml" line="358"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 Einträge</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="356"/>
+        <location filename="../screens/MediaListScreen.qml" line="359"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="203"/>
-        <location filename="../screens/SystemsScreen.qml" line="301"/>
+        <location filename="../screens/SystemsScreen.qml" line="205"/>
+        <location filename="../screens/SystemsScreen.qml" line="303"/>
         <source>%1 systems</source>
         <translation>%1 Systeme</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="204"/>
-        <location filename="../screens/SystemsScreen.qml" line="318"/>
+        <location filename="../screens/SystemsScreen.qml" line="206"/>
+        <location filename="../screens/SystemsScreen.qml" line="320"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="336"/>
+        <location filename="../screens/SystemsScreen.qml" line="338"/>
         <source>No systems in this category</source>
         <translation>Keine Systeme in dieser Kategorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="337"/>
+        <location filename="../screens/SystemsScreen.qml" line="339"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="200"/>
-        <location filename="../screens/SystemsScreen.qml" line="298"/>
+        <location filename="../screens/SystemsScreen.qml" line="203"/>
+        <location filename="../screens/SystemsScreen.qml" line="301"/>
         <source>%1 systems</source>
         <translation>%1 Systeme</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="201"/>
-        <location filename="../screens/SystemsScreen.qml" line="315"/>
+        <location filename="../screens/SystemsScreen.qml" line="204"/>
+        <location filename="../screens/SystemsScreen.qml" line="318"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="333"/>
+        <location filename="../screens/SystemsScreen.qml" line="336"/>
         <source>No systems in this category</source>
         <translation>Keine Systeme in dieser Kategorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="334"/>
+        <location filename="../screens/SystemsScreen.qml" line="337"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -849,12 +849,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Wird geladen…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="354"/>
+        <location filename="../screens/MediaListScreen.qml" line="355"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 Einträge</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="355"/>
+        <location filename="../screens/MediaListScreen.qml" line="356"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="199"/>
-        <location filename="../screens/SystemsScreen.qml" line="297"/>
+        <location filename="../screens/SystemsScreen.qml" line="200"/>
+        <location filename="../screens/SystemsScreen.qml" line="298"/>
         <source>%1 systems</source>
         <translation>%1 Systeme</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="200"/>
-        <location filename="../screens/SystemsScreen.qml" line="314"/>
+        <location filename="../screens/SystemsScreen.qml" line="201"/>
+        <location filename="../screens/SystemsScreen.qml" line="315"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <location filename="../screens/SystemsScreen.qml" line="333"/>
         <source>No systems in this category</source>
         <translation>Keine Systeme in dieser Kategorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="331"/>
+        <location filename="../screens/SystemsScreen.qml" line="334"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -849,12 +849,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Φόρτωση…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="355"/>
+        <location filename="../screens/MediaListScreen.qml" line="358"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 εγγραφές</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="356"/>
+        <location filename="../screens/MediaListScreen.qml" line="359"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -849,12 +849,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Φόρτωση…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="354"/>
+        <location filename="../screens/MediaListScreen.qml" line="355"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 εγγραφές</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="355"/>
+        <location filename="../screens/MediaListScreen.qml" line="356"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="199"/>
-        <location filename="../screens/SystemsScreen.qml" line="297"/>
+        <location filename="../screens/SystemsScreen.qml" line="200"/>
+        <location filename="../screens/SystemsScreen.qml" line="298"/>
         <source>%1 systems</source>
         <translation>%1 συστήματα</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="200"/>
-        <location filename="../screens/SystemsScreen.qml" line="314"/>
+        <location filename="../screens/SystemsScreen.qml" line="201"/>
+        <location filename="../screens/SystemsScreen.qml" line="315"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <location filename="../screens/SystemsScreen.qml" line="333"/>
         <source>No systems in this category</source>
         <translation>Δεν υπάρχουν συστήματα σε αυτή την κατηγορία</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="331"/>
+        <location filename="../screens/SystemsScreen.qml" line="334"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="200"/>
-        <location filename="../screens/SystemsScreen.qml" line="298"/>
+        <location filename="../screens/SystemsScreen.qml" line="203"/>
+        <location filename="../screens/SystemsScreen.qml" line="301"/>
         <source>%1 systems</source>
         <translation>%1 συστήματα</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="201"/>
-        <location filename="../screens/SystemsScreen.qml" line="315"/>
+        <location filename="../screens/SystemsScreen.qml" line="204"/>
+        <location filename="../screens/SystemsScreen.qml" line="318"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="333"/>
+        <location filename="../screens/SystemsScreen.qml" line="336"/>
         <source>No systems in this category</source>
         <translation>Δεν υπάρχουν συστήματα σε αυτή την κατηγορία</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="334"/>
+        <location filename="../screens/SystemsScreen.qml" line="337"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="203"/>
-        <location filename="../screens/SystemsScreen.qml" line="301"/>
+        <location filename="../screens/SystemsScreen.qml" line="205"/>
+        <location filename="../screens/SystemsScreen.qml" line="303"/>
         <source>%1 systems</source>
         <translation>%1 συστήματα</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="204"/>
-        <location filename="../screens/SystemsScreen.qml" line="318"/>
+        <location filename="../screens/SystemsScreen.qml" line="206"/>
+        <location filename="../screens/SystemsScreen.qml" line="320"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="336"/>
+        <location filename="../screens/SystemsScreen.qml" line="338"/>
         <source>No systems in this category</source>
         <translation>Δεν υπάρχουν συστήματα σε αυτή την κατηγορία</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="337"/>
+        <location filename="../screens/SystemsScreen.qml" line="339"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -837,12 +837,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Loading…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="355"/>
+        <location filename="../screens/MediaListScreen.qml" line="358"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 entries</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="356"/>
+        <location filename="../screens/MediaListScreen.qml" line="359"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -1343,24 +1343,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="200"/>
-        <location filename="../screens/SystemsScreen.qml" line="298"/>
+        <location filename="../screens/SystemsScreen.qml" line="203"/>
+        <location filename="../screens/SystemsScreen.qml" line="301"/>
         <source>%1 systems</source>
         <translation>%1 systems</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="201"/>
-        <location filename="../screens/SystemsScreen.qml" line="315"/>
+        <location filename="../screens/SystemsScreen.qml" line="204"/>
+        <location filename="../screens/SystemsScreen.qml" line="318"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="333"/>
+        <location filename="../screens/SystemsScreen.qml" line="336"/>
         <source>No systems in this category</source>
         <translation>No systems in this category</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="334"/>
+        <location filename="../screens/SystemsScreen.qml" line="337"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -1343,24 +1343,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="203"/>
-        <location filename="../screens/SystemsScreen.qml" line="301"/>
+        <location filename="../screens/SystemsScreen.qml" line="205"/>
+        <location filename="../screens/SystemsScreen.qml" line="303"/>
         <source>%1 systems</source>
         <translation>%1 systems</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="204"/>
-        <location filename="../screens/SystemsScreen.qml" line="318"/>
+        <location filename="../screens/SystemsScreen.qml" line="206"/>
+        <location filename="../screens/SystemsScreen.qml" line="320"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="336"/>
+        <location filename="../screens/SystemsScreen.qml" line="338"/>
         <source>No systems in this category</source>
         <translation>No systems in this category</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="337"/>
+        <location filename="../screens/SystemsScreen.qml" line="339"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -837,12 +837,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Loading…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="354"/>
+        <location filename="../screens/MediaListScreen.qml" line="355"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 entries</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="355"/>
+        <location filename="../screens/MediaListScreen.qml" line="356"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1343,24 +1343,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="199"/>
-        <location filename="../screens/SystemsScreen.qml" line="297"/>
+        <location filename="../screens/SystemsScreen.qml" line="200"/>
+        <location filename="../screens/SystemsScreen.qml" line="298"/>
         <source>%1 systems</source>
         <translation>%1 systems</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="200"/>
-        <location filename="../screens/SystemsScreen.qml" line="314"/>
+        <location filename="../screens/SystemsScreen.qml" line="201"/>
+        <location filename="../screens/SystemsScreen.qml" line="315"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <location filename="../screens/SystemsScreen.qml" line="333"/>
         <source>No systems in this category</source>
         <translation>No systems in this category</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="331"/>
+        <location filename="../screens/SystemsScreen.qml" line="334"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="200"/>
-        <location filename="../screens/SystemsScreen.qml" line="298"/>
+        <location filename="../screens/SystemsScreen.qml" line="203"/>
+        <location filename="../screens/SystemsScreen.qml" line="301"/>
         <source>%1 systems</source>
         <translation>%1 sistemas</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="201"/>
-        <location filename="../screens/SystemsScreen.qml" line="315"/>
+        <location filename="../screens/SystemsScreen.qml" line="204"/>
+        <location filename="../screens/SystemsScreen.qml" line="318"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="333"/>
+        <location filename="../screens/SystemsScreen.qml" line="336"/>
         <source>No systems in this category</source>
         <translation>No hay sistemas en esta categoría</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="334"/>
+        <location filename="../screens/SystemsScreen.qml" line="337"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="203"/>
-        <location filename="../screens/SystemsScreen.qml" line="301"/>
+        <location filename="../screens/SystemsScreen.qml" line="205"/>
+        <location filename="../screens/SystemsScreen.qml" line="303"/>
         <source>%1 systems</source>
         <translation>%1 sistemas</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="204"/>
-        <location filename="../screens/SystemsScreen.qml" line="318"/>
+        <location filename="../screens/SystemsScreen.qml" line="206"/>
+        <location filename="../screens/SystemsScreen.qml" line="320"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="336"/>
+        <location filename="../screens/SystemsScreen.qml" line="338"/>
         <source>No systems in this category</source>
         <translation>No hay sistemas en esta categoría</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="337"/>
+        <location filename="../screens/SystemsScreen.qml" line="339"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -849,12 +849,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Cargando…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="354"/>
+        <location filename="../screens/MediaListScreen.qml" line="355"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 entradas</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="355"/>
+        <location filename="../screens/MediaListScreen.qml" line="356"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="199"/>
-        <location filename="../screens/SystemsScreen.qml" line="297"/>
+        <location filename="../screens/SystemsScreen.qml" line="200"/>
+        <location filename="../screens/SystemsScreen.qml" line="298"/>
         <source>%1 systems</source>
         <translation>%1 sistemas</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="200"/>
-        <location filename="../screens/SystemsScreen.qml" line="314"/>
+        <location filename="../screens/SystemsScreen.qml" line="201"/>
+        <location filename="../screens/SystemsScreen.qml" line="315"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <location filename="../screens/SystemsScreen.qml" line="333"/>
         <source>No systems in this category</source>
         <translation>No hay sistemas en esta categoría</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="331"/>
+        <location filename="../screens/SystemsScreen.qml" line="334"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -849,12 +849,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Cargando…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="355"/>
+        <location filename="../screens/MediaListScreen.qml" line="358"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 entradas</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="356"/>
+        <location filename="../screens/MediaListScreen.qml" line="359"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -1371,24 +1371,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="203"/>
-        <location filename="../screens/SystemsScreen.qml" line="301"/>
+        <location filename="../screens/SystemsScreen.qml" line="205"/>
+        <location filename="../screens/SystemsScreen.qml" line="303"/>
         <source>%1 systems</source>
         <translation>%1 sistema</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="204"/>
-        <location filename="../screens/SystemsScreen.qml" line="318"/>
+        <location filename="../screens/SystemsScreen.qml" line="206"/>
+        <location filename="../screens/SystemsScreen.qml" line="320"/>
         <source>%1 / %2</source>
         <translation type="unfinished">%1 / %2</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="336"/>
+        <location filename="../screens/SystemsScreen.qml" line="338"/>
         <source>No systems in this category</source>
         <translation>Ez dago sistemarik kategoria honetan</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="337"/>
+        <location filename="../screens/SystemsScreen.qml" line="339"/>
         <source>Loading systems…</source>
         <translation type="unfinished">Sistemak kargatzen</translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -1371,24 +1371,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="200"/>
-        <location filename="../screens/SystemsScreen.qml" line="298"/>
+        <location filename="../screens/SystemsScreen.qml" line="203"/>
+        <location filename="../screens/SystemsScreen.qml" line="301"/>
         <source>%1 systems</source>
         <translation>%1 sistema</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="201"/>
-        <location filename="../screens/SystemsScreen.qml" line="315"/>
+        <location filename="../screens/SystemsScreen.qml" line="204"/>
+        <location filename="../screens/SystemsScreen.qml" line="318"/>
         <source>%1 / %2</source>
         <translation type="unfinished">%1 / %2</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="333"/>
+        <location filename="../screens/SystemsScreen.qml" line="336"/>
         <source>No systems in this category</source>
         <translation>Ez dago sistemarik kategoria honetan</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="334"/>
+        <location filename="../screens/SystemsScreen.qml" line="337"/>
         <source>Loading systems…</source>
         <translation type="unfinished">Sistemak kargatzen</translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -857,12 +857,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Kargatzen…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="354"/>
+        <location filename="../screens/MediaListScreen.qml" line="355"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 sarrera</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="355"/>
+        <location filename="../screens/MediaListScreen.qml" line="356"/>
         <source>%1 / %2</source>
         <translation type="unfinished">%1 / %2</translation>
     </message>
@@ -1371,24 +1371,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="199"/>
-        <location filename="../screens/SystemsScreen.qml" line="297"/>
+        <location filename="../screens/SystemsScreen.qml" line="200"/>
+        <location filename="../screens/SystemsScreen.qml" line="298"/>
         <source>%1 systems</source>
         <translation>%1 sistema</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="200"/>
-        <location filename="../screens/SystemsScreen.qml" line="314"/>
+        <location filename="../screens/SystemsScreen.qml" line="201"/>
+        <location filename="../screens/SystemsScreen.qml" line="315"/>
         <source>%1 / %2</source>
         <translation type="unfinished">%1 / %2</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <location filename="../screens/SystemsScreen.qml" line="333"/>
         <source>No systems in this category</source>
         <translation>Ez dago sistemarik kategoria honetan</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="331"/>
+        <location filename="../screens/SystemsScreen.qml" line="334"/>
         <source>Loading systems…</source>
         <translation type="unfinished">Sistemak kargatzen</translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -857,12 +857,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Kargatzen…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="355"/>
+        <location filename="../screens/MediaListScreen.qml" line="358"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 sarrera</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="356"/>
+        <location filename="../screens/MediaListScreen.qml" line="359"/>
         <source>%1 / %2</source>
         <translation type="unfinished">%1 / %2</translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -849,12 +849,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">טוען…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="354"/>
+        <location filename="../screens/MediaListScreen.qml" line="355"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 פריטים</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="355"/>
+        <location filename="../screens/MediaListScreen.qml" line="356"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="199"/>
-        <location filename="../screens/SystemsScreen.qml" line="297"/>
+        <location filename="../screens/SystemsScreen.qml" line="200"/>
+        <location filename="../screens/SystemsScreen.qml" line="298"/>
         <source>%1 systems</source>
         <translation>%1 מערכות</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="200"/>
-        <location filename="../screens/SystemsScreen.qml" line="314"/>
+        <location filename="../screens/SystemsScreen.qml" line="201"/>
+        <location filename="../screens/SystemsScreen.qml" line="315"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <location filename="../screens/SystemsScreen.qml" line="333"/>
         <source>No systems in this category</source>
         <translation>אין מערכות בקטגוריה זו</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="331"/>
+        <location filename="../screens/SystemsScreen.qml" line="334"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="200"/>
-        <location filename="../screens/SystemsScreen.qml" line="298"/>
+        <location filename="../screens/SystemsScreen.qml" line="203"/>
+        <location filename="../screens/SystemsScreen.qml" line="301"/>
         <source>%1 systems</source>
         <translation>%1 מערכות</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="201"/>
-        <location filename="../screens/SystemsScreen.qml" line="315"/>
+        <location filename="../screens/SystemsScreen.qml" line="204"/>
+        <location filename="../screens/SystemsScreen.qml" line="318"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="333"/>
+        <location filename="../screens/SystemsScreen.qml" line="336"/>
         <source>No systems in this category</source>
         <translation>אין מערכות בקטגוריה זו</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="334"/>
+        <location filename="../screens/SystemsScreen.qml" line="337"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="203"/>
-        <location filename="../screens/SystemsScreen.qml" line="301"/>
+        <location filename="../screens/SystemsScreen.qml" line="205"/>
+        <location filename="../screens/SystemsScreen.qml" line="303"/>
         <source>%1 systems</source>
         <translation>%1 מערכות</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="204"/>
-        <location filename="../screens/SystemsScreen.qml" line="318"/>
+        <location filename="../screens/SystemsScreen.qml" line="206"/>
+        <location filename="../screens/SystemsScreen.qml" line="320"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="336"/>
+        <location filename="../screens/SystemsScreen.qml" line="338"/>
         <source>No systems in this category</source>
         <translation>אין מערכות בקטגוריה זו</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="337"/>
+        <location filename="../screens/SystemsScreen.qml" line="339"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -849,12 +849,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">טוען…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="355"/>
+        <location filename="../screens/MediaListScreen.qml" line="358"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 פריטים</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="356"/>
+        <location filename="../screens/MediaListScreen.qml" line="359"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="200"/>
-        <location filename="../screens/SystemsScreen.qml" line="298"/>
+        <location filename="../screens/SystemsScreen.qml" line="203"/>
+        <location filename="../screens/SystemsScreen.qml" line="301"/>
         <source>%1 systems</source>
         <translation>%1 सिस्टम</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="201"/>
-        <location filename="../screens/SystemsScreen.qml" line="315"/>
+        <location filename="../screens/SystemsScreen.qml" line="204"/>
+        <location filename="../screens/SystemsScreen.qml" line="318"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="333"/>
+        <location filename="../screens/SystemsScreen.qml" line="336"/>
         <source>No systems in this category</source>
         <translation>इस श्रेणी में कोई सिस्टम नहीं है</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="334"/>
+        <location filename="../screens/SystemsScreen.qml" line="337"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="203"/>
-        <location filename="../screens/SystemsScreen.qml" line="301"/>
+        <location filename="../screens/SystemsScreen.qml" line="205"/>
+        <location filename="../screens/SystemsScreen.qml" line="303"/>
         <source>%1 systems</source>
         <translation>%1 सिस्टम</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="204"/>
-        <location filename="../screens/SystemsScreen.qml" line="318"/>
+        <location filename="../screens/SystemsScreen.qml" line="206"/>
+        <location filename="../screens/SystemsScreen.qml" line="320"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="336"/>
+        <location filename="../screens/SystemsScreen.qml" line="338"/>
         <source>No systems in this category</source>
         <translation>इस श्रेणी में कोई सिस्टम नहीं है</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="337"/>
+        <location filename="../screens/SystemsScreen.qml" line="339"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -849,12 +849,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">लोड हो रहा है…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="355"/>
+        <location filename="../screens/MediaListScreen.qml" line="358"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 प्रविष्टियाँ</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="356"/>
+        <location filename="../screens/MediaListScreen.qml" line="359"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -849,12 +849,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">लोड हो रहा है…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="354"/>
+        <location filename="../screens/MediaListScreen.qml" line="355"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 प्रविष्टियाँ</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="355"/>
+        <location filename="../screens/MediaListScreen.qml" line="356"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="199"/>
-        <location filename="../screens/SystemsScreen.qml" line="297"/>
+        <location filename="../screens/SystemsScreen.qml" line="200"/>
+        <location filename="../screens/SystemsScreen.qml" line="298"/>
         <source>%1 systems</source>
         <translation>%1 सिस्टम</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="200"/>
-        <location filename="../screens/SystemsScreen.qml" line="314"/>
+        <location filename="../screens/SystemsScreen.qml" line="201"/>
+        <location filename="../screens/SystemsScreen.qml" line="315"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <location filename="../screens/SystemsScreen.qml" line="333"/>
         <source>No systems in this category</source>
         <translation>इस श्रेणी में कोई सिस्टम नहीं है</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="331"/>
+        <location filename="../screens/SystemsScreen.qml" line="334"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="200"/>
-        <location filename="../screens/SystemsScreen.qml" line="298"/>
+        <location filename="../screens/SystemsScreen.qml" line="203"/>
+        <location filename="../screens/SystemsScreen.qml" line="301"/>
         <source>%1 systems</source>
         <translation>%1 sistemi</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="201"/>
-        <location filename="../screens/SystemsScreen.qml" line="315"/>
+        <location filename="../screens/SystemsScreen.qml" line="204"/>
+        <location filename="../screens/SystemsScreen.qml" line="318"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="333"/>
+        <location filename="../screens/SystemsScreen.qml" line="336"/>
         <source>No systems in this category</source>
         <translation>Nessun sistema in questa categoria</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="334"/>
+        <location filename="../screens/SystemsScreen.qml" line="337"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -849,12 +849,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Caricamento…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="354"/>
+        <location filename="../screens/MediaListScreen.qml" line="355"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 elementi</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="355"/>
+        <location filename="../screens/MediaListScreen.qml" line="356"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="199"/>
-        <location filename="../screens/SystemsScreen.qml" line="297"/>
+        <location filename="../screens/SystemsScreen.qml" line="200"/>
+        <location filename="../screens/SystemsScreen.qml" line="298"/>
         <source>%1 systems</source>
         <translation>%1 sistemi</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="200"/>
-        <location filename="../screens/SystemsScreen.qml" line="314"/>
+        <location filename="../screens/SystemsScreen.qml" line="201"/>
+        <location filename="../screens/SystemsScreen.qml" line="315"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <location filename="../screens/SystemsScreen.qml" line="333"/>
         <source>No systems in this category</source>
         <translation>Nessun sistema in questa categoria</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="331"/>
+        <location filename="../screens/SystemsScreen.qml" line="334"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="203"/>
-        <location filename="../screens/SystemsScreen.qml" line="301"/>
+        <location filename="../screens/SystemsScreen.qml" line="205"/>
+        <location filename="../screens/SystemsScreen.qml" line="303"/>
         <source>%1 systems</source>
         <translation>%1 sistemi</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="204"/>
-        <location filename="../screens/SystemsScreen.qml" line="318"/>
+        <location filename="../screens/SystemsScreen.qml" line="206"/>
+        <location filename="../screens/SystemsScreen.qml" line="320"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="336"/>
+        <location filename="../screens/SystemsScreen.qml" line="338"/>
         <source>No systems in this category</source>
         <translation>Nessun sistema in questa categoria</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="337"/>
+        <location filename="../screens/SystemsScreen.qml" line="339"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -849,12 +849,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Caricamento…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="355"/>
+        <location filename="../screens/MediaListScreen.qml" line="358"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 elementi</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="356"/>
+        <location filename="../screens/MediaListScreen.qml" line="359"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="200"/>
-        <location filename="../screens/SystemsScreen.qml" line="298"/>
+        <location filename="../screens/SystemsScreen.qml" line="203"/>
+        <location filename="../screens/SystemsScreen.qml" line="301"/>
         <source>%1 systems</source>
         <translation>%1 システム</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="201"/>
-        <location filename="../screens/SystemsScreen.qml" line="315"/>
+        <location filename="../screens/SystemsScreen.qml" line="204"/>
+        <location filename="../screens/SystemsScreen.qml" line="318"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="333"/>
+        <location filename="../screens/SystemsScreen.qml" line="336"/>
         <source>No systems in this category</source>
         <translation>このカテゴリにシステムはありません</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="334"/>
+        <location filename="../screens/SystemsScreen.qml" line="337"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="203"/>
-        <location filename="../screens/SystemsScreen.qml" line="301"/>
+        <location filename="../screens/SystemsScreen.qml" line="205"/>
+        <location filename="../screens/SystemsScreen.qml" line="303"/>
         <source>%1 systems</source>
         <translation>%1 システム</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="204"/>
-        <location filename="../screens/SystemsScreen.qml" line="318"/>
+        <location filename="../screens/SystemsScreen.qml" line="206"/>
+        <location filename="../screens/SystemsScreen.qml" line="320"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="336"/>
+        <location filename="../screens/SystemsScreen.qml" line="338"/>
         <source>No systems in this category</source>
         <translation>このカテゴリにシステムはありません</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="337"/>
+        <location filename="../screens/SystemsScreen.qml" line="339"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -849,12 +849,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">読み込み中…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="355"/>
+        <location filename="../screens/MediaListScreen.qml" line="358"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 件</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="356"/>
+        <location filename="../screens/MediaListScreen.qml" line="359"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -849,12 +849,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">読み込み中…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="354"/>
+        <location filename="../screens/MediaListScreen.qml" line="355"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 件</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="355"/>
+        <location filename="../screens/MediaListScreen.qml" line="356"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="199"/>
-        <location filename="../screens/SystemsScreen.qml" line="297"/>
+        <location filename="../screens/SystemsScreen.qml" line="200"/>
+        <location filename="../screens/SystemsScreen.qml" line="298"/>
         <source>%1 systems</source>
         <translation>%1 システム</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="200"/>
-        <location filename="../screens/SystemsScreen.qml" line="314"/>
+        <location filename="../screens/SystemsScreen.qml" line="201"/>
+        <location filename="../screens/SystemsScreen.qml" line="315"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <location filename="../screens/SystemsScreen.qml" line="333"/>
         <source>No systems in this category</source>
         <translation>このカテゴリにシステムはありません</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="331"/>
+        <location filename="../screens/SystemsScreen.qml" line="334"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="203"/>
-        <location filename="../screens/SystemsScreen.qml" line="301"/>
+        <location filename="../screens/SystemsScreen.qml" line="205"/>
+        <location filename="../screens/SystemsScreen.qml" line="303"/>
         <source>%1 systems</source>
         <translation>시스템 %1개</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="204"/>
-        <location filename="../screens/SystemsScreen.qml" line="318"/>
+        <location filename="../screens/SystemsScreen.qml" line="206"/>
+        <location filename="../screens/SystemsScreen.qml" line="320"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="336"/>
+        <location filename="../screens/SystemsScreen.qml" line="338"/>
         <source>No systems in this category</source>
         <translation>이 카테고리에는 시스템이 없습니다</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="337"/>
+        <location filename="../screens/SystemsScreen.qml" line="339"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="200"/>
-        <location filename="../screens/SystemsScreen.qml" line="298"/>
+        <location filename="../screens/SystemsScreen.qml" line="203"/>
+        <location filename="../screens/SystemsScreen.qml" line="301"/>
         <source>%1 systems</source>
         <translation>시스템 %1개</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="201"/>
-        <location filename="../screens/SystemsScreen.qml" line="315"/>
+        <location filename="../screens/SystemsScreen.qml" line="204"/>
+        <location filename="../screens/SystemsScreen.qml" line="318"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="333"/>
+        <location filename="../screens/SystemsScreen.qml" line="336"/>
         <source>No systems in this category</source>
         <translation>이 카테고리에는 시스템이 없습니다</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="334"/>
+        <location filename="../screens/SystemsScreen.qml" line="337"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -849,12 +849,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="355"/>
+        <location filename="../screens/MediaListScreen.qml" line="358"/>
         <source>%1 entries</source>
         <translation type="unfinished">항목 %1개</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="356"/>
+        <location filename="../screens/MediaListScreen.qml" line="359"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -849,12 +849,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="354"/>
+        <location filename="../screens/MediaListScreen.qml" line="355"/>
         <source>%1 entries</source>
         <translation type="unfinished">항목 %1개</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="355"/>
+        <location filename="../screens/MediaListScreen.qml" line="356"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="199"/>
-        <location filename="../screens/SystemsScreen.qml" line="297"/>
+        <location filename="../screens/SystemsScreen.qml" line="200"/>
+        <location filename="../screens/SystemsScreen.qml" line="298"/>
         <source>%1 systems</source>
         <translation>시스템 %1개</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="200"/>
-        <location filename="../screens/SystemsScreen.qml" line="314"/>
+        <location filename="../screens/SystemsScreen.qml" line="201"/>
+        <location filename="../screens/SystemsScreen.qml" line="315"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <location filename="../screens/SystemsScreen.qml" line="333"/>
         <source>No systems in this category</source>
         <translation>이 카테고리에는 시스템이 없습니다</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="331"/>
+        <location filename="../screens/SystemsScreen.qml" line="334"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -849,12 +849,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Laden…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="355"/>
+        <location filename="../screens/MediaListScreen.qml" line="358"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 items</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="356"/>
+        <location filename="../screens/MediaListScreen.qml" line="359"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="200"/>
-        <location filename="../screens/SystemsScreen.qml" line="298"/>
+        <location filename="../screens/SystemsScreen.qml" line="203"/>
+        <location filename="../screens/SystemsScreen.qml" line="301"/>
         <source>%1 systems</source>
         <translation>%1 systemen</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="201"/>
-        <location filename="../screens/SystemsScreen.qml" line="315"/>
+        <location filename="../screens/SystemsScreen.qml" line="204"/>
+        <location filename="../screens/SystemsScreen.qml" line="318"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="333"/>
+        <location filename="../screens/SystemsScreen.qml" line="336"/>
         <source>No systems in this category</source>
         <translation>Geen systemen in deze categorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="334"/>
+        <location filename="../screens/SystemsScreen.qml" line="337"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="203"/>
-        <location filename="../screens/SystemsScreen.qml" line="301"/>
+        <location filename="../screens/SystemsScreen.qml" line="205"/>
+        <location filename="../screens/SystemsScreen.qml" line="303"/>
         <source>%1 systems</source>
         <translation>%1 systemen</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="204"/>
-        <location filename="../screens/SystemsScreen.qml" line="318"/>
+        <location filename="../screens/SystemsScreen.qml" line="206"/>
+        <location filename="../screens/SystemsScreen.qml" line="320"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="336"/>
+        <location filename="../screens/SystemsScreen.qml" line="338"/>
         <source>No systems in this category</source>
         <translation>Geen systemen in deze categorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="337"/>
+        <location filename="../screens/SystemsScreen.qml" line="339"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -849,12 +849,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Laden…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="354"/>
+        <location filename="../screens/MediaListScreen.qml" line="355"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 items</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="355"/>
+        <location filename="../screens/MediaListScreen.qml" line="356"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="199"/>
-        <location filename="../screens/SystemsScreen.qml" line="297"/>
+        <location filename="../screens/SystemsScreen.qml" line="200"/>
+        <location filename="../screens/SystemsScreen.qml" line="298"/>
         <source>%1 systems</source>
         <translation>%1 systemen</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="200"/>
-        <location filename="../screens/SystemsScreen.qml" line="314"/>
+        <location filename="../screens/SystemsScreen.qml" line="201"/>
+        <location filename="../screens/SystemsScreen.qml" line="315"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <location filename="../screens/SystemsScreen.qml" line="333"/>
         <source>No systems in this category</source>
         <translation>Geen systemen in deze categorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="331"/>
+        <location filename="../screens/SystemsScreen.qml" line="334"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -849,12 +849,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Se încarcă…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="355"/>
+        <location filename="../screens/MediaListScreen.qml" line="358"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 intrări</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="356"/>
+        <location filename="../screens/MediaListScreen.qml" line="359"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="203"/>
-        <location filename="../screens/SystemsScreen.qml" line="301"/>
+        <location filename="../screens/SystemsScreen.qml" line="205"/>
+        <location filename="../screens/SystemsScreen.qml" line="303"/>
         <source>%1 systems</source>
         <translation>%1 sisteme</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="204"/>
-        <location filename="../screens/SystemsScreen.qml" line="318"/>
+        <location filename="../screens/SystemsScreen.qml" line="206"/>
+        <location filename="../screens/SystemsScreen.qml" line="320"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="336"/>
+        <location filename="../screens/SystemsScreen.qml" line="338"/>
         <source>No systems in this category</source>
         <translation>Niciun sistem în această categorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="337"/>
+        <location filename="../screens/SystemsScreen.qml" line="339"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="200"/>
-        <location filename="../screens/SystemsScreen.qml" line="298"/>
+        <location filename="../screens/SystemsScreen.qml" line="203"/>
+        <location filename="../screens/SystemsScreen.qml" line="301"/>
         <source>%1 systems</source>
         <translation>%1 sisteme</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="201"/>
-        <location filename="../screens/SystemsScreen.qml" line="315"/>
+        <location filename="../screens/SystemsScreen.qml" line="204"/>
+        <location filename="../screens/SystemsScreen.qml" line="318"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="333"/>
+        <location filename="../screens/SystemsScreen.qml" line="336"/>
         <source>No systems in this category</source>
         <translation>Niciun sistem în această categorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="334"/>
+        <location filename="../screens/SystemsScreen.qml" line="337"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -849,12 +849,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Se încarcă…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="354"/>
+        <location filename="../screens/MediaListScreen.qml" line="355"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 intrări</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="355"/>
+        <location filename="../screens/MediaListScreen.qml" line="356"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="199"/>
-        <location filename="../screens/SystemsScreen.qml" line="297"/>
+        <location filename="../screens/SystemsScreen.qml" line="200"/>
+        <location filename="../screens/SystemsScreen.qml" line="298"/>
         <source>%1 systems</source>
         <translation>%1 sisteme</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="200"/>
-        <location filename="../screens/SystemsScreen.qml" line="314"/>
+        <location filename="../screens/SystemsScreen.qml" line="201"/>
+        <location filename="../screens/SystemsScreen.qml" line="315"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <location filename="../screens/SystemsScreen.qml" line="333"/>
         <source>No systems in this category</source>
         <translation>Niciun sistem în această categorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="331"/>
+        <location filename="../screens/SystemsScreen.qml" line="334"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -849,12 +849,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Načítanie…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="354"/>
+        <location filename="../screens/MediaListScreen.qml" line="355"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 položiek</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="355"/>
+        <location filename="../screens/MediaListScreen.qml" line="356"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="199"/>
-        <location filename="../screens/SystemsScreen.qml" line="297"/>
+        <location filename="../screens/SystemsScreen.qml" line="200"/>
+        <location filename="../screens/SystemsScreen.qml" line="298"/>
         <source>%1 systems</source>
         <translation>%1 systémov</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="200"/>
-        <location filename="../screens/SystemsScreen.qml" line="314"/>
+        <location filename="../screens/SystemsScreen.qml" line="201"/>
+        <location filename="../screens/SystemsScreen.qml" line="315"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <location filename="../screens/SystemsScreen.qml" line="333"/>
         <source>No systems in this category</source>
         <translation>V tejto kategórii nie sú žiadne systémy</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="331"/>
+        <location filename="../screens/SystemsScreen.qml" line="334"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="203"/>
-        <location filename="../screens/SystemsScreen.qml" line="301"/>
+        <location filename="../screens/SystemsScreen.qml" line="205"/>
+        <location filename="../screens/SystemsScreen.qml" line="303"/>
         <source>%1 systems</source>
         <translation>%1 systémov</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="204"/>
-        <location filename="../screens/SystemsScreen.qml" line="318"/>
+        <location filename="../screens/SystemsScreen.qml" line="206"/>
+        <location filename="../screens/SystemsScreen.qml" line="320"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="336"/>
+        <location filename="../screens/SystemsScreen.qml" line="338"/>
         <source>No systems in this category</source>
         <translation>V tejto kategórii nie sú žiadne systémy</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="337"/>
+        <location filename="../screens/SystemsScreen.qml" line="339"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="200"/>
-        <location filename="../screens/SystemsScreen.qml" line="298"/>
+        <location filename="../screens/SystemsScreen.qml" line="203"/>
+        <location filename="../screens/SystemsScreen.qml" line="301"/>
         <source>%1 systems</source>
         <translation>%1 systémov</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="201"/>
-        <location filename="../screens/SystemsScreen.qml" line="315"/>
+        <location filename="../screens/SystemsScreen.qml" line="204"/>
+        <location filename="../screens/SystemsScreen.qml" line="318"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="333"/>
+        <location filename="../screens/SystemsScreen.qml" line="336"/>
         <source>No systems in this category</source>
         <translation>V tejto kategórii nie sú žiadne systémy</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="334"/>
+        <location filename="../screens/SystemsScreen.qml" line="337"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -849,12 +849,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Načítanie…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="355"/>
+        <location filename="../screens/MediaListScreen.qml" line="358"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 položiek</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="356"/>
+        <location filename="../screens/MediaListScreen.qml" line="359"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -849,12 +849,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Завантаження…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="354"/>
+        <location filename="../screens/MediaListScreen.qml" line="355"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 записів</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="355"/>
+        <location filename="../screens/MediaListScreen.qml" line="356"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="199"/>
-        <location filename="../screens/SystemsScreen.qml" line="297"/>
+        <location filename="../screens/SystemsScreen.qml" line="200"/>
+        <location filename="../screens/SystemsScreen.qml" line="298"/>
         <source>%1 systems</source>
         <translation>%1 систем</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="200"/>
-        <location filename="../screens/SystemsScreen.qml" line="314"/>
+        <location filename="../screens/SystemsScreen.qml" line="201"/>
+        <location filename="../screens/SystemsScreen.qml" line="315"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <location filename="../screens/SystemsScreen.qml" line="333"/>
         <source>No systems in this category</source>
         <translation>У цій категорії немає систем</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="331"/>
+        <location filename="../screens/SystemsScreen.qml" line="334"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -849,12 +849,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Завантаження…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="355"/>
+        <location filename="../screens/MediaListScreen.qml" line="358"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 записів</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="356"/>
+        <location filename="../screens/MediaListScreen.qml" line="359"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="203"/>
-        <location filename="../screens/SystemsScreen.qml" line="301"/>
+        <location filename="../screens/SystemsScreen.qml" line="205"/>
+        <location filename="../screens/SystemsScreen.qml" line="303"/>
         <source>%1 systems</source>
         <translation>%1 систем</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="204"/>
-        <location filename="../screens/SystemsScreen.qml" line="318"/>
+        <location filename="../screens/SystemsScreen.qml" line="206"/>
+        <location filename="../screens/SystemsScreen.qml" line="320"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="336"/>
+        <location filename="../screens/SystemsScreen.qml" line="338"/>
         <source>No systems in this category</source>
         <translation>У цій категорії немає систем</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="337"/>
+        <location filename="../screens/SystemsScreen.qml" line="339"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="200"/>
-        <location filename="../screens/SystemsScreen.qml" line="298"/>
+        <location filename="../screens/SystemsScreen.qml" line="203"/>
+        <location filename="../screens/SystemsScreen.qml" line="301"/>
         <source>%1 systems</source>
         <translation>%1 систем</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="201"/>
-        <location filename="../screens/SystemsScreen.qml" line="315"/>
+        <location filename="../screens/SystemsScreen.qml" line="204"/>
+        <location filename="../screens/SystemsScreen.qml" line="318"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="333"/>
+        <location filename="../screens/SystemsScreen.qml" line="336"/>
         <source>No systems in this category</source>
         <translation>У цій категорії немає систем</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="334"/>
+        <location filename="../screens/SystemsScreen.qml" line="337"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -849,12 +849,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">正在加载…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="355"/>
+        <location filename="../screens/MediaListScreen.qml" line="358"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 个条目</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="356"/>
+        <location filename="../screens/MediaListScreen.qml" line="359"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="200"/>
-        <location filename="../screens/SystemsScreen.qml" line="298"/>
+        <location filename="../screens/SystemsScreen.qml" line="203"/>
+        <location filename="../screens/SystemsScreen.qml" line="301"/>
         <source>%1 systems</source>
         <translation>%1 个系统</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="201"/>
-        <location filename="../screens/SystemsScreen.qml" line="315"/>
+        <location filename="../screens/SystemsScreen.qml" line="204"/>
+        <location filename="../screens/SystemsScreen.qml" line="318"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="333"/>
+        <location filename="../screens/SystemsScreen.qml" line="336"/>
         <source>No systems in this category</source>
         <translation>此类别中没有系统</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="334"/>
+        <location filename="../screens/SystemsScreen.qml" line="337"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -849,12 +849,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">正在加载…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="354"/>
+        <location filename="../screens/MediaListScreen.qml" line="355"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 个条目</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="355"/>
+        <location filename="../screens/MediaListScreen.qml" line="356"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="199"/>
-        <location filename="../screens/SystemsScreen.qml" line="297"/>
+        <location filename="../screens/SystemsScreen.qml" line="200"/>
+        <location filename="../screens/SystemsScreen.qml" line="298"/>
         <source>%1 systems</source>
         <translation>%1 个系统</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="200"/>
-        <location filename="../screens/SystemsScreen.qml" line="314"/>
+        <location filename="../screens/SystemsScreen.qml" line="201"/>
+        <location filename="../screens/SystemsScreen.qml" line="315"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="330"/>
+        <location filename="../screens/SystemsScreen.qml" line="333"/>
         <source>No systems in this category</source>
         <translation>此类别中没有系统</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="331"/>
+        <location filename="../screens/SystemsScreen.qml" line="334"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -1363,24 +1363,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="203"/>
-        <location filename="../screens/SystemsScreen.qml" line="301"/>
+        <location filename="../screens/SystemsScreen.qml" line="205"/>
+        <location filename="../screens/SystemsScreen.qml" line="303"/>
         <source>%1 systems</source>
         <translation>%1 个系统</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="204"/>
-        <location filename="../screens/SystemsScreen.qml" line="318"/>
+        <location filename="../screens/SystemsScreen.qml" line="206"/>
+        <location filename="../screens/SystemsScreen.qml" line="320"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="336"/>
+        <location filename="../screens/SystemsScreen.qml" line="338"/>
         <source>No systems in this category</source>
         <translation>此类别中没有系统</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="337"/>
+        <location filename="../screens/SystemsScreen.qml" line="339"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>

--- a/tests/ui/tst_navigation.qml
+++ b/tests/ui/tst_navigation.qml
@@ -352,7 +352,7 @@ TestCase {
         // qmllint disable compiler
         compare(main._isRepeatableAction("accept"), false);
         compare(main._isRepeatableAction("cancel"), false);
-        compare(main._isRepeatableAction("write_card"), false);
+        compare(main._isRepeatableAction("context_menu"), false);
         compare(main._isRepeatableAction(""), false);
     // qmllint enable compiler
     }


### PR DESCRIPTION
## Summary
- keep media and systems content hidden through delayed loading overlay tail
- treat overlay tail as loading so input does not act while centered loading text remains
- update translation source line numbers from lint

## Tests
- just lint
- just test-qml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Loading overlay now fully hides list/grid content and temporarily blocks directional navigation to prevent flicker and accidental movement.

* **Behavior Changes**
  * Right-click/context action unified to open the context menu; accept/cancel behavior updated accordingly.
  * The Tab key now opens the context menu.

* **Localization**
  * Updated translation metadata across many languages to match UI line changes (no visible text changed).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->