### PR TITLE
Reduce-motion setting and interaction-animation system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ rust/target/
 
 # cxx-qt 0.8 generates this with absolute paths for qmlls/qmllint
 rust/frontend/.qmlls.ini
+
+# Dev-run log that lands in the repo root (real log goes to ~/.local/share/zaparoo/logs/)
+/frontend.log

--- a/docs/qml-gotchas.md
+++ b/docs/qml-gotchas.md
@@ -77,7 +77,7 @@ Frame cost on raster ≈ **painted pixels per frame × per-pixel cost**. The
 animation type matters less than people expect — what matters is what each
 animation choice does to that product:
 
-1. **How big is the dirty rectangle?** Animating a 20×20 page-dot dirties
+1. **How big is the dirty rectangle?** Animating a 20×20 scroll-thumb dirties
    400 pixels. Animating a full-screen overlay dirties ~2 M pixels. Same
    property (`opacity`), 5000× the cost.
 2. **What's *in* the dirty rectangle?** A cached pixmap blit is cheap.
@@ -98,7 +98,7 @@ mark dirty per frame?**" and pick whatever keeps that small.
 Two follow-on rules from the same model:
 
 - **Translation is free, but its content isn't.** Moving an Item by 1 px
-  costs almost nothing if the Item is small (a page-dot, a single tile).
+  costs almost nothing if the Item is small (a single tile, the scroll-thumb).
   Moving a band of 12 tiles costs the rasterize of all 12 tiles per
   frame, because the dirty rectangle covers the whole band.
 - **Fractional DPR is the absolute version of this.** When Qt's screen
@@ -114,8 +114,8 @@ Pick animations from the cheap column when targeting MiSTer.
 
 | Cheap on raster | Expensive on raster |
 |---|---|
-| Instant cut + small animated cue (page-dot pulse, focus-ring blink) | Translucent overlays of any size (see below) |
-| Translation of small items (one Tile, page dots) | Translation of large content (band of N tiles) |
+| Instant cut + small one-shot cue (the tile/row push-in) | Translucent overlays of any size (see below) |
+| Translation/scale of small items (one Tile, the scroll-thumb) | Translation of large content (band of N tiles) |
 | ColorAnimation on tints / borders | Concurrent slide + scale (compounds raster cost) |
 | Static scenes with one ramping property on a small element | `ShaderEffect` of any kind, `Qt5Compat.GraphicalEffects` |
 | `layer.enabled` for caching a complex sub-tree | `Animator` types (no benefit on basic render loop) |
@@ -162,7 +162,7 @@ plain animations, and `layer.enabled` without an effect.
 ### Recommendation
 
 For state-change feedback, prefer instant cuts with a small localized cue
-(page-dot pulse, focus-ring blink, help-bar text change) over any fade.
+(the push-in cue, a help-bar text change) over any fade.
 Cues are small elements with small dirty rectangles; they paint cheaply
 on raster regardless of DPR or partial-update status. Reach for a fade
 only after diagnosing DPR and ensuring the destination scene is
@@ -175,18 +175,16 @@ The rule above bans **persistent** motion that runs every frame while content
 is busy (e.g., a scale held on every focused tile on every d-pad move). It
 does NOT ban short one-shot animations on a single small element triggered
 at a state-change moment (activate/launch, selection land). Those are cheap
-for the same reason page-dot pulses are cheap: one element, one short burst,
-then back to a static scene.
+for the same reason a single-tile push-in is cheap: one element, one short
+burst, then back to a static scene.
 
 Sanctioned patterns and why they are safe:
 
 | Cue | Cost analysis |
 |---|---|
-| Tile push-in on activate or launch (single scale leg, ~90 ms, held) | Single tile's pixmap scales transiently; dirty rect = one tile; the host screen's `settling` flag resets `scale` to 1.0 off-screen so there is no resampling per frame once the screen is hidden. One shared cue covers both forward navigation and game launch |
-| Row focus nudge on list selection (x offset, ~140 ms) | One row's three sub-elements translate right; dirty rect = one row height; all neighboring rows are static |
-| Scroll-thumb glide (y, ~140 ms) | One small Rectangle; dirty rect negligible |
-| Settings toggle handle slide (x, ~140 ms) | One tiny Rectangle handle; 1 pctW |
-| Focus-border color fade (ColorAnimation, ~140 ms) | Border only; no pixmap, no text; cheapest possible paint |
+| Tile push-in on activate or launch (single scale leg, ~80 ms, held) | Single tile's pixmap scales transiently; dirty rect = one tile; the host screen's `settling` flag resets `scale` to 1.0 off-screen so there is no resampling per frame once the screen is hidden. One shared cue covers both forward navigation and game launch |
+| List-detail row push-in on activate or launch (single scale leg, ~80 ms, held) | The same cue as the tile, applied to the selected list row; dirty rect = one row; all neighboring rows are static |
+| Settings toggle-knob slide (x, ~110 ms) | One tiny Rectangle handle; 1 pctW |
 
 The shared constraint: the source scene must be static or near-static during
 the cue. The tile grid is not scrolling; the list row content is not
@@ -234,9 +232,12 @@ Token summary (`Motion.qml`):
 
 | Token | Value | Use |
 |---|---|---|
-| `pressMs` | 90 | Push-in cue; at the perceivable-motion floor |
-| `settleMs` | 140 | Nudge, glide, toggle, border fade |
+| `pressMs` | 80 | Push-in cue (accept/activate) |
+| `settleMs` | 110 | Push-in release leg; toggle-knob slide |
 | `pressScale` | 0.96 | Push-in target |
+
+Both durations sit just above MiSTer's frame-budget floor (~3 frames at
+~30fps); see the comments in `Motion.qml` before lowering them.
 
 Pulse counter pattern (how hosts trigger tile cues without coupling to
 animation internals): the host increments the `activatePulse` int property

--- a/docs/qml-gotchas.md
+++ b/docs/qml-gotchas.md
@@ -168,3 +168,81 @@ on raster regardless of DPR or partial-update status. Reach for a fade
 only after diagnosing DPR and ensuring the destination scene is
 genuinely static — and then use `Item.grabToImage()` rather than a
 translucent overlay.
+
+### Sanctioned one-shot transient cues
+
+The rule above bans **persistent** motion that runs every frame while content
+is busy (e.g., a scale held on every focused tile on every d-pad move). It
+does NOT ban short one-shot animations on a single small element triggered
+at a state-change moment (activate/launch, selection land). Those are cheap
+for the same reason page-dot pulses are cheap: one element, one short burst,
+then back to a static scene.
+
+Sanctioned patterns and why they are safe:
+
+| Cue | Cost analysis |
+|---|---|
+| Tile push-in on activate or launch (single scale leg, ~90 ms, held) | Single tile's pixmap scales transiently; dirty rect = one tile; the host screen's `settling` flag resets `scale` to 1.0 off-screen so there is no resampling per frame once the screen is hidden. One shared cue covers both forward navigation and game launch |
+| Row focus nudge on list selection (x offset, ~140 ms) | One row's three sub-elements translate right; dirty rect = one row height; all neighboring rows are static |
+| Scroll-thumb glide (y, ~140 ms) | One small Rectangle; dirty rect negligible |
+| Settings toggle handle slide (x, ~140 ms) | One tiny Rectangle handle; 1 pctW |
+| Focus-border color fade (ColorAnimation, ~140 ms) | Border only; no pixmap, no text; cheapest possible paint |
+
+The shared constraint: the source scene must be static or near-static during
+the cue. The tile grid is not scrolling; the list row content is not
+changing. If there is any chance the surrounding content is busy (rapid
+scroll, prefetch, incoming model update), gate the Behavior off via a
+`rapidScrollActive` flag or equivalent so the cue collapses to instant.
+
+The previously removed 1.06x Tile focus scale was **persistent** - held
+across every d-pad move while the grid was live. Any tile that held the old
+scale forced its pixmap to be bilinear-filtered on every rendered frame,
+compounding across focus moves. That is the pattern being banned; the
+one-shot transients above do not share that cost profile.
+
+### Motion tokens and the reduce-motion convention
+
+All animation durations in QML go through the `Motion` singleton in
+`Zaparoo.Theme`. Never hardcode a duration inline:
+
+```qml
+// Good
+NumberAnimation { duration: Motion.dur(Motion.settleMs) }
+Behavior on x { enabled: Motion.enabled; NumberAnimation { duration: Motion.dur(Motion.settleMs) } }
+
+// Bad - not controlled by reduce-motion, not adjustable from one place
+NumberAnimation { duration: 140 }
+```
+
+`Motion.dur(ms)` returns `ms` when `Motion.enabled` is true and `0` when
+false. A duration of `0` causes a Behavior or SequentialAnimation to resolve
+in one frame (instant cut). This is the reduce-motion path: zero code
+branches, zero dead animation objects, no visible change to the rest of the
+logic.
+
+`Motion.enabled` is fed from the app layer via a `Binding` in `Main.qml`:
+
+```qml
+Binding { target: Motion; property: "enabled"; value: !Browse.Settings.current_reduce_motion }
+```
+
+The `Motion` singleton itself does not import `Zaparoo.Browse` - the app
+layer crosses the module boundary. This keeps `Zaparoo.Theme` free of
+dependencies on the models module, consistent with `Sizing` and `Theme`.
+
+Token summary (`Motion.qml`):
+
+| Token | Value | Use |
+|---|---|---|
+| `pressMs` | 90 | Push-in cue; at the perceivable-motion floor |
+| `settleMs` | 140 | Nudge, glide, toggle, border fade |
+| `pressScale` | 0.96 | Push-in target |
+
+Pulse counter pattern (how hosts trigger tile cues without coupling to
+animation internals): the host increments the `activatePulse` int property
+on the grid or TileLoader; `Tile.qml` watches the delegate contract
+`delegateActivatePulse` and fires the push-in `NumberAnimation` if
+`_focusedSelection` is true. This keeps the animation entirely inside
+`Tile.qml` - hosts only bump a counter. There is a single push-in cue for
+every button-like action: forward navigation and game launch both use it,
+so there is no separate launch animation or pulse counter.

--- a/rust/frontend/src/lib.rs
+++ b/rust/frontend/src/lib.rs
@@ -5,6 +5,7 @@
 #[macro_use]
 mod bind;
 mod media_image_cache;
+mod media_meta_cache;
 mod mister_runtime;
 mod models;
 pub mod system_image_overrides;

--- a/rust/frontend/src/media_meta_cache.rs
+++ b/rust/frontend/src/media_meta_cache.rs
@@ -1,0 +1,223 @@
+// Zaparoo Frontend
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+//
+// Process-wide, in-memory cache for `media.meta` results, keyed by the
+// canonical `(system_id, path)` pair (`MediaKey`). It exists so the list +
+// detail browse view can paint a focused row's metadata synchronously instead
+// of blanking and re-fetching on every move:
+//
+//   * The detail pane reads the cache the moment the focused row changes. A
+//     warm neighbor (prefetched while dwelling on the previous row) is an
+//     instant hit, so the table never shows the previous row's stale values
+//     and never flickers blank-then-populate.
+//
+//   * A `None` outcome (Core returned an error or nothing usable) is memoized
+//     as a definite negative, so an item with no metadata resolves instantly
+//     on revisit and never flashes.
+//
+// In-memory only and strictly bounded by an LRU cap — Core is the canonical
+// metadata store and the frontend must not persist scraped metadata, nor grow
+// without bound on MiSTer's tight RAM budget (see CLAUDE.md). Metadata is a
+// handful of small strings per row, so the entry-count cap keeps the footprint
+// well under a megabyte.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use tracing::debug;
+use zaparoo_core::media_types::{MediaMeta, MediaMetaParams};
+
+use crate::media_image_cache::MediaKey;
+use crate::models::{global_handle, global_store};
+
+/// Maximum number of cached metadata entries before LRU eviction kicks in.
+const META_CACHE_CAP: usize = 512;
+
+/// Outcome of a synchronous cache probe.
+pub enum MetaLookup {
+    /// Metadata is cached for this key. Boxed because `MediaMeta` is large and
+    /// the other variants carry no data — keeps the enum cheap to pass around.
+    Hit(Box<MediaMeta>),
+    /// Core was asked and returned nothing usable — a memoized negative so
+    /// revisits resolve instantly and never re-fetch.
+    Negative,
+    /// Not in the cache; the caller should fetch.
+    Miss,
+}
+
+struct Entry {
+    /// `Some` = positive hit, `None` = memoized negative.
+    meta: Option<MediaMeta>,
+    /// LRU recency stamp, bumped on insert and on every read.
+    clock: u64,
+}
+
+struct State {
+    map: HashMap<MediaKey, Entry>,
+    /// Keys with a prefetch fetch in flight, so concurrent prefetch passes do
+    /// not double-request the same row.
+    inflight: HashSet<MediaKey>,
+    clock: u64,
+}
+
+pub struct MediaMetaCache {
+    state: Mutex<State>,
+}
+
+impl MediaMetaCache {
+    fn new() -> Self {
+        Self {
+            state: Mutex::new(State {
+                map: HashMap::new(),
+                inflight: HashSet::new(),
+                clock: 0,
+            }),
+        }
+    }
+
+    /// Probe the cache for `key`, bumping its LRU recency on a hit.
+    pub fn lookup(&self, key: &MediaKey) -> MetaLookup {
+        #[allow(clippy::unwrap_used, reason = "Mutex poisoning is unrecoverable")]
+        let mut guard = self.state.lock().unwrap();
+        guard.clock += 1;
+        let now = guard.clock;
+        match guard.map.get_mut(key) {
+            Some(entry) => {
+                entry.clock = now;
+                match &entry.meta {
+                    Some(meta) => MetaLookup::Hit(Box::new(meta.clone())),
+                    None => MetaLookup::Negative,
+                }
+            }
+            None => MetaLookup::Miss,
+        }
+    }
+
+    /// Insert a resolved fetch outcome. `Some` is a positive hit, `None` a
+    /// negative memo. Evicts the least-recently-used entry past the cap.
+    pub fn store(&self, key: MediaKey, meta: Option<MediaMeta>) {
+        #[allow(clippy::unwrap_used, reason = "Mutex poisoning is unrecoverable")]
+        let mut guard = self.state.lock().unwrap();
+        store_locked(&mut guard, key, meta);
+    }
+
+    /// Best-effort background warm of `requests` (key + params) that are not
+    /// already cached or in flight. Fire-and-forget: results land in the cache
+    /// for the next synchronous `lookup`.
+    pub fn prefetch(&self, requests: Vec<(MediaKey, MediaMetaParams)>) {
+        let mut to_fetch: Vec<(MediaKey, MediaMetaParams)> = Vec::new();
+        {
+            #[allow(clippy::unwrap_used, reason = "Mutex poisoning is unrecoverable")]
+            let mut guard = self.state.lock().unwrap();
+            for (key, params) in requests {
+                if guard.map.contains_key(&key) || guard.inflight.contains(&key) {
+                    continue;
+                }
+                guard.inflight.insert(key.clone());
+                to_fetch.push((key, params));
+            }
+        }
+        if to_fetch.is_empty() {
+            return;
+        }
+        global_handle().spawn(async move {
+            let store = global_store();
+            let cache = global_media_meta_cache();
+            for (key, params) in to_fetch {
+                let meta = match store.client().media_meta(params).await {
+                    Ok(result) => Some(result.media),
+                    Err(_) => None,
+                };
+                cache.store(key, meta);
+            }
+        });
+    }
+}
+
+fn store_locked(guard: &mut State, key: MediaKey, meta: Option<MediaMeta>) {
+    guard.clock += 1;
+    let now = guard.clock;
+    guard.inflight.remove(&key);
+    guard.map.insert(key, Entry { meta, clock: now });
+    while guard.map.len() > META_CACHE_CAP {
+        let victim = guard
+            .map
+            .iter()
+            .min_by_key(|(_, entry)| entry.clock)
+            .map(|(k, _)| k.clone());
+        match victim {
+            Some(v) => {
+                guard.map.remove(&v);
+                debug!("media_meta_cache: evicted entry");
+            }
+            None => break,
+        }
+    }
+}
+
+static GLOBAL_MEDIA_META_CACHE: OnceLock<Arc<MediaMetaCache>> = OnceLock::new();
+
+/// Lazily initialise the process-wide media metadata cache and return a handle.
+/// Constructed on first call from any thread; subsequent calls return the same
+/// `Arc`.
+pub fn global_media_meta_cache() -> Arc<MediaMetaCache> {
+    GLOBAL_MEDIA_META_CACHE
+        .get_or_init(|| Arc::new(MediaMetaCache::new()))
+        .clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(path: &str) -> MediaKey {
+        MediaKey::new("SNES", path)
+    }
+
+    fn meta_with_path(path: &str) -> MediaMeta {
+        MediaMeta {
+            path: path.to_string(),
+            ..MediaMeta::default()
+        }
+    }
+
+    #[test]
+    fn positive_hit_round_trips() {
+        let cache = MediaMetaCache::new();
+        cache.store(key("a"), Some(meta_with_path("a")));
+        assert!(matches!(cache.lookup(&key("a")), MetaLookup::Hit(meta) if meta.path == "a"));
+    }
+
+    #[test]
+    fn negative_is_memoized() {
+        let cache = MediaMetaCache::new();
+        cache.store(key("b"), None);
+        assert!(matches!(cache.lookup(&key("b")), MetaLookup::Negative));
+    }
+
+    #[test]
+    fn miss_for_unknown_key() {
+        let cache = MediaMetaCache::new();
+        assert!(matches!(cache.lookup(&key("missing")), MetaLookup::Miss));
+    }
+
+    #[test]
+    fn evicts_least_recently_used_past_cap() {
+        let cache = MediaMetaCache::new();
+        for i in 0..META_CACHE_CAP {
+            cache.store(
+                key(&format!("k{i}")),
+                Some(meta_with_path(&format!("k{i}"))),
+            );
+        }
+        // Touch k0 so it is the most-recently-used, then overflow by one.
+        assert!(matches!(cache.lookup(&key("k0")), MetaLookup::Hit(_)));
+        cache.store(key("overflow"), Some(meta_with_path("overflow")));
+        // k1 was the least-recently-used and should have been evicted; k0
+        // survived because the lookup refreshed its recency.
+        assert!(matches!(cache.lookup(&key("k1")), MetaLookup::Miss));
+        assert!(matches!(cache.lookup(&key("k0")), MetaLookup::Hit(_)));
+        assert!(matches!(cache.lookup(&key("overflow")), MetaLookup::Hit(_)));
+    }
+}

--- a/rust/frontend/src/models/favorites.rs
+++ b/rust/frontend/src/models/favorites.rs
@@ -657,19 +657,17 @@ impl ffi::FavoritesModel {
         let entry = &self.entries[index as usize];
         let system = entry.system.id.clone();
         let path = entry.path.clone();
-        let media_id = entry.media_id;
         if system.trim().is_empty() || path.trim().is_empty() {
             clear_current_detail_state(self.as_mut());
             return;
         }
-        let detail_key = match media_id {
-            Some(id) => MediaKey::with_media_id(system.clone(), path.clone(), id),
-            None => MediaKey::new(system.clone(), path.clone()),
-        }
-        .with_current_cover_preference();
-        self.as_mut().rust_mut().current_detail_media_key = Some(detail_key);
-        self.as_mut().rust_mut().current_detail_media_id = media_id;
-        sync_current_detail_image_key(self.as_mut());
+        // Deliberately do NOT switch the visible cover here. The cover has its
+        // own grace-window hold (BrowseDetailPane coverHold) and is settled by
+        // the debounced `load_detail_at`. Re-pointing the 512px cover Image on
+        // every keypress kept `_coverBusy` true through sustained navigation
+        // (tripping the hourglass after the grace) and monopolized Qt's async
+        // image loader so the next-row cover never got prefetched. Peek only
+        // updates the metadata table and warms the prefetch hints below.
         refresh_adjacent_cover_prefetch(self.as_mut());
 
         let meta_key = MediaKey::new(system.clone(), path.clone());

--- a/rust/frontend/src/models/favorites.rs
+++ b/rust/frontend/src/models/favorites.rs
@@ -23,6 +23,7 @@
 // QR/card-write payloads prefer Core's portable ZapScript.
 
 use crate::media_image_cache::{global_media_image_cache, MediaImageCache, MediaKey};
+use crate::media_meta_cache::{global_media_meta_cache, MetaLookup};
 use crate::models::nav_timing::NavTiming;
 use crate::models::tag_utils::tag_display_value;
 use crate::models::{global_handle, global_store};
@@ -198,6 +199,9 @@ pub mod ffi {
 
         #[qinvokable]
         fn system_id_at(self: &FavoritesModel, index: i32) -> QString;
+
+        #[qinvokable]
+        fn peek_detail_at(self: Pin<&mut FavoritesModel>, index: i32);
 
         #[qinvokable]
         fn load_detail_at(self: Pin<&mut FavoritesModel>, index: i32);
@@ -633,6 +637,61 @@ impl ffi::FavoritesModel {
         QString::from(self.entries[index as usize].system.id.as_str())
     }
 
+    // Immediate, non-debounced sibling of `load_detail_at`. Called the moment
+    // the focused row changes so the detail table reflects THIS row at once —
+    // cached metadata (instant), a memoized blank, or a clean blank while a
+    // fetch is pending — instead of holding the previous row's values through
+    // the load debounce. Also warms neighboring rows' metadata so the next
+    // move is a synchronous cache hit. Never issues a foreground RPC.
+    fn peek_detail_at(mut self: Pin<&mut Self>, index: i32) {
+        self.as_mut()
+            .rust_mut()
+            .detail_seq
+            .fetch_add(1, Ordering::SeqCst);
+        if index < 0 || index >= self.count {
+            clear_current_detail_state(self.as_mut());
+            return;
+        }
+        self.as_mut().rust_mut().detail_prefetch_row = Some(index);
+        prefetch_around_cursor(&self.entries, self.count, index, self.cover_requests_paused);
+        let entry = &self.entries[index as usize];
+        let system = entry.system.id.clone();
+        let path = entry.path.clone();
+        let media_id = entry.media_id;
+        if system.trim().is_empty() || path.trim().is_empty() {
+            clear_current_detail_state(self.as_mut());
+            return;
+        }
+        let detail_key = match media_id {
+            Some(id) => MediaKey::with_media_id(system.clone(), path.clone(), id),
+            None => MediaKey::new(system.clone(), path.clone()),
+        }
+        .with_current_cover_preference();
+        self.as_mut().rust_mut().current_detail_media_key = Some(detail_key);
+        self.as_mut().rust_mut().current_detail_media_id = media_id;
+        sync_current_detail_image_key(self.as_mut());
+        refresh_adjacent_cover_prefetch(self.as_mut());
+
+        let meta_key = MediaKey::new(system.clone(), path.clone());
+        match global_media_meta_cache().lookup(&meta_key) {
+            MetaLookup::Hit(meta) => {
+                self.as_mut()
+                    .set_current_detail_tags(QString::from(detail_tags_from_meta(&meta).as_str()));
+                self.as_mut().set_current_detail_loading(false);
+            }
+            MetaLookup::Negative => {
+                self.as_mut().set_current_detail_tags(QString::default());
+                self.as_mut().set_current_detail_loading(false);
+            }
+            MetaLookup::Miss => {
+                self.as_mut().set_current_detail_tags(QString::default());
+                self.as_mut().set_current_detail_loading(true);
+            }
+        }
+
+        enqueue_meta_prefetch(&self.entries, self.count, index);
+    }
+
     fn load_detail_at(mut self: Pin<&mut Self>, index: i32) {
         let ticket = self
             .as_mut()
@@ -666,16 +725,43 @@ impl ffi::FavoritesModel {
         self.as_mut().rust_mut().current_detail_media_id = media_id;
         sync_current_detail_image_key(self.as_mut());
         refresh_adjacent_cover_prefetch(self.as_mut());
+
+        // Resolve synchronously from the metadata cache when warm (a neighbor
+        // prefetched while dwelling on the previous row, or a revisit), so the
+        // table fills with the correct rows on this frame and never re-fetches.
+        let meta_key = MediaKey::new(system.clone(), path.clone());
+        match global_media_meta_cache().lookup(&meta_key) {
+            MetaLookup::Hit(meta) => {
+                self.as_mut()
+                    .set_current_detail_tags(QString::from(detail_tags_from_meta(&meta).as_str()));
+                self.as_mut().set_current_detail_loading(false);
+                return;
+            }
+            MetaLookup::Negative => {
+                self.as_mut().set_current_detail_tags(QString::default());
+                self.as_mut().set_current_detail_loading(false);
+                return;
+            }
+            MetaLookup::Miss => {}
+        }
+
         self.as_mut().set_current_detail_loading(true);
         self.as_mut().set_current_detail_tags(QString::default());
         let seq = self.rust().detail_seq.clone();
         let qt_thread = self.qt_thread();
         let store = global_store();
+        let store_key = meta_key.clone();
         global_handle().spawn(async move {
             let result = store
                 .client()
                 .media_meta(MediaMetaParams::for_media(system, path.clone()))
                 .await;
+            // Cache the outcome (positive or negative) regardless of whether
+            // this callback is still current, so a later revisit is instant.
+            match &result {
+                Ok(r) => global_media_meta_cache().store(store_key, Some(r.media.clone())),
+                Err(_) => global_media_meta_cache().store(store_key, None),
+            }
             let _ = qt_thread.queue(move |mut model| {
                 if seq.load(Ordering::SeqCst) != ticket {
                     return;
@@ -842,6 +928,32 @@ fn detail_tags_from_meta(meta: &MediaMeta) -> String {
         .map(|(label, value)| format!("{label}\t{value}"))
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+// Warm the metadata cache for the rows immediately around `row` so a move to
+// a neighbor is a synchronous cache hit. Best-effort and fire-and-forget;
+// already-cached or in-flight keys are skipped inside the cache.
+fn enqueue_meta_prefetch(entries: &[MediaItem], count: i32, row: i32) {
+    let mut requests = Vec::new();
+    for delta in [-2_i32, -1, 1, 2] {
+        let i = row + delta;
+        if i < 0 || i >= count {
+            continue;
+        }
+        let entry = &entries[i as usize];
+        let system = entry.system.id.clone();
+        let path = entry.path.clone();
+        if system.trim().is_empty() || path.trim().is_empty() {
+            continue;
+        }
+        requests.push((
+            MediaKey::new(system.clone(), path.clone()),
+            MediaMetaParams::for_media(system, path),
+        ));
+    }
+    if !requests.is_empty() {
+        global_media_meta_cache().prefetch(requests);
+    }
 }
 
 fn detail_value_for_aliases(source: &[TagInfo], aliases: &[&str]) -> String {

--- a/rust/frontend/src/models/games.rs
+++ b/rust/frontend/src/models/games.rs
@@ -433,6 +433,9 @@ pub mod ffi {
         fn description_at(self: &GamesModel, index: i32) -> QString;
 
         #[qinvokable]
+        fn peek_description_at(self: Pin<&mut GamesModel>, index: i32);
+
+        #[qinvokable]
         fn load_description_at(self: Pin<&mut GamesModel>, index: i32);
 
         #[qinvokable]
@@ -872,6 +875,51 @@ impl ffi::GamesModel {
             return QString::default();
         }
         QString::from(self.entries[index as usize].description.as_str())
+    }
+
+    // Immediate, non-debounced sibling of `load_description_at`. Called the
+    // moment the focused row changes so the detail pane reflects THIS row's
+    // local metadata (description + entry tags) at once, instead of holding the
+    // previous row's values through the load debounce. The debounced
+    // `load_description_at` then enriches it from media.meta. Games entries
+    // carry their own tags, so this needs no metadata cache.
+    fn peek_description_at(mut self: Pin<&mut Self>, index: i32) {
+        self.as_mut()
+            .rust_mut()
+            .description_seq
+            .fetch_add(1, Ordering::SeqCst);
+        if index < 0 || index >= self.count {
+            self.as_mut().set_current_detail_loading(false);
+            self.as_mut().set_current_description(QString::default());
+            self.as_mut().set_current_detail_tags(QString::default());
+            clear_detail_images(self.as_mut());
+            return;
+        }
+        self.as_mut().rust_mut().detail_prefetch_row = Some(index);
+        prefetch_cursor_window(&self, index);
+
+        let entry = &self.entries[index as usize];
+        if !is_media_capable_entry(entry) {
+            self.as_mut().set_current_detail_loading(false);
+            self.as_mut().set_current_description(QString::default());
+            self.as_mut().set_current_detail_tags(QString::default());
+            clear_detail_images(self.as_mut());
+            return;
+        }
+
+        let description = entry.description.clone();
+        let detail_tags = detail_tags_from_entry(entry);
+        let detail_image_key = media_key_for(entry).map(MediaKey::with_current_cover_preference);
+        // Local tags paint immediately, so mark loading without blanking: the
+        // detail pane shows this row's values while the richer media.meta fetch
+        // is still pending.
+        self.as_mut().set_current_detail_loading(true);
+        self.as_mut()
+            .set_current_description(QString::from(description.as_str()));
+        self.as_mut()
+            .set_current_detail_tags(QString::from(detail_tags.as_str()));
+        set_single_detail_image_key(self.as_mut(), detail_image_key);
+        refresh_adjacent_cover_prefetch(self.as_mut());
     }
 
     #[allow(

--- a/rust/frontend/src/models/games.rs
+++ b/rust/frontend/src/models/games.rs
@@ -909,7 +909,6 @@ impl ffi::GamesModel {
 
         let description = entry.description.clone();
         let detail_tags = detail_tags_from_entry(entry);
-        let detail_image_key = media_key_for(entry).map(MediaKey::with_current_cover_preference);
         // Local tags paint immediately, so mark loading without blanking: the
         // detail pane shows this row's values while the richer media.meta fetch
         // is still pending.
@@ -918,7 +917,13 @@ impl ffi::GamesModel {
             .set_current_description(QString::from(description.as_str()));
         self.as_mut()
             .set_current_detail_tags(QString::from(detail_tags.as_str()));
-        set_single_detail_image_key(self.as_mut(), detail_image_key);
+        // Deliberately do NOT switch the visible cover here. The cover has its
+        // own grace-window hold (BrowseDetailPane coverHold) and is settled by
+        // the debounced `load_description_at`. Re-pointing the 512px cover Image
+        // on every keypress kept `_coverBusy` true through sustained navigation
+        // (tripping the hourglass after the grace) and monopolized Qt's async
+        // image loader so the next-row cover never got prefetched. Peek only
+        // updates the metadata table and warms the prefetch hints below.
         refresh_adjacent_cover_prefetch(self.as_mut());
     }
 

--- a/rust/frontend/src/models/recents.rs
+++ b/rust/frontend/src/models/recents.rs
@@ -23,6 +23,7 @@
 // recents launches by `run`-ing the entry's launcher route.
 
 use crate::media_image_cache::{global_media_image_cache, MediaImageCache, MediaKey};
+use crate::media_meta_cache::{global_media_meta_cache, MetaLookup};
 use crate::models::nav_timing::NavTiming;
 use crate::models::tag_utils::tag_display_value;
 use crate::models::{global_handle, global_store};
@@ -200,6 +201,9 @@ pub mod ffi {
         fn system_id_at(self: &RecentsModel, index: i32) -> QString;
 
         #[qinvokable]
+        fn peek_detail_at(self: Pin<&mut RecentsModel>, index: i32);
+
+        #[qinvokable]
         fn load_detail_at(self: Pin<&mut RecentsModel>, index: i32);
 
         #[qinvokable]
@@ -299,7 +303,14 @@ fn apply_state(
         // any in-flight `fetch_more` sees a stale ticket and bails.
         model.as_mut().rust_mut().seq.fetch_add(1, Ordering::SeqCst);
         model.as_mut().ensure_cover_subscription();
+        let raw_len = entries.len();
         let entries = dedupe_latest_by_path(entries);
+        info!(
+            raw_len,
+            deduped_len = entries.len(),
+            has_next_page,
+            "recents-diag: apply_state Ready branch"
+        );
         if !model.cover_requests_paused {
             enqueue_recents_covers(&entries);
         }
@@ -348,6 +359,10 @@ fn apply_state(
             model.as_mut().fetch_more();
         }
     } else if err.is_empty() {
+        info!(
+            count = model.count,
+            "recents-diag: apply_state Pending branch (loading, entries untouched)"
+        );
         // Pending (Idle/Loading): show the spinner; don't touch entries.
         // Disarm pagination so a grid scroll during a refetch doesn't
         // fire `fetch_more` against a stale cursor — `has_next_page`
@@ -371,6 +386,11 @@ fn apply_state(
             model.as_mut().set_has_next_page(false);
         }
     } else {
+        info!(
+            error = err.as_str(),
+            count = model.count,
+            "recents-diag: apply_state Errored branch (history_requested reset, entries untouched)"
+        );
         model.as_mut().rust_mut().history_requested = false;
         model.as_mut().rust_mut().history_fetching = false;
         model.as_mut().rust_mut().history_subscription = None;
@@ -456,11 +476,20 @@ impl ffi::RecentsModel {
     }
 
     fn ensure_loaded(mut self: Pin<&mut Self>) {
+        info!(
+            history_requested = self.history_requested,
+            history_fetching = self.history_fetching,
+            count = self.count,
+            loading = self.loading,
+            "recents-diag: ensure_loaded called"
+        );
         if self.history_requested {
+            info!("recents-diag: ensure_loaded short-circuit (already-loaded), NO refetch");
             NavTiming::new("cache").log_release("recents", "already-loaded", 0);
             return;
         }
         if self.history_fetching {
+            info!("recents-diag: ensure_loaded short-circuit (already-fetching)");
             return;
         }
         self.as_mut().rust_mut().history_fetching = true;
@@ -545,6 +574,18 @@ impl ffi::RecentsModel {
                     systems: Vec::new(),
                 })
                 .await;
+            match &result {
+                Ok(r) => info!(
+                    entries_len = r.entries.len(),
+                    has_next_page = r.has_next_page(),
+                    next_cursor_set = r.next_cursor().is_some(),
+                    "recents-diag: initial media.history returned"
+                ),
+                Err(e) => info!(
+                    error = e.message.as_str(),
+                    "recents-diag: initial media.history failed"
+                ),
+            }
             let projected = match result {
                 Ok(result) => (Some(page_snapshot(&result)), String::new()),
                 Err(e) => (None, e.message),
@@ -666,6 +707,61 @@ impl ffi::RecentsModel {
         QString::from(self.entries[index as usize].system_id.as_str())
     }
 
+    // Immediate, non-debounced sibling of `load_detail_at`. Called the moment
+    // the focused row changes so the detail table reflects THIS row at once —
+    // cached metadata (instant), a memoized blank, or a clean blank while a
+    // fetch is pending — instead of holding the previous row's values through
+    // the load debounce. Also warms neighboring rows' metadata so the next
+    // move is a synchronous cache hit. Never issues a foreground RPC.
+    fn peek_detail_at(mut self: Pin<&mut Self>, index: i32) {
+        self.as_mut()
+            .rust_mut()
+            .detail_seq
+            .fetch_add(1, Ordering::SeqCst);
+        if index < 0 || index >= self.count {
+            clear_current_detail_state(self.as_mut());
+            return;
+        }
+        self.as_mut().rust_mut().detail_prefetch_row = Some(index);
+        prefetch_around_cursor(&self.entries, self.count, index, self.cover_requests_paused);
+        let entry = &self.entries[index as usize];
+        let system = entry.system_id.clone();
+        let path = entry.media_path.clone();
+        let media_id = entry.media_id;
+        if system.trim().is_empty() || path.trim().is_empty() {
+            clear_current_detail_state(self.as_mut());
+            return;
+        }
+        let detail_key = match media_id {
+            Some(id) => MediaKey::with_media_id(system.clone(), path.clone(), id),
+            None => MediaKey::new(system.clone(), path.clone()),
+        }
+        .with_current_cover_preference();
+        self.as_mut().rust_mut().current_detail_media_key = Some(detail_key);
+        self.as_mut().rust_mut().current_detail_media_id = media_id;
+        sync_current_detail_image_key(self.as_mut());
+        refresh_adjacent_cover_prefetch(self.as_mut());
+
+        let meta_key = MediaKey::new(system.clone(), path.clone());
+        match global_media_meta_cache().lookup(&meta_key) {
+            MetaLookup::Hit(meta) => {
+                self.as_mut()
+                    .set_current_detail_tags(QString::from(detail_tags_from_meta(&meta).as_str()));
+                self.as_mut().set_current_detail_loading(false);
+            }
+            MetaLookup::Negative => {
+                self.as_mut().set_current_detail_tags(QString::default());
+                self.as_mut().set_current_detail_loading(false);
+            }
+            MetaLookup::Miss => {
+                self.as_mut().set_current_detail_tags(QString::default());
+                self.as_mut().set_current_detail_loading(true);
+            }
+        }
+
+        enqueue_meta_prefetch(&self.entries, self.count, index);
+    }
+
     fn load_detail_at(mut self: Pin<&mut Self>, index: i32) {
         let ticket = self
             .as_mut()
@@ -699,16 +795,43 @@ impl ffi::RecentsModel {
         self.as_mut().rust_mut().current_detail_media_id = media_id;
         sync_current_detail_image_key(self.as_mut());
         refresh_adjacent_cover_prefetch(self.as_mut());
+
+        // Resolve synchronously from the metadata cache when warm (a neighbor
+        // prefetched while dwelling on the previous row, or a revisit), so the
+        // table fills with the correct rows on this frame and never re-fetches.
+        let meta_key = MediaKey::new(system.clone(), path.clone());
+        match global_media_meta_cache().lookup(&meta_key) {
+            MetaLookup::Hit(meta) => {
+                self.as_mut()
+                    .set_current_detail_tags(QString::from(detail_tags_from_meta(&meta).as_str()));
+                self.as_mut().set_current_detail_loading(false);
+                return;
+            }
+            MetaLookup::Negative => {
+                self.as_mut().set_current_detail_tags(QString::default());
+                self.as_mut().set_current_detail_loading(false);
+                return;
+            }
+            MetaLookup::Miss => {}
+        }
+
         self.as_mut().set_current_detail_loading(true);
         self.as_mut().set_current_detail_tags(QString::default());
         let seq = self.rust().detail_seq.clone();
         let qt_thread = self.qt_thread();
         let store = global_store();
+        let store_key = meta_key.clone();
         global_handle().spawn(async move {
             let result = store
                 .client()
                 .media_meta(MediaMetaParams::for_media(system, path.clone()))
                 .await;
+            // Cache the outcome (positive or negative) regardless of whether
+            // this callback is still current, so a later revisit is instant.
+            match &result {
+                Ok(r) => global_media_meta_cache().store(store_key, Some(r.media.clone())),
+                Err(_) => global_media_meta_cache().store(store_key, None),
+            }
             let _ = qt_thread.queue(move |mut model| {
                 if seq.load(Ordering::SeqCst) != ticket {
                     return;
@@ -961,6 +1084,32 @@ fn detail_tags_from_meta(meta: &MediaMeta) -> String {
         .map(|(label, value)| format!("{label}\t{value}"))
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+// Warm the metadata cache for the rows immediately around `row` so a move to
+// a neighbor is a synchronous cache hit. Best-effort and fire-and-forget;
+// already-cached or in-flight keys are skipped inside the cache.
+fn enqueue_meta_prefetch(entries: &[MediaHistoryEntry], count: i32, row: i32) {
+    let mut requests = Vec::new();
+    for delta in [-2_i32, -1, 1, 2] {
+        let i = row + delta;
+        if i < 0 || i >= count {
+            continue;
+        }
+        let entry = &entries[i as usize];
+        let system = entry.system_id.clone();
+        let path = entry.media_path.clone();
+        if system.trim().is_empty() || path.trim().is_empty() {
+            continue;
+        }
+        requests.push((
+            MediaKey::new(system.clone(), path.clone()),
+            MediaMetaParams::for_media(system, path),
+        ));
+    }
+    if !requests.is_empty() {
+        global_media_meta_cache().prefetch(requests);
+    }
 }
 
 fn detail_value_for_aliases(source: &[TagInfo], aliases: &[&str]) -> String {

--- a/rust/frontend/src/models/recents.rs
+++ b/rust/frontend/src/models/recents.rs
@@ -727,19 +727,17 @@ impl ffi::RecentsModel {
         let entry = &self.entries[index as usize];
         let system = entry.system_id.clone();
         let path = entry.media_path.clone();
-        let media_id = entry.media_id;
         if system.trim().is_empty() || path.trim().is_empty() {
             clear_current_detail_state(self.as_mut());
             return;
         }
-        let detail_key = match media_id {
-            Some(id) => MediaKey::with_media_id(system.clone(), path.clone(), id),
-            None => MediaKey::new(system.clone(), path.clone()),
-        }
-        .with_current_cover_preference();
-        self.as_mut().rust_mut().current_detail_media_key = Some(detail_key);
-        self.as_mut().rust_mut().current_detail_media_id = media_id;
-        sync_current_detail_image_key(self.as_mut());
+        // Deliberately do NOT switch the visible cover here. The cover has its
+        // own grace-window hold (BrowseDetailPane coverHold) and is settled by
+        // the debounced `load_detail_at`. Re-pointing the 512px cover Image on
+        // every keypress kept `_coverBusy` true through sustained navigation
+        // (tripping the hourglass after the grace) and monopolized Qt's async
+        // image loader so the next-row cover never got prefetched. Peek only
+        // updates the metadata table and warms the prefetch hints below.
         refresh_adjacent_cover_prefetch(self.as_mut());
 
         let meta_key = MediaKey::new(system.clone(), path.clone());

--- a/rust/frontend/src/models/settings.rs
+++ b/rust/frontend/src/models/settings.rs
@@ -49,6 +49,9 @@
 //     selection across the rename.
 //   * `current_mouse_enabled` — READ + NOTIFY, persisted. Defaults to true
 //     so existing installs keep the visible cursor and mouse hit targets.
+//   * `current_reduce_motion` — READ + NOTIFY, persisted. Defaults to false
+//     (motion on). When true, all Behavior durations in the UI collapse to
+//     0 via Motion.dur() so animations complete in one frame.
 //   * `current_debug_logging` — READ + NOTIFY, persisted. Defaults to false.
 //     Toggling it writes `[logging] debug = …` into frontend.toml; the
 //     tracing subscriber is built once at startup so the change only takes
@@ -185,6 +188,7 @@ pub struct SettingsRust {
     available_button_layouts: QStringList,
     current_button_layout: QString,
     current_mouse_enabled: bool,
+    current_reduce_motion: bool,
     current_discover_arcade_alternate_versions: bool,
     current_debug_logging: bool,
     current_show_hidden: bool,
@@ -223,6 +227,7 @@ pub mod ffi {
         #[qproperty(QStringList, available_button_layouts, READ, CONSTANT)]
         #[qproperty(QString, current_button_layout, READ, WRITE = set_button_layout, NOTIFY)]
         #[qproperty(bool, current_mouse_enabled, READ, WRITE = set_mouse_enabled, NOTIFY)]
+        #[qproperty(bool, current_reduce_motion, READ, WRITE = set_reduce_motion, NOTIFY)]
         #[qproperty(bool, current_discover_arcade_alternate_versions, READ, WRITE = set_discover_arcade_alternate_versions, NOTIFY)]
         #[qproperty(bool, current_debug_logging, READ, WRITE = set_debug_logging, NOTIFY)]
         #[qproperty(bool, current_show_hidden, READ, WRITE = set_show_hidden, NOTIFY)]
@@ -254,6 +259,9 @@ pub mod ffi {
 
         #[qinvokable]
         fn set_mouse_enabled(self: Pin<&mut Settings>, value: bool);
+
+        #[qinvokable]
+        fn set_reduce_motion(self: Pin<&mut Settings>, value: bool);
 
         #[qinvokable]
         fn set_discover_arcade_alternate_versions(self: Pin<&mut Settings>, value: bool);
@@ -308,6 +316,7 @@ impl Initialize for ffi::Settings {
         self.as_mut().rust_mut().current_button_layout =
             QString::from(merged.button_layout.as_str());
         self.as_mut().rust_mut().current_mouse_enabled = merged.mouse_enabled;
+        self.as_mut().rust_mut().current_reduce_motion = merged.reduce_motion;
         self.as_mut()
             .rust_mut()
             .current_discover_arcade_alternate_versions = merged.discover_arcade_alternate_versions;
@@ -427,6 +436,16 @@ impl ffi::Settings {
         self.as_mut().current_mouse_enabled_changed();
     }
 
+    fn set_reduce_motion(mut self: Pin<&mut Self>, value: bool) {
+        if self.current_reduce_motion == value {
+            return;
+        }
+        let snapshot = persist_settings(|s| s.reduce_motion = value);
+        mirror_settings_to_config(&config_file_path(), &snapshot.settings);
+        self.as_mut().rust_mut().current_reduce_motion = value;
+        self.as_mut().current_reduce_motion_changed();
+    }
+
     fn set_discover_arcade_alternate_versions(mut self: Pin<&mut Self>, value: bool) {
         if self.current_discover_arcade_alternate_versions == value {
             return;
@@ -537,6 +556,7 @@ fn mirror_settings_to_config(config_path: &std::path::Path, settings: &SettingsS
             browse_layout: settings.browse_layout.as_str(),
             button_layout: settings.button_layout.as_str(),
             mouse_enabled: settings.mouse_enabled,
+            reduce_motion: settings.reduce_motion,
             discover_arcade_alternate_versions: settings.discover_arcade_alternate_versions,
             debug_logging: settings.debug_logging,
             screensaver_timeout: settings.screensaver_timeout.as_str(),
@@ -596,6 +616,10 @@ fn merge_settings(snapshot: &SettingsState, config: &Config) -> SettingsState {
             .settings
             .mouse_enabled
             .unwrap_or(snapshot.mouse_enabled),
+        reduce_motion: config
+            .settings
+            .reduce_motion
+            .unwrap_or(snapshot.reduce_motion),
         discover_arcade_alternate_versions: config
             .settings
             .discover_arcade_alternate_versions

--- a/rust/zaparoo-core/src/config.rs
+++ b/rust/zaparoo-core/src/config.rs
@@ -715,6 +715,7 @@ mod tests {
         assert_eq!(cfg.settings.browse_layout.as_deref(), Some("list"));
         assert_eq!(cfg.settings.button_layout.as_deref(), Some("b"));
         assert_eq!(cfg.settings.mouse_enabled, Some(false));
+        assert_eq!(cfg.settings.reduce_motion, Some(true));
         assert_eq!(cfg.settings.discover_arcade_alternate_versions, Some(true));
         assert_eq!(cfg.settings.screensaver_timeout.as_deref(), Some("300"));
         assert_eq!(cfg.settings.show_hidden, Some(true));
@@ -759,6 +760,7 @@ mod tests {
         assert_eq!(cfg.settings.browse_layout.as_deref(), Some("grid"));
         assert_eq!(cfg.settings.button_layout.as_deref(), Some("a"));
         assert_eq!(cfg.settings.mouse_enabled, Some(true));
+        assert_eq!(cfg.settings.reduce_motion, Some(false));
         assert_eq!(cfg.settings.discover_arcade_alternate_versions, Some(false));
         assert_eq!(cfg.settings.screensaver_timeout.as_deref(), Some("60"));
         assert!(!cfg.debug_logging);
@@ -805,6 +807,7 @@ mod tests {
         assert_eq!(cfg.settings.browse_layout.as_deref(), Some("list"));
         assert_eq!(cfg.settings.button_layout.as_deref(), Some("c"));
         assert_eq!(cfg.settings.mouse_enabled, Some(false));
+        assert_eq!(cfg.settings.reduce_motion, Some(false));
         assert_eq!(cfg.settings.discover_arcade_alternate_versions, Some(true));
         assert_eq!(cfg.settings.screensaver_timeout.as_deref(), Some("off"));
         assert!(cfg.debug_logging);

--- a/rust/zaparoo-core/src/config.rs
+++ b/rust/zaparoo-core/src/config.rs
@@ -55,6 +55,7 @@ pub struct SettingsConfig {
     pub browse_layout: Option<String>,
     pub button_layout: Option<String>,
     pub mouse_enabled: Option<bool>,
+    pub reduce_motion: Option<bool>,
     pub discover_arcade_alternate_versions: Option<bool>,
     pub screensaver_timeout: Option<String>,
     pub media_image_type: Option<String>,
@@ -75,6 +76,7 @@ pub struct SettingsMirror<'a> {
     pub browse_layout: &'a str,
     pub button_layout: &'a str,
     pub mouse_enabled: bool,
+    pub reduce_motion: bool,
     pub discover_arcade_alternate_versions: bool,
     pub debug_logging: bool,
     pub screensaver_timeout: &'a str,
@@ -159,6 +161,7 @@ struct RawSettings {
     browse_layout: Option<String>,
     button_layout: Option<String>,
     mouse_enabled: Option<bool>,
+    reduce_motion: Option<bool>,
     discover_arcade_alternate_versions: Option<bool>,
     screensaver_timeout: Option<String>,
     media_image_type: Option<String>,
@@ -251,6 +254,7 @@ pub fn load_config(path: &Path) -> Config {
             .button_layout
             .map(|value| value.trim().to_string()),
         mouse_enabled: raw.settings.mouse_enabled,
+        reduce_motion: raw.settings.reduce_motion,
         discover_arcade_alternate_versions: raw.settings.discover_arcade_alternate_versions,
         screensaver_timeout: raw
             .settings
@@ -333,6 +337,10 @@ pub fn save_settings_mirror(path: &Path, mirror: SettingsMirror<'_>) -> Result<(
     settings.insert(
         "mouse_enabled".into(),
         toml::Value::Boolean(mirror.mouse_enabled),
+    );
+    settings.insert(
+        "reduce_motion".into(),
+        toml::Value::Boolean(mirror.reduce_motion),
     );
     settings.insert(
         "discover_arcade_alternate_versions".into(),
@@ -687,6 +695,7 @@ mod tests {
                 browse_layout: "list",
                 button_layout: "b",
                 mouse_enabled: false,
+                reduce_motion: true,
                 discover_arcade_alternate_versions: true,
                 debug_logging: true,
                 screensaver_timeout: "300",
@@ -728,6 +737,7 @@ mod tests {
                 browse_layout: "grid",
                 button_layout: "a",
                 mouse_enabled: true,
+                reduce_motion: false,
                 discover_arcade_alternate_versions: false,
                 debug_logging: false,
                 screensaver_timeout: "60",
@@ -767,6 +777,7 @@ mod tests {
                 browse_layout: "list",
                 button_layout: "c",
                 mouse_enabled: false,
+                reduce_motion: false,
                 discover_arcade_alternate_versions: true,
                 debug_logging: true,
                 screensaver_timeout: "off",

--- a/rust/zaparoo-core/src/persist.rs
+++ b/rust/zaparoo-core/src/persist.rs
@@ -362,6 +362,8 @@ resolution = "1920x1080"
         assert_eq!(state.hub.hidden_categories, Vec::<String>::new());
         assert_eq!(state.systems.hidden_system_ids, Vec::<String>::new());
         assert!(!state.settings.show_hidden);
+        // reduce_motion absent from an older state file defaults to false.
+        assert!(!state.settings.reduce_motion);
     }
 
     #[test]

--- a/rust/zaparoo-core/src/persist.rs
+++ b/rust/zaparoo-core/src/persist.rs
@@ -120,6 +120,8 @@ pub struct SettingsState {
     #[serde(default = "default_mouse_enabled")]
     pub mouse_enabled: bool,
     #[serde(default)]
+    pub reduce_motion: bool,
+    #[serde(default)]
     pub discover_arcade_alternate_versions: bool,
     #[serde(default)]
     pub debug_logging: bool,
@@ -148,6 +150,7 @@ impl Default for SettingsState {
             browse_layout: default_browse_layout(),
             button_layout: default_button_layout(),
             mouse_enabled: default_mouse_enabled(),
+            reduce_motion: false,
             discover_arcade_alternate_versions: false,
             debug_logging: false,
             screensaver_timeout: default_screensaver_timeout(),
@@ -325,6 +328,7 @@ mod tests {
                 browse_layout: "list".into(),
                 button_layout: "b".into(),
                 mouse_enabled: false,
+                reduce_motion: true,
                 discover_arcade_alternate_versions: true,
                 debug_logging: true,
                 screensaver_timeout: "300".into(),

--- a/scripts/deploy-mister.sh
+++ b/scripts/deploy-mister.sh
@@ -74,7 +74,9 @@ echo "=== Deploying to MiSTer at ${MISTER_IP} ==="
 # that stub. Here we only rotate after a size-verified upload, then force
 # the write to the card with `sync` — exFAT has no journal, so a metadata
 # update lost to a power cut is what leaks clusters.
-LOCAL_SIZE="$(stat -c %s "${BINARY}")"
+# `wc -c` is portable (GNU + BSD/macOS); `stat -c` is GNU-only. The remote
+# size check below runs on the MiSTer (always Linux) so it keeps `stat -c`.
+LOCAL_SIZE="$(wc -c < "${BINARY}" | tr -d '[:space:]')"
 scp "${BINARY}" "root@${MISTER_IP}:${REMOTE_PATH}.new"
 
 ssh "root@${MISTER_IP}" "

--- a/scripts/deploy-mister.sh
+++ b/scripts/deploy-mister.sh
@@ -67,22 +67,41 @@ fi
 echo ""
 echo "=== Deploying to MiSTer at ${MISTER_IP} ==="
 
+# Upload to a side path first so an interrupted transfer can never clobber
+# the working binary. The old flow scp'd straight over the live path and
+# pre-rotated it to .bak unconditionally: a failed transfer then left a
+# truncated frontend AND the next run would overwrite the good backup with
+# that stub. Here we only rotate after a size-verified upload, then force
+# the write to the card with `sync` — exFAT has no journal, so a metadata
+# update lost to a power cut is what leaks clusters.
+LOCAL_SIZE="$(stat -c %s "${BINARY}")"
+scp "${BINARY}" "root@${MISTER_IP}:${REMOTE_PATH}.new"
+
 ssh "root@${MISTER_IP}" "
+    set -e
+    new_size=\$(stat -c %s '${REMOTE_PATH}.new' 2>/dev/null || echo 0)
+    if [ \$new_size -ne ${LOCAL_SIZE} ]; then
+        echo \"Upload incomplete (\$new_size of ${LOCAL_SIZE} bytes); existing binary left untouched\" >&2
+        rm -f '${REMOTE_PATH}.new'
+        exit 1
+    fi
     if [ -f '${REMOTE_PATH}' ]; then
         mv '${REMOTE_PATH}' '${REMOTE_PATH}.bak'
-        echo 'Moved existing binary to ${REMOTE_PATH}.bak'
     fi
+    mv '${REMOTE_PATH}.new' '${REMOTE_PATH}'
+    sync
+    echo 'Installed new binary (previous kept as ${REMOTE_PATH}.bak)'
 "
-
-scp "${BINARY}" "root@${MISTER_IP}:${REMOTE_PATH}"
 echo "Deployed ${BINARY} → root@${MISTER_IP}:${REMOTE_PATH}"
 
 ssh "root@${MISTER_IP}" "
     rm -f /tmp/zaparoo/frontend.log
-    # SIGKILL the running frontend; MiSTer's wrapper respawns it
-    # ~1s later with the new binary. SIGTERM here would be misclassified as
-    # an 'escape' and MiSTer would refuse to respawn. Note: counts as a crash
-    # toward the 3-strike give-up limit, so if you deploy 3 times without
-    # cleanly exiting the frontend in between, killall MiSTer_Zaparoo to reset.
+    # Flush pending card writes before disrupting the frontend so it is never
+    # pulled mid-write. The signal stays SIGKILL on purpose: MiSTer's wrapper
+    # respawns the frontend ~1s later with the new binary, whereas a clean
+    # SIGTERM exit is misclassified as an 'escape' and the wrapper refuses to
+    # respawn. (SIGKILL counts as a crash toward the 3-strike give-up limit,
+    # so after 3 deploys without a clean exit, killall MiSTer_Zaparoo to reset.)
+    sync
     killall -KILL frontend 2>/dev/null && echo 'Killed running frontend; MiSTer will respawn it' || echo 'No running frontend to kill'
 "

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -69,7 +69,11 @@ MainLayout {
     // reduce-motion setting. Keeping Motion dependency-free (no
     // Browse import) means Zaparoo.Theme stays independent; the app
     // layer is the only place that crosses the module boundary.
-    Binding { target: Motion; property: "enabled"; value: !Browse.Settings.current_reduce_motion }
+    Binding {
+        target: Motion
+        property: "enabled"
+        value: !Browse.Settings.current_reduce_motion
+    }
 
     // Bound here (not in GamesScreen.qml) because `set_system` can fire
     // from the accept handler before the games screen mounts; binding
@@ -228,13 +232,16 @@ MainLayout {
         root._startupTrace("startup/qml Component.onCompleted", "savedScreen=" + savedScreen, "initialActiveScreen=" + root.activeScreen, "startupRestorePending=" + root._startupRestorePending, "connectionState=" + Browse.AppStatus.connection_state);
         Browse.FavoritesModel.cover_requests_paused = root.activeScreen !== root.screenFavorites;
         Browse.RecentsModel.cover_requests_paused = root.activeScreen !== root.screenRecents;
-        // If the catalog is already ready, fire the restore here so
-        // the cascade (set_category → SystemsModel reset → seed
-        // currentIndex → set_system → GamesModel reset) lands before
-        // first paint. Otherwise the CategoriesModel.onModelReset
-        // Connection below fires it on first delivery.
-        if (Browse.CategoriesModel.count > 0)
-            root.hubScreen.restoreFromCategoriesReset();
+        // Fire the restore here so focus is seated and marked ready before
+        // first paint. When the catalog is already ready the cascade
+        // (set_category → SystemsModel reset → seed currentIndex →
+        // set_system → GamesModel reset) also lands now. On a cold boot the
+        // catalog is empty (it is in-memory only, never persisted), so the
+        // call only marks focus ready — without it the Hub paints with no
+        // focus ring until Core connects and the onModelReset Connection
+        // below first runs the restore. The cascade is deferred to that
+        // same onModelReset, which re-runs this once the catalog lands.
+        root.hubScreen.restoreFromCategoriesReset();
         root._maybeArmHubResumeFocus();
         // Open the commercial-use notice on first paint of an unacked
         // install. Sits in front of the media-DB first-run modal in the
@@ -872,6 +879,10 @@ MainLayout {
         const savedSystem = root.activeScreen === root.screenGames ? (Browse.GamesState.system_id !== "" ? Browse.GamesState.system_id : Browse.SystemsState.system_id) : Browse.SystemsState.system_id;
         const idx = savedSystem === "" ? -1 : Browse.SystemsModel.index_for_system_id(savedSystem);
         root.systemsScreen.systemsGrid.setCurrentIndexImmediate(idx >= 0 ? idx : 0);
+        // Focus is now finalized from persisted state; let the grid render
+        // focus (snapped, since the screen's _focusArmed is still false until
+        // the first user input).
+        root.systemsScreen._restoreDone = true;
         if (idx >= 0) {
             Browse.GamesModel.set_system(savedSystem);
             const stack = Browse.GamesState.path_stack;
@@ -889,6 +900,9 @@ MainLayout {
         root.gamesScreen.suppressSelectionPersist = true;
         root.gamesScreen.gamesGrid.setCurrentIndexImmediate(index);
         root.gamesScreen.suppressSelectionPersist = false;
+        // Selection finalized from persisted state; let the grid render focus
+        // (snapped, since _focusArmed is still false until the first input).
+        root.gamesScreen._restoreDone = true;
     }
 
     function _restoreGamesScreenSelection(): bool {

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -65,6 +65,12 @@ MainLayout {
     readonly property bool activeCardWritePending: root.cardWriteOwner === "systems" ? Browse.SystemsModel.card_write_pending : root.cardWriteOwner === "games" ? Browse.GamesModel.card_write_pending : root.cardWriteOwner === "favorites" ? Browse.FavoritesModel.card_write_pending : false
     readonly property string activeCardWriteError: root.cardWriteOwner === "systems" ? Browse.SystemsModel.card_write_error : root.cardWriteOwner === "games" ? Browse.GamesModel.card_write_error : root.cardWriteOwner === "favorites" ? Browse.FavoritesModel.card_write_error : ""
 
+    // Feed the Motion singleton's master switch from the persisted
+    // reduce-motion setting. Keeping Motion dependency-free (no
+    // Browse import) means Zaparoo.Theme stays independent; the app
+    // layer is the only place that crosses the module boundary.
+    Binding { target: Motion; property: "enabled"; value: !Browse.Settings.current_reduce_motion }
+
     // Bound here (not in GamesScreen.qml) because `set_system` can fire
     // from the accept handler before the games screen mounts; binding
     // inside the screen fires only on `Component.onCompleted`, after the

--- a/src/ui/app/MainLayout.qml
+++ b/src/ui/app/MainLayout.qml
@@ -595,6 +595,7 @@ ApplicationWindow {
                         SystemsScreen {
                             anchors.fill: parent
                             transitioning: root.transitionCueVisible
+                            active: root.activeScreen === root.screenSystems
                             optimisticLoading: root.activeScreen === root.screenSystems && root.catalogStillBooting
                         }
                     }
@@ -609,6 +610,7 @@ ApplicationWindow {
                         GamesScreen {
                             anchors.fill: parent
                             transitioning: root.transitionCueVisible
+                            active: root.activeScreen === root.screenGames
                             optimisticLoading: root.activeScreen === root.screenGames && root.catalogStillBooting
                         }
                     }

--- a/src/ui/components/BrowseDetailPane.qml
+++ b/src/ui/components/BrowseDetailPane.qml
@@ -101,31 +101,13 @@ Item {
     // Holds the last resolved cover URL so we can display it during the
     // loading grace window instead of blanking the cover area.
     property url _lastGoodCoverSource: ""
-    // Holds the last metadata rows that carried real values. Displayed while a
-    // meta fetch is in flight and the live rows are still value-less, so the
-    // table does not blank-then-repopulate on every move. Mirrors coverHold.
-    property var _heldDetailRows: []
+    // The detail table tracks the focused row's metadata directly. The model
+    // keeps `current_detail_tags` identity-correct on every move — an immediate
+    // peek shows cached/local rows or a clean blank, never the previous row's
+    // values — so no client-side hold is needed. (The cover keeps its own hold;
+    // see `coverHold`/`_lastGoodCoverSource` below.)
+    readonly property var _displayRows: root._detailRows
 
-    // Live rows when they carry values (immediate swap on cached/preloaded meta)
-    // or when loading has settled (truthful blank for metadata-less items);
-    // held rows only while a fetch is in flight and the live rows are value-less.
-    readonly property var _displayRows: (root._rowsHaveContent(root._detailRows) || !root.loading) ? root._detailRows : root._heldDetailRows
-
-    onDetailTagsChanged: {
-        if (root._rowsHaveContent(root._detailRows))
-            root._heldDetailRows = root._detailRows;
-        // Do not reset _labelColumnNaturalWidth here. Label keys (Year,
-        // Genre, Players, Developer, Publisher, Rating) are the same six
-        // strings for every item, so the accumulated max width measured by
-        // TextMetrics on first delegate creation stays correct indefinitely.
-        // Resetting it to 0 mid-session causes a one-frame label collapse
-        // while the Repeater defers delegate recreation to the next update
-        // cycle — the flicker the hold mechanic is designed to prevent.
-    }
-    onDetailSuppressedChanged: {
-        if (root.detailSuppressed)
-            root._heldDetailRows = [];
-    }
     onLoadingChanged: root._updatePaneLoadingDelay()
     onLoadingDelayMsChanged: {
         root._updatePaneLoadingDelay();
@@ -171,17 +153,6 @@ Item {
             return;
         }
         coverLoadingDelayTimer.restart();
-    }
-
-    // Returns true if any row in `rows` carries a non-empty value string.
-    // Used to decide whether to capture the hold and whether to show live
-    // or held rows in the tag table.
-    function _rowsHaveContent(rows: var): bool {
-        for (let i = 0; i < rows.length; ++i) {
-            if ((rows[i].value ?? "") !== "")
-                return true;
-        }
-        return false;
     }
 
     function _tagLabel(fullLabel: string, shortLabel: string): var {

--- a/src/ui/components/BrowseList.qml
+++ b/src/ui/components/BrowseList.qml
@@ -11,6 +11,13 @@ Item {
 
     required property var model
     property int currentIndex: 0
+    // Gates whether the selected row paints its highlight (selection surface +
+    // accent bar + bright text). The host leaves it false until the screen's
+    // selection is finalized (restore or first input) so the default row 0
+    // never lights up during the window before restore points currentIndex at
+    // the saved item on a cold start. Default true so unwired hosts highlight
+    // the selection normally.
+    property bool focusReady: true
     property string currentName: ""
     property string currentCoverKey: ""
     property int totalItemsOverride: -1
@@ -62,6 +69,11 @@ Item {
     // the Tile activation-pulse vocabulary. Forward navigation and game
     // launch share this single cue.
     property int activatePulse: 0
+    // Release counter for the row nudge. Incremented by the host to settle the
+    // selected row's slide back to 0 after a launch that keeps the frontend on
+    // the same screen. Forward navigation never increments it (the screen
+    // transition resets the nudge off-screen via screenSettling).
+    property int releasePulse: 0
     // When true, resets the row nudge back to 0 so a held slide does
     // not persist when the screen is shown again. Set by the host to
     // !active while the screen is off-screen.
@@ -159,6 +171,11 @@ Item {
             height: root.rowHeight
 
             readonly property bool selected: row.index === root.currentIndex
+            // Visual highlight is withheld until the host marks focus ready, so
+            // the default row 0 never paints the accent before restore lands.
+            // `selected` itself stays ungated so the detail-pane bindings below
+            // still track content during the pre-restore window.
+            readonly property bool _highlightVisible: row.selected && root.focusReady
             readonly property string displayTitle: row.name !== "" ? row.name : row.fileStem
             // Activate nudge: selected row slides right on accept/activate,
             // identical to the tile push-in trigger. Driven by root.activatePulse
@@ -169,7 +186,10 @@ Item {
 
             Behavior on _nudge {
                 enabled: Motion.enabled && !root.rapidScrollActive
-                NumberAnimation { duration: Motion.dur(Motion.settleMs); easing.type: Easing.OutCubic }
+                NumberAnimation {
+                    duration: Motion.dur(Motion.settleMs)
+                    easing.type: Easing.OutCubic
+                }
             }
 
             Connections {
@@ -177,6 +197,10 @@ Item {
                 function onActivatePulseChanged(): void {
                     if (row.selected)
                         row._nudge = Sizing.pctW(1.2);
+                }
+                function onReleasePulseChanged(): void {
+                    if (row.selected)
+                        row._nudge = 0;
                 }
                 function onScreenSettlingChanged(): void {
                     if (root.screenSettling)
@@ -204,7 +228,7 @@ Item {
                 x: row._nudge
                 width: parent.width - row._nudge
                 height: parent.height
-                visible: row.selected
+                visible: row._highlightVisible
 
                 Rectangle {
                     anchors.fill: parent
@@ -227,7 +251,7 @@ Item {
                 anchors.bottom: parent.bottom
                 width: root._selectionAccentWidth
                 color: Theme.accent
-                visible: row.selected
+                visible: row._highlightVisible
                 radius: Math.max(0, Sizing.px(width / 3))
             }
 
@@ -238,7 +262,7 @@ Item {
                 anchors.rightMargin: row.favorite !== 0 ? root._favoriteRightPadding + Sizing.pctH(3.2) + root._rowTextRightPadding : root._rowTextRightPadding
                 anchors.verticalCenter: parent.verticalCenter
                 text: row.displayTitle
-                color: row.selected ? Theme.textPrimary : Theme.textLabel
+                color: row._highlightVisible ? Theme.textPrimary : Theme.textLabel
                 font.family: Theme.fontUi
                 font.pixelSize: Sizing.fontSize(2.9)
                 elide: Text.ElideRight

--- a/src/ui/components/BrowseList.qml
+++ b/src/ui/components/BrowseList.qml
@@ -169,6 +169,10 @@ Item {
 
             width: listView.width
             height: root.rowHeight
+            // One-shot push-in cue, identical to the tile vocabulary: the
+            // selected row scales to Motion.pressScale on accept/activate.
+            scale: row._activateScale
+            transformOrigin: Item.Center
 
             readonly property bool selected: row.index === root.currentIndex
             // Visual highlight is withheld until the host marks focus ready, so
@@ -177,34 +181,49 @@ Item {
             // still track content during the pre-restore window.
             readonly property bool _highlightVisible: row.selected && root.focusReady
             readonly property string displayTitle: row.name !== "" ? row.name : row.fileStem
-            // Activate nudge: selected row slides right on accept/activate,
-            // identical to the tile push-in trigger. Driven by root.activatePulse
-            // incrementing (only for the selected row); the Behavior below
-            // animates the transition. Not triggered by focus movement —
-            // matches the tile vocabulary where push-in = navigation.
-            property real _nudge: 0
+            property real _activateScale: 1.0
 
-            Behavior on _nudge {
-                enabled: Motion.enabled && !root.rapidScrollActive
-                NumberAnimation {
-                    duration: Motion.dur(Motion.settleMs)
-                    easing.type: Easing.OutCubic
-                }
+            // Push in and hold — mirrors Tile.qml. The activate leg has no
+            // return-to-rest because a forward navigation holds the row pressed
+            // while the screen transitions; the release leg settles it back only
+            // when the launch stays on this screen (e.g. an Audio track), and
+            // `screenSettling` resets it off-screen so it is clean on return.
+            NumberAnimation {
+                id: activateAnim
+                target: row
+                property: "_activateScale"
+                to: Motion.pressScale
+                duration: Motion.dur(Motion.pressMs)
+                easing.type: Easing.OutQuad
+            }
+
+            NumberAnimation {
+                id: releaseAnim
+                target: row
+                property: "_activateScale"
+                to: 1.0
+                duration: Motion.dur(Motion.settleMs)
+                easing.type: Easing.OutQuad
             }
 
             Connections {
                 target: root
                 function onActivatePulseChanged(): void {
                     if (row.selected)
-                        row._nudge = Sizing.pctW(1.2);
+                        activateAnim.restart();
                 }
                 function onReleasePulseChanged(): void {
-                    if (row.selected)
-                        row._nudge = 0;
+                    if (row.selected) {
+                        activateAnim.stop();
+                        releaseAnim.restart();
+                    }
                 }
                 function onScreenSettlingChanged(): void {
-                    if (root.screenSettling)
-                        row._nudge = 0;
+                    if (root.screenSettling) {
+                        activateAnim.stop();
+                        releaseAnim.stop();
+                        row._activateScale = 1.0;
+                    }
                 }
             }
 
@@ -225,8 +244,7 @@ Item {
             }
 
             Item {
-                x: row._nudge
-                width: parent.width - row._nudge
+                width: parent.width
                 height: parent.height
                 visible: row._highlightVisible
 
@@ -246,7 +264,6 @@ Item {
             }
 
             Rectangle {
-                x: row._nudge
                 anchors.top: parent.top
                 anchors.bottom: parent.bottom
                 width: root._selectionAccentWidth
@@ -257,7 +274,7 @@ Item {
 
             Text {
                 anchors.left: parent.left
-                anchors.leftMargin: root._rowTextLeftPadding + row._nudge
+                anchors.leftMargin: root._rowTextLeftPadding
                 anchors.right: parent.right
                 anchors.rightMargin: row.favorite !== 0 ? root._favoriteRightPadding + Sizing.pctH(3.2) + root._rowTextRightPadding : root._rowTextRightPadding
                 anchors.verticalCenter: parent.verticalCenter

--- a/src/ui/components/BrowseList.qml
+++ b/src/ui/components/BrowseList.qml
@@ -24,9 +24,6 @@ Item {
     property int targetVisibleRowCount: 0
     property bool showChrome: true
     property var layoutProfile: null
-    // When true, disables the focus-nudge Behavior and scroll-thumb
-    // glide so held-key rapid scroll stays responsive.
-    property bool rapidScrollActive: false
     // layoutProfile and its sub-objects (_list, _grid, _surface) are JS-object
     // vars; the QML compiler cannot statically type their properties. Suppress
     // the compiler category for these bindings only.
@@ -64,17 +61,17 @@ Item {
     readonly property int _favoriteRightPadding: root._list ? root._list.favoriteRightPadding : Sizing.pctW(1.6)
     // qmllint enable compiler
 
-    // Pulse counter for the one-shot row nudge. Callers increment via
+    // Pulse counter for the one-shot row push-in. Callers increment via
     // activatePulse; only the selected row fires its animation, matching
     // the Tile activation-pulse vocabulary. Forward navigation and game
     // launch share this single cue.
     property int activatePulse: 0
-    // Release counter for the row nudge. Incremented by the host to settle the
-    // selected row's slide back to 0 after a launch that keeps the frontend on
-    // the same screen. Forward navigation never increments it (the screen
-    // transition resets the nudge off-screen via screenSettling).
+    // Release counter for the row push-in. Incremented by the host to settle
+    // the selected row's scale back to 1.0 after a launch that keeps the
+    // frontend on the same screen. Forward navigation never increments it (the
+    // screen transition resets the push-in off-screen via screenSettling).
     property int releasePulse: 0
-    // When true, resets the row nudge back to 0 so a held slide does
+    // When true, resets the row push-in scale back to 1.0 so a held press does
     // not persist when the screen is shown again. Set by the host to
     // !active while the screen is off-screen.
     property bool screenSettling: false
@@ -170,7 +167,7 @@ Item {
             width: listView.width
             height: root.rowHeight
             // One-shot push-in cue, identical to the tile vocabulary: the
-            // selected row scales to Motion.pressScale on accept/activate.
+            // selected row scales to Motion.rowPressScale on accept/activate.
             scale: row._activateScale
             transformOrigin: Item.Center
 
@@ -192,7 +189,7 @@ Item {
                 id: activateAnim
                 target: row
                 property: "_activateScale"
-                to: Motion.pressScale
+                to: Motion.rowPressScale
                 duration: Motion.dur(Motion.pressMs)
                 easing.type: Easing.OutQuad
             }

--- a/src/ui/components/BrowseList.qml
+++ b/src/ui/components/BrowseList.qml
@@ -17,6 +17,9 @@ Item {
     property int targetVisibleRowCount: 0
     property bool showChrome: true
     property var layoutProfile: null
+    // When true, disables the focus-nudge Behavior and scroll-thumb
+    // glide so held-key rapid scroll stays responsive.
+    property bool rapidScrollActive: false
     // layoutProfile and its sub-objects (_list, _grid, _surface) are JS-object
     // vars; the QML compiler cannot statically type their properties. Suppress
     // the compiler category for these bindings only.
@@ -53,6 +56,16 @@ Item {
     readonly property int _rowTextRightPadding: root._list ? root._list.rowTextRightPadding : Sizing.pctW(1.6)
     readonly property int _favoriteRightPadding: root._list ? root._list.favoriteRightPadding : Sizing.pctW(1.6)
     // qmllint enable compiler
+
+    // Pulse counter for the one-shot row nudge. Callers increment via
+    // activatePulse; only the selected row fires its animation, matching
+    // the Tile activation-pulse vocabulary. Forward navigation and game
+    // launch share this single cue.
+    property int activatePulse: 0
+    // When true, resets the row nudge back to 0 so a held slide does
+    // not persist when the screen is shown again. Set by the host to
+    // !active while the screen is off-screen.
+    property bool screenSettling: false
 
     signal itemHovered(int index)
     signal itemClicked(int index)
@@ -147,6 +160,29 @@ Item {
 
             readonly property bool selected: row.index === root.currentIndex
             readonly property string displayTitle: row.name !== "" ? row.name : row.fileStem
+            // Activate nudge: selected row slides right on accept/activate,
+            // identical to the tile push-in trigger. Driven by root.activatePulse
+            // incrementing (only for the selected row); the Behavior below
+            // animates the transition. Not triggered by focus movement —
+            // matches the tile vocabulary where push-in = navigation.
+            property real _nudge: 0
+
+            Behavior on _nudge {
+                enabled: Motion.enabled && !root.rapidScrollActive
+                NumberAnimation { duration: Motion.dur(Motion.settleMs); easing.type: Easing.OutCubic }
+            }
+
+            Connections {
+                target: root
+                function onActivatePulseChanged(): void {
+                    if (row.selected)
+                        row._nudge = Sizing.pctW(1.2);
+                }
+                function onScreenSettlingChanged(): void {
+                    if (root.screenSettling)
+                        row._nudge = 0;
+                }
+            }
 
             Binding {
                 target: root
@@ -165,7 +201,9 @@ Item {
             }
 
             Item {
-                anchors.fill: parent
+                x: row._nudge
+                width: parent.width - row._nudge
+                height: parent.height
                 visible: row.selected
 
                 Rectangle {
@@ -184,7 +222,7 @@ Item {
             }
 
             Rectangle {
-                anchors.left: parent.left
+                x: row._nudge
                 anchors.top: parent.top
                 anchors.bottom: parent.bottom
                 width: root._selectionAccentWidth
@@ -195,7 +233,7 @@ Item {
 
             Text {
                 anchors.left: parent.left
-                anchors.leftMargin: root._rowTextLeftPadding
+                anchors.leftMargin: root._rowTextLeftPadding + row._nudge
                 anchors.right: parent.right
                 anchors.rightMargin: row.favorite !== 0 ? root._favoriteRightPadding + Sizing.pctH(3.2) + root._rowTextRightPadding : root._rowTextRightPadding
                 anchors.verticalCenter: parent.verticalCenter

--- a/src/ui/components/BrowseListDetailView.qml
+++ b/src/ui/components/BrowseListDetailView.qml
@@ -27,7 +27,6 @@ Item {
     property alias detailLoading: detailPane.loading
     property alias detailLoadingText: detailPane.loadingText
     property alias detailSuppressed: detailPane.detailSuppressed
-    property alias listRapidScrollActive: browseList.rapidScrollActive
     property alias activatePulse: browseList.activatePulse
     property alias releasePulse: browseList.releasePulse
     property alias screenSettling: browseList.screenSettling

--- a/src/ui/components/BrowseListDetailView.qml
+++ b/src/ui/components/BrowseListDetailView.qml
@@ -27,6 +27,9 @@ Item {
     property alias detailLoading: detailPane.loading
     property alias detailLoadingText: detailPane.loadingText
     property alias detailSuppressed: detailPane.detailSuppressed
+    property alias listRapidScrollActive: browseList.rapidScrollActive
+    property alias activatePulse: browseList.activatePulse
+    property alias screenSettling: browseList.screenSettling
     property alias detailCanPreviousImage: detailPane.canPreviousImage
     property alias detailCanNextImage: detailPane.canNextImage
     property alias detailReserveImageNav: detailPane.reserveImageNav

--- a/src/ui/components/BrowseListDetailView.qml
+++ b/src/ui/components/BrowseListDetailView.qml
@@ -29,7 +29,9 @@ Item {
     property alias detailSuppressed: detailPane.detailSuppressed
     property alias listRapidScrollActive: browseList.rapidScrollActive
     property alias activatePulse: browseList.activatePulse
+    property alias releasePulse: browseList.releasePulse
     property alias screenSettling: browseList.screenSettling
+    property alias focusReady: browseList.focusReady
     property alias detailCanPreviousImage: detailPane.canPreviousImage
     property alias detailCanNextImage: detailPane.canNextImage
     property alias detailReserveImageNav: detailPane.reserveImageNav
@@ -102,5 +104,4 @@ Item {
         layoutProfile: root.layoutProfile
         showChrome: false
     }
-
 }

--- a/src/ui/components/CMakeLists.txt
+++ b/src/ui/components/CMakeLists.txt
@@ -11,6 +11,7 @@ qt_add_qml_module(
     QML_FILES
         ActiveLabel.qml
         BootOverlay.qml
+        DeferredAction.qml
         BrowseDetailPane.qml
         BrowseList.qml
         BrowseListDetailView.qml

--- a/src/ui/components/ContextMenu.qml
+++ b/src/ui/components/ContextMenu.qml
@@ -31,6 +31,10 @@ Item {
     property int currentIndex: 0
     property int bottomUnsafeHeight: Sizing.pctH(6) + Sizing.pctH(2)
 
+    // Push-in scale for the activated row, mirroring the tile push-in.
+    property real _pressScale: 1.0
+    property string _pendingId: ""
+
     signal accepted(string id)
     signal closeRequested
 
@@ -63,8 +67,12 @@ Item {
     z: 250
 
     onOpenChanged: {
-        if (open)
+        if (open) {
             currentIndex = 0;
+            menu._pressScale = 1.0;
+            pressAnim.stop();
+            menu._pendingId = "";
+        }
     }
 
     onEntriesChanged: {
@@ -100,9 +108,36 @@ Item {
             menu.move(1);
         else if (action === "accept") {
             if (menu.currentIndex >= 0 && menu.currentIndex < menu.entries.length)
-                menu.accepted(menu.entries[menu.currentIndex].id);
+                menu._commitAccept(menu.entries[menu.currentIndex].id);
         } else if (action === "cancel" || action === "context_menu")
             menu.closeRequested();
+    }
+
+    // Play the push-in cue on the focused row, then emit accepted(id)
+    // deferred so the animation completes before the caller acts.
+    function _commitAccept(id: string): void {
+        menu._pendingId = id;
+        pressAnim.restart();
+        acceptCommit.arm();
+    }
+
+    NumberAnimation {
+        id: pressAnim
+        target: menu
+        property: "_pressScale"
+        to: Motion.pressScale
+        duration: Motion.dur(Motion.pressMs)
+        easing.type: Easing.OutQuad
+    }
+
+    DeferredAction {
+        id: acceptCommit
+        onDeferred: {
+            const id = menu._pendingId;
+            menu._pendingId = "";
+            if (id !== "")
+                menu.accepted(id);
+        }
     }
 
     FontMetrics {
@@ -203,6 +238,13 @@ Item {
                     border.width: index === menu.currentIndex ? Sizing.stroke(2) : Sizing.stroke(1)
                     border.color: index === menu.currentIndex ? Theme.accent : Theme.borderMid
                     radius: Sizing.cornerRadius
+                    transformOrigin: Item.Center
+                    scale: row.index === menu.currentIndex ? menu._pressScale : 1.0
+
+                    Behavior on border.color {
+                        enabled: Motion.enabled
+                        ColorAnimation { duration: Motion.dur(Motion.settleMs) }
+                    }
 
                     Text {
                         anchors.left: parent.left
@@ -224,7 +266,7 @@ Item {
                         acceptedButtons: Qt.LeftButton
                         cursorShape: Qt.PointingHandCursor
                         onEntered: menu.currentIndex = row.index
-                        onClicked: menu.accepted(row.modelData.id)
+                        onClicked: menu._commitAccept(row.modelData.id)
                     }
                 }
             }

--- a/src/ui/components/ContextMenu.qml
+++ b/src/ui/components/ContextMenu.qml
@@ -29,6 +29,11 @@ Item {
     // dynamic per-owner menus silently re-shuffled the index/action map.
     property var entries: []
     property int currentIndex: 0
+    // False until the user moves the selection within an open menu. Gates the
+    // row border-color fade so the index reset on open (back to 0 from a stale
+    // prior selection) snaps instead of cross-fading the old row off and row 0
+    // on. Every user move arms it, so navigation fades exactly as before.
+    property bool _navArmed: false
     property int bottomUnsafeHeight: Sizing.pctH(6) + Sizing.pctH(2)
 
     // Push-in scale for the activated row, mirroring the tile push-in.
@@ -68,6 +73,7 @@ Item {
 
     onOpenChanged: {
         if (open) {
+            menu._navArmed = false;
             currentIndex = 0;
             menu._pressScale = 1.0;
             pressAnim.stop();
@@ -98,6 +104,7 @@ Item {
     function move(delta: int): void {
         if (menu.entries.length <= 0)
             return;
+        menu._navArmed = true;
         menu.currentIndex = ((menu.currentIndex + delta) % menu.entries.length + menu.entries.length) % menu.entries.length;
     }
 
@@ -242,8 +249,10 @@ Item {
                     scale: row.index === menu.currentIndex ? menu._pressScale : 1.0
 
                     Behavior on border.color {
-                        enabled: Motion.enabled
-                        ColorAnimation { duration: Motion.dur(Motion.settleMs) }
+                        enabled: Motion.enabled && menu._navArmed
+                        ColorAnimation {
+                            duration: Motion.dur(Motion.settleMs)
+                        }
                     }
 
                     Text {
@@ -265,7 +274,10 @@ Item {
                         hoverEnabled: true
                         acceptedButtons: Qt.LeftButton
                         cursorShape: Qt.PointingHandCursor
-                        onEntered: menu.currentIndex = row.index
+                        onEntered: {
+                            menu._navArmed = true;
+                            menu.currentIndex = row.index;
+                        }
                         onClicked: menu._commitAccept(row.modelData.id)
                     }
                 }

--- a/src/ui/components/ContextMenu.qml
+++ b/src/ui/components/ContextMenu.qml
@@ -29,11 +29,6 @@ Item {
     // dynamic per-owner menus silently re-shuffled the index/action map.
     property var entries: []
     property int currentIndex: 0
-    // False until the user moves the selection within an open menu. Gates the
-    // row border-color fade so the index reset on open (back to 0 from a stale
-    // prior selection) snaps instead of cross-fading the old row off and row 0
-    // on. Every user move arms it, so navigation fades exactly as before.
-    property bool _navArmed: false
     property int bottomUnsafeHeight: Sizing.pctH(6) + Sizing.pctH(2)
 
     // Push-in scale for the activated row, mirroring the tile push-in.
@@ -73,7 +68,6 @@ Item {
 
     onOpenChanged: {
         if (open) {
-            menu._navArmed = false;
             currentIndex = 0;
             menu._pressScale = 1.0;
             pressAnim.stop();
@@ -104,7 +98,6 @@ Item {
     function move(delta: int): void {
         if (menu.entries.length <= 0)
             return;
-        menu._navArmed = true;
         menu.currentIndex = ((menu.currentIndex + delta) % menu.entries.length + menu.entries.length) % menu.entries.length;
     }
 
@@ -248,13 +241,6 @@ Item {
                     transformOrigin: Item.Center
                     scale: row.index === menu.currentIndex ? menu._pressScale : 1.0
 
-                    Behavior on border.color {
-                        enabled: Motion.enabled && menu._navArmed
-                        ColorAnimation {
-                            duration: Motion.dur(Motion.settleMs)
-                        }
-                    }
-
                     Text {
                         anchors.left: parent.left
                         anchors.right: parent.right
@@ -274,10 +260,7 @@ Item {
                         hoverEnabled: true
                         acceptedButtons: Qt.LeftButton
                         cursorShape: Qt.PointingHandCursor
-                        onEntered: {
-                            menu._navArmed = true;
-                            menu.currentIndex = row.index;
-                        }
+                        onEntered: menu.currentIndex = row.index
                         onClicked: menu._commitAccept(row.modelData.id)
                     }
                 }

--- a/src/ui/components/ContextMenu.qml
+++ b/src/ui/components/ContextMenu.qml
@@ -125,7 +125,7 @@ Item {
         id: pressAnim
         target: menu
         property: "_pressScale"
-        to: Motion.pressScale
+        to: Motion.rowPressScale
         duration: Motion.dur(Motion.pressMs)
         easing.type: Easing.OutQuad
     }

--- a/src/ui/components/DeferredAction.qml
+++ b/src/ui/components/DeferredAction.qml
@@ -32,7 +32,7 @@ import Zaparoo.Theme
 Timer {
     id: ctl
 
-    signal deferred()
+    signal deferred
     interval: Motion.dur(Motion.pressMs)
     repeat: false
 

--- a/src/ui/components/DeferredAction.qml
+++ b/src/ui/components/DeferredAction.qml
@@ -1,0 +1,50 @@
+// Zaparoo Frontend
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+import QtQuick
+import Zaparoo.Theme
+
+// Non-visual helper that sequences a press cue ahead of a dispatch.
+// The host fires its tile pulse counter (which starts the push-in animation),
+// then calls `arm()`. The `deferred` signal fires after `Motion.pressMs` —
+// long enough for the tile push-in's downward leg to complete on a static
+// scene before the navigation starts. That lead sits inside the existing
+// 300 ms loading-overlay grace window (MainLayout.loadingIndicatorDelayMs),
+// so it adds no perceptible navigation latency in the common case.
+//
+// Usage: declare an `onDeferred:` handler on the DeferredAction instance
+// (evaluated in the outer screen's scope, so all screen ids are accessible),
+// then call `arm()` in the accept path:
+//
+//   DeferredAction {
+//       id: pressCommit
+//       onDeferred: hub._emitActivate()
+//   }
+//   ...
+//   hub.activatePulse++;
+//   pressCommit.arm();
+//
+// Re-arming while the timer is running is a no-op — debounces a double-accept
+// inside the lead window since the router's input gate only closes after the
+// `onDeferred` handler sets `pendingTransition`. Under reduce-motion the
+// `deferred` signal fires synchronously with no event-loop hop.
+Timer {
+    id: ctl
+
+    signal deferred()
+    interval: Motion.dur(Motion.pressMs)
+    repeat: false
+
+    onTriggered: ctl.deferred()
+
+    function arm(): void {
+        if (ctl.running)
+            return;
+        if (!Motion.enabled) {
+            ctl.deferred();
+            return;
+        }
+        ctl.restart();
+    }
+}

--- a/src/ui/components/FocusedMediaDetailController.qml
+++ b/src/ui/components/FocusedMediaDetailController.qml
@@ -16,6 +16,11 @@ Item {
     property var mediaModel: null
     property var identityForIndex: null
     property var loadForIndex: null
+    // Optional immediate (non-debounced) hook fired the moment the focused row
+    // changes, so the detail pane reflects THIS row at once (cached/local
+    // metadata or a clean blank) instead of holding the previous row's values
+    // through the load debounce. Defaults to the model's `peek_detail_at`.
+    property var peekForIndex: null
     property var clearDetail: null
     property bool clearOnDisable: true
     property bool rapidScrollActive: false
@@ -23,6 +28,9 @@ Item {
     property string _requestedKey: ""
     property string _pendingKey: ""
     property int _pendingIndex: -1
+    // Identity the immediate peek last ran for, so a repeated schedule for the
+    // same row does not re-peek.
+    property string _peekedKey: ""
 
     visible: false
 
@@ -62,8 +70,16 @@ Item {
         root._requestedKey = "";
         root._pendingKey = "";
         root._pendingIndex = -1;
+        root._peekedKey = "";
         if (clearDetail)
             root._clearDetail();
+    }
+
+    function _peek(index: int): void {
+        if (typeof root.peekForIndex === "function")
+            root.peekForIndex(index);
+        else if (root.mediaModel !== null && typeof root.mediaModel.peek_detail_at === "function")
+            root.mediaModel.peek_detail_at(index);
     }
 
     function _schedule(force: bool): void {
@@ -77,6 +93,13 @@ Item {
         if (key === "") {
             root._resetTransientState(true);
             return;
+        }
+        // Reflect the focused row immediately (cached/local metadata or a clean
+        // blank), before the debounce, so the table never shows the previous
+        // row's values during the load window.
+        if (root._peekedKey !== key) {
+            root._peekedKey = key;
+            root._peek(root.currentIndex);
         }
         if (!force && key === root._requestedKey)
             return;

--- a/src/ui/components/ListPickerModal.qml
+++ b/src/ui/components/ListPickerModal.qml
@@ -37,12 +37,6 @@ Item {
     // whose id matches. Empty string or no match falls back to 0.
     property string initialId: ""
     property int currentIndex: 0
-    // False until the user moves the selection within an open modal. Gates the
-    // row border-color fade so the initial selection set on open (jumping from
-    // the default index 0 to the `initialId` match) snaps instead of
-    // cross-fading the row 0 highlight off and the real row on. Every user move
-    // arms it, so keyboard navigation fades exactly as before.
-    property bool _navArmed: false
 
     // Push-in scale for the activated row, mirroring the tile push-in.
     property real _pressScale: 1.0
@@ -87,7 +81,6 @@ Item {
             }
         }
         viewport.contentY = 0;
-        modal._navArmed = false;
         modal.currentIndex = next;
         modal._scrollCurrentIntoView();
         modal._pressScale = 1.0;
@@ -109,7 +102,6 @@ Item {
     function move(delta: int): void {
         if (modal.entries.length <= 0)
             return;
-        modal._navArmed = true;
         const len = modal.entries.length;
         modal.currentIndex = ((modal.currentIndex + delta) % len + len) % len;
     }
@@ -203,13 +195,6 @@ Item {
                             transformOrigin: Item.Center
                             scale: row.index === modal.currentIndex ? modal._pressScale : 1.0
 
-                            Behavior on border.color {
-                                enabled: Motion.enabled && modal._navArmed
-                                ColorAnimation {
-                                    duration: Motion.dur(Motion.settleMs)
-                                }
-                            }
-
                             Text {
                                 anchors.left: parent.left
                                 anchors.right: parent.right
@@ -230,10 +215,7 @@ Item {
                                 hoverEnabled: true
                                 acceptedButtons: Qt.LeftButton
                                 cursorShape: Qt.PointingHandCursor
-                                onEntered: {
-                                    modal._navArmed = true;
-                                    modal.currentIndex = row.index;
-                                }
+                                onEntered: modal.currentIndex = row.index
                                 onClicked: modal._commitAccept(row.modelData.id)
                             }
                         }

--- a/src/ui/components/ListPickerModal.qml
+++ b/src/ui/components/ListPickerModal.qml
@@ -38,6 +38,10 @@ Item {
     property string initialId: ""
     property int currentIndex: 0
 
+    // Push-in scale for the activated row, mirroring the tile push-in.
+    property real _pressScale: 1.0
+    property string _pendingId: ""
+
     signal accepted(string id)
     signal closeRequested
 
@@ -79,6 +83,9 @@ Item {
         viewport.contentY = 0;
         modal.currentIndex = next;
         modal._scrollCurrentIntoView();
+        modal._pressScale = 1.0;
+        pressAnim.stop();
+        modal._pendingId = "";
     }
 
     function _scrollCurrentIntoView(): void {
@@ -106,9 +113,34 @@ Item {
             modal.move(1);
         } else if (action === "accept") {
             if (modal.currentIndex >= 0 && modal.currentIndex < modal.entries.length)
-                modal.accepted(modal.entries[modal.currentIndex].id);
+                modal._commitAccept(modal.entries[modal.currentIndex].id);
         } else if (action === "cancel") {
             modal.closeRequested();
+        }
+    }
+
+    function _commitAccept(id: string): void {
+        modal._pendingId = id;
+        pressAnim.restart();
+        acceptCommit.arm();
+    }
+
+    NumberAnimation {
+        id: pressAnim
+        target: modal
+        property: "_pressScale"
+        to: Motion.pressScale
+        duration: Motion.dur(Motion.pressMs)
+        easing.type: Easing.OutQuad
+    }
+
+    DeferredAction {
+        id: acceptCommit
+        onDeferred: {
+            const id = modal._pendingId;
+            modal._pendingId = "";
+            if (id !== "")
+                modal.accepted(id);
         }
     }
 
@@ -160,6 +192,13 @@ Item {
                             border.width: row.index === modal.currentIndex ? Sizing.stroke(2) : Sizing.stroke(1)
                             border.color: row.index === modal.currentIndex ? Theme.accent : Theme.borderMid
                             radius: Sizing.cornerRadius
+                            transformOrigin: Item.Center
+                            scale: row.index === modal.currentIndex ? modal._pressScale : 1.0
+
+                            Behavior on border.color {
+                                enabled: Motion.enabled
+                                ColorAnimation { duration: Motion.dur(Motion.settleMs) }
+                            }
 
                             Text {
                                 anchors.left: parent.left
@@ -182,7 +221,7 @@ Item {
                                 acceptedButtons: Qt.LeftButton
                                 cursorShape: Qt.PointingHandCursor
                                 onEntered: modal.currentIndex = row.index
-                                onClicked: modal.accepted(row.modelData.id)
+                                onClicked: modal._commitAccept(row.modelData.id)
                             }
                         }
                     }

--- a/src/ui/components/ListPickerModal.qml
+++ b/src/ui/components/ListPickerModal.qml
@@ -69,8 +69,12 @@ Item {
     z: 300
 
     onOpenChanged: {
-        if (!modal.open)
+        if (!modal.open) {
+            // Disarm a pending accept so a press-then-close inside the deferred
+            // window cannot apply a selection after the modal is dismissed.
+            acceptCommit.stop();
             return;
+        }
         let next = 0;
         if (modal.initialId !== "") {
             for (let i = 0; i < modal.entries.length; ++i) {
@@ -129,7 +133,7 @@ Item {
         id: pressAnim
         target: modal
         property: "_pressScale"
-        to: Motion.pressScale
+        to: Motion.rowPressScale
         duration: Motion.dur(Motion.pressMs)
         easing.type: Easing.OutQuad
     }

--- a/src/ui/components/ListPickerModal.qml
+++ b/src/ui/components/ListPickerModal.qml
@@ -37,6 +37,12 @@ Item {
     // whose id matches. Empty string or no match falls back to 0.
     property string initialId: ""
     property int currentIndex: 0
+    // False until the user moves the selection within an open modal. Gates the
+    // row border-color fade so the initial selection set on open (jumping from
+    // the default index 0 to the `initialId` match) snaps instead of
+    // cross-fading the row 0 highlight off and the real row on. Every user move
+    // arms it, so keyboard navigation fades exactly as before.
+    property bool _navArmed: false
 
     // Push-in scale for the activated row, mirroring the tile push-in.
     property real _pressScale: 1.0
@@ -81,6 +87,7 @@ Item {
             }
         }
         viewport.contentY = 0;
+        modal._navArmed = false;
         modal.currentIndex = next;
         modal._scrollCurrentIntoView();
         modal._pressScale = 1.0;
@@ -102,6 +109,7 @@ Item {
     function move(delta: int): void {
         if (modal.entries.length <= 0)
             return;
+        modal._navArmed = true;
         const len = modal.entries.length;
         modal.currentIndex = ((modal.currentIndex + delta) % len + len) % len;
     }
@@ -196,8 +204,10 @@ Item {
                             scale: row.index === modal.currentIndex ? modal._pressScale : 1.0
 
                             Behavior on border.color {
-                                enabled: Motion.enabled
-                                ColorAnimation { duration: Motion.dur(Motion.settleMs) }
+                                enabled: Motion.enabled && modal._navArmed
+                                ColorAnimation {
+                                    duration: Motion.dur(Motion.settleMs)
+                                }
                             }
 
                             Text {
@@ -220,7 +230,10 @@ Item {
                                 hoverEnabled: true
                                 acceptedButtons: Qt.LeftButton
                                 cursorShape: Qt.PointingHandCursor
-                                onEntered: modal.currentIndex = row.index
+                                onEntered: {
+                                    modal._navArmed = true;
+                                    modal.currentIndex = row.index;
+                                }
                                 onClicked: modal._commitAccept(row.modelData.id)
                             }
                         }

--- a/src/ui/components/Modal.qml
+++ b/src/ui/components/Modal.qml
@@ -81,14 +81,18 @@ Item {
     z: 300
 
     onOpenChanged: {
-        if (modal.open && modal.kind === "confirm")
-            modal._focusYes = false;
-        if (modal.open) {
-            modal._pressScale = 1.0;
-            modal._pressTarget = "";
-            modal._pendingSignal = "";
-            pressAnim.stop();
+        if (!modal.open) {
+            // Disarm a pending deferred signal so a press-then-close inside the
+            // deferred window cannot emit confirmed/accepted after dismissal.
+            actionCommit.stop();
+            return;
         }
+        if (modal.kind === "confirm")
+            modal._focusYes = false;
+        modal._pressScale = 1.0;
+        modal._pressTarget = "";
+        modal._pendingSignal = "";
+        pressAnim.stop();
     }
 
     // confirm-only input dispatch. Main.qml routes key/controller

--- a/src/ui/components/Modal.qml
+++ b/src/ui/components/Modal.qml
@@ -38,7 +38,7 @@ import Zaparoo.Theme
 // `confirmed` (confirm Yes).
 //
 // Software-rendering safe — only Item, Rectangle, Text, Column, Row,
-// MouseArea. No transforms, no shaders, no animations.
+// MouseArea, and scale transforms (buttons push in on activation).
 Item {
     id: modal
 
@@ -60,6 +60,13 @@ Item {
     // into the next prompt.
     property bool _focusYes: false
 
+    // Push-in scale for button activation, mirroring the tile push-in.
+    // _pressTarget identifies which button is currently scaled; the others
+    // stay at 1.0 so only the pressed button cues the user's intention.
+    property real _pressScale: 1.0
+    property string _pressTarget: ""
+    property string _pendingSignal: ""
+
     // Shell-mode content slot. Children declared inside a Modal are
     // routed here; only rendered when kind === "shell" so a stray child
     // on a prebaked-kind modal can't leak into the panel.
@@ -76,6 +83,12 @@ Item {
     onOpenChanged: {
         if (modal.open && modal.kind === "confirm")
             modal._focusYes = false;
+        if (modal.open) {
+            modal._pressScale = 1.0;
+            modal._pressTarget = "";
+            modal._pendingSignal = "";
+            pressAnim.stop();
+        }
     }
 
     // confirm-only input dispatch. Main.qml routes key/controller
@@ -89,11 +102,44 @@ Item {
             modal._focusYes = true;
         } else if (action === "accept") {
             if (modal._focusYes)
-                modal.confirmed();
+                modal._commit("yes", "confirmed");
             else
-                modal.cancelRequested();
+                modal._commit("no", "cancelRequested");
         } else if (action === "cancel") {
+            // Back-key dismissal — not an on-screen button, no push-in.
             modal.cancelRequested();
+        }
+    }
+
+    // Play the push-in cue on the named button, then emit the pending
+    // signal deferred so the animation completes before the caller acts.
+    function _commit(target: string, sig: string): void {
+        modal._pressTarget = target;
+        modal._pendingSignal = sig;
+        pressAnim.restart();
+        actionCommit.arm();
+    }
+
+    NumberAnimation {
+        id: pressAnim
+        target: modal
+        property: "_pressScale"
+        to: Motion.pressScale
+        duration: Motion.dur(Motion.pressMs)
+        easing.type: Easing.OutQuad
+    }
+
+    DeferredAction {
+        id: actionCommit
+        onDeferred: {
+            const sig = modal._pendingSignal;
+            modal._pendingSignal = "";
+            if (sig === "accepted")
+                modal.accepted();
+            else if (sig === "confirmed")
+                modal.confirmed();
+            else if (sig === "cancelRequested")
+                modal.cancelRequested();
         }
     }
 
@@ -191,6 +237,8 @@ Item {
                         border.width: Sizing.stroke(2)
                         border.color: Theme.accent
                         radius: Sizing.cornerRadius
+                        transformOrigin: Item.Center
+                        scale: modal._pressTarget === "cancel" ? modal._pressScale : 1.0
 
                         Text {
                             x: Sizing.center(parent.width, width)
@@ -205,7 +253,7 @@ Item {
                         MouseArea {
                             anchors.fill: parent
                             cursorShape: Qt.PointingHandCursor
-                            onClicked: modal.cancelRequested()
+                            onClicked: modal._commit("cancel", "cancelRequested")
                         }
                     }
                 }
@@ -229,6 +277,8 @@ Item {
                         border.width: Sizing.stroke(2)
                         border.color: Theme.accent
                         radius: Sizing.cornerRadius
+                        transformOrigin: Item.Center
+                        scale: modal._pressTarget === "ok" ? modal._pressScale : 1.0
 
                         Text {
                             x: Sizing.center(parent.width, width)
@@ -243,7 +293,7 @@ Item {
                         MouseArea {
                             anchors.fill: parent
                             cursorShape: Qt.PointingHandCursor
-                            onClicked: modal.accepted()
+                            onClicked: modal._commit("ok", "accepted")
                         }
                     }
                 }
@@ -278,6 +328,13 @@ Item {
                             border.width: modal._focusYes ? Sizing.stroke(1) : Sizing.stroke(2)
                             border.color: modal._focusYes ? Theme.borderMid : Theme.accent
                             radius: Sizing.cornerRadius
+                            transformOrigin: Item.Center
+                            scale: modal._pressTarget === "no" ? modal._pressScale : 1.0
+
+                            Behavior on border.color {
+                                enabled: Motion.enabled
+                                ColorAnimation { duration: Motion.dur(Motion.settleMs) }
+                            }
 
                             Text {
                                 x: Sizing.center(parent.width, width)
@@ -294,7 +351,7 @@ Item {
                                 cursorShape: Qt.PointingHandCursor
                                 onClicked: {
                                     modal._focusYes = false;
-                                    modal.cancelRequested();
+                                    modal._commit("no", "cancelRequested");
                                 }
                             }
                         }
@@ -306,6 +363,13 @@ Item {
                             border.width: modal._focusYes ? Sizing.stroke(2) : Sizing.stroke(1)
                             border.color: modal._focusYes ? Theme.accent : Theme.borderMid
                             radius: Sizing.cornerRadius
+                            transformOrigin: Item.Center
+                            scale: modal._pressTarget === "yes" ? modal._pressScale : 1.0
+
+                            Behavior on border.color {
+                                enabled: Motion.enabled
+                                ColorAnimation { duration: Motion.dur(Motion.settleMs) }
+                            }
 
                             Text {
                                 x: Sizing.center(parent.width, width)
@@ -322,7 +386,7 @@ Item {
                                 cursorShape: Qt.PointingHandCursor
                                 onClicked: {
                                     modal._focusYes = true;
-                                    modal.confirmed();
+                                    modal._commit("yes", "confirmed");
                                 }
                             }
                         }

--- a/src/ui/components/Modal.qml
+++ b/src/ui/components/Modal.qml
@@ -59,6 +59,12 @@ Item {
     // focused. Reset on every open so a previous Yes-focus doesn't leak
     // into the next prompt.
     property bool _focusYes: false
+    // False until the user moves between the confirm buttons. Gates the button
+    // border-color fade so the focus reset on open (back to "no" from a stale
+    // "yes" left over from a prior prompt) snaps instead of cross-fading the
+    // old button off and the default on. User left/right arms it, so moving
+    // between the buttons fades exactly as before.
+    property bool _navArmed: false
 
     // Push-in scale for button activation, mirroring the tile push-in.
     // _pressTarget identifies which button is currently scaled; the others
@@ -81,8 +87,10 @@ Item {
     z: 300
 
     onOpenChanged: {
-        if (modal.open && modal.kind === "confirm")
+        if (modal.open && modal.kind === "confirm") {
+            modal._navArmed = false;
             modal._focusYes = false;
+        }
         if (modal.open) {
             modal._pressScale = 1.0;
             modal._pressTarget = "";
@@ -97,8 +105,10 @@ Item {
         if (modal.kind !== "confirm")
             return;
         if (action === "left") {
+            modal._navArmed = true;
             modal._focusYes = false;
         } else if (action === "right") {
+            modal._navArmed = true;
             modal._focusYes = true;
         } else if (action === "accept") {
             if (modal._focusYes)
@@ -332,8 +342,10 @@ Item {
                             scale: modal._pressTarget === "no" ? modal._pressScale : 1.0
 
                             Behavior on border.color {
-                                enabled: Motion.enabled
-                                ColorAnimation { duration: Motion.dur(Motion.settleMs) }
+                                enabled: Motion.enabled && modal._navArmed
+                                ColorAnimation {
+                                    duration: Motion.dur(Motion.settleMs)
+                                }
                             }
 
                             Text {
@@ -367,8 +379,10 @@ Item {
                             scale: modal._pressTarget === "yes" ? modal._pressScale : 1.0
 
                             Behavior on border.color {
-                                enabled: Motion.enabled
-                                ColorAnimation { duration: Motion.dur(Motion.settleMs) }
+                                enabled: Motion.enabled && modal._navArmed
+                                ColorAnimation {
+                                    duration: Motion.dur(Motion.settleMs)
+                                }
                             }
 
                             Text {

--- a/src/ui/components/Modal.qml
+++ b/src/ui/components/Modal.qml
@@ -59,12 +59,6 @@ Item {
     // focused. Reset on every open so a previous Yes-focus doesn't leak
     // into the next prompt.
     property bool _focusYes: false
-    // False until the user moves between the confirm buttons. Gates the button
-    // border-color fade so the focus reset on open (back to "no" from a stale
-    // "yes" left over from a prior prompt) snaps instead of cross-fading the
-    // old button off and the default on. User left/right arms it, so moving
-    // between the buttons fades exactly as before.
-    property bool _navArmed: false
 
     // Push-in scale for button activation, mirroring the tile push-in.
     // _pressTarget identifies which button is currently scaled; the others
@@ -87,10 +81,8 @@ Item {
     z: 300
 
     onOpenChanged: {
-        if (modal.open && modal.kind === "confirm") {
-            modal._navArmed = false;
+        if (modal.open && modal.kind === "confirm")
             modal._focusYes = false;
-        }
         if (modal.open) {
             modal._pressScale = 1.0;
             modal._pressTarget = "";
@@ -105,10 +97,8 @@ Item {
         if (modal.kind !== "confirm")
             return;
         if (action === "left") {
-            modal._navArmed = true;
             modal._focusYes = false;
         } else if (action === "right") {
-            modal._navArmed = true;
             modal._focusYes = true;
         } else if (action === "accept") {
             if (modal._focusYes)
@@ -341,13 +331,6 @@ Item {
                             transformOrigin: Item.Center
                             scale: modal._pressTarget === "no" ? modal._pressScale : 1.0
 
-                            Behavior on border.color {
-                                enabled: Motion.enabled && modal._navArmed
-                                ColorAnimation {
-                                    duration: Motion.dur(Motion.settleMs)
-                                }
-                            }
-
                             Text {
                                 x: Sizing.center(parent.width, width)
                                 y: Sizing.center(parent.height, height)
@@ -377,13 +360,6 @@ Item {
                             radius: Sizing.cornerRadius
                             transformOrigin: Item.Center
                             scale: modal._pressTarget === "yes" ? modal._pressScale : 1.0
-
-                            Behavior on border.color {
-                                enabled: Motion.enabled && modal._navArmed
-                                ColorAnimation {
-                                    duration: Motion.dur(Motion.settleMs)
-                                }
-                            }
 
                             Text {
                                 x: Sizing.center(parent.width, width)

--- a/src/ui/components/PagedGrid.qml
+++ b/src/ui/components/PagedGrid.qml
@@ -56,6 +56,21 @@ Item {
     property bool coverLoadingPaused: false
     property bool rapidRenderMode: false
     readonly property int _coverRetentionPages: Math.max(1, Math.ceil(Sizing.visibleCovers))
+    // Pulse counter for the one-shot tile push-in. Callers increment via
+    // pulseActivate(); TileLoader forwards the value to Tile where only the
+    // focused+selected delegate fires its cue. The same cue serves both
+    // forward navigation and game launch.
+    property int activatePulse: 0
+    function pulseActivate(): void { root.activatePulse++; }
+    // When true, Tile delegates reset their push-in scale back to 1.0
+    // so a held push-in from the previous visit does not persist when
+    // the screen is shown again. Set by the host screen to `!active`
+    // (i.e. true while the screen is off-screen).
+    property bool screenSettling: false
+    // Forwarded to each Tile's ring-fade gate. Host screens leave this
+    // false until the user takes control of focus so the restore reseat
+    // snaps; default true keeps the fade for hosts that do not wire it.
+    property bool ringFadeReady: true
     property var layoutProfile: null
     readonly property var _gridProfile: root.layoutProfile && root.layoutProfile.grid ? root.layoutProfile.grid : null
 
@@ -600,6 +615,17 @@ Item {
                     color: Theme.surfaceCard
                     border.color: Theme.borderMid
                     border.width: Sizing.stroke(1)
+                    // Track the loaded Tile's push-in scale so the card
+                    // silhouette and the Tile surface shrink together.
+                    // Falls back to 1.0 when no Tile is loaded (skeleton
+                    // state), so the placeholder stays full-size until
+                    // the Tile appears. `cardScale` is a readonly alias
+                    // for `_activateScale` exposed by Tile for exactly
+                    // this cross-sibling binding.
+                    transformOrigin: Item.Center
+                    // qmllint disable missing-property
+                    scale: tileLoader.status === Loader.Ready && tileLoader.item ? tileLoader.item.cardScale : 1.0
+                    // qmllint enable missing-property
                 }
 
                 // Standalone selected-cell ring for skeleton/rapid mode.
@@ -657,6 +683,9 @@ Item {
                     coverKey: cellItem._gatedCoverKey
                     favorite: cellItem.favorite
                     hidden: cellItem.hidden
+                    activatePulse: root.activatePulse
+                    settling: root.screenSettling
+                    ringFadeReady: root.ringFadeReady
                 }
 
                 MouseArea {
@@ -691,10 +720,12 @@ Item {
     // Up arrow at the top, down arrow at the bottom, free-floating thumb
     // in between. No painted track — the indicator is just the arrows
     // and the thumb. Hidden when the dataset fits on a single page.
-    // Snaps page-by-page; no animation on the thumb (matches the instant
-    // page flip and keeps the software renderer's dirty rect off the
-    // cell area). Sits after the cell `track` in the visual tree so the
-    // indicator paints on top of any focus-scale bleed at the right edge.
+    // The thumb snaps to each page position with no glide animation:
+    // scrolling is a hot path (cover prefetch + data load run on the same
+    // frames), so an animated thumb would repaint while the system is
+    // already busy.
+    // Sits after the cell `track` in the visual tree so the indicator
+    // paints on top of any brief scale-animation bleed at the right edge.
     Item {
         id: scrollGutter
 

--- a/src/ui/components/PagedGrid.qml
+++ b/src/ui/components/PagedGrid.qml
@@ -78,10 +78,6 @@ Item {
     // the screen is shown again. Set by the host screen to `!active`
     // (i.e. true while the screen is off-screen).
     property bool screenSettling: false
-    // Forwarded to each Tile's ring-fade gate. Host screens leave this
-    // false until the user takes control of focus so the restore reseat
-    // snaps; default true keeps the fade for hosts that do not wire it.
-    property bool ringFadeReady: true
     // Forwarded to each Tile's focus-visibility gate. Host screens leave this
     // false until the grid's selection is finalized (restore or first input)
     // so the default tile 0 never paints a ring before restore lands; default
@@ -702,7 +698,6 @@ Item {
                     activatePulse: root.activatePulse
                     releasePulse: root.releasePulse
                     settling: root.screenSettling
-                    ringFadeReady: root.ringFadeReady
                     focusReady: root.focusReady
                 }
 

--- a/src/ui/components/PagedGrid.qml
+++ b/src/ui/components/PagedGrid.qml
@@ -61,7 +61,18 @@ Item {
     // focused+selected delegate fires its cue. The same cue serves both
     // forward navigation and game launch.
     property int activatePulse: 0
-    function pulseActivate(): void { root.activatePulse++; }
+    function pulseActivate(): void {
+        root.activatePulse++;
+    }
+    // Release counter for the push-in cue. Callers increment via
+    // releaseActivate() to settle the focused tile back to rest after a launch
+    // that keeps the frontend on the same screen (e.g. an Audio track). Forward
+    // navigation never calls this — the screen transition + `settling` reset
+    // handle the held scale off-screen.
+    property int releasePulse: 0
+    function releaseActivate(): void {
+        root.releasePulse++;
+    }
     // When true, Tile delegates reset their push-in scale back to 1.0
     // so a held push-in from the previous visit does not persist when
     // the screen is shown again. Set by the host screen to `!active`
@@ -71,6 +82,11 @@ Item {
     // false until the user takes control of focus so the restore reseat
     // snaps; default true keeps the fade for hosts that do not wire it.
     property bool ringFadeReady: true
+    // Forwarded to each Tile's focus-visibility gate. Host screens leave this
+    // false until the grid's selection is finalized (restore or first input)
+    // so the default tile 0 never paints a ring before restore lands; default
+    // true keeps focus rendering on for hosts that do not wire it.
+    property bool focusReady: true
     property var layoutProfile: null
     readonly property var _gridProfile: root.layoutProfile && root.layoutProfile.grid ? root.layoutProfile.grid : null
 
@@ -642,7 +658,7 @@ Item {
                     color: Theme.accent
                     radius: Math.max(0, Sizing.cornerRadius - Sizing.pctH(0.4))
                     antialiasing: true
-                    visible: cellItem.isSelected && root.focused && (root.rapidRenderMode || tileLoader.status !== Loader.Ready)
+                    visible: cellItem.isSelected && root.focused && root.focusReady && (root.rapidRenderMode || tileLoader.status !== Loader.Ready)
                 }
 
                 Rectangle {
@@ -684,8 +700,10 @@ Item {
                     favorite: cellItem.favorite
                     hidden: cellItem.hidden
                     activatePulse: root.activatePulse
+                    releasePulse: root.releasePulse
                     settling: root.screenSettling
                     ringFadeReady: root.ringFadeReady
+                    focusReady: root.focusReady
                 }
 
                 MouseArea {

--- a/src/ui/components/SettingsField.qml
+++ b/src/ui/components/SettingsField.qml
@@ -29,6 +29,11 @@ Item {
     property string control: "picker"
     property bool checked: false
     property bool isFocused: false
+    // Set false by SettingsScreen during a page switch so reused delegates
+    // do not animate the focus-border or toggle position when the new
+    // page's model data lands. Restored to true on the next event-loop
+    // tick so ordinary user navigation still animates.
+    property bool animateChanges: true
     // For `control: "action"` — short live-state string painted on the
     // right ("In progress", "Paused", or "" when idle). The screen
     // owns the binding; the field treats it as a plain caption.
@@ -57,6 +62,11 @@ Item {
         color: Theme.surfaceCard
         border.color: root.isFocused ? Theme.accent : Theme.borderMid
         border.width: root.isFocused ? Sizing.stroke(2) : Sizing.stroke(1)
+
+        Behavior on border.color {
+            enabled: Motion.enabled && root.animateChanges
+            ColorAnimation { duration: Motion.dur(Motion.settleMs) }
+        }
     }
 
     Text {
@@ -117,6 +127,11 @@ Item {
             // the always-on card behind the toggle a static pill
             // border read as chrome-on-chrome.
             color: root.checked ? Theme.accent : Theme.borderMid
+
+            Behavior on color {
+                enabled: Motion.enabled && root.animateChanges
+                ColorAnimation { duration: Motion.dur(Motion.settleMs) }
+            }
         }
 
         Rectangle {
@@ -126,6 +141,11 @@ Item {
             x: root.checked ? Sizing.px(toggle.width - width - Sizing.pctH(0.45)) : Sizing.pctH(0.45)
             anchors.verticalCenter: parent.verticalCenter
             color: Theme.textPrimary
+
+            Behavior on x {
+                enabled: Motion.enabled && root.animateChanges
+                NumberAnimation { duration: Motion.dur(Motion.settleMs); easing.type: Easing.OutCubic }
+            }
         }
     }
 

--- a/src/ui/components/SettingsField.qml
+++ b/src/ui/components/SettingsField.qml
@@ -62,13 +62,6 @@ Item {
         color: Theme.surfaceCard
         border.color: root.isFocused ? Theme.accent : Theme.borderMid
         border.width: root.isFocused ? Sizing.stroke(2) : Sizing.stroke(1)
-
-        Behavior on border.color {
-            enabled: Motion.enabled && root.animateChanges
-            ColorAnimation {
-                duration: Motion.dur(Motion.settleMs)
-            }
-        }
     }
 
     Text {
@@ -129,13 +122,6 @@ Item {
             // the always-on card behind the toggle a static pill
             // border read as chrome-on-chrome.
             color: root.checked ? Theme.accent : Theme.borderMid
-
-            Behavior on color {
-                enabled: Motion.enabled && root.animateChanges
-                ColorAnimation {
-                    duration: Motion.dur(Motion.settleMs)
-                }
-            }
         }
 
         Rectangle {
@@ -150,7 +136,7 @@ Item {
                 enabled: Motion.enabled && root.animateChanges
                 NumberAnimation {
                     duration: Motion.dur(Motion.settleMs)
-                    easing.type: Easing.OutCubic
+                    easing.type: Easing.OutQuad
                 }
             }
         }

--- a/src/ui/components/SettingsField.qml
+++ b/src/ui/components/SettingsField.qml
@@ -65,7 +65,9 @@ Item {
 
         Behavior on border.color {
             enabled: Motion.enabled && root.animateChanges
-            ColorAnimation { duration: Motion.dur(Motion.settleMs) }
+            ColorAnimation {
+                duration: Motion.dur(Motion.settleMs)
+            }
         }
     }
 
@@ -130,7 +132,9 @@ Item {
 
             Behavior on color {
                 enabled: Motion.enabled && root.animateChanges
-                ColorAnimation { duration: Motion.dur(Motion.settleMs) }
+                ColorAnimation {
+                    duration: Motion.dur(Motion.settleMs)
+                }
             }
         }
 
@@ -144,7 +148,10 @@ Item {
 
             Behavior on x {
                 enabled: Motion.enabled && root.animateChanges
-                NumberAnimation { duration: Motion.dur(Motion.settleMs); easing.type: Easing.OutCubic }
+                NumberAnimation {
+                    duration: Motion.dur(Motion.settleMs)
+                    easing.type: Easing.OutCubic
+                }
             }
         }
     }

--- a/src/ui/components/SettingsField.qml
+++ b/src/ui/components/SettingsField.qml
@@ -38,6 +38,14 @@ Item {
     // right ("In progress", "Paused", or "" when idle). The screen
     // owns the binding; the field treats it as a plain caption.
     property string actionStatus: ""
+    // Push-in cue, matching the tile vocabulary. The host increments this on
+    // accept; the focused row plays a one-shot tap (scale down then back). A
+    // tap rather than a held press because settings rows stay on screen (a
+    // picker opens a modal over the row, an action runs in place), so a held
+    // scale would look stuck. Toggle rows are exempt — the knob slide is their
+    // feedback — so they ignore the pulse below.
+    property int activatePulse: 0
+    property real _pressScale: 1.0
 
     signal hovered
     signal clicked
@@ -53,6 +61,35 @@ Item {
     // when one of the two is in flight — Core serialises them).
     opacity: enabled ? 1 : 0.4
     implicitHeight: Sizing.pctH(8)
+    scale: root._pressScale
+    transformOrigin: Item.Center
+
+    // One-shot push-in tap. Non-toggle rows only; the focused row plays it.
+    // `animateChanges` is false during a page switch (same gate the field's
+    // other animations use), so a reused delegate cannot tap as a new page
+    // mounts.
+    onActivatePulseChanged: {
+        if (root.isFocused && root.control !== "toggle" && root.animateChanges)
+            pressAnim.restart();
+    }
+
+    SequentialAnimation {
+        id: pressAnim
+        NumberAnimation {
+            target: root
+            property: "_pressScale"
+            to: Motion.rowPressScale
+            duration: Motion.dur(Motion.pressMs)
+            easing.type: Easing.OutQuad
+        }
+        NumberAnimation {
+            target: root
+            property: "_pressScale"
+            to: 1.0
+            duration: Motion.dur(Motion.settleMs)
+            easing.type: Easing.OutQuad
+        }
+    }
 
     Rectangle {
         id: surface

--- a/src/ui/components/Tile.qml
+++ b/src/ui/components/Tile.qml
@@ -94,8 +94,8 @@ Item {
     // tile is back at 1.0 before the screen is shown again.
     readonly property bool delegateSettling: parent.settling ?? false
     // `focusReady` gates whether this tile renders its focused styling at all
-    // (ring + focused cover ramp), not merely whether the ring fade animates.
-    // The host leaves it false until the screen's focus index is finalized
+    // (ring + focused cover ramp). The host leaves it false until the screen's
+    // focus index is finalized
     // (programmatic restore or first input). Before that, a tile that happens
     // to sit at the default index must not paint a ring, or the wrong tile
     // flashes focused for the frames before restore corrects the index.

--- a/src/ui/components/Tile.qml
+++ b/src/ui/components/Tile.qml
@@ -47,15 +47,19 @@ Item {
     // on the MiSTer software target it is a regression, not an
     // optimization.
     // qmllint enable missing-property compiler
-    // No focus scale bump. The earlier 1.06 scale on the focused tile
-    // forced a bilinear resample of the cover pixmap on every focus
-    // move and overflowed the cell by ~3% on each side, dirtying
-    // strips of up to four neighbours per press — under software
-    // rendering on MiSTer that read as choppy d-pad navigation on
-    // covered grids. The focus outline ring + caption + active-label
-    // already mark the selection clearly, so the size cue isn't worth
-    // the per-press repaint cost. See `docs/qml-gotchas.md` →
-    // "Software-renderer animation costs".
+    // No persistent focus scale. The earlier 1.06 scale held on every
+    // focused tile forced a bilinear resample of the cover pixmap on
+    // every d-pad move and overflowed the cell by ~3% on each side,
+    // dirtying strips of up to four neighbours per press. Under Qt's
+    // software adaptation on MiSTer that read as choppy navigation on
+    // covered grids. That scale was a persistent, per-focus-move cost
+    // across the whole visible grid.
+    //
+    // The activate/launch animations below are a different cost class:
+    // a one-shot transient triggered on a single tile at the moment of
+    // activation. The dirty rect is bounded to one cell for ~90-360ms
+    // total and neighbours are unaffected. See `docs/qml-gotchas.md` →
+    // "Software-renderer animation costs" for the full distinction.
     // Bottom caption strip (caption mode only). Single line, ellipsised
     // when long. Tints to `textPrimary` on the focused tile so the
     // selection reads at a glance even when the focus outline ring is
@@ -72,7 +76,23 @@ Item {
     readonly property bool delegateFavorite: parent.favorite !== 0
     // qmllint disable missing-property compiler
     readonly property bool delegateHidden: parent.hidden === true
-    // qmllint enable missing-property compiler
+    // Pulse counter forwarded by TileLoader — increment to trigger the
+    // push-in cue on the focused tile. Every button-like action (folder
+    // drill-in, system select, game launch) shares this single cue, so
+    // there is no separate launch animation. Default to 0 so hosts that
+    // do not wire it are silently no-ops.
+    readonly property int delegateActivatePulse: parent.activatePulse ?? 0
+    // `settling` is set true by the host screen when the screen becomes
+    // inactive (off-screen). Used to reset a held push-in scale so the
+    // tile is back at 1.0 before the screen is shown again.
+    readonly property bool delegateSettling: parent.settling ?? false
+    // `ringFadeReady` gates the focus-ring fade. The host screen leaves it
+    // false until the user takes control of focus (first input), so the
+    // programmatic focus reseat during state restore snaps instead of
+    // cross-fading the wrong tile's ring on load. Defaults true for hosts
+    // that do not wire it.
+    readonly property bool delegateRingFadeReady: parent.ringFadeReady ?? true
+    // qmllint enable missing-property
     property var layoutProfile: null
     readonly property var _surfaceProfile: root.layoutProfile && root.layoutProfile.surface ? root.layoutProfile.surface : null
     // Opt-in per-tile name caption. Off by default so Hub and Systems
@@ -98,6 +118,15 @@ Item {
     readonly property int _captionTextWidth: Math.min(root._captionTextMaxWidth, root._captionMeasuredWidth)
 
     readonly property bool _focusedSelection: root.delegateIsSelected && root.delegateIsFocused
+    // Ring opacity — fades 0→1 when focus lands, 1→0 when it leaves.
+    // The Behavior below animates transitions; initial binding eval does
+    // not trigger the Behavior, so a freshly-loaded focused delegate starts
+    // fully opaque without a fade-in delay. The two ring Rectangles use
+    // `opacity: root._ringOpacity` and `visible: root._ringOpacity > 0`
+    // so they paint during the fade and disappear once fully transparent.
+    // The fade is gated on `delegateRingFadeReady` so the programmatic
+    // focus reseat during state restore snaps instead of cross-fading.
+    property real _ringOpacity: root._focusedSelection ? 1.0 : 0.0
     // `coverKey` is the relative path under `resources/images/` without
     // extension — `systems/snes`, `categories/Consoles`, etc. The model
     // chooses the subdirectory; Tile is agnostic. Resources.coverUrl is
@@ -125,14 +154,81 @@ Item {
     // selection — used to suppress coverBase so the two renders don't stack
     // (which would double the effective opacity on hidden tiles).
     readonly property bool _focusCoverActive: root._focusedSelection && root._isTinted && coverFocus.status === Image.Ready
-    readonly property bool _hasCover: coverBase.status === Image.Ready || coverFocus.status === Image.Ready
-    readonly property bool _fallbackVisible: !root.showCaption && !root._hasCover && !root._coverPending
+    // Show the procedural name fallback only when the icon genuinely failed
+    // to load (no such logo), never while it is merely decoding. During the
+    // Loading/Null window the slot stays blank so the name does not flash in
+    // before the icon pops in. coverBase always has a real source when not
+    // _coverPending, so it reliably reaches Ready or Error.
+    readonly property bool _fallbackVisible: !root.showCaption && !root._coverPending && coverBase.status === Image.Error
     readonly property int _fallbackTextSize: root._systemCover ? Sizing.fontSize(5.8) : Sizing.fontSize(2.4)
     readonly property int _fallbackMinimumTextSize: root._systemCover ? Sizing.fontSize(2.8) : Sizing.fontSize(2.4)
     readonly property bool _startupTraceResource: root.delegateCoverKey.startsWith("categories/") || root.delegateCoverKey === "icons/PlayOutline" || root.delegateCoverKey === "icons/HeartOutline" || root.delegateCoverKey === "icons/History" || root.delegateCoverKey === "icons/Settings"
     property double _startupTraceLoadStartedAt: 0
 
     anchors.fill: parent
+    // One-shot push-in scale, shared by every button-like action. The
+    // persistent 1.06 focus scale was removed; this is a bounded transient
+    // on a single tile at activation time. See the comment above for the
+    // cost-profile distinction.
+    property real _activateScale: 1.0
+    // Public read for siblings that must track this scale (e.g.
+    // PagedGrid's placeholderCard, which sits behind TileLoader).
+    readonly property real cardScale: root._activateScale
+    scale: root._activateScale
+    transformOrigin: Item.Center
+
+    onDelegateActivatePulseChanged: {
+        if (root._focusedSelection)
+            activateAnim.restart();
+    }
+
+    // Bleed guard — stop and reset if the delegate is rebound to a
+    // different entry while an animation is in flight (rapid-scroll +
+    // accept on the same frame). delegateName changes only on a genuine
+    // content rebind, not on cover-load completion, so this never cuts
+    // a legitimate same-tile cue short. DeferredAction's lead means the
+    // cue usually completes before teardown anyway; this is belt-and-suspenders.
+    onDelegateNameChanged: {
+        activateAnim.stop();
+        root._activateScale = 1.0;
+    }
+
+    // Reset scale when the host screen goes inactive so the tile is at
+    // 1.0 before it is shown again. The single-leg push-in holds at
+    // pressScale; without this reset, returning to a screen with a
+    // persistent delegate would show a permanently shrunken tile.
+    onDelegateSettlingChanged: {
+        if (root.delegateSettling) {
+            activateAnim.stop();
+            root._activateScale = 1.0;
+        }
+    }
+
+    // Ring fade Behavior — see _ringOpacity above.
+    Behavior on _ringOpacity {
+        enabled: Motion.enabled && root.delegateRingFadeReady
+        NumberAnimation {
+            duration: Motion.dur(Motion.settleMs)
+            easing.type: Easing.OutQuad
+        }
+    }
+
+    // Push in and hold — the single cue for every button-like action,
+    // whether the press navigates forward or launches a game. The screen
+    // changes while the tile is held at pressScale; the host screen's
+    // `settling` flag resets scale to 1.0 off-screen so the tile is clean
+    // when the user returns. No return-to-normal leg — the user is
+    // navigating away; a bounce-back was visible and unwanted because the
+    // source screen is held visible for the full 300 ms deferred-flip grace.
+    NumberAnimation {
+        id: activateAnim
+        target: root
+        property: "_activateScale"
+        to: Motion.pressScale
+        duration: Motion.dur(Motion.pressMs)
+        easing.type: Easing.OutQuad
+    }
+
     Component.onCompleted: {
         // Self-check the parent contract. Logs once at construction so
         // a future caller that drops Tile into a non-conforming wrapper
@@ -193,6 +289,18 @@ Item {
     // step visibly at the corners (see QTBUG-123210). Both rectangles
     // are still inside the card edge by `_outlineGap`, so the ring
     // never bleeds past the cell bounds.
+    //
+    // Fade mechanics: only the accent rect carries `opacity:
+    // _ringOpacity`. The inner mask stays fully opaque (`opacity: 1`)
+    // and is only hidden when the ring is invisible. On Qt's software
+    // renderer, `opacity` on an `Item` is NOT flattened to a texture
+    // first (that requires `layer.enabled`, which is forbidden here) —
+    // it propagates multiplicatively to each child independently. A
+    // shared-parent approach would therefore make the inner mask
+    // semi-transparent too, letting the accent fill bleed through the
+    // centre of the tile during the fade. Keeping the mask at full
+    // opacity ensures it always occludes the accent exactly in the ring
+    // band.
     Rectangle {
         id: focusRingOuter
 
@@ -201,7 +309,8 @@ Item {
         color: Theme.accent
         radius: Math.max(0, root._tileCornerRadius - root._outlineGap)
         antialiasing: true
-        visible: root._focusedSelection
+        opacity: root._ringOpacity
+        visible: root._ringOpacity > 0
     }
 
     Rectangle {
@@ -215,7 +324,9 @@ Item {
         // negative-radius garbage.
         radius: Math.max(0, focusRingOuter.radius - root._outlineWidth)
         antialiasing: true
-        visible: root._focusedSelection
+        // Always fully opaque so it cleanly occludes the accent in the
+        // ring centre throughout the fade — see comment above.
+        visible: root._ringOpacity > 0
     }
 
     // Icon area — two stacked Images for the unfocused and focused tint ramps.
@@ -365,14 +476,15 @@ Item {
         visible: root.delegateHidden
     }
 
-    // Non-caption procedural fallback. Sits at the same geometry as
-    // the cover and snaps to the cover the moment Image.status hits
-    // Ready. Missing system logos use a larger fitted wordmark-style
-    // treatment so the tile reads as intentional text artwork, not a
-    // broken-image placeholder. In caption mode this is suppressed —
-    // the bottom caption already shows the name and the hourglass
-    // above signals load progress, so a wrapping copy of the name in
-    // this slot is redundant.
+    // Non-caption procedural fallback. Sits at the same geometry as the
+    // cover and appears only when the icon fails to load (Image.Error), not
+    // while it is decoding — the slot stays blank until the icon pops in so
+    // the name never flashes in first. Missing system logos use a larger
+    // fitted wordmark-style treatment so the tile reads as intentional text
+    // artwork, not a broken-image placeholder. In caption mode this is
+    // suppressed — the bottom caption already shows the name and the
+    // hourglass above signals load progress, so a wrapping copy of the name
+    // in this slot is redundant.
     Text {
         anchors.fill: coverBase
         anchors.margins: root._systemCover ? Sizing.pctH(1) : 0

--- a/src/ui/components/Tile.qml
+++ b/src/ui/components/Tile.qml
@@ -82,6 +82,13 @@ Item {
     // there is no separate launch animation. Default to 0 so hosts that
     // do not wire it are silently no-ops.
     readonly property int delegateActivatePulse: parent.activatePulse ?? 0
+    // Release counter forwarded by TileLoader — increment to settle the
+    // push-in cue back to rest (scale 1.0). Fired only after a launch that
+    // keeps the frontend on the same screen (e.g. an Audio track that does
+    // not take the FPGA); forward navigation never fires it because the
+    // screen transition + `settling` already reset the held scale off-screen.
+    // Defaults to 0 so hosts that do not wire it are silently no-ops.
+    readonly property int delegateReleasePulse: parent.releasePulse ?? 0
     // `settling` is set true by the host screen when the screen becomes
     // inactive (off-screen). Used to reset a held push-in scale so the
     // tile is back at 1.0 before the screen is shown again.
@@ -92,6 +99,14 @@ Item {
     // cross-fading the wrong tile's ring on load. Defaults true for hosts
     // that do not wire it.
     readonly property bool delegateRingFadeReady: parent.ringFadeReady ?? true
+    // `focusReady` gates whether this tile renders its focused styling at all
+    // (ring + focused cover ramp), not merely whether the ring fade animates.
+    // The host leaves it false until the screen's focus index is finalized
+    // (programmatic restore or first input). Before that, a tile that happens
+    // to sit at the default index must not paint a ring, or the wrong tile
+    // flashes focused for the frames before restore corrects the index.
+    // Defaults true for hosts that do not wire it.
+    readonly property bool delegateFocusReady: parent.focusReady ?? true
     // qmllint enable missing-property
     property var layoutProfile: null
     readonly property var _surfaceProfile: root.layoutProfile && root.layoutProfile.surface ? root.layoutProfile.surface : null
@@ -117,7 +132,14 @@ Item {
     readonly property int _captionMeasuredWidth: Math.ceil(Math.max(captionMetrics.advanceWidth, captionMetrics.boundingRect.width) + root._textMeasureSlack)
     readonly property int _captionTextWidth: Math.min(root._captionTextMaxWidth, root._captionMeasuredWidth)
 
-    readonly property bool _focusedSelection: root.delegateIsSelected && root.delegateIsFocused
+    // Focused styling (ring + focused cover ramp) is withheld until the host
+    // marks focus ready via `delegateFocusReady`. This keeps a default-index
+    // tile from painting a ring during the window between first paint and the
+    // programmatic restore that finalizes the real selection — the source of
+    // the load-time "wrong tile flashes focused" bug. Once ready, the correct
+    // tile lights up; the `delegateRingFadeReady` gate below still governs
+    // whether that reveal snaps (restore) or cross-fades (user navigation).
+    readonly property bool _focusedSelection: root.delegateIsSelected && root.delegateIsFocused && root.delegateFocusReady
     // Ring opacity — fades 0→1 when focus lands, 1→0 when it leaves.
     // The Behavior below animates transitions; initial binding eval does
     // not trigger the Behavior, so a freshly-loaded focused delegate starts
@@ -177,9 +199,34 @@ Item {
     scale: root._activateScale
     transformOrigin: Item.Center
 
+    // Fire the push-in cue only for a genuine activation, never as a
+    // side effect of delegate creation. A freshly built delegate sees its
+    // `delegateActivatePulse` resolve from the `?? 0` fallback up to the
+    // current pulse, which fires this handler once during construction. When
+    // such a delegate is momentarily the focused selection (e.g. the Settings
+    // category grid rebuilt with a stale currentIndex on a page switch), that
+    // spurious change would restart the animation and leave the wrong tile
+    // pushed in. `_mounted` flips true one event-loop pass after completion,
+    // after every construction-time transient has settled, so only real pulse
+    // increments (always delivered well after mount) play the cue.
+    property bool _mounted: false
     onDelegateActivatePulseChanged: {
-        if (root._focusedSelection)
+        if (root._mounted && root._focusedSelection)
             activateAnim.restart();
+    }
+
+    // Settle the held push-in back to rest. Used when the activation kept us
+    // on the same screen (a launcher that did not take the FPGA), so the cue
+    // does not stay stuck pushed in. The `_mounted` guard ignores any
+    // construction-time pulse transient, matching the activate handler above.
+    onDelegateReleasePulseChanged: {
+        // Only the focused selection can be holding a push-in, so only it needs
+        // to settle back — matches the activate handler's gate and avoids
+        // starting a redundant animation on every tile in the grid.
+        if (root._mounted && root._focusedSelection) {
+            activateAnim.stop();
+            releaseAnim.restart();
+        }
     }
 
     // Bleed guard — stop and reset if the delegate is rebound to a
@@ -229,6 +276,18 @@ Item {
         easing.type: Easing.OutQuad
     }
 
+    // Release leg — settles the held push-in back to rest after a launch that
+    // stays on the page. Stops `activateAnim` first so a release that lands
+    // mid-push does not fight it. See `onDelegateReleasePulseChanged`.
+    NumberAnimation {
+        id: releaseAnim
+        target: root
+        property: "_activateScale"
+        to: 1.0
+        duration: Motion.dur(Motion.settleMs)
+        easing.type: Easing.OutQuad
+    }
+
     Component.onCompleted: {
         // Self-check the parent contract. Logs once at construction so
         // a future caller that drops Tile into a non-conforming wrapper
@@ -237,6 +296,11 @@ Item {
         // qmllint disable missing-property compiler
         if (typeof parent.isSelected !== "boolean" || typeof parent.isFocused !== "boolean" || typeof parent.name !== "string" || typeof parent.coverKey !== "string")
             console.warn("Tile: parent does not satisfy the delegate contract " + "(expected isSelected:bool, isFocused:bool, " + "name:string, coverKey:string)");
+        // Defer one event-loop pass so construction-time activate-pulse
+        // transients (see onDelegateActivatePulseChanged) do not fire the cue.
+        Qt.callLater(() => {
+            root._mounted = true;
+        });
     }
 
     function _startupTrace(stage: string, details: string): void {

--- a/src/ui/components/Tile.qml
+++ b/src/ui/components/Tile.qml
@@ -93,12 +93,6 @@ Item {
     // inactive (off-screen). Used to reset a held push-in scale so the
     // tile is back at 1.0 before the screen is shown again.
     readonly property bool delegateSettling: parent.settling ?? false
-    // `ringFadeReady` gates the focus-ring fade. The host screen leaves it
-    // false until the user takes control of focus (first input), so the
-    // programmatic focus reseat during state restore snaps instead of
-    // cross-fading the wrong tile's ring on load. Defaults true for hosts
-    // that do not wire it.
-    readonly property bool delegateRingFadeReady: parent.ringFadeReady ?? true
     // `focusReady` gates whether this tile renders its focused styling at all
     // (ring + focused cover ramp), not merely whether the ring fade animates.
     // The host leaves it false until the screen's focus index is finalized
@@ -136,19 +130,9 @@ Item {
     // marks focus ready via `delegateFocusReady`. This keeps a default-index
     // tile from painting a ring during the window between first paint and the
     // programmatic restore that finalizes the real selection — the source of
-    // the load-time "wrong tile flashes focused" bug. Once ready, the correct
-    // tile lights up; the `delegateRingFadeReady` gate below still governs
-    // whether that reveal snaps (restore) or cross-fades (user navigation).
+    // the load-time "wrong tile flashes focused" bug. The focus ring snaps on
+    // and off with selection; the only per-tile motion is the push-in cue.
     readonly property bool _focusedSelection: root.delegateIsSelected && root.delegateIsFocused && root.delegateFocusReady
-    // Ring opacity — fades 0→1 when focus lands, 1→0 when it leaves.
-    // The Behavior below animates transitions; initial binding eval does
-    // not trigger the Behavior, so a freshly-loaded focused delegate starts
-    // fully opaque without a fade-in delay. The two ring Rectangles use
-    // `opacity: root._ringOpacity` and `visible: root._ringOpacity > 0`
-    // so they paint during the fade and disappear once fully transparent.
-    // The fade is gated on `delegateRingFadeReady` so the programmatic
-    // focus reseat during state restore snaps instead of cross-fading.
-    property real _ringOpacity: root._focusedSelection ? 1.0 : 0.0
     // `coverKey` is the relative path under `resources/images/` without
     // extension — `systems/snes`, `categories/Consoles`, etc. The model
     // chooses the subdirectory; Tile is agnostic. Resources.coverUrl is
@@ -251,15 +235,6 @@ Item {
         }
     }
 
-    // Ring fade Behavior — see _ringOpacity above.
-    Behavior on _ringOpacity {
-        enabled: Motion.enabled && root.delegateRingFadeReady
-        NumberAnimation {
-            duration: Motion.dur(Motion.settleMs)
-            easing.type: Easing.OutQuad
-        }
-    }
-
     // Push in and hold — the single cue for every button-like action,
     // whether the press navigates forward or launches a game. The screen
     // changes while the tile is held at pressScale; the host screen's
@@ -352,19 +327,9 @@ Item {
     // rounded *borders* are tessellated without subpixel coverage and
     // step visibly at the corners (see QTBUG-123210). Both rectangles
     // are still inside the card edge by `_outlineGap`, so the ring
-    // never bleeds past the cell bounds.
-    //
-    // Fade mechanics: only the accent rect carries `opacity:
-    // _ringOpacity`. The inner mask stays fully opaque (`opacity: 1`)
-    // and is only hidden when the ring is invisible. On Qt's software
-    // renderer, `opacity` on an `Item` is NOT flattened to a texture
-    // first (that requires `layer.enabled`, which is forbidden here) —
-    // it propagates multiplicatively to each child independently. A
-    // shared-parent approach would therefore make the inner mask
-    // semi-transparent too, letting the accent fill bleed through the
-    // centre of the tile during the fade. Keeping the mask at full
-    // opacity ensures it always occludes the accent exactly in the ring
-    // band.
+    // never bleeds past the cell bounds. The ring is an accent rect with a
+    // surface-colored inner mask punched out of its center; both snap on and
+    // off with `_focusedSelection` (no fade).
     Rectangle {
         id: focusRingOuter
 
@@ -373,8 +338,7 @@ Item {
         color: Theme.accent
         radius: Math.max(0, root._tileCornerRadius - root._outlineGap)
         antialiasing: true
-        opacity: root._ringOpacity
-        visible: root._ringOpacity > 0
+        visible: root._focusedSelection
     }
 
     Rectangle {
@@ -388,9 +352,7 @@ Item {
         // negative-radius garbage.
         radius: Math.max(0, focusRingOuter.radius - root._outlineWidth)
         antialiasing: true
-        // Always fully opaque so it cleanly occludes the accent in the
-        // ring centre throughout the fade — see comment above.
-        visible: root._ringOpacity > 0
+        visible: root._focusedSelection
     }
 
     // Icon area — two stacked Images for the unfocused and focused tint ramps.

--- a/src/ui/components/TileLoader.qml
+++ b/src/ui/components/TileLoader.qml
@@ -37,11 +37,6 @@ Loader {
     // to 1.0 off-screen so a held push-in does not persist when the user
     // returns to the screen.
     property bool settling: false
-    // Gates the Tile focus-ring fade. The host leaves it false until the
-    // user takes control of focus (first input) so the programmatic reseat
-    // during state restore snaps instead of cross-fading. Default true so
-    // hosts that do not wire it keep the fade on every focus change.
-    property bool ringFadeReady: true
     // Gates whether the Tile renders its focused styling at all (ring +
     // focused cover ramp). The host leaves it false until the screen's focus
     // index is finalized (restore or first input) so a default-index tile

--- a/src/ui/components/TileLoader.qml
+++ b/src/ui/components/TileLoader.qml
@@ -27,6 +27,11 @@ Loader {
     // hosts can safely forward the same counter to every TileLoader in a
     // row or grid.
     property int activatePulse: 0
+    // Optional release counter — incremented by the host to settle the
+    // push-in cue back to rest after a launch that keeps the frontend on the
+    // same screen. Tile.qml reads it via `parent.releasePulse`. Default 0 so
+    // hosts that do not wire it are no-ops.
+    property int releasePulse: 0
     // Set true while the host screen is inactive (off-screen). Tile.qml
     // watches this via `delegateSettling` to reset `_activateScale` back
     // to 1.0 off-screen so a held push-in does not persist when the user
@@ -37,4 +42,10 @@ Loader {
     // during state restore snaps instead of cross-fading. Default true so
     // hosts that do not wire it keep the fade on every focus change.
     property bool ringFadeReady: true
+    // Gates whether the Tile renders its focused styling at all (ring +
+    // focused cover ramp). The host leaves it false until the screen's focus
+    // index is finalized (restore or first input) so a default-index tile
+    // never paints a ring before the real selection lands. Default true so
+    // hosts that do not wire it focus normally.
+    property bool focusReady: true
 }

--- a/src/ui/components/TileLoader.qml
+++ b/src/ui/components/TileLoader.qml
@@ -20,4 +20,21 @@ Loader {
     required property string coverKey
     property int favorite: 0
     property bool hidden: false
+    // Optional pulse counter — incremented by the host when the user
+    // commits on the focused tile (forward navigation or game launch, which
+    // share one push-in cue). Tile.qml reads it via `parent.activatePulse`
+    // and only fires its animation when it is the focused selection, so
+    // hosts can safely forward the same counter to every TileLoader in a
+    // row or grid.
+    property int activatePulse: 0
+    // Set true while the host screen is inactive (off-screen). Tile.qml
+    // watches this via `delegateSettling` to reset `_activateScale` back
+    // to 1.0 off-screen so a held push-in does not persist when the user
+    // returns to the screen.
+    property bool settling: false
+    // Gates the Tile focus-ring fade. The host leaves it false until the
+    // user takes control of focus (first input) so the programmatic reseat
+    // during state restore snaps instead of cross-fading. Default true so
+    // hosts that do not wire it keep the fade on every focus change.
+    property bool ringFadeReady: true
 }

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -61,6 +61,7 @@ MediaListScreen {
         return systemId !== "" && path !== "" ? systemId + "\n" + path : "";
     }
     loadDetailForIndex: index => Browse.GamesModel.load_description_at(index)
+    peekDetailForIndex: index => Browse.GamesModel.peek_description_at(index)
     clearDetailAction: () => Browse.GamesModel.clear_current_detail()
     restoreSelectionPath: () => {
         const selected = Browse.GamesState.selected_at_level;
@@ -209,6 +210,10 @@ MediaListScreen {
                 const idx = _launchIndex;
                 _launchIndex = -1;
                 Browse.GamesModel.launch_at(idx);
+                // Settle the push-in back to rest. Invisible when the launch
+                // takes the FPGA or kills us; prevents a stuck pushed-in tile
+                // when the launcher stays on the page (e.g. an Audio track).
+                games.releaseActivate();
             }
         }
     }

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -109,6 +109,9 @@ MediaListScreen {
         pressCommit.arm();
     }
     cancelAction: () => {
+        // Disarm any pending accept so a press-then-back inside the deferred
+        // window cannot launch/navigate after the user has backed out.
+        pressCommit.stop();
         games.flushSelectedPersist();
         if (games._atFolderLevel())
             games.requestNavigateOutOfFolder();

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -4,6 +4,7 @@
 
 import QtQuick
 import Zaparoo.Theme
+import Zaparoo.Ui
 import Zaparoo.Browse as Browse
 
 // cxx-qt 0.8 patches `isFinal: true` on singleton properties but the
@@ -88,13 +89,23 @@ MediaListScreen {
     acceptAction: index => {
         const entryType = Browse.GamesModel.entry_type_at(index);
         if ((entryType === "directory" || entryType === "root") && !Browse.GamesModel.is_media_capable_at(index)) {
+            // Persist synchronously (MiSTer may be killed at any time), then
+            // play the cue and defer the navigation signal so the push-in
+            // completes on a static scene before the model reload starts.
             games.flushSelectedPersist();
-            games.requestNavigateIntoFolder(Browse.GamesModel.path_at(index));
+            games.pulseActivate();
+            pressCommit._folderPath = Browse.GamesModel.path_at(index);
+            pressCommit.arm();
             return;
         }
+        // State persistence is synchronous; launch_at is deferred so the
+        // push-in cue plays on a fully static scene before Core takes the
+        // FPGA. Launch shares the same push-in as forward navigation.
         games._scheduleSelectedPersist(Browse.GamesModel.path_at(index));
         games.flushSelectedPersist();
-        Browse.GamesModel.launch_at(index);
+        games.pulseActivate();
+        pressCommit._launchIndex = index;
+        pressCommit.arm();
     }
     cancelAction: () => {
         games.flushSelectedPersist();
@@ -184,6 +195,23 @@ MediaListScreen {
     // 250 ms interval is shorter than a deliberate single tap → hold
     // gap, so isolated presses still persist quickly.
     property string _pendingSelectedPath: ""
+
+    DeferredAction {
+        id: pressCommit
+        property string _folderPath: ""
+        property int _launchIndex: -1
+        onDeferred: {
+            if (_folderPath !== "") {
+                const p = _folderPath;
+                _folderPath = "";
+                games.requestNavigateIntoFolder(p);
+            } else if (_launchIndex >= 0) {
+                const idx = _launchIndex;
+                _launchIndex = -1;
+                Browse.GamesModel.launch_at(idx);
+            }
+        }
+    }
 
     Timer {
         id: persistDebounce

--- a/src/ui/screens/HubScreen.qml
+++ b/src/ui/screens/HubScreen.qml
@@ -96,11 +96,9 @@ Item {
     // animation. Forwarded to every TileLoader; only the focused+selected
     // Tile fires its animation.
     property int activatePulse: 0
-    // False until the user takes control of focus (first input). Forwarded
-    // to the tiles as `ringFadeReady` so the programmatic focus reseat that
-    // state restore performs on load snaps instead of cross-fading the
-    // wrong tile's focus ring. Every user-driven focus move happens after
-    // this is armed, so navigation cross-fades exactly as before.
+    // False until the user takes control of focus (first input). Combined
+    // with `_restoreDone` into `_focusReady`, which gates whether the tiles
+    // render focus at all.
     property bool _focusArmed: false
     // Set true once the load-time category restore has run. Combined with
     // `_focusArmed` into `_focusReady`, which gates whether the tiles render
@@ -570,7 +568,6 @@ Item {
                     hidden: cellItem.modelData.hidden ?? false
                     activatePulse: hub.activatePulse
                     settling: !hub.visible
-                    ringFadeReady: hub._focusArmed
                     focusReady: hub._focusReady
                 }
 
@@ -658,7 +655,6 @@ Item {
                     coverKey: actionCellItem.modelData.coverKey
                     activatePulse: hub.activatePulse
                     settling: !hub.visible
-                    ringFadeReady: hub._focusArmed
                     focusReady: hub._focusReady
                 }
 

--- a/src/ui/screens/HubScreen.qml
+++ b/src/ui/screens/HubScreen.qml
@@ -102,6 +102,13 @@ Item {
     // wrong tile's focus ring. Every user-driven focus move happens after
     // this is armed, so navigation cross-fades exactly as before.
     property bool _focusArmed: false
+    // Set true once the load-time category restore has run. Combined with
+    // `_focusArmed` into `_focusReady`, which gates whether the tiles render
+    // focus at all — so the action row's default Resume selection never paints
+    // a ring during the window before `restoreFromCategoriesReset` corrects
+    // focus to the saved tile on a cold start.
+    property bool _restoreDone: false
+    readonly property bool _focusReady: hub._focusArmed || hub._restoreDone
     // Source-row index from the most recent cross. Used to make a
     // Down → Up (or Up → Down) round-trip return to the originating
     // tile, which the centered visual-nearest mapping in `_mapCrossRow`
@@ -235,6 +242,10 @@ Item {
     // category — otherwise the visible focus drifts off whichever
     // screen the user is on.
     function restoreFromCategoriesReset(): void {
+        // Focus is now being finalized from persisted state; let the tiles
+        // render focus from here on (snapped, since `_focusArmed` is still
+        // false until the first user input).
+        hub._restoreDone = true;
         const savedCategory = CategoryIds.canonicalize(Browse.HubState.category);
         const idx = savedCategory === "" ? -1 : Browse.CategoriesModel.index_for_category(savedCategory);
         const chosenCategoryIndex = idx >= 0 ? idx : 0;
@@ -270,6 +281,14 @@ Item {
         // point past the new category list).
         hub._crossSavedIndex = -1;
 
+        // Cold boot before Core delivers the catalog: focus was seated above
+        // (and `_restoreDone` set, so the focus ring paints immediately
+        // instead of waiting for the connection), but the set_category
+        // cascade needs the real catalog. Defer it — this function re-runs
+        // on CategoriesModel.onModelReset once the catalog lands, and the
+        // cascade fires then.
+        if (Browse.CategoriesModel.count <= 0)
+            return;
         if (Browse.SystemsModel.current_category === chosenCategory && Browse.SystemsModel.count > 0)
             return;
         Browse.SystemsModel.set_category(chosenCategory);
@@ -552,6 +571,7 @@ Item {
                     activatePulse: hub.activatePulse
                     settling: !hub.visible
                     ringFadeReady: hub._focusArmed
+                    focusReady: hub._focusReady
                 }
 
                 MouseArea {
@@ -639,6 +659,7 @@ Item {
                     activatePulse: hub.activatePulse
                     settling: !hub.visible
                     ringFadeReady: hub._focusArmed
+                    focusReady: hub._focusReady
                 }
 
                 MouseArea {

--- a/src/ui/screens/HubScreen.qml
+++ b/src/ui/screens/HubScreen.qml
@@ -92,6 +92,16 @@ Item {
     property int currentRow: 1
     // Index within the active row. Resume is first while optimistic/history is unknown.
     property int currentIndex: 0
+    // Incremented on each Accept so the focused tile plays its push-in
+    // animation. Forwarded to every TileLoader; only the focused+selected
+    // Tile fires its animation.
+    property int activatePulse: 0
+    // False until the user takes control of focus (first input). Forwarded
+    // to the tiles as `ringFadeReady` so the programmatic focus reseat that
+    // state restore performs on load snaps instead of cross-fading the
+    // wrong tile's focus ring. Every user-driven focus move happens after
+    // this is armed, so navigation cross-fades exactly as before.
+    property bool _focusArmed: false
     // Source-row index from the most recent cross. Used to make a
     // Down → Up (or Up → Down) round-trip return to the originating
     // tile, which the centered visual-nearest mapping in `_mapCrossRow`
@@ -375,6 +385,7 @@ Item {
     function _focusCategory(index: int): void {
         if (index < 0 || index >= hub.visibleCategoryEntries.length)
             return;
+        hub._focusArmed = true;
         hub.currentRow = 0;
         hub.currentIndex = index;
         // Mouse focus is a deliberate landing on a specific tile — any
@@ -386,14 +397,17 @@ Item {
     function _focusAction(index: int): void {
         if (index < 0 || index >= hub.actionEntries.length)
             return;
+        hub._focusArmed = true;
         hub.currentRow = 1;
         hub.currentIndex = index;
         hub._crossSavedIndex = -1;
         hub._commitActionSelection();
     }
 
-    function _activateCurrent(): void {
-        hub._commitCurrent();
+    // Emit the navigation signal for the currently selected entry.
+    // Separated from _activateCurrent so DeferredAction can call it
+    // after the push-in cue has had time to play.
+    function _emitActivate(): void {
         if (hub.currentRow === 0) {
             // During optimistic boot the visible category row is backed
             // by localized placeholder labels. Accept the stable category
@@ -414,6 +428,12 @@ Item {
             hub.requestSettingsScreen();
     }
 
+    function _activateCurrent(): void {
+        hub.activatePulse++;
+        hub._commitCurrent();
+        pressCommit.arm();
+    }
+
     // Returns the bounding rect of the currently focused category cell,
     // mapped to hub coordinates. Used to anchor the context menu.
     function _currentCategoryCellRect(): rect {
@@ -424,6 +444,7 @@ Item {
     }
 
     function handleAction(action: string): void {
+        hub._focusArmed = true;
         if (action === "left") {
             if (hub._navigate(-1))
                 hub._commitCurrent();
@@ -437,7 +458,7 @@ Item {
             hub._activateCurrent();
         } else if (action === "cancel") {
             hub.requestQuit();
-        } else if (action === "write_card") {
+        } else if (action === "context_menu") {
             // Only open the context menu for real (non-placeholder) category
             // tiles — placeholders have no category to hide or scrape.
             if (hub.currentRow === 0 && hub.currentIndex < Browse.CategoriesModel.count)
@@ -446,6 +467,11 @@ Item {
     }
 
     // ── Visual tree ───────────────────────────────────────────────────────────
+
+    DeferredAction {
+        id: pressCommit
+        onDeferred: hub._emitActivate()
+    }
 
     Item {
         id: categoriesRow
@@ -523,6 +549,9 @@ Item {
                     name: cellItem.modelData.name
                     coverKey: cellItem.modelData.coverKey
                     hidden: cellItem.modelData.hidden ?? false
+                    activatePulse: hub.activatePulse
+                    settling: !hub.visible
+                    ringFadeReady: hub._focusArmed
                 }
 
                 MouseArea {
@@ -607,6 +636,9 @@ Item {
                     isFocused: hub.currentRow === 1
                     name: actionCellItem.modelData.text
                     coverKey: actionCellItem.modelData.coverKey
+                    activatePulse: hub.activatePulse
+                    settling: !hub.visible
+                    ringFadeReady: hub._focusArmed
                 }
 
                 MouseArea {

--- a/src/ui/screens/MediaListScreen.qml
+++ b/src/ui/screens/MediaListScreen.qml
@@ -72,6 +72,7 @@ Item {
     property alias activeLabel: activeLabel
 
     property bool transitioning: false
+    property bool active: true
     property bool gridFocused: true
     property bool optimisticLoading: false
     property bool detailRapidScrollActive: false
@@ -126,6 +127,17 @@ Item {
         if (typeof root.onListLayoutEntered === "function")
             root.onListLayoutEntered();
         focusedDetail.requestNow();
+    }
+
+    // Layout-aware pulse routing. In grid layout this forwards to the
+    // PagedGrid tile; in list layout it increments the BrowseListDetailView
+    // pulse so the selected row fires its activate nudge. The same push-in
+    // cue serves both forward navigation and game launch.
+    function pulseActivate(): void {
+        if (root._listLayout)
+            listCard.activatePulse++;
+        else
+            mediaGrid.pulseActivate();
     }
 
     function _count(): int {
@@ -316,10 +328,13 @@ Item {
                     root.mediaModel.fetch_more();
                 return;
             }
-            if (typeof root.acceptAction === "function")
+            if (typeof root.acceptAction === "function") {
                 root.acceptAction(mediaGrid.currentIndex);
-            else
-                root.mediaModel.launch_at(mediaGrid.currentIndex);
+            } else {
+                root.pulseActivate();
+                defaultLaunchCommit._idx = mediaGrid.currentIndex;
+                defaultLaunchCommit.arm();
+            }
         } else if (action === "context_menu") {
             if (mediaGrid.itemCount > 0) {
                 const idx = mediaGrid.currentIndex;
@@ -334,6 +349,21 @@ Item {
                 root.cancelAction();
             else
                 root.requestHubScreen();
+        }
+    }
+
+    // Defers the default launch_at call so the push-in cue (pulseActivate)
+    // completes on a static scene before Core takes the FPGA.
+    // Only used when no `acceptAction` override is provided (Favorites,
+    // Recents). GamesScreen owns its own pressCommit with folder routing.
+    DeferredAction {
+        id: defaultLaunchCommit
+        property int _idx: -1
+        onDeferred: {
+            const i = _idx;
+            _idx = -1;
+            if (i >= 0 && root.mediaModel !== null)
+                root.mediaModel.launch_at(i);
         }
     }
 
@@ -390,6 +420,8 @@ Item {
         detailTags: root._detailTags()
         detailLoading: root._detailLoading()
         detailSuppressed: root.detailRapidScrollActive
+        listRapidScrollActive: root.detailRapidScrollActive
+        screenSettling: !root.active
         detailLoadingText: root.detailLoadingText
         detailCanPreviousImage: root.detailCanPreviousImage
         detailCanNextImage: root.detailCanNextImage
@@ -417,6 +449,7 @@ Item {
         anchors.bottom: parent.bottom
         anchors.bottomMargin: root.gridBottomMargin
         focused: root.gridFocused
+        screenSettling: !root.active
         model: root.mediaModel
         delegate: Tile {
             layoutProfile: root._gridLayoutProfile

--- a/src/ui/screens/MediaListScreen.qml
+++ b/src/ui/screens/MediaListScreen.qml
@@ -148,8 +148,8 @@ Item {
 
     // Layout-aware pulse routing. In grid layout this forwards to the
     // PagedGrid tile; in list layout it increments the BrowseListDetailView
-    // pulse so the selected row fires its activate nudge. The same push-in
-    // cue serves both forward navigation and game launch.
+    // pulse so the selected row fires its push-in. The same push-in cue
+    // serves both forward navigation and game launch.
     function pulseActivate(): void {
         if (root._listLayout)
             listCard.activatePulse++;
@@ -462,7 +462,6 @@ Item {
         detailTags: root._detailTags()
         detailLoading: root._detailLoading()
         detailSuppressed: root.detailRapidScrollActive
-        listRapidScrollActive: root.detailRapidScrollActive
         screenSettling: !root.active
         detailLoadingText: root.detailLoadingText
         detailCanPreviousImage: root.detailCanPreviousImage

--- a/src/ui/screens/MediaListScreen.qml
+++ b/src/ui/screens/MediaListScreen.qml
@@ -40,6 +40,11 @@ Item {
     property bool detailReserveImageNav: false
     property var detailIdentityForIndex: null
     property var loadDetailForIndex: null
+    // Optional immediate (non-debounced) detail hook. Defaults (when null) to
+    // the model's `peek_detail_at`; GamesScreen overrides it with
+    // `peek_description_at`. Keeps the detail table identity-correct the instant
+    // the focus moves, so it never shows the previous row's metadata.
+    property var peekDetailForIndex: null
     property var clearDetailAction: null
     property var retryAction: null
     property var acceptAction: null
@@ -75,6 +80,18 @@ Item {
     property bool active: true
     property bool gridFocused: true
     property bool optimisticLoading: false
+    // False until the user takes control of focus (first input). Forwarded to
+    // the grid tiles as `ringFadeReady` so the programmatic restore reseat
+    // snaps instead of cross-fading the wrong tile's ring.
+    property bool _focusArmed: false
+    // Set true once the selection has been finalized from persisted state
+    // (restoreSelection for favorites/recents; Main.qml's
+    // `_setGamesRestoreIndex` for games). Combined with `_focusArmed` into
+    // `_focusReady`, which gates whether the grid tiles and list rows render
+    // selection at all - so the default index 0 never paints before restore
+    // lands on a cold-start / forward entry.
+    property bool _restoreDone: false
+    readonly property bool _focusReady: root._focusArmed || root._restoreDone
     property bool detailRapidScrollActive: false
     property bool detailRapidIndicatorActive: detailRapidScrollActive
     property string detailRapidScrollAction: ""
@@ -140,6 +157,18 @@ Item {
             mediaGrid.pulseActivate();
     }
 
+    // Settle the push-in cue back to rest after a launch that keeps the
+    // frontend on the same screen (a launcher that does not take the FPGA or
+    // quit us, e.g. an Audio track). Routed like pulseActivate to whichever
+    // layout is live. Not called for forward navigation, which transitions the
+    // screen and resets the cue off-screen on its own.
+    function releaseActivate(): void {
+        if (root._listLayout)
+            listCard.releasePulse++;
+        else
+            mediaGrid.releaseActivate();
+    }
+
     function _count(): int {
         return root.mediaModel !== null ? root.mediaModel.count : 0;
     }
@@ -167,6 +196,9 @@ Item {
     function restoreSelection(): void {
         if (root._count() <= 0)
             return;
+        // The model is loaded; the selection is now finalized (either the
+        // saved path below or the default index 0). Let the tiles/rows render.
+        root._restoreDone = true;
         const path = typeof root.restoreSelectionPath === "function" ? (root.restoreSelectionPath() ?? "") : (root.mediaState !== null ? (root.mediaState.selected_path ?? "") : "");
         if (path === "")
             return;
@@ -193,6 +225,7 @@ Item {
     function _focusIndex(index: int): void {
         if (index < 0 || index >= mediaGrid.itemCount)
             return;
+        root._focusArmed = true;
         mediaGrid.currentIndex = index;
     }
 
@@ -283,6 +316,8 @@ Item {
         if ((action === "left" || action === "right" || action === "up" || action === "down" || action === "context_menu") && root._gateHide)
             return;
 
+        root._focusArmed = true;
+
         if (action === "left") {
             if (root._listLayout && typeof root.listLeftAction === "function")
                 root.listLeftAction();
@@ -362,8 +397,13 @@ Item {
         onDeferred: {
             const i = _idx;
             _idx = -1;
-            if (i >= 0 && root.mediaModel !== null)
+            if (i >= 0 && root.mediaModel !== null) {
                 root.mediaModel.launch_at(i);
+                // Settle the push-in back to rest. If the launch takes the FPGA
+                // or kills us the release is never seen; if it stays on the page
+                // (e.g. an Audio track) the cue does not stick pushed in.
+                root.releaseActivate();
+            }
         }
     }
 
@@ -376,6 +416,7 @@ Item {
         rapidScrollActive: root.detailRapidScrollActive
         identityForIndex: root.detailIdentityForIndex
         loadForIndex: root.loadDetailForIndex
+        peekForIndex: root.peekDetailForIndex
         clearDetail: root.clearDetailAction
         mediaModel: root.mediaModel
     }
@@ -413,6 +454,7 @@ Item {
         totalItemsOverride: root.totalItemsOverride
         targetVisibleRowCount: root.targetVisibleRowCount
         currentIndex: mediaGrid.currentIndex
+        focusReady: root._focusReady
         detailTitle: listCard.currentName
         detailCoverKey: root.detailRapidScrollActive ? root.detailPlaceholderKey : (root._detailImageKey() !== "" ? root._detailImageKey() : listCard.currentCoverKey)
         detailShowDescription: root.detailShowDescription
@@ -450,6 +492,8 @@ Item {
         anchors.bottomMargin: root.gridBottomMargin
         focused: root.gridFocused
         screenSettling: !root.active
+        ringFadeReady: root._focusArmed
+        focusReady: root._focusReady
         model: root.mediaModel
         delegate: Tile {
             layoutProfile: root._gridLayoutProfile

--- a/src/ui/screens/MediaListScreen.qml
+++ b/src/ui/screens/MediaListScreen.qml
@@ -80,9 +80,9 @@ Item {
     property bool active: true
     property bool gridFocused: true
     property bool optimisticLoading: false
-    // False until the user takes control of focus (first input). Forwarded to
-    // the grid tiles as `ringFadeReady` so the programmatic restore reseat
-    // snaps instead of cross-fading the wrong tile's ring.
+    // False until the user takes control of focus (first input). Combined with
+    // `_restoreDone` into `_focusReady`, which gates whether the grid tiles and
+    // list rows render selection at all.
     property bool _focusArmed: false
     // Set true once the selection has been finalized from persisted state
     // (restoreSelection for favorites/recents; Main.qml's
@@ -492,7 +492,6 @@ Item {
         anchors.bottomMargin: root.gridBottomMargin
         focused: root.gridFocused
         screenSettling: !root.active
-        ringFadeReady: root._focusArmed
         focusReady: root._focusReady
         model: root.mediaModel
         delegate: Tile {

--- a/src/ui/screens/SettingsScreen.qml
+++ b/src/ui/screens/SettingsScreen.qml
@@ -56,6 +56,21 @@ Item {
     property string currentPage: settings.pageRoot
     readonly property bool showingRootGrid: settings.currentPage === settings.pageRoot
     property var _pageIndexes: ({})
+    // Incremented when the user accepts a category tile so it plays the
+    // push-in animation. Forwarded to all category TileLoaders.
+    property int activatePulse: 0
+    // False until the user takes control of focus (first input). Forwarded
+    // to the category tiles as `ringFadeReady` so the programmatic focus
+    // settle on load snaps instead of cross-fading the wrong tile's focus
+    // ring. User navigation, which always follows input, cross-fades as
+    // before.
+    property bool _focusArmed: false
+    // True for one event-loop tick during a page switch. Passed as
+    // `animateChanges: false` to SettingsField delegates so reused
+    // delegates do not animate focus-border or toggle-position changes
+    // when the new page's field model lands. Normal user navigation
+    // animates because `_pageSwitching` is false at that point.
+    property bool _pageSwitching: false
 
     // Page-aware field registries. The root mirrors console settings
     // menus: stable domain categories first, short subpages second.
@@ -148,6 +163,11 @@ Item {
             kind: "field",
             id: "mouseEnabled",
             label: qsTr("Mouse support")
+        },
+        {
+            kind: "field",
+            id: "reduceMotion",
+            label: qsTr("Reduce motion")
         }
     ]
     readonly property var libraryDataFields: [
@@ -335,7 +355,7 @@ Item {
     }
 
     function _fieldControl(id: string): string {
-        if (id === "mouseEnabled" || id === "showHidden" || id === "discoverArcadeAlternateVersions" || id === "debugLogging" || id === "rescrapeExisting")
+        if (id === "mouseEnabled" || id === "showHidden" || id === "discoverArcadeAlternateVersions" || id === "debugLogging" || id === "rescrapeExisting" || id === "reduceMotion")
             return "toggle";
         if (id === "aboutLicense" || id === "pageDisplayInterface" || id === "pageControlsInput" || id === "pageLibraryData" || id === "pageSupportAbout")
             return "navigate";
@@ -353,6 +373,8 @@ Item {
             return settings._visibleRescrapeExisting;
         if (id === "showHidden")
             return Browse.Settings.current_show_hidden;
+        if (id === "reduceMotion")
+            return Browse.Settings.current_reduce_motion;
         return Browse.Settings.current_mouse_enabled;
     }
 
@@ -432,6 +454,7 @@ Item {
     function _focusRootIndex(index: int): void {
         if (index < 0 || index >= settings.fieldCount)
             return;
+        settings._focusArmed = true;
         settings.currentIndex = index;
     }
 
@@ -439,7 +462,7 @@ Item {
         if (!settings._isField(settings.currentIndex))
             return false;
         const id = settings.fields[settings.currentIndex].id;
-        return id === "mouseEnabled" || id === "showHidden" || id === "discoverArcadeAlternateVersions" || id === "debugLogging" || id === "rescrapeExisting";
+        return id === "mouseEnabled" || id === "showHidden" || id === "discoverArcadeAlternateVersions" || id === "debugLogging" || id === "rescrapeExisting" || id === "reduceMotion";
     }
     // True when the focused field is a list-picker row (Accept opens a
     // modal; left/right is a no-op — pickers don't cycle inline). Drives
@@ -828,6 +851,14 @@ Item {
         Browse.Settings.set_debug_logging(!Browse.Settings.current_debug_logging);
     }
 
+    function _setReduceMotion(direction: int): void {
+        Browse.Settings.set_reduce_motion(direction > 0);
+    }
+
+    function _toggleReduceMotion(): void {
+        Browse.Settings.set_reduce_motion(!Browse.Settings.current_reduce_motion);
+    }
+
     function _setDiscoverArcadeAlternateVersions(direction: int): void {
         Browse.Settings.set_discover_arcade_alternate_versions(direction > 0);
     }
@@ -865,6 +896,8 @@ Item {
             settings._setDebugLogging(direction);
         else if (id === "rescrapeExisting")
             settings._setRescrapeExisting(direction);
+        else if (id === "reduceMotion")
+            settings._setReduceMotion(direction);
     }
 
     function _rememberPageFocus(): void {
@@ -881,22 +914,37 @@ Item {
     }
 
     function _switchPage(page: string): void {
+        // Disable SettingsField Behaviors for this synchronous block so
+        // reused delegates don't animate focus-border or toggle-position
+        // changes when the new page's field model lands. The flag is
+        // cleared on the next event-loop tick so subsequent user moves
+        // still animate normally.
+        settings._pageSwitching = true;
         settings._rememberPageFocus();
         settings.currentPage = page;
         settings._restorePageFocus();
+        Qt.callLater(() => { settings._pageSwitching = false; });
     }
 
     function _openPage(id: string): bool {
+        // Resolve the target page first so we can return false quickly for
+        // non-page IDs. Then fire the pulse (cue plays on the still-visible
+        // tile) and defer _switchPage so the push-in's downward leg is
+        // fully visible before the page swaps out.
+        let page = "";
         if (id === "pageDisplayInterface")
-            settings._switchPage(settings.pageDisplayInterface);
+            page = settings.pageDisplayInterface;
         else if (id === "pageControlsInput")
-            settings._switchPage(settings.pageControlsInput);
+            page = settings.pageControlsInput;
         else if (id === "pageLibraryData")
-            settings._switchPage(settings.pageLibraryData);
+            page = settings.pageLibraryData;
         else if (id === "pageSupportAbout")
-            settings._switchPage(settings.pageSupportAbout);
+            page = settings.pageSupportAbout;
         else
             return false;
+        settings.activatePulse++;
+        pressCommit._page = page;
+        pressCommit.arm();
         return true;
     }
 
@@ -914,6 +962,7 @@ Item {
                 settings._goBack();
             return;
         }
+        settings._focusArmed = true;
         if (action === "up") {
             if (settings.showingRootGrid)
                 settings._moveRootGrid(0, -1);
@@ -950,6 +999,8 @@ Item {
                 settings._toggleDebugLogging();
             else if (id === "rescrapeExisting")
                 settings._toggleRescrapeExisting();
+            else if (id === "reduceMotion")
+                settings._toggleReduceMotion();
             else if (id === "updateMediaDb")
                 settings._triggerIndex();
             else if (id === "runScraper")
@@ -966,6 +1017,16 @@ Item {
     }
 
     // ── Visual tree ───────────────────────────────────────────────────────────
+
+    DeferredAction {
+        id: pressCommit
+        property string _page: ""
+        onDeferred: {
+            const p = _page;
+            _page = "";
+            settings._switchPage(p);
+        }
+    }
 
     MouseArea {
         anchors.fill: parent
@@ -1069,6 +1130,8 @@ Item {
                     isFocused: true
                     name: categoryCell.modelData.label
                     coverKey: categoryCell.modelData.coverKey
+                    activatePulse: settings.activatePulse
+                    ringFadeReady: settings._focusArmed
                 }
 
                 MouseArea {
@@ -1177,6 +1240,7 @@ Item {
                         anchors.left: parent.left
                         anchors.right: parent.right
                         isFocused: row.index === settings.currentIndex
+                        animateChanges: !settings._pageSwitching
                         // Index and scrape can't run together; while
                         // one operation is in flight the other row
                         // dims and its MouseArea stops responding.
@@ -1201,6 +1265,8 @@ Item {
                                 settings._toggleDebugLogging();
                             else if (row.modelData.id === "rescrapeExisting")
                                 settings._toggleRescrapeExisting();
+                            else if (row.modelData.id === "reduceMotion")
+                                settings._toggleReduceMotion();
                         }
                         onRightClicked: settings._goBack()
                         // Picker, action, and navigate rows route

--- a/src/ui/screens/SettingsScreen.qml
+++ b/src/ui/screens/SettingsScreen.qml
@@ -59,17 +59,11 @@ Item {
     // Incremented when the user accepts a category tile so it plays the
     // push-in animation. Forwarded to all category TileLoaders.
     property int activatePulse: 0
-    // False until the user takes control of focus (first input). Forwarded
-    // to the category tiles as `ringFadeReady` so the programmatic focus
-    // settle on load snaps instead of cross-fading the wrong tile's focus
-    // ring. User navigation, which always follows input, cross-fades as
-    // before.
-    property bool _focusArmed: false
     // True for one event-loop tick during a page switch. Passed as
-    // `animateChanges: false` to SettingsField delegates so reused
-    // delegates do not animate focus-border or toggle-position changes
-    // when the new page's field model lands. Normal user navigation
-    // animates because `_pageSwitching` is false at that point.
+    // `animateChanges: false` to SettingsField delegates so a reused delegate
+    // does not animate its toggle-knob slide when the new page's field model
+    // lands. Normal user navigation animates because `_pageSwitching` is false
+    // at that point.
     property bool _pageSwitching: false
 
     // Page-aware field registries. The root mirrors console settings
@@ -454,7 +448,6 @@ Item {
     function _focusRootIndex(index: int): void {
         if (index < 0 || index >= settings.fieldCount)
             return;
-        settings._focusArmed = true;
         settings.currentIndex = index;
     }
 
@@ -964,7 +957,6 @@ Item {
                 settings._goBack();
             return;
         }
-        settings._focusArmed = true;
         if (action === "up") {
             if (settings.showingRootGrid)
                 settings._moveRootGrid(0, -1);
@@ -1133,15 +1125,6 @@ Item {
                     name: categoryCell.modelData.label
                     coverKey: categoryCell.modelData.coverKey
                     activatePulse: settings.activatePulse
-                    // Suppress the ring fade during a page switch. Returning to
-                    // the root grid rebuilds these tiles with the stale
-                    // subpage currentIndex (tile 0) before `_restorePageFocus`
-                    // points it at the remembered root tile, so an armed fade
-                    // would cross-fade the ring off tile 0 and onto the real
-                    // tile — the visible "tile 0 flashes then focus jumps" bug.
-                    // `_pageSwitching` gates it the same way SettingsField rows
-                    // suppress their own Behaviors during the switch.
-                    ringFadeReady: settings._focusArmed && !settings._pageSwitching
                 }
 
                 MouseArea {

--- a/src/ui/screens/SettingsScreen.qml
+++ b/src/ui/screens/SettingsScreen.qml
@@ -923,7 +923,9 @@ Item {
         settings._rememberPageFocus();
         settings.currentPage = page;
         settings._restorePageFocus();
-        Qt.callLater(() => { settings._pageSwitching = false; });
+        Qt.callLater(() => {
+            settings._pageSwitching = false;
+        });
     }
 
     function _openPage(id: string): bool {
@@ -1131,7 +1133,15 @@ Item {
                     name: categoryCell.modelData.label
                     coverKey: categoryCell.modelData.coverKey
                     activatePulse: settings.activatePulse
-                    ringFadeReady: settings._focusArmed
+                    // Suppress the ring fade during a page switch. Returning to
+                    // the root grid rebuilds these tiles with the stale
+                    // subpage currentIndex (tile 0) before `_restorePageFocus`
+                    // points it at the remembered root tile, so an armed fade
+                    // would cross-fade the ring off tile 0 and onto the real
+                    // tile — the visible "tile 0 flashes then focus jumps" bug.
+                    // `_pageSwitching` gates it the same way SettingsField rows
+                    // suppress their own Behaviors during the switch.
+                    ringFadeReady: settings._focusArmed && !settings._pageSwitching
                 }
 
                 MouseArea {

--- a/src/ui/screens/SettingsScreen.qml
+++ b/src/ui/screens/SettingsScreen.qml
@@ -59,6 +59,10 @@ Item {
     // Incremented when the user accepts a category tile so it plays the
     // push-in animation. Forwarded to all category TileLoaders.
     property int activatePulse: 0
+    // Sibling of `activatePulse` for the in-page SettingsField rows: bumped on
+    // a field accept so the focused non-toggle row plays its push-in tap.
+    // Toggle rows ignore it (their knob slide is the feedback).
+    property int fieldActivatePulse: 0
     // True for one event-loop tick during a page switch. Passed as
     // `animateChanges: false` to SettingsField delegates so a reused delegate
     // does not animate its toggle-knob slide when the new page's field model
@@ -944,6 +948,10 @@ Item {
     }
 
     function _goBack(): void {
+        // Disarm pending accepts so a press-then-back inside the deferred
+        // window cannot drill into a subpage / open a picker after backing out.
+        pressCommit.stop();
+        fieldCommit.stop();
         if (settings.currentPage !== settings.pageRoot) {
             settings._switchPage(settings.pageRoot);
             return;
@@ -983,28 +991,31 @@ Item {
             const id = settings.fields[settings.currentIndex].id;
             if (settings._openPage(id))
                 return;
-            if (id === "mouseEnabled")
-                settings._toggleMouseEnabled();
-            else if (id === "showHidden")
-                settings._toggleShowHidden();
-            else if (id === "discoverArcadeAlternateVersions")
-                settings._toggleDiscoverArcadeAlternateVersions();
-            else if (id === "debugLogging")
-                settings._toggleDebugLogging();
-            else if (id === "rescrapeExisting")
-                settings._toggleRescrapeExisting();
-            else if (id === "reduceMotion")
-                settings._toggleReduceMotion();
-            else if (id === "updateMediaDb")
-                settings._triggerIndex();
-            else if (id === "runScraper")
-                settings._triggerScrape();
-            else if (id === "uploadLog")
-                settings.requestAccept("uploadLog");
-            else if (id === "aboutLicense")
-                settings.requestAccept("aboutLicense");
-            else
-                settings._openPickerForField(id);
+            // Toggles flip in place — the knob slide is their cue, so act now
+            // and skip the push-in.
+            if (settings._fieldControl(id) === "toggle") {
+                if (id === "mouseEnabled")
+                    settings._toggleMouseEnabled();
+                else if (id === "showHidden")
+                    settings._toggleShowHidden();
+                else if (id === "discoverArcadeAlternateVersions")
+                    settings._toggleDiscoverArcadeAlternateVersions();
+                else if (id === "debugLogging")
+                    settings._toggleDebugLogging();
+                else if (id === "rescrapeExisting")
+                    settings._toggleRescrapeExisting();
+                else if (id === "reduceMotion")
+                    settings._toggleReduceMotion();
+                return;
+            }
+            // Picker / action / about either open a modal or navigate away,
+            // which would cover or replace the row before its push-in could
+            // show. Play the cue, then run the action deferred (the same
+            // deferred-flip the tiles use) so the press is visible on the
+            // still-static settings screen first.
+            settings.fieldActivatePulse++;
+            fieldCommit._id = id;
+            fieldCommit.arm();
         } else if (action === "cancel") {
             settings._goBack();
         }
@@ -1019,6 +1030,29 @@ Item {
             const p = _page;
             _page = "";
             settings._switchPage(p);
+        }
+    }
+
+    // Deferred-flip for non-toggle field activations: the focused row's push-in
+    // plays on the still-visible settings screen, then this fires `pressMs`
+    // later to open the modal / navigate. Without the defer the modal scrim or
+    // screen change covers the row before the cue can render.
+    DeferredAction {
+        id: fieldCommit
+        property string _id: ""
+        onDeferred: {
+            const id = fieldCommit._id;
+            fieldCommit._id = "";
+            if (id === "updateMediaDb")
+                settings._triggerIndex();
+            else if (id === "runScraper")
+                settings._triggerScrape();
+            else if (id === "uploadLog")
+                settings.requestAccept("uploadLog");
+            else if (id === "aboutLicense")
+                settings.requestAccept("aboutLicense");
+            else
+                settings._openPickerForField(id);
         }
     }
 
@@ -1234,6 +1268,7 @@ Item {
                         anchors.right: parent.right
                         isFocused: row.index === settings.currentIndex
                         animateChanges: !settings._pageSwitching
+                        activatePulse: settings.fieldActivatePulse
                         // Index and scrape can't run together; while
                         // one operation is in flight the other row
                         // dims and its MouseArea stops responding.
@@ -1271,16 +1306,12 @@ Item {
                             settings.currentIndex = row.index;
                             if (settings._openPage(row.modelData.id))
                                 return;
-                            if (row.modelData.id === "updateMediaDb")
-                                settings._triggerIndex();
-                            else if (row.modelData.id === "runScraper")
-                                settings._triggerScrape();
-                            else if (row.modelData.id === "uploadLog")
-                                settings.requestAccept("uploadLog");
-                            else if (row.modelData.id === "aboutLicense")
-                                settings.requestAccept("aboutLicense");
-                            else
-                                settings._openPickerForField(row.modelData.id);
+                            // Non-toggle rows route here (toggles use onClicked).
+                            // Defer like the keyboard path so the push-in shows
+                            // before the modal opens / the screen navigates.
+                            settings.fieldActivatePulse++;
+                            fieldCommit._id = row.modelData.id;
+                            fieldCommit.arm();
                         }
                     }
                 }

--- a/src/ui/screens/SystemsScreen.qml
+++ b/src/ui/screens/SystemsScreen.qml
@@ -48,6 +48,13 @@ Item {
     // that state restore performs on load snaps instead of cross-fading the
     // wrong tile's focus ring. User navigation cross-fades as before.
     property bool _focusArmed: false
+    // Set true once the load-time system restore has run (see Main.qml's
+    // `_restoreSystemsScreenSelection`). Combined with `_focusArmed` into
+    // `_focusReady`, which gates whether the grid tiles render focus at all —
+    // so the grid's default tile 0 never paints a ring during the window
+    // before restore points `currentIndex` at the saved system on a cold start.
+    property bool _restoreDone: false
+    readonly property bool _focusReady: systems._focusArmed || systems._restoreDone
     readonly property bool _listLayout: Browse.Settings.current_browse_layout === "list"
     readonly property bool _crtGridLayout: Theme.crtNativePath && !systems._listLayout
     readonly property bool _crtListStrip: Theme.crtNativePath && systems._listLayout
@@ -245,6 +252,7 @@ Item {
         anchors.bottomMargin: systems._listProfile ? systems._listProfile.cardBottomMargin : Sizing.pctH(8)
         model: Browse.SystemsModel
         currentIndex: systemsGrid.currentIndex
+        focusReady: systems._focusReady
         layoutProfile: systems._viewProfile
         detailTitle: listCard.currentName
         detailCoverKey: listCard.currentCoverKey
@@ -276,6 +284,7 @@ Item {
         focused: systems.gridFocused
         screenSettling: !systems.active
         ringFadeReady: systems._focusArmed
+        focusReady: systems._focusReady
         model: Browse.SystemsModel
         layoutProfile: systems._viewProfile
         columnsOverride: systems._gridShape.columns

--- a/src/ui/screens/SystemsScreen.qml
+++ b/src/ui/screens/SystemsScreen.qml
@@ -43,10 +43,9 @@ Item {
     // times. The ring restores automatically when the modal pops.
     property bool gridFocused: true
     property bool optimisticLoading: false
-    // False until the user takes control of focus (first input). Forwarded
-    // to the grid tiles as `ringFadeReady` so the programmatic focus reseat
-    // that state restore performs on load snaps instead of cross-fading the
-    // wrong tile's focus ring. User navigation cross-fades as before.
+    // False until the user takes control of focus (first input). Combined
+    // with `_restoreDone` into `_focusReady`, which gates whether the grid
+    // tiles render focus at all.
     property bool _focusArmed: false
     // Set true once the load-time system restore has run (see Main.qml's
     // `_restoreSystemsScreenSelection`). Combined with `_focusArmed` into
@@ -182,7 +181,14 @@ Item {
                 return;
             }
             const chosen = Browse.SystemsModel.system_id_at(systems.systemsGrid.currentIndex);
-            systems.systemsGrid.pulseActivate();
+            // Route the push-in cue to the visible layout. In list mode the
+            // grid is hidden and the BrowseList is shown, so pulsing the grid
+            // would animate nothing; mirror the layout-aware routing
+            // MediaListScreen.pulseActivate() uses.
+            if (systems._listLayout)
+                listCard.activatePulse++;
+            else
+                systems.systemsGrid.pulseActivate();
             pressCommit._systemId = chosen;
             pressCommit.arm();
         } else if (action === "context_menu") {
@@ -283,7 +289,6 @@ Item {
         anchors.bottomMargin: systems._footerProfile ? systems._footerProfile.gridBottomMargin : (Sizing.pctH(8) + Sizing.pctH(7))
         focused: systems.gridFocused
         screenSettling: !systems.active
-        ringFadeReady: systems._focusArmed
         focusReady: systems._focusReady
         model: Browse.SystemsModel
         layoutProfile: systems._viewProfile

--- a/src/ui/screens/SystemsScreen.qml
+++ b/src/ui/screens/SystemsScreen.qml
@@ -198,6 +198,9 @@ Item {
                 systems.requestContextMenu(idx, systems._listLayout ? listCard.currentCellRectIn(systems) : systems.systemsGrid.currentCellRectIn(systems));
             }
         } else if (action === "cancel") {
+            // Disarm a pending accept so a press-then-back inside the deferred
+            // window cannot drill into a system after the user has backed out.
+            pressCommit.stop();
             systems.requestHubScreen();
         }
     }

--- a/src/ui/screens/SystemsScreen.qml
+++ b/src/ui/screens/SystemsScreen.qml
@@ -30,6 +30,10 @@ Item {
     property alias systemsGrid: systemsGrid
     property alias listCard: listCard
     property bool transitioning: false
+    // Set false by MainLayout when this screen is not the active screen.
+    // Forwarded to systemsGrid.screenSettling so tile delegates reset
+    // their push-in scale off-screen.
+    property bool active: true
     // Router-driven flag: `MainLayout` writes this to
     // `!ScreenManager.hasModal` so the focused tile's accent ring
     // hides while a modal (the context menu) is on top of the stack.
@@ -39,6 +43,11 @@ Item {
     // times. The ring restores automatically when the modal pops.
     property bool gridFocused: true
     property bool optimisticLoading: false
+    // False until the user takes control of focus (first input). Forwarded
+    // to the grid tiles as `ringFadeReady` so the programmatic focus reseat
+    // that state restore performs on load snaps instead of cross-fading the
+    // wrong tile's focus ring. User navigation cross-fades as before.
+    property bool _focusArmed: false
     readonly property bool _listLayout: Browse.Settings.current_browse_layout === "list"
     readonly property bool _crtGridLayout: Theme.crtNativePath && !systems._listLayout
     readonly property bool _crtListStrip: Theme.crtNativePath && systems._listLayout
@@ -107,6 +116,7 @@ Item {
     function _focusIndex(index: int): void {
         if (index < 0 || index >= systems.systemsGrid.itemCount)
             return;
+        systems._focusArmed = true;
         systems.systemsGrid.currentIndex = index;
         Browse.SystemsState.system_id = Browse.SystemsModel.system_id_at(systems.systemsGrid.currentIndex);
     }
@@ -128,6 +138,7 @@ Item {
             return;
         if (action === "context_menu" && systems._gateHide)
             return;
+        systems._focusArmed = true;
 
         if (action === "left") {
             systems._performMove(-1, 0);
@@ -164,7 +175,9 @@ Item {
                 return;
             }
             const chosen = Browse.SystemsModel.system_id_at(systems.systemsGrid.currentIndex);
-            systems.requestAccept(chosen);
+            systems.systemsGrid.pulseActivate();
+            pressCommit._systemId = chosen;
+            pressCommit.arm();
         } else if (action === "context_menu") {
             if (systems.systemsGrid.itemCount > 0) {
                 const idx = systems.systemsGrid.currentIndex;
@@ -177,6 +190,16 @@ Item {
     }
 
     // ── Visual tree ───────────────────────────────────────────────────────────
+
+    DeferredAction {
+        id: pressCommit
+        property string _systemId: ""
+        onDeferred: {
+            const id = _systemId;
+            _systemId = "";
+            systems.requestAccept(id);
+        }
+    }
 
     // Top status strip — page counter (left), category title (center),
     // total-systems badge (right). Replaces the standalone top label
@@ -251,6 +274,8 @@ Item {
         anchors.bottom: parent.bottom
         anchors.bottomMargin: systems._footerProfile ? systems._footerProfile.gridBottomMargin : (Sizing.pctH(8) + Sizing.pctH(7))
         focused: systems.gridFocused
+        screenSettling: !systems.active
+        ringFadeReady: systems._focusArmed
         model: Browse.SystemsModel
         layoutProfile: systems._viewProfile
         columnsOverride: systems._gridShape.columns

--- a/src/ui/theme/BrowseLayouts.qml
+++ b/src/ui/theme/BrowseLayouts.qml
@@ -847,7 +847,7 @@ QtObject {
             if (fnName === "sum")
                 // qmllint disable compiler
                 return args.reduce((total, entry) => total + entry, 0);
-                // qmllint enable compiler
+            // qmllint enable compiler
         }
 
         const numeric = Number(value);

--- a/src/ui/theme/CMakeLists.txt
+++ b/src/ui/theme/CMakeLists.txt
@@ -7,6 +7,7 @@ qt_add_library(zaparoo_ui_theme STATIC)
 set_source_files_properties(
     BrowseLayouts.qml
     CategoryIds.qml
+    Motion.qml
     Resources.qml
     Sizing.qml
     Theme.qml
@@ -20,6 +21,7 @@ qt_add_qml_module(
     QML_FILES
         BrowseLayouts.qml
         CategoryIds.qml
+        Motion.qml
         Resources.qml
         Sizing.qml
         Theme.qml

--- a/src/ui/theme/Motion.qml
+++ b/src/ui/theme/Motion.qml
@@ -30,9 +30,14 @@ QtObject {
     readonly property int pressMs: 80
     readonly property int settleMs: 110
 
-    // Scale target for the one-shot tile push-in cue, shared by every
-    // button-like action (navigation and game launch alike).
+    // Scale target for the one-shot push-in cue on squarish surfaces — tiles
+    // and dialog buttons.
     readonly property real pressScale: 0.96
+    // Gentler target for wide, short rows (list-detail rows, settings fields,
+    // menu/picker rows). The same scale factor moves a full-width row's edges
+    // far more than a squarish tile's, so a wider row needs a value closer to
+    // 1.0 to read as the same subtle press.
+    readonly property real rowPressScale: 0.985
 
     // Collapse all durations to 0 under reduce-motion so Behaviors that
     // use dur() resolve instantly without per-call branching.

--- a/src/ui/theme/Motion.qml
+++ b/src/ui/theme/Motion.qml
@@ -18,12 +18,17 @@ QtObject {
     // Master switch. Written from Main.qml via a Binding.
     property bool enabled: true
 
-    // Duration buckets (milliseconds).
-    // `pressMs` sits at the ~90ms perceivable-motion floor — feels
-    // instant but registers as tactile feedback.
-    // `settleMs` covers small-element motion (100-200ms band).
-    readonly property int pressMs: 90
-    readonly property int settleMs: 140
+    // Duration buckets (milliseconds). The practical floor here is the frame
+    // budget, not perception: on MiSTer's software renderer (~30fps) motion the
+    // eye tracks needs ~3 frames (~100ms) to read as smooth rather than a
+    // two-frame jump. So `settleMs` (tracked motion) stays above that floor,
+    // while `pressMs` can sit a little under it because it reads as a punchy
+    // tactile snap, not tracked motion. Don't drop these much further or the
+    // cues turn choppy on hardware.
+    // `pressMs`  — push-in feedback on accept/activate.
+    // `settleMs` — settle/release legs and the toggle-knob slide.
+    readonly property int pressMs: 80
+    readonly property int settleMs: 110
 
     // Scale target for the one-shot tile push-in cue, shared by every
     // button-like action (navigation and game launch alike).

--- a/src/ui/theme/Motion.qml
+++ b/src/ui/theme/Motion.qml
@@ -1,0 +1,35 @@
+// Zaparoo Frontend
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+pragma Singleton
+import QtQuick
+
+// Motion tokens — durations, scale targets, and the global on/off switch
+// for all interaction animations.
+//
+// `enabled` is written by the app layer from the persisted reduce-motion
+// setting (see `Main.qml` for the Binding). Keeping this singleton
+// dependency-free means `Zaparoo.Theme` does not depend on `Zaparoo.Browse`.
+//
+// When `enabled` is false, `dur()` returns 0 and every Behavior that reads
+// `Motion.enabled` is inert — animations complete in one frame with no
+// branching in the consuming code.
+QtObject {
+    // Master switch. Written from Main.qml via a Binding.
+    property bool enabled: true
+
+    // Duration buckets (milliseconds).
+    // `pressMs` sits at the ~90ms perceivable-motion floor — feels
+    // instant but registers as tactile feedback.
+    // `settleMs` covers small-element motion (100-200ms band).
+    readonly property int pressMs: 90
+    readonly property int settleMs: 140
+
+    // Scale target for the one-shot tile push-in cue, shared by every
+    // button-like action (navigation and game launch alike).
+    readonly property real pressScale: 0.96
+
+    // Collapse all durations to 0 under reduce-motion so Behaviors that
+    // use dur() resolve instantly without per-call branching.
+    function dur(ms: int): int { return enabled ? ms : 0; }
+}

--- a/src/ui/theme/Motion.qml
+++ b/src/ui/theme/Motion.qml
@@ -31,5 +31,7 @@ QtObject {
 
     // Collapse all durations to 0 under reduce-motion so Behaviors that
     // use dur() resolve instantly without per-call branching.
-    function dur(ms: int): int { return enabled ? ms : 0; }
+    function dur(ms: int): int {
+        return enabled ? ms : 0;
+    }
 }

--- a/src/ui/theme/Resources.qml
+++ b/src/ui/theme/Resources.qml
@@ -40,7 +40,7 @@ QtObject {
 
     // Empty key returns an empty URL so the caller can use it as a
     // "no cover" sentinel.
-    function _colorToken(colorValue): string {
+    function _colorToken(colorValue: var): string {
         const text = String(colorValue === undefined ? "#ffffff" : colorValue);
         return text.charAt(0) === "#" ? text.substring(1) : text;
     }
@@ -53,7 +53,7 @@ QtObject {
         return key;
     }
 
-    function coverUrl(key: string, foreground, secondary, background): url {
+    function coverUrl(key: string, foreground: var, secondary: var, background: var): url {
         if (key === "")
             return "";
 

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -425,34 +425,34 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="116"/>
-        <location filename="../screens/GamesScreen.qml" line="151"/>
+        <location filename="../screens/GamesScreen.qml" line="127"/>
+        <location filename="../screens/GamesScreen.qml" line="162"/>
         <source>%1 files</source>
         <translation>%1 ملفات</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="53"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="125"/>
-        <location filename="../screens/GamesScreen.qml" line="152"/>
+        <location filename="../screens/GamesScreen.qml" line="136"/>
+        <location filename="../screens/GamesScreen.qml" line="163"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="47"/>
+        <location filename="../screens/GamesScreen.qml" line="48"/>
         <source>No games in this system</source>
         <translation>لا توجد ألعاب في هذا النظام</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="48"/>
+        <location filename="../screens/GamesScreen.qml" line="49"/>
         <source>Loading games…</source>
         <translation>جارٍ تحميل الألعاب…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="121"/>
+        <location filename="../screens/GamesScreen.qml" line="132"/>
         <source>Loading more…</source>
         <translation>جارٍ تحميل المزيد…</translation>
     </message>
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="139"/>
+        <location filename="../screens/HubScreen.qml" line="149"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="145"/>
+        <location filename="../screens/HubScreen.qml" line="155"/>
         <source>Favorites</source>
         <translation>المفضلة</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="150"/>
+        <location filename="../screens/HubScreen.qml" line="160"/>
         <source>Recently Played</source>
         <translation>تم لعبها مؤخرًا</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="155"/>
+        <location filename="../screens/HubScreen.qml" line="165"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">الإعدادات</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="669"/>
+        <location filename="../screens/HubScreen.qml" line="701"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>لا توجد أنظمة متاحة. شغّل تحديث قاعدة بيانات الوسائط من الإعدادات.</translation>
     </message>
@@ -553,138 +553,138 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1361"/>
+        <location filename="../app/Main.qml" line="1367"/>
         <source>Launch core</source>
         <translation>تشغيل النواة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1367"/>
-        <location filename="../app/Main.qml" line="1606"/>
+        <location filename="../app/Main.qml" line="1373"/>
+        <location filename="../app/Main.qml" line="1612"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1374"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1380"/>
+        <location filename="../app/Main.qml" line="1403"/>
         <source>Update media database</source>
         <translation type="unfinished">تحديث قاعدة بيانات الوسائط</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1377"/>
-        <location filename="../app/Main.qml" line="1400"/>
+        <location filename="../app/Main.qml" line="1383"/>
+        <location filename="../app/Main.qml" line="1406"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">استخراج البيانات الوصفية</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1382"/>
-        <location filename="../app/Main.qml" line="1391"/>
+        <location filename="../app/Main.qml" line="1388"/>
+        <location filename="../app/Main.qml" line="1397"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1382"/>
-        <location filename="../app/Main.qml" line="1391"/>
+        <location filename="../app/Main.qml" line="1388"/>
+        <location filename="../app/Main.qml" line="1397"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1409"/>
-        <location filename="../app/Main.qml" line="1444"/>
+        <location filename="../app/Main.qml" line="1415"/>
+        <location filename="../app/Main.qml" line="1450"/>
         <source>Launch game</source>
         <translation>تشغيل اللعبة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1425"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Remove from favorites</source>
         <translation>إزالة من المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1425"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Add to favorites</source>
         <translation>أضف إلى المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1430"/>
+        <location filename="../app/Main.qml" line="1436"/>
         <source>Write to NFC token</source>
         <translation>الكتابة إلى رمز NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1434"/>
+        <location filename="../app/Main.qml" line="1440"/>
         <source>QR code</source>
         <translation>رمز QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1602"/>
+        <location filename="../app/Main.qml" line="1608"/>
         <source>Default</source>
         <translation type="unfinished">افتراضي</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1602"/>
+        <location filename="../app/Main.qml" line="1608"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1926"/>
+        <location filename="../app/Main.qml" line="1932"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1930"/>
+        <location filename="../app/Main.qml" line="1936"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1944"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1948"/>
+        <location filename="../app/Main.qml" line="1954"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1952"/>
+        <location filename="../app/Main.qml" line="1958"/>
         <source>Retry</source>
         <translation type="unfinished">إعادة المحاولة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1956"/>
+        <location filename="../app/Main.qml" line="1962"/>
         <source>Cancel</source>
         <translation type="unfinished">إلغاء</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2604"/>
+        <location filename="../app/Main.qml" line="2610"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2606"/>
+        <location filename="../app/Main.qml" line="2612"/>
         <source>Loading games…</source>
         <translation>جارٍ تحميل الألعاب…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2608"/>
+        <location filename="../app/Main.qml" line="2614"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2616"/>
         <source>Loading favorites…</source>
         <translation>جارٍ تحميل المفضلة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2612"/>
+        <location filename="../app/Main.qml" line="2618"/>
         <source>Loading recently played…</source>
         <translation>جارٍ تحميل آخر ما تم لعبه…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2620"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2616"/>
+        <location filename="../app/Main.qml" line="2622"/>
         <source>Loading…</source>
         <translation>جارٍ التحميل…</translation>
     </message>
@@ -692,12 +692,12 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="683"/>
+        <location filename="../app/MainLayout.qml" line="685"/>
         <source>Writing failed</source>
         <translation>فشلت الكتابة</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="683"/>
+        <location filename="../app/MainLayout.qml" line="685"/>
         <source>Put a writable card near the reader</source>
         <translation>ضع بطاقة قابلة للكتابة بالقرب من القارئ</translation>
     </message>
@@ -717,141 +717,141 @@ Euskara - devilschile2</source>
         <translation type="unfinished">تم لعبها مؤخرًا</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="699"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="700"/>
+        <location filename="../app/MainLayout.qml" line="702"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="810"/>
+        <location filename="../app/MainLayout.qml" line="812"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="811"/>
+        <location filename="../app/MainLayout.qml" line="813"/>
         <source>Are you sure you want to exit?</source>
         <translation>هل أنت متأكد أنك تريد الخروج؟</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="890"/>
-        <location filename="../app/MainLayout.qml" line="964"/>
-        <location filename="../app/MainLayout.qml" line="1010"/>
-        <location filename="../app/MainLayout.qml" line="1047"/>
-        <location filename="../app/MainLayout.qml" line="1097"/>
-        <location filename="../app/MainLayout.qml" line="1146"/>
-        <location filename="../app/MainLayout.qml" line="1165"/>
-        <location filename="../app/MainLayout.qml" line="1232"/>
+        <location filename="../app/MainLayout.qml" line="892"/>
+        <location filename="../app/MainLayout.qml" line="966"/>
+        <location filename="../app/MainLayout.qml" line="1012"/>
+        <location filename="../app/MainLayout.qml" line="1049"/>
+        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1148"/>
+        <location filename="../app/MainLayout.qml" line="1167"/>
+        <location filename="../app/MainLayout.qml" line="1234"/>
         <source>Move</source>
         <translation>تحريك</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="894"/>
-        <location filename="../app/MainLayout.qml" line="968"/>
+        <location filename="../app/MainLayout.qml" line="896"/>
+        <location filename="../app/MainLayout.qml" line="970"/>
         <source>Select</source>
         <translation>تحديد</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="902"/>
-        <location filename="../app/MainLayout.qml" line="916"/>
-        <location filename="../app/MainLayout.qml" line="931"/>
-        <location filename="../app/MainLayout.qml" line="942"/>
+        <location filename="../app/MainLayout.qml" line="900"/>
+        <location filename="../app/MainLayout.qml" line="904"/>
+        <location filename="../app/MainLayout.qml" line="918"/>
+        <location filename="../app/MainLayout.qml" line="933"/>
+        <location filename="../app/MainLayout.qml" line="944"/>
         <source>Close</source>
         <translation>إغلاق</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="909"/>
-        <location filename="../app/MainLayout.qml" line="949"/>
-        <location filename="../app/MainLayout.qml" line="972"/>
-        <location filename="../app/MainLayout.qml" line="983"/>
+        <location filename="../app/MainLayout.qml" line="911"/>
+        <location filename="../app/MainLayout.qml" line="951"/>
+        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="985"/>
         <source>Cancel</source>
         <translation>إلغاء</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="927"/>
+        <location filename="../app/MainLayout.qml" line="929"/>
         <source>Done</source>
         <translation>تم</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1070"/>
-        <location filename="../app/MainLayout.qml" line="1123"/>
-        <location filename="../app/MainLayout.qml" line="1258"/>
+        <location filename="../app/MainLayout.qml" line="940"/>
+        <location filename="../app/MainLayout.qml" line="1072"/>
+        <location filename="../app/MainLayout.qml" line="1125"/>
+        <location filename="../app/MainLayout.qml" line="1260"/>
         <source>Retry</source>
         <translation>إعادة المحاولة</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="957"/>
+        <location filename="../app/MainLayout.qml" line="959"/>
         <source>I understand</source>
         <translation>أفهم</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="991"/>
+        <location filename="../app/MainLayout.qml" line="993"/>
         <source>Start</source>
         <translation>ابدأ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1014"/>
-        <location filename="../app/MainLayout.qml" line="1057"/>
-        <location filename="../app/MainLayout.qml" line="1107"/>
-        <location filename="../app/MainLayout.qml" line="1151"/>
-        <location filename="../app/MainLayout.qml" line="1242"/>
+        <location filename="../app/MainLayout.qml" line="1016"/>
+        <location filename="../app/MainLayout.qml" line="1059"/>
+        <location filename="../app/MainLayout.qml" line="1109"/>
+        <location filename="../app/MainLayout.qml" line="1153"/>
+        <location filename="../app/MainLayout.qml" line="1244"/>
         <source>Open</source>
         <translation>فتح</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1024"/>
+        <location filename="../app/MainLayout.qml" line="1026"/>
         <source>Quit</source>
         <translation>إنهاء</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1033"/>
-        <location filename="../app/MainLayout.qml" line="1063"/>
-        <location filename="../app/MainLayout.qml" line="1074"/>
-        <location filename="../app/MainLayout.qml" line="1089"/>
-        <location filename="../app/MainLayout.qml" line="1116"/>
-        <location filename="../app/MainLayout.qml" line="1127"/>
-        <location filename="../app/MainLayout.qml" line="1139"/>
-        <location filename="../app/MainLayout.qml" line="1155"/>
-        <location filename="../app/MainLayout.qml" line="1189"/>
-        <location filename="../app/MainLayout.qml" line="1207"/>
-        <location filename="../app/MainLayout.qml" line="1216"/>
-        <location filename="../app/MainLayout.qml" line="1251"/>
-        <location filename="../app/MainLayout.qml" line="1262"/>
+        <location filename="../app/MainLayout.qml" line="1035"/>
+        <location filename="../app/MainLayout.qml" line="1065"/>
+        <location filename="../app/MainLayout.qml" line="1076"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
+        <location filename="../app/MainLayout.qml" line="1118"/>
+        <location filename="../app/MainLayout.qml" line="1129"/>
+        <location filename="../app/MainLayout.qml" line="1141"/>
+        <location filename="../app/MainLayout.qml" line="1157"/>
+        <location filename="../app/MainLayout.qml" line="1191"/>
+        <location filename="../app/MainLayout.qml" line="1209"/>
+        <location filename="../app/MainLayout.qml" line="1218"/>
+        <location filename="../app/MainLayout.qml" line="1253"/>
+        <location filename="../app/MainLayout.qml" line="1264"/>
         <source>Back</source>
         <translation>رجوع</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1053"/>
-        <location filename="../app/MainLayout.qml" line="1103"/>
-        <location filename="../app/MainLayout.qml" line="1238"/>
+        <location filename="../app/MainLayout.qml" line="1055"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
+        <location filename="../app/MainLayout.qml" line="1240"/>
         <source>Page</source>
         <translation>صفحة</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1060"/>
-        <location filename="../app/MainLayout.qml" line="1112"/>
-        <location filename="../app/MainLayout.qml" line="1247"/>
+        <location filename="../app/MainLayout.qml" line="1022"/>
+        <location filename="../app/MainLayout.qml" line="1062"/>
+        <location filename="../app/MainLayout.qml" line="1114"/>
+        <location filename="../app/MainLayout.qml" line="1249"/>
         <source>Options</source>
         <translation>الخيارات</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1174"/>
+        <location filename="../app/MainLayout.qml" line="1176"/>
         <source>Change</source>
         <translation>تغيير</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1180"/>
+        <location filename="../app/MainLayout.qml" line="1182"/>
         <source>Toggle</source>
         <translation>تبديل</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1203"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Scroll</source>
         <translation>تمرير</translation>
     </message>
@@ -864,12 +864,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">جارٍ التحميل…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="365"/>
+        <location filename="../screens/MediaListScreen.qml" line="395"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 عناصر</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="366"/>
+        <location filename="../screens/MediaListScreen.qml" line="396"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>لا</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="198"/>
+        <location filename="../components/Modal.qml" line="246"/>
         <source>Cancel</source>
         <translation>إلغاء</translation>
     </message>
@@ -940,64 +940,64 @@ Euskara - devilschile2</source>
         <translation type="vanished">عام</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="132"/>
-        <location filename="../screens/SettingsScreen.qml" line="718"/>
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
+        <location filename="../screens/SettingsScreen.qml" line="741"/>
         <source>Language</source>
         <translation>اللغة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="745"/>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="768"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="754"/>
+        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <location filename="../screens/SettingsScreen.qml" line="777"/>
         <source>Browsing layout</source>
         <translation>تخطيط التصفح</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="145"/>
-        <location filename="../screens/SettingsScreen.qml" line="763"/>
+        <location filename="../screens/SettingsScreen.qml" line="160"/>
+        <location filename="../screens/SettingsScreen.qml" line="786"/>
         <source>Button style</source>
         <translation>نمط الأزرار</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="772"/>
+        <location filename="../screens/SettingsScreen.qml" line="132"/>
+        <location filename="../screens/SettingsScreen.qml" line="795"/>
         <source>Screensaver</source>
         <translation>شاشة التوقف</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="80"/>
-        <location filename="../screens/SettingsScreen.qml" line="209"/>
+        <location filename="../screens/SettingsScreen.qml" line="95"/>
+        <location filename="../screens/SettingsScreen.qml" line="229"/>
         <source>Library</source>
         <translation>المكتبة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="162"/>
+        <location filename="../screens/SettingsScreen.qml" line="182"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="112"/>
-        <location filename="../screens/SettingsScreen.qml" line="781"/>
+        <location filename="../screens/SettingsScreen.qml" line="127"/>
+        <location filename="../screens/SettingsScreen.qml" line="804"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="157"/>
+        <location filename="../screens/SettingsScreen.qml" line="177"/>
         <source>Update media database</source>
         <translation>تحديث قاعدة بيانات الوسائط</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="167"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
         <source>Scrape metadata</source>
         <translation>استخراج البيانات الوصفية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="172"/>
+        <location filename="../screens/SettingsScreen.qml" line="192"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1006,402 +1006,407 @@ Euskara - devilschile2</source>
         <translation type="vanished">متقدم</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="150"/>
+        <location filename="../screens/SettingsScreen.qml" line="165"/>
         <source>Mouse support</source>
         <translation>دعم الفأرة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="184"/>
+        <location filename="../screens/SettingsScreen.qml" line="204"/>
         <source>Debug logging</source>
         <translation>تسجيل التصحيح</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="189"/>
+        <location filename="../screens/SettingsScreen.qml" line="209"/>
         <source>Upload log file</source>
         <translation>رفع ملف السجل</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="179"/>
+        <location filename="../screens/SettingsScreen.qml" line="199"/>
         <source>About / License</source>
         <translation>حول / الترخيص</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
-        <location filename="../screens/SettingsScreen.qml" line="727"/>
+        <location filename="../screens/SettingsScreen.qml" line="137"/>
+        <location filename="../screens/SettingsScreen.qml" line="750"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="127"/>
-        <location filename="../screens/SettingsScreen.qml" line="736"/>
+        <location filename="../screens/SettingsScreen.qml" line="142"/>
+        <location filename="../screens/SettingsScreen.qml" line="759"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="137"/>
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="226"/>
+        <location filename="../screens/SettingsScreen.qml" line="170"/>
+        <source>Reduce motion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
         <source>Optimizing</source>
         <translation>جارٍ التحسين</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="228"/>
-        <location filename="../screens/SettingsScreen.qml" line="237"/>
+        <location filename="../screens/SettingsScreen.qml" line="248"/>
+        <location filename="../screens/SettingsScreen.qml" line="257"/>
         <source>Paused</source>
         <translation>متوقف مؤقتًا</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="228"/>
-        <location filename="../screens/SettingsScreen.qml" line="237"/>
+        <location filename="../screens/SettingsScreen.qml" line="248"/>
+        <location filename="../screens/SettingsScreen.qml" line="257"/>
         <source>In progress</source>
         <translation>قيد التنفيذ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="231"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>%1 indexed</source>
         <translation>تمت فهرسة %1</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="240"/>
+        <location filename="../screens/SettingsScreen.qml" line="260"/>
         <source>%1 scraped</source>
         <translation>تم استخراج %1</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="472"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Cancel</source>
         <translation>إلغاء</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="472"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Start</source>
         <translation>ابدأ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="474"/>
+        <location filename="../screens/SettingsScreen.qml" line="497"/>
         <source>Upload</source>
         <translation>رفع</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Open</source>
         <translation>فتح</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="526"/>
+        <location filename="../screens/SettingsScreen.qml" line="549"/>
         <source>Default</source>
         <translation>افتراضي</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="556"/>
+        <location filename="../screens/SettingsScreen.qml" line="579"/>
         <source>English</source>
         <translation>الإنجليزية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="558"/>
+        <location filename="../screens/SettingsScreen.qml" line="581"/>
         <source>Italian</source>
         <translation>الإيطالية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="560"/>
+        <location filename="../screens/SettingsScreen.qml" line="583"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="562"/>
+        <location filename="../screens/SettingsScreen.qml" line="585"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="564"/>
+        <location filename="../screens/SettingsScreen.qml" line="587"/>
         <source>German</source>
         <translation>الألمانية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="566"/>
+        <location filename="../screens/SettingsScreen.qml" line="589"/>
         <source>Greek</source>
         <translation>اليونانية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="568"/>
+        <location filename="../screens/SettingsScreen.qml" line="591"/>
         <source>Japanese</source>
         <translation>اليابانية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="570"/>
+        <location filename="../screens/SettingsScreen.qml" line="593"/>
         <source>Korean</source>
         <translation>الكورية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="595"/>
         <source>Dutch</source>
         <translation>الهولندية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="597"/>
         <source>Romanian</source>
         <translation>الرومانية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="599"/>
         <source>Slovak</source>
         <translation>السلوفاكية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="601"/>
         <source>Ukrainian</source>
         <translation>الأوكرانية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="603"/>
         <source>Chinese (Simplified)</source>
         <translation>الصينية المبسطة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="605"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="607"/>
         <source>Hebrew</source>
         <translation>العبرية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
         <source>Arabic</source>
         <translation>العربية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="588"/>
+        <location filename="../screens/SettingsScreen.qml" line="611"/>
         <source>Hindi</source>
         <translation>الهندية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="589"/>
-        <location filename="../screens/SettingsScreen.qml" line="597"/>
-        <location filename="../screens/SettingsScreen.qml" line="671"/>
+        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="620"/>
+        <location filename="../screens/SettingsScreen.qml" line="694"/>
         <source>Auto</source>
         <translation>تلقائي</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="594"/>
+        <location filename="../screens/SettingsScreen.qml" line="617"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="596"/>
+        <location filename="../screens/SettingsScreen.qml" line="619"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="607"/>
+        <location filename="../screens/SettingsScreen.qml" line="630"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="632"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="611"/>
+        <location filename="../screens/SettingsScreen.qml" line="634"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="635"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="640"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="619"/>
+        <location filename="../screens/SettingsScreen.qml" line="642"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="620"/>
+        <location filename="../screens/SettingsScreen.qml" line="643"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="625"/>
+        <location filename="../screens/SettingsScreen.qml" line="648"/>
         <source>Detailed list view</source>
         <translation>عرض قائمة مفصلة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="626"/>
+        <location filename="../screens/SettingsScreen.qml" line="649"/>
         <source>Grid view</source>
         <translation>عرض الشبكة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="631"/>
+        <location filename="../screens/SettingsScreen.qml" line="654"/>
         <source>Style B</source>
         <translation>النمط B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="633"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Style C</source>
         <translation>النمط C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="658"/>
         <source>Style D</source>
         <translation>النمط D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="659"/>
         <source>Style A</source>
         <translation>النمط A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="674"/>
         <source>Off</source>
         <translation>إيقاف</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="653"/>
+        <location filename="../screens/SettingsScreen.qml" line="676"/>
         <source>1 second (testing)</source>
         <translation>ثانية واحدة (اختبار)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="655"/>
+        <location filename="../screens/SettingsScreen.qml" line="678"/>
         <source>1 minute</source>
         <translation>دقيقة واحدة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="657"/>
+        <location filename="../screens/SettingsScreen.qml" line="680"/>
         <source>2 minutes</source>
         <translation>دقيقتان</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="659"/>
+        <location filename="../screens/SettingsScreen.qml" line="682"/>
         <source>5 minutes</source>
         <translation>5 دقائق</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="661"/>
+        <location filename="../screens/SettingsScreen.qml" line="684"/>
         <source>10 minutes</source>
         <translation>10 دقائق</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="663"/>
+        <location filename="../screens/SettingsScreen.qml" line="686"/>
         <source>15 minutes</source>
         <translation>15 دقيقة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="665"/>
+        <location filename="../screens/SettingsScreen.qml" line="688"/>
         <source>30 minutes</source>
         <translation>30 دقيقة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="666"/>
+        <location filename="../screens/SettingsScreen.qml" line="689"/>
         <source>%1 seconds</source>
         <translation>%1 ثوانٍ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1292"/>
+        <location filename="../screens/SettingsScreen.qml" line="1358"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="96"/>
-        <location filename="../screens/SettingsScreen.qml" line="709"/>
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="732"/>
         <source>Resolution</source>
         <translation>الدقة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="68"/>
-        <location filename="../screens/SettingsScreen.qml" line="205"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="74"/>
-        <location filename="../screens/SettingsScreen.qml" line="207"/>
+        <location filename="../screens/SettingsScreen.qml" line="89"/>
+        <location filename="../screens/SettingsScreen.qml" line="227"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="86"/>
-        <location filename="../screens/SettingsScreen.qml" line="211"/>
+        <location filename="../screens/SettingsScreen.qml" line="101"/>
+        <location filename="../screens/SettingsScreen.qml" line="231"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="673"/>
+        <location filename="../screens/SettingsScreen.qml" line="696"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="675"/>
+        <location filename="../screens/SettingsScreen.qml" line="698"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="677"/>
+        <location filename="../screens/SettingsScreen.qml" line="700"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="679"/>
+        <location filename="../screens/SettingsScreen.qml" line="702"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="681"/>
+        <location filename="../screens/SettingsScreen.qml" line="704"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="683"/>
+        <location filename="../screens/SettingsScreen.qml" line="706"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="685"/>
+        <location filename="../screens/SettingsScreen.qml" line="708"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="687"/>
+        <location filename="../screens/SettingsScreen.qml" line="710"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="712"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="691"/>
+        <location filename="../screens/SettingsScreen.qml" line="714"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="693"/>
+        <location filename="../screens/SettingsScreen.qml" line="716"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="695"/>
+        <location filename="../screens/SettingsScreen.qml" line="718"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="212"/>
+        <location filename="../screens/SettingsScreen.qml" line="232"/>
         <source>Settings</source>
         <translation>الإعدادات</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1280"/>
+        <location filename="../screens/SettingsScreen.qml" line="1346"/>
         <source>No settings available on this platform</source>
         <translation>لا توجد إعدادات متاحة على هذه المنصة</translation>
     </message>
@@ -1409,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="206"/>
-        <location filename="../screens/SystemsScreen.qml" line="304"/>
+        <location filename="../screens/SystemsScreen.qml" line="229"/>
+        <location filename="../screens/SystemsScreen.qml" line="329"/>
         <source>%1 systems</source>
         <translation>%1 أنظمة</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="207"/>
-        <location filename="../screens/SystemsScreen.qml" line="321"/>
+        <location filename="../screens/SystemsScreen.qml" line="230"/>
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="339"/>
+        <location filename="../screens/SystemsScreen.qml" line="364"/>
         <source>No systems in this category</source>
         <translation>لا توجد أنظمة في هذه الفئة</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="340"/>
+        <location filename="../screens/SystemsScreen.qml" line="365"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>
@@ -1434,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="364"/>
+        <location filename="../components/Tile.qml" line="475"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="156"/>
+        <location filename="../screens/HubScreen.qml" line="154"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="162"/>
+        <location filename="../screens/HubScreen.qml" line="160"/>
         <source>Favorites</source>
         <translation>المفضلة</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="167"/>
+        <location filename="../screens/HubScreen.qml" line="165"/>
         <source>Recently Played</source>
         <translation>تم لعبها مؤخرًا</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="172"/>
+        <location filename="../screens/HubScreen.qml" line="170"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">الإعدادات</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="722"/>
+        <location filename="../screens/HubScreen.qml" line="718"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>لا توجد أنظمة متاحة. شغّل تحديث قاعدة بيانات الوسائط من الإعدادات.</translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>لا</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="256"/>
+        <location filename="../components/Modal.qml" line="246"/>
         <source>Cancel</source>
         <translation>إلغاء</translation>
     </message>
@@ -940,64 +940,64 @@ Euskara - devilschile2</source>
         <translation type="vanished">عام</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147"/>
-        <location filename="../screens/SettingsScreen.qml" line="741"/>
+        <location filename="../screens/SettingsScreen.qml" line="141"/>
+        <location filename="../screens/SettingsScreen.qml" line="734"/>
         <source>Language</source>
         <translation>اللغة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="768"/>
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="761"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
-        <location filename="../screens/SettingsScreen.qml" line="777"/>
+        <location filename="../screens/SettingsScreen.qml" line="116"/>
+        <location filename="../screens/SettingsScreen.qml" line="770"/>
         <source>Browsing layout</source>
         <translation>تخطيط التصفح</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="160"/>
-        <location filename="../screens/SettingsScreen.qml" line="786"/>
+        <location filename="../screens/SettingsScreen.qml" line="154"/>
+        <location filename="../screens/SettingsScreen.qml" line="779"/>
         <source>Button style</source>
         <translation>نمط الأزرار</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="132"/>
-        <location filename="../screens/SettingsScreen.qml" line="795"/>
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
+        <location filename="../screens/SettingsScreen.qml" line="788"/>
         <source>Screensaver</source>
         <translation>شاشة التوقف</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="95"/>
-        <location filename="../screens/SettingsScreen.qml" line="229"/>
+        <location filename="../screens/SettingsScreen.qml" line="89"/>
+        <location filename="../screens/SettingsScreen.qml" line="223"/>
         <source>Library</source>
         <translation>المكتبة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="182"/>
+        <location filename="../screens/SettingsScreen.qml" line="176"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="127"/>
-        <location filename="../screens/SettingsScreen.qml" line="804"/>
+        <location filename="../screens/SettingsScreen.qml" line="121"/>
+        <location filename="../screens/SettingsScreen.qml" line="797"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="177"/>
+        <location filename="../screens/SettingsScreen.qml" line="171"/>
         <source>Update media database</source>
         <translation>تحديث قاعدة بيانات الوسائط</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <location filename="../screens/SettingsScreen.qml" line="181"/>
         <source>Scrape metadata</source>
         <translation>استخراج البيانات الوصفية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="192"/>
+        <location filename="../screens/SettingsScreen.qml" line="186"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1006,407 +1006,407 @@ Euskara - devilschile2</source>
         <translation type="vanished">متقدم</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="165"/>
+        <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>Mouse support</source>
         <translation>دعم الفأرة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="204"/>
+        <location filename="../screens/SettingsScreen.qml" line="198"/>
         <source>Debug logging</source>
         <translation>تسجيل التصحيح</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="209"/>
+        <location filename="../screens/SettingsScreen.qml" line="203"/>
         <source>Upload log file</source>
         <translation>رفع ملف السجل</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="199"/>
+        <location filename="../screens/SettingsScreen.qml" line="193"/>
         <source>About / License</source>
         <translation>حول / الترخيص</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="137"/>
-        <location filename="../screens/SettingsScreen.qml" line="750"/>
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="743"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="142"/>
-        <location filename="../screens/SettingsScreen.qml" line="759"/>
+        <location filename="../screens/SettingsScreen.qml" line="136"/>
+        <location filename="../screens/SettingsScreen.qml" line="752"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152"/>
+        <location filename="../screens/SettingsScreen.qml" line="146"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="170"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
         <source>Reduce motion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="240"/>
         <source>Optimizing</source>
         <translation>جارٍ التحسين</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="248"/>
-        <location filename="../screens/SettingsScreen.qml" line="257"/>
+        <location filename="../screens/SettingsScreen.qml" line="242"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>Paused</source>
         <translation>متوقف مؤقتًا</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="248"/>
-        <location filename="../screens/SettingsScreen.qml" line="257"/>
+        <location filename="../screens/SettingsScreen.qml" line="242"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>In progress</source>
         <translation>قيد التنفيذ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="245"/>
         <source>%1 indexed</source>
         <translation>تمت فهرسة %1</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="260"/>
+        <location filename="../screens/SettingsScreen.qml" line="254"/>
         <source>%1 scraped</source>
         <translation>تم استخراج %1</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="495"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Cancel</source>
         <translation>إلغاء</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="495"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Start</source>
         <translation>ابدأ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="497"/>
+        <location filename="../screens/SettingsScreen.qml" line="490"/>
         <source>Upload</source>
         <translation>رفع</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <location filename="../screens/SettingsScreen.qml" line="491"/>
         <source>Open</source>
         <translation>فتح</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="549"/>
+        <location filename="../screens/SettingsScreen.qml" line="542"/>
         <source>Default</source>
         <translation>افتراضي</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="579"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>English</source>
         <translation>الإنجليزية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="581"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Italian</source>
         <translation>الإيطالية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="583"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="585"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="587"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>German</source>
         <translation>الألمانية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="589"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Greek</source>
         <translation>اليونانية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="591"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Japanese</source>
         <translation>اليابانية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="593"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Korean</source>
         <translation>الكورية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="595"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Dutch</source>
         <translation>الهولندية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="597"/>
+        <location filename="../screens/SettingsScreen.qml" line="590"/>
         <source>Romanian</source>
         <translation>الرومانية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="599"/>
+        <location filename="../screens/SettingsScreen.qml" line="592"/>
         <source>Slovak</source>
         <translation>السلوفاكية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="601"/>
+        <location filename="../screens/SettingsScreen.qml" line="594"/>
         <source>Ukrainian</source>
         <translation>الأوكرانية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="603"/>
+        <location filename="../screens/SettingsScreen.qml" line="596"/>
         <source>Chinese (Simplified)</source>
         <translation>الصينية المبسطة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="605"/>
+        <location filename="../screens/SettingsScreen.qml" line="598"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="607"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Hebrew</source>
         <translation>العبرية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Arabic</source>
         <translation>العربية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="611"/>
+        <location filename="../screens/SettingsScreen.qml" line="604"/>
         <source>Hindi</source>
         <translation>الهندية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
-        <location filename="../screens/SettingsScreen.qml" line="620"/>
-        <location filename="../screens/SettingsScreen.qml" line="694"/>
+        <location filename="../screens/SettingsScreen.qml" line="605"/>
+        <location filename="../screens/SettingsScreen.qml" line="613"/>
+        <location filename="../screens/SettingsScreen.qml" line="687"/>
         <source>Auto</source>
         <translation>تلقائي</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="610"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="619"/>
+        <location filename="../screens/SettingsScreen.qml" line="612"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="630"/>
+        <location filename="../screens/SettingsScreen.qml" line="623"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="632"/>
+        <location filename="../screens/SettingsScreen.qml" line="625"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="634"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="628"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="640"/>
+        <location filename="../screens/SettingsScreen.qml" line="633"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="642"/>
+        <location filename="../screens/SettingsScreen.qml" line="635"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="643"/>
+        <location filename="../screens/SettingsScreen.qml" line="636"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="648"/>
+        <location filename="../screens/SettingsScreen.qml" line="641"/>
         <source>Detailed list view</source>
         <translation>عرض قائمة مفصلة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="642"/>
         <source>Grid view</source>
         <translation>عرض الشبكة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="654"/>
+        <location filename="../screens/SettingsScreen.qml" line="647"/>
         <source>Style B</source>
         <translation>النمط B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="656"/>
+        <location filename="../screens/SettingsScreen.qml" line="649"/>
         <source>Style C</source>
         <translation>النمط C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="658"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
         <source>Style D</source>
         <translation>النمط D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="659"/>
+        <location filename="../screens/SettingsScreen.qml" line="652"/>
         <source>Style A</source>
         <translation>النمط A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="674"/>
+        <location filename="../screens/SettingsScreen.qml" line="667"/>
         <source>Off</source>
         <translation>إيقاف</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="676"/>
+        <location filename="../screens/SettingsScreen.qml" line="669"/>
         <source>1 second (testing)</source>
         <translation>ثانية واحدة (اختبار)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="678"/>
+        <location filename="../screens/SettingsScreen.qml" line="671"/>
         <source>1 minute</source>
         <translation>دقيقة واحدة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="680"/>
+        <location filename="../screens/SettingsScreen.qml" line="673"/>
         <source>2 minutes</source>
         <translation>دقيقتان</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="682"/>
+        <location filename="../screens/SettingsScreen.qml" line="675"/>
         <source>5 minutes</source>
         <translation>5 دقائق</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="684"/>
+        <location filename="../screens/SettingsScreen.qml" line="677"/>
         <source>10 minutes</source>
         <translation>10 دقائق</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="686"/>
+        <location filename="../screens/SettingsScreen.qml" line="679"/>
         <source>15 minutes</source>
         <translation>15 دقيقة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="688"/>
+        <location filename="../screens/SettingsScreen.qml" line="681"/>
         <source>30 minutes</source>
         <translation>30 دقيقة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="682"/>
         <source>%1 seconds</source>
         <translation>%1 ثوانٍ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1368"/>
+        <location filename="../screens/SettingsScreen.qml" line="1351"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
-        <location filename="../screens/SettingsScreen.qml" line="732"/>
+        <location filename="../screens/SettingsScreen.qml" line="105"/>
+        <location filename="../screens/SettingsScreen.qml" line="725"/>
         <source>Resolution</source>
         <translation>الدقة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="225"/>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="219"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="89"/>
-        <location filename="../screens/SettingsScreen.qml" line="227"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="221"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="101"/>
-        <location filename="../screens/SettingsScreen.qml" line="231"/>
+        <location filename="../screens/SettingsScreen.qml" line="95"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="696"/>
+        <location filename="../screens/SettingsScreen.qml" line="689"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="698"/>
+        <location filename="../screens/SettingsScreen.qml" line="691"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="700"/>
+        <location filename="../screens/SettingsScreen.qml" line="693"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="702"/>
+        <location filename="../screens/SettingsScreen.qml" line="695"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="704"/>
+        <location filename="../screens/SettingsScreen.qml" line="697"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="706"/>
+        <location filename="../screens/SettingsScreen.qml" line="699"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="708"/>
+        <location filename="../screens/SettingsScreen.qml" line="701"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="710"/>
+        <location filename="../screens/SettingsScreen.qml" line="703"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="712"/>
+        <location filename="../screens/SettingsScreen.qml" line="705"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="714"/>
+        <location filename="../screens/SettingsScreen.qml" line="707"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="716"/>
+        <location filename="../screens/SettingsScreen.qml" line="709"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="718"/>
+        <location filename="../screens/SettingsScreen.qml" line="711"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="232"/>
+        <location filename="../screens/SettingsScreen.qml" line="226"/>
         <source>Settings</source>
         <translation>الإعدادات</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1356"/>
+        <location filename="../screens/SettingsScreen.qml" line="1339"/>
         <source>No settings available on this platform</source>
         <translation>لا توجد إعدادات متاحة على هذه المنصة</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="236"/>
-        <location filename="../screens/SystemsScreen.qml" line="338"/>
+        <location filename="../screens/SystemsScreen.qml" line="242"/>
+        <location filename="../screens/SystemsScreen.qml" line="343"/>
         <source>%1 systems</source>
         <translation>%1 أنظمة</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="237"/>
-        <location filename="../screens/SystemsScreen.qml" line="355"/>
+        <location filename="../screens/SystemsScreen.qml" line="243"/>
+        <location filename="../screens/SystemsScreen.qml" line="360"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="373"/>
+        <location filename="../screens/SystemsScreen.qml" line="378"/>
         <source>No systems in this category</source>
         <translation>لا توجد أنظمة في هذه الفئة</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="374"/>
+        <location filename="../screens/SystemsScreen.qml" line="379"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>
@@ -1439,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="539"/>
+        <location filename="../components/Tile.qml" line="501"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -97,100 +97,100 @@ Euskara - devilschile2</source>
         <translation type="unfinished">جارٍ التحميل…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="196"/>
+        <location filename="../components/BrowseDetailPane.qml" line="167"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="196"/>
+        <location filename="../components/BrowseDetailPane.qml" line="167"/>
         <source>Yr</source>
         <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="198"/>
+        <location filename="../components/BrowseDetailPane.qml" line="169"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="198"/>
+        <location filename="../components/BrowseDetailPane.qml" line="169"/>
         <source>Gen</source>
         <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="200"/>
+        <location filename="../components/BrowseDetailPane.qml" line="171"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="200"/>
+        <location filename="../components/BrowseDetailPane.qml" line="171"/>
         <source>Plyr</source>
         <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="202"/>
+        <location filename="../components/BrowseDetailPane.qml" line="173"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="202"/>
+        <location filename="../components/BrowseDetailPane.qml" line="173"/>
         <source>Dev</source>
         <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="204"/>
+        <location filename="../components/BrowseDetailPane.qml" line="175"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="204"/>
+        <location filename="../components/BrowseDetailPane.qml" line="175"/>
         <source>Pub</source>
         <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="206"/>
+        <location filename="../components/BrowseDetailPane.qml" line="177"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="206"/>
+        <location filename="../components/BrowseDetailPane.qml" line="177"/>
         <source>Rtg</source>
         <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="208"/>
+        <location filename="../components/BrowseDetailPane.qml" line="179"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="208"/>
+        <location filename="../components/BrowseDetailPane.qml" line="179"/>
         <source>Cat</source>
         <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="210"/>
+        <location filename="../components/BrowseDetailPane.qml" line="181"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="210"/>
+        <location filename="../components/BrowseDetailPane.qml" line="181"/>
         <source>Date</source>
         <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="212"/>
+        <location filename="../components/BrowseDetailPane.qml" line="183"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="212"/>
+        <location filename="../components/BrowseDetailPane.qml" line="183"/>
         <source>Mfr</source>
         <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
@@ -425,8 +425,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="127"/>
-        <location filename="../screens/GamesScreen.qml" line="162"/>
+        <location filename="../screens/GamesScreen.qml" line="128"/>
+        <location filename="../screens/GamesScreen.qml" line="163"/>
         <source>%1 files</source>
         <translation>%1 ملفات</translation>
     </message>
@@ -436,8 +436,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="136"/>
-        <location filename="../screens/GamesScreen.qml" line="163"/>
+        <location filename="../screens/GamesScreen.qml" line="137"/>
+        <location filename="../screens/GamesScreen.qml" line="164"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -452,7 +452,7 @@ Euskara - devilschile2</source>
         <translation>جارٍ تحميل الألعاب…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="132"/>
+        <location filename="../screens/GamesScreen.qml" line="133"/>
         <source>Loading more…</source>
         <translation>جارٍ تحميل المزيد…</translation>
     </message>
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="149"/>
+        <location filename="../screens/HubScreen.qml" line="156"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="155"/>
+        <location filename="../screens/HubScreen.qml" line="162"/>
         <source>Favorites</source>
         <translation>المفضلة</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="160"/>
+        <location filename="../screens/HubScreen.qml" line="167"/>
         <source>Recently Played</source>
         <translation>تم لعبها مؤخرًا</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="165"/>
+        <location filename="../screens/HubScreen.qml" line="172"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">الإعدادات</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="701"/>
+        <location filename="../screens/HubScreen.qml" line="722"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>لا توجد أنظمة متاحة. شغّل تحديث قاعدة بيانات الوسائط من الإعدادات.</translation>
     </message>
@@ -553,138 +553,138 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1367"/>
+        <location filename="../app/Main.qml" line="1381"/>
         <source>Launch core</source>
         <translation>تشغيل النواة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1373"/>
-        <location filename="../app/Main.qml" line="1612"/>
+        <location filename="../app/Main.qml" line="1387"/>
+        <location filename="../app/Main.qml" line="1626"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1380"/>
-        <location filename="../app/Main.qml" line="1403"/>
+        <location filename="../app/Main.qml" line="1394"/>
+        <location filename="../app/Main.qml" line="1417"/>
         <source>Update media database</source>
         <translation type="unfinished">تحديث قاعدة بيانات الوسائط</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1383"/>
-        <location filename="../app/Main.qml" line="1406"/>
+        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1420"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">استخراج البيانات الوصفية</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1388"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1411"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1388"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1411"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1415"/>
-        <location filename="../app/Main.qml" line="1450"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1464"/>
         <source>Launch game</source>
         <translation>تشغيل اللعبة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1445"/>
         <source>Remove from favorites</source>
         <translation>إزالة من المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1445"/>
         <source>Add to favorites</source>
         <translation>أضف إلى المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1436"/>
+        <location filename="../app/Main.qml" line="1450"/>
         <source>Write to NFC token</source>
         <translation>الكتابة إلى رمز NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1440"/>
+        <location filename="../app/Main.qml" line="1454"/>
         <source>QR code</source>
         <translation>رمز QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1608"/>
+        <location filename="../app/Main.qml" line="1622"/>
         <source>Default</source>
         <translation type="unfinished">افتراضي</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1608"/>
+        <location filename="../app/Main.qml" line="1622"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1932"/>
+        <location filename="../app/Main.qml" line="1946"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1936"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1950"/>
+        <location filename="../app/Main.qml" line="1964"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1954"/>
+        <location filename="../app/Main.qml" line="1968"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1958"/>
+        <location filename="../app/Main.qml" line="1972"/>
         <source>Retry</source>
         <translation type="unfinished">إعادة المحاولة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1962"/>
+        <location filename="../app/Main.qml" line="1976"/>
         <source>Cancel</source>
         <translation type="unfinished">إلغاء</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2624"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2612"/>
+        <location filename="../app/Main.qml" line="2626"/>
         <source>Loading games…</source>
         <translation>جارٍ تحميل الألعاب…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2628"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2616"/>
+        <location filename="../app/Main.qml" line="2630"/>
         <source>Loading favorites…</source>
         <translation>جارٍ تحميل المفضلة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2618"/>
+        <location filename="../app/Main.qml" line="2632"/>
         <source>Loading recently played…</source>
         <translation>جارٍ تحميل آخر ما تم لعبه…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2620"/>
+        <location filename="../app/Main.qml" line="2634"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2622"/>
+        <location filename="../app/Main.qml" line="2636"/>
         <source>Loading…</source>
         <translation>جارٍ التحميل…</translation>
     </message>
@@ -864,12 +864,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">جارٍ التحميل…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="395"/>
+        <location filename="../screens/MediaListScreen.qml" line="436"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 عناصر</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="396"/>
+        <location filename="../screens/MediaListScreen.qml" line="437"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>لا</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="246"/>
+        <location filename="../components/Modal.qml" line="256"/>
         <source>Cancel</source>
         <translation>إلغاء</translation>
     </message>
@@ -1312,7 +1312,7 @@ Euskara - devilschile2</source>
         <translation>%1 ثوانٍ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1358"/>
+        <location filename="../screens/SettingsScreen.qml" line="1368"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1406,7 +1406,7 @@ Euskara - devilschile2</source>
         <translation>الإعدادات</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1346"/>
+        <location filename="../screens/SettingsScreen.qml" line="1356"/>
         <source>No settings available on this platform</source>
         <translation>لا توجد إعدادات متاحة على هذه المنصة</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="229"/>
-        <location filename="../screens/SystemsScreen.qml" line="329"/>
+        <location filename="../screens/SystemsScreen.qml" line="236"/>
+        <location filename="../screens/SystemsScreen.qml" line="338"/>
         <source>%1 systems</source>
         <translation>%1 أنظمة</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="230"/>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="237"/>
+        <location filename="../screens/SystemsScreen.qml" line="355"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="364"/>
+        <location filename="../screens/SystemsScreen.qml" line="373"/>
         <source>No systems in this category</source>
         <translation>لا توجد أنظمة في هذه الفئة</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="365"/>
+        <location filename="../screens/SystemsScreen.qml" line="374"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>
@@ -1439,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="475"/>
+        <location filename="../components/Tile.qml" line="539"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -425,8 +425,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="128"/>
-        <location filename="../screens/GamesScreen.qml" line="163"/>
+        <location filename="../screens/GamesScreen.qml" line="131"/>
+        <location filename="../screens/GamesScreen.qml" line="166"/>
         <source>%1 files</source>
         <translation>%1 ملفات</translation>
     </message>
@@ -436,8 +436,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="137"/>
-        <location filename="../screens/GamesScreen.qml" line="164"/>
+        <location filename="../screens/GamesScreen.qml" line="140"/>
+        <location filename="../screens/GamesScreen.qml" line="167"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -452,7 +452,7 @@ Euskara - devilschile2</source>
         <translation>جارٍ تحميل الألعاب…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="133"/>
+        <location filename="../screens/GamesScreen.qml" line="136"/>
         <source>Loading more…</source>
         <translation>جارٍ تحميل المزيد…</translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>لا</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="246"/>
+        <location filename="../components/Modal.qml" line="250"/>
         <source>Cancel</source>
         <translation>إلغاء</translation>
     </message>
@@ -940,64 +940,64 @@ Euskara - devilschile2</source>
         <translation type="vanished">عام</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="141"/>
-        <location filename="../screens/SettingsScreen.qml" line="734"/>
+        <location filename="../screens/SettingsScreen.qml" line="145"/>
+        <location filename="../screens/SettingsScreen.qml" line="738"/>
         <source>Language</source>
         <translation>اللغة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
-        <location filename="../screens/SettingsScreen.qml" line="761"/>
+        <location filename="../screens/SettingsScreen.qml" line="115"/>
+        <location filename="../screens/SettingsScreen.qml" line="765"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116"/>
-        <location filename="../screens/SettingsScreen.qml" line="770"/>
+        <location filename="../screens/SettingsScreen.qml" line="120"/>
+        <location filename="../screens/SettingsScreen.qml" line="774"/>
         <source>Browsing layout</source>
         <translation>تخطيط التصفح</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="154"/>
-        <location filename="../screens/SettingsScreen.qml" line="779"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="783"/>
         <source>Button style</source>
         <translation>نمط الأزرار</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
-        <location filename="../screens/SettingsScreen.qml" line="788"/>
+        <location filename="../screens/SettingsScreen.qml" line="130"/>
+        <location filename="../screens/SettingsScreen.qml" line="792"/>
         <source>Screensaver</source>
         <translation>شاشة التوقف</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="89"/>
-        <location filename="../screens/SettingsScreen.qml" line="223"/>
+        <location filename="../screens/SettingsScreen.qml" line="93"/>
+        <location filename="../screens/SettingsScreen.qml" line="227"/>
         <source>Library</source>
         <translation>المكتبة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="176"/>
+        <location filename="../screens/SettingsScreen.qml" line="180"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121"/>
-        <location filename="../screens/SettingsScreen.qml" line="797"/>
+        <location filename="../screens/SettingsScreen.qml" line="125"/>
+        <location filename="../screens/SettingsScreen.qml" line="801"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="171"/>
+        <location filename="../screens/SettingsScreen.qml" line="175"/>
         <source>Update media database</source>
         <translation>تحديث قاعدة بيانات الوسائط</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="181"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
         <source>Scrape metadata</source>
         <translation>استخراج البيانات الوصفية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="186"/>
+        <location filename="../screens/SettingsScreen.qml" line="190"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1006,407 +1006,407 @@ Euskara - devilschile2</source>
         <translation type="vanished">متقدم</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="159"/>
+        <location filename="../screens/SettingsScreen.qml" line="163"/>
         <source>Mouse support</source>
         <translation>دعم الفأرة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="198"/>
+        <location filename="../screens/SettingsScreen.qml" line="202"/>
         <source>Debug logging</source>
         <translation>تسجيل التصحيح</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="203"/>
+        <location filename="../screens/SettingsScreen.qml" line="207"/>
         <source>Upload log file</source>
         <translation>رفع ملف السجل</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="193"/>
+        <location filename="../screens/SettingsScreen.qml" line="197"/>
         <source>About / License</source>
         <translation>حول / الترخيص</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
-        <location filename="../screens/SettingsScreen.qml" line="743"/>
+        <location filename="../screens/SettingsScreen.qml" line="135"/>
+        <location filename="../screens/SettingsScreen.qml" line="747"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="136"/>
-        <location filename="../screens/SettingsScreen.qml" line="752"/>
+        <location filename="../screens/SettingsScreen.qml" line="140"/>
+        <location filename="../screens/SettingsScreen.qml" line="756"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="146"/>
+        <location filename="../screens/SettingsScreen.qml" line="150"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="168"/>
         <source>Reduce motion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="240"/>
+        <location filename="../screens/SettingsScreen.qml" line="244"/>
         <source>Optimizing</source>
         <translation>جارٍ التحسين</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="242"/>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="255"/>
         <source>Paused</source>
         <translation>متوقف مؤقتًا</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="242"/>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="255"/>
         <source>In progress</source>
         <translation>قيد التنفيذ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="245"/>
+        <location filename="../screens/SettingsScreen.qml" line="249"/>
         <source>%1 indexed</source>
         <translation>تمت فهرسة %1</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="254"/>
+        <location filename="../screens/SettingsScreen.qml" line="258"/>
         <source>%1 scraped</source>
         <translation>تم استخراج %1</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="488"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Cancel</source>
         <translation>إلغاء</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="488"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Start</source>
         <translation>ابدأ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="490"/>
+        <location filename="../screens/SettingsScreen.qml" line="494"/>
         <source>Upload</source>
         <translation>رفع</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="491"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Open</source>
         <translation>فتح</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="542"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>Default</source>
         <translation>افتراضي</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>English</source>
         <translation>الإنجليزية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Italian</source>
         <translation>الإيطالية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>German</source>
         <translation>الألمانية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Greek</source>
         <translation>اليونانية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Japanese</source>
         <translation>اليابانية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="590"/>
         <source>Korean</source>
         <translation>الكورية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="588"/>
+        <location filename="../screens/SettingsScreen.qml" line="592"/>
         <source>Dutch</source>
         <translation>الهولندية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="590"/>
+        <location filename="../screens/SettingsScreen.qml" line="594"/>
         <source>Romanian</source>
         <translation>الرومانية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="592"/>
+        <location filename="../screens/SettingsScreen.qml" line="596"/>
         <source>Slovak</source>
         <translation>السلوفاكية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="594"/>
+        <location filename="../screens/SettingsScreen.qml" line="598"/>
         <source>Ukrainian</source>
         <translation>الأوكرانية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="596"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Chinese (Simplified)</source>
         <translation>الصينية المبسطة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="598"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="600"/>
+        <location filename="../screens/SettingsScreen.qml" line="604"/>
         <source>Hebrew</source>
         <translation>العبرية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="602"/>
+        <location filename="../screens/SettingsScreen.qml" line="606"/>
         <source>Arabic</source>
         <translation>العربية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="604"/>
+        <location filename="../screens/SettingsScreen.qml" line="608"/>
         <source>Hindi</source>
         <translation>الهندية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="605"/>
-        <location filename="../screens/SettingsScreen.qml" line="613"/>
-        <location filename="../screens/SettingsScreen.qml" line="687"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="691"/>
         <source>Auto</source>
         <translation>تلقائي</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="610"/>
+        <location filename="../screens/SettingsScreen.qml" line="614"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="616"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="623"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="625"/>
+        <location filename="../screens/SettingsScreen.qml" line="629"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="627"/>
+        <location filename="../screens/SettingsScreen.qml" line="631"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="628"/>
+        <location filename="../screens/SettingsScreen.qml" line="632"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="633"/>
+        <location filename="../screens/SettingsScreen.qml" line="637"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="639"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="640"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="641"/>
+        <location filename="../screens/SettingsScreen.qml" line="645"/>
         <source>Detailed list view</source>
         <translation>عرض قائمة مفصلة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="642"/>
+        <location filename="../screens/SettingsScreen.qml" line="646"/>
         <source>Grid view</source>
         <translation>عرض الشبكة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
         <source>Style B</source>
         <translation>النمط B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Style C</source>
         <translation>النمط C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="655"/>
         <source>Style D</source>
         <translation>النمط D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="652"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Style A</source>
         <translation>النمط A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="667"/>
+        <location filename="../screens/SettingsScreen.qml" line="671"/>
         <source>Off</source>
         <translation>إيقاف</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="669"/>
+        <location filename="../screens/SettingsScreen.qml" line="673"/>
         <source>1 second (testing)</source>
         <translation>ثانية واحدة (اختبار)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="671"/>
+        <location filename="../screens/SettingsScreen.qml" line="675"/>
         <source>1 minute</source>
         <translation>دقيقة واحدة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="673"/>
+        <location filename="../screens/SettingsScreen.qml" line="677"/>
         <source>2 minutes</source>
         <translation>دقيقتان</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="675"/>
+        <location filename="../screens/SettingsScreen.qml" line="679"/>
         <source>5 minutes</source>
         <translation>5 دقائق</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="677"/>
+        <location filename="../screens/SettingsScreen.qml" line="681"/>
         <source>10 minutes</source>
         <translation>10 دقائق</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="679"/>
+        <location filename="../screens/SettingsScreen.qml" line="683"/>
         <source>15 minutes</source>
         <translation>15 دقيقة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="681"/>
+        <location filename="../screens/SettingsScreen.qml" line="685"/>
         <source>30 minutes</source>
         <translation>30 دقيقة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="682"/>
+        <location filename="../screens/SettingsScreen.qml" line="686"/>
         <source>%1 seconds</source>
         <translation>%1 ثوانٍ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1351"/>
+        <location filename="../screens/SettingsScreen.qml" line="1382"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="105"/>
-        <location filename="../screens/SettingsScreen.qml" line="725"/>
+        <location filename="../screens/SettingsScreen.qml" line="109"/>
+        <location filename="../screens/SettingsScreen.qml" line="729"/>
         <source>Resolution</source>
         <translation>الدقة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="77"/>
-        <location filename="../screens/SettingsScreen.qml" line="219"/>
+        <location filename="../screens/SettingsScreen.qml" line="81"/>
+        <location filename="../screens/SettingsScreen.qml" line="223"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="221"/>
+        <location filename="../screens/SettingsScreen.qml" line="87"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="95"/>
-        <location filename="../screens/SettingsScreen.qml" line="225"/>
+        <location filename="../screens/SettingsScreen.qml" line="99"/>
+        <location filename="../screens/SettingsScreen.qml" line="229"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="693"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="691"/>
+        <location filename="../screens/SettingsScreen.qml" line="695"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="693"/>
+        <location filename="../screens/SettingsScreen.qml" line="697"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="695"/>
+        <location filename="../screens/SettingsScreen.qml" line="699"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="697"/>
+        <location filename="../screens/SettingsScreen.qml" line="701"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="699"/>
+        <location filename="../screens/SettingsScreen.qml" line="703"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="701"/>
+        <location filename="../screens/SettingsScreen.qml" line="705"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="703"/>
+        <location filename="../screens/SettingsScreen.qml" line="707"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="705"/>
+        <location filename="../screens/SettingsScreen.qml" line="709"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="707"/>
+        <location filename="../screens/SettingsScreen.qml" line="711"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="709"/>
+        <location filename="../screens/SettingsScreen.qml" line="713"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="711"/>
+        <location filename="../screens/SettingsScreen.qml" line="715"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="226"/>
+        <location filename="../screens/SettingsScreen.qml" line="230"/>
         <source>Settings</source>
         <translation>الإعدادات</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1339"/>
+        <location filename="../screens/SettingsScreen.qml" line="1370"/>
         <source>No settings available on this platform</source>
         <translation>لا توجد إعدادات متاحة على هذه المنصة</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="242"/>
-        <location filename="../screens/SystemsScreen.qml" line="343"/>
+        <location filename="../screens/SystemsScreen.qml" line="245"/>
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>%1 systems</source>
         <translation>%1 أنظمة</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="243"/>
-        <location filename="../screens/SystemsScreen.qml" line="360"/>
+        <location filename="../screens/SystemsScreen.qml" line="246"/>
+        <location filename="../screens/SystemsScreen.qml" line="363"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="378"/>
+        <location filename="../screens/SystemsScreen.qml" line="381"/>
         <source>No systems in this category</source>
         <translation>لا توجد أنظمة في هذه الفئة</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="379"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -425,8 +425,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="128"/>
-        <location filename="../screens/GamesScreen.qml" line="163"/>
+        <location filename="../screens/GamesScreen.qml" line="131"/>
+        <location filename="../screens/GamesScreen.qml" line="166"/>
         <source>%1 files</source>
         <translation>%1 Dateien</translation>
     </message>
@@ -436,8 +436,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="137"/>
-        <location filename="../screens/GamesScreen.qml" line="164"/>
+        <location filename="../screens/GamesScreen.qml" line="140"/>
+        <location filename="../screens/GamesScreen.qml" line="167"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -447,7 +447,7 @@ Euskara - devilschile2</source>
         <translation>Spiele werden geladen…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="133"/>
+        <location filename="../screens/GamesScreen.qml" line="136"/>
         <source>Loading more…</source>
         <translation>Mehr laden…</translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>Nein</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="246"/>
+        <location filename="../components/Modal.qml" line="250"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
@@ -936,24 +936,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="141"/>
-        <location filename="../screens/SettingsScreen.qml" line="734"/>
+        <location filename="../screens/SettingsScreen.qml" line="145"/>
+        <location filename="../screens/SettingsScreen.qml" line="738"/>
         <source>Language</source>
         <translation>Sprache</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116"/>
-        <location filename="../screens/SettingsScreen.qml" line="770"/>
+        <location filename="../screens/SettingsScreen.qml" line="120"/>
+        <location filename="../screens/SettingsScreen.qml" line="774"/>
         <source>Browsing layout</source>
         <translation>Darstellungsmodus</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="159"/>
+        <location filename="../screens/SettingsScreen.qml" line="163"/>
         <source>Mouse support</source>
         <translation>Mausunterstützung</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="171"/>
+        <location filename="../screens/SettingsScreen.qml" line="175"/>
         <source>Update media database</source>
         <translation>Mediendatenbank aktualisieren</translation>
     </message>
@@ -962,47 +962,47 @@ Euskara - devilschile2</source>
         <translation type="vanished">Allgemein</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
-        <location filename="../screens/SettingsScreen.qml" line="761"/>
+        <location filename="../screens/SettingsScreen.qml" line="115"/>
+        <location filename="../screens/SettingsScreen.qml" line="765"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="154"/>
-        <location filename="../screens/SettingsScreen.qml" line="779"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="783"/>
         <source>Button style</source>
         <translation>Schaltflächenstil</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
-        <location filename="../screens/SettingsScreen.qml" line="788"/>
+        <location filename="../screens/SettingsScreen.qml" line="130"/>
+        <location filename="../screens/SettingsScreen.qml" line="792"/>
         <source>Screensaver</source>
         <translation>Bildschirmschoner</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="89"/>
-        <location filename="../screens/SettingsScreen.qml" line="223"/>
+        <location filename="../screens/SettingsScreen.qml" line="93"/>
+        <location filename="../screens/SettingsScreen.qml" line="227"/>
         <source>Library</source>
         <translation>Bibliothek</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="176"/>
+        <location filename="../screens/SettingsScreen.qml" line="180"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121"/>
-        <location filename="../screens/SettingsScreen.qml" line="797"/>
+        <location filename="../screens/SettingsScreen.qml" line="125"/>
+        <location filename="../screens/SettingsScreen.qml" line="801"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="181"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
         <source>Scrape metadata</source>
         <translation>Metadaten abrufen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="186"/>
+        <location filename="../screens/SettingsScreen.qml" line="190"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1011,402 +1011,402 @@ Euskara - devilschile2</source>
         <translation type="vanished">Erweitert</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="198"/>
+        <location filename="../screens/SettingsScreen.qml" line="202"/>
         <source>Debug logging</source>
         <translation>Debug-Protokollierung</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="203"/>
+        <location filename="../screens/SettingsScreen.qml" line="207"/>
         <source>Upload log file</source>
         <translation>Protokolldatei hochladen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="193"/>
+        <location filename="../screens/SettingsScreen.qml" line="197"/>
         <source>About / License</source>
         <translation>Über / Lizenz</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
-        <location filename="../screens/SettingsScreen.qml" line="743"/>
+        <location filename="../screens/SettingsScreen.qml" line="135"/>
+        <location filename="../screens/SettingsScreen.qml" line="747"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="136"/>
-        <location filename="../screens/SettingsScreen.qml" line="752"/>
+        <location filename="../screens/SettingsScreen.qml" line="140"/>
+        <location filename="../screens/SettingsScreen.qml" line="756"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="146"/>
+        <location filename="../screens/SettingsScreen.qml" line="150"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="168"/>
         <source>Reduce motion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="240"/>
+        <location filename="../screens/SettingsScreen.qml" line="244"/>
         <source>Optimizing</source>
         <translation>Wird optimiert</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="242"/>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="255"/>
         <source>Paused</source>
         <translation>Pausiert</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="242"/>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="255"/>
         <source>In progress</source>
         <translation>In Bearbeitung</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="245"/>
+        <location filename="../screens/SettingsScreen.qml" line="249"/>
         <source>%1 indexed</source>
         <translation>%1 indiziert</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="254"/>
+        <location filename="../screens/SettingsScreen.qml" line="258"/>
         <source>%1 scraped</source>
         <translation>%1 erfasst</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="488"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="488"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Start</source>
         <translation>Starten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="490"/>
+        <location filename="../screens/SettingsScreen.qml" line="494"/>
         <source>Upload</source>
         <translation>Hochladen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="491"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Open</source>
         <translation>Öffnen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>English</source>
         <translation>Englisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Italian</source>
         <translation>Italienisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>German</source>
         <translation>Deutsch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Greek</source>
         <translation>Griechisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Japanese</source>
         <translation>Japanisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="590"/>
         <source>Korean</source>
         <translation>Koreanisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="588"/>
+        <location filename="../screens/SettingsScreen.qml" line="592"/>
         <source>Dutch</source>
         <translation>Niederländisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="590"/>
+        <location filename="../screens/SettingsScreen.qml" line="594"/>
         <source>Romanian</source>
         <translation>Rumänisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="592"/>
+        <location filename="../screens/SettingsScreen.qml" line="596"/>
         <source>Slovak</source>
         <translation>Slowakisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="594"/>
+        <location filename="../screens/SettingsScreen.qml" line="598"/>
         <source>Ukrainian</source>
         <translation>Ukrainisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="596"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Chinese (Simplified)</source>
         <translation>Chinesisch (vereinfacht)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="598"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="600"/>
+        <location filename="../screens/SettingsScreen.qml" line="604"/>
         <source>Hebrew</source>
         <translation>Hebräisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="602"/>
+        <location filename="../screens/SettingsScreen.qml" line="606"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="604"/>
+        <location filename="../screens/SettingsScreen.qml" line="608"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="605"/>
-        <location filename="../screens/SettingsScreen.qml" line="613"/>
-        <location filename="../screens/SettingsScreen.qml" line="687"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="691"/>
         <source>Auto</source>
         <translation>Automatisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="610"/>
+        <location filename="../screens/SettingsScreen.qml" line="614"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="616"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="623"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="625"/>
+        <location filename="../screens/SettingsScreen.qml" line="629"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="627"/>
+        <location filename="../screens/SettingsScreen.qml" line="631"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="628"/>
+        <location filename="../screens/SettingsScreen.qml" line="632"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="633"/>
+        <location filename="../screens/SettingsScreen.qml" line="637"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="639"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="640"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="641"/>
+        <location filename="../screens/SettingsScreen.qml" line="645"/>
         <source>Detailed list view</source>
         <translation>Detaillierte Listenansicht</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="642"/>
+        <location filename="../screens/SettingsScreen.qml" line="646"/>
         <source>Grid view</source>
         <translation>Rasteransicht</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
         <source>Style B</source>
         <translation>Stil B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Style C</source>
         <translation>Stil C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="655"/>
         <source>Style D</source>
         <translation>Stil D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="652"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Style A</source>
         <translation>Stil A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1351"/>
+        <location filename="../screens/SettingsScreen.qml" line="1382"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="542"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>Default</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="667"/>
+        <location filename="../screens/SettingsScreen.qml" line="671"/>
         <source>Off</source>
         <translation>Aus</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="669"/>
+        <location filename="../screens/SettingsScreen.qml" line="673"/>
         <source>1 second (testing)</source>
         <translation>1 Sekunde (Test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="671"/>
+        <location filename="../screens/SettingsScreen.qml" line="675"/>
         <source>1 minute</source>
         <translation>1 Minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="673"/>
+        <location filename="../screens/SettingsScreen.qml" line="677"/>
         <source>2 minutes</source>
         <translation>2 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="675"/>
+        <location filename="../screens/SettingsScreen.qml" line="679"/>
         <source>5 minutes</source>
         <translation>5 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="677"/>
+        <location filename="../screens/SettingsScreen.qml" line="681"/>
         <source>10 minutes</source>
         <translation>10 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="679"/>
+        <location filename="../screens/SettingsScreen.qml" line="683"/>
         <source>15 minutes</source>
         <translation>15 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="681"/>
+        <location filename="../screens/SettingsScreen.qml" line="685"/>
         <source>30 minutes</source>
         <translation>30 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="682"/>
+        <location filename="../screens/SettingsScreen.qml" line="686"/>
         <source>%1 seconds</source>
         <translation>%1 Sekunden</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="105"/>
-        <location filename="../screens/SettingsScreen.qml" line="725"/>
+        <location filename="../screens/SettingsScreen.qml" line="109"/>
+        <location filename="../screens/SettingsScreen.qml" line="729"/>
         <source>Resolution</source>
         <translation>Auflösung</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="77"/>
-        <location filename="../screens/SettingsScreen.qml" line="219"/>
+        <location filename="../screens/SettingsScreen.qml" line="81"/>
+        <location filename="../screens/SettingsScreen.qml" line="223"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="221"/>
+        <location filename="../screens/SettingsScreen.qml" line="87"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="95"/>
-        <location filename="../screens/SettingsScreen.qml" line="225"/>
+        <location filename="../screens/SettingsScreen.qml" line="99"/>
+        <location filename="../screens/SettingsScreen.qml" line="229"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="693"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="691"/>
+        <location filename="../screens/SettingsScreen.qml" line="695"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="693"/>
+        <location filename="../screens/SettingsScreen.qml" line="697"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="695"/>
+        <location filename="../screens/SettingsScreen.qml" line="699"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="697"/>
+        <location filename="../screens/SettingsScreen.qml" line="701"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="699"/>
+        <location filename="../screens/SettingsScreen.qml" line="703"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="701"/>
+        <location filename="../screens/SettingsScreen.qml" line="705"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="703"/>
+        <location filename="../screens/SettingsScreen.qml" line="707"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="705"/>
+        <location filename="../screens/SettingsScreen.qml" line="709"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="707"/>
+        <location filename="../screens/SettingsScreen.qml" line="711"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="709"/>
+        <location filename="../screens/SettingsScreen.qml" line="713"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="711"/>
+        <location filename="../screens/SettingsScreen.qml" line="715"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="226"/>
+        <location filename="../screens/SettingsScreen.qml" line="230"/>
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1339"/>
+        <location filename="../screens/SettingsScreen.qml" line="1370"/>
         <source>No settings available on this platform</source>
         <translation>Keine Einstellungen für diese Plattform verfügbar</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="242"/>
-        <location filename="../screens/SystemsScreen.qml" line="343"/>
+        <location filename="../screens/SystemsScreen.qml" line="245"/>
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>%1 systems</source>
         <translation>%1 Systeme</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="243"/>
-        <location filename="../screens/SystemsScreen.qml" line="360"/>
+        <location filename="../screens/SystemsScreen.qml" line="246"/>
+        <location filename="../screens/SystemsScreen.qml" line="363"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="378"/>
+        <location filename="../screens/SystemsScreen.qml" line="381"/>
         <source>No systems in this category</source>
         <translation>Keine Systeme in dieser Kategorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="379"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -97,100 +97,100 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Wird geladen…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="196"/>
+        <location filename="../components/BrowseDetailPane.qml" line="167"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="196"/>
+        <location filename="../components/BrowseDetailPane.qml" line="167"/>
         <source>Yr</source>
         <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="198"/>
+        <location filename="../components/BrowseDetailPane.qml" line="169"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="198"/>
+        <location filename="../components/BrowseDetailPane.qml" line="169"/>
         <source>Gen</source>
         <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="200"/>
+        <location filename="../components/BrowseDetailPane.qml" line="171"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="200"/>
+        <location filename="../components/BrowseDetailPane.qml" line="171"/>
         <source>Plyr</source>
         <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="202"/>
+        <location filename="../components/BrowseDetailPane.qml" line="173"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="202"/>
+        <location filename="../components/BrowseDetailPane.qml" line="173"/>
         <source>Dev</source>
         <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="204"/>
+        <location filename="../components/BrowseDetailPane.qml" line="175"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="204"/>
+        <location filename="../components/BrowseDetailPane.qml" line="175"/>
         <source>Pub</source>
         <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="206"/>
+        <location filename="../components/BrowseDetailPane.qml" line="177"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="206"/>
+        <location filename="../components/BrowseDetailPane.qml" line="177"/>
         <source>Rtg</source>
         <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="208"/>
+        <location filename="../components/BrowseDetailPane.qml" line="179"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="208"/>
+        <location filename="../components/BrowseDetailPane.qml" line="179"/>
         <source>Cat</source>
         <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="210"/>
+        <location filename="../components/BrowseDetailPane.qml" line="181"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="210"/>
+        <location filename="../components/BrowseDetailPane.qml" line="181"/>
         <source>Date</source>
         <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="212"/>
+        <location filename="../components/BrowseDetailPane.qml" line="183"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="212"/>
+        <location filename="../components/BrowseDetailPane.qml" line="183"/>
         <source>Mfr</source>
         <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
@@ -425,8 +425,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="127"/>
-        <location filename="../screens/GamesScreen.qml" line="162"/>
+        <location filename="../screens/GamesScreen.qml" line="128"/>
+        <location filename="../screens/GamesScreen.qml" line="163"/>
         <source>%1 files</source>
         <translation>%1 Dateien</translation>
     </message>
@@ -436,8 +436,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="136"/>
-        <location filename="../screens/GamesScreen.qml" line="163"/>
+        <location filename="../screens/GamesScreen.qml" line="137"/>
+        <location filename="../screens/GamesScreen.qml" line="164"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -447,7 +447,7 @@ Euskara - devilschile2</source>
         <translation>Spiele werden geladen…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="132"/>
+        <location filename="../screens/GamesScreen.qml" line="133"/>
         <source>Loading more…</source>
         <translation>Mehr laden…</translation>
     </message>
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="149"/>
+        <location filename="../screens/HubScreen.qml" line="156"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="155"/>
+        <location filename="../screens/HubScreen.qml" line="162"/>
         <source>Favorites</source>
         <translation>Favoriten</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="160"/>
+        <location filename="../screens/HubScreen.qml" line="167"/>
         <source>Recently Played</source>
         <translation>Zuletzt gespielt</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="165"/>
+        <location filename="../screens/HubScreen.qml" line="172"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Einstellungen</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="701"/>
+        <location filename="../screens/HubScreen.qml" line="722"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Keine Systeme verfügbar. Bitte Mediendatenbank unter Einstellungen aktualisieren.</translation>
     </message>
@@ -553,138 +553,138 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1367"/>
+        <location filename="../app/Main.qml" line="1381"/>
         <source>Launch core</source>
         <translation>Core starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1373"/>
-        <location filename="../app/Main.qml" line="1612"/>
+        <location filename="../app/Main.qml" line="1387"/>
+        <location filename="../app/Main.qml" line="1626"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1445"/>
         <source>Remove from favorites</source>
         <translation>Aus Favoriten entfernen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1445"/>
         <source>Add to favorites</source>
         <translation>Zu Favoriten hinzufügen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1436"/>
+        <location filename="../app/Main.qml" line="1450"/>
         <source>Write to NFC token</source>
         <translation>Auf NFC-Token schreiben</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1440"/>
+        <location filename="../app/Main.qml" line="1454"/>
         <source>QR code</source>
         <translation>QR-Code</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1415"/>
-        <location filename="../app/Main.qml" line="1450"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1464"/>
         <source>Launch game</source>
         <translation>Spiel starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2624"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2616"/>
+        <location filename="../app/Main.qml" line="2630"/>
         <source>Loading favorites…</source>
         <translation>Favoriten werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2612"/>
+        <location filename="../app/Main.qml" line="2626"/>
         <source>Loading games…</source>
         <translation>Spiele werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1380"/>
-        <location filename="../app/Main.qml" line="1403"/>
+        <location filename="../app/Main.qml" line="1394"/>
+        <location filename="../app/Main.qml" line="1417"/>
         <source>Update media database</source>
         <translation type="unfinished">Mediendatenbank aktualisieren</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1383"/>
-        <location filename="../app/Main.qml" line="1406"/>
+        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1420"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadaten abrufen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1388"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1411"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1388"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1411"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1608"/>
+        <location filename="../app/Main.qml" line="1622"/>
         <source>Default</source>
         <translation type="unfinished">Standard</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1608"/>
+        <location filename="../app/Main.qml" line="1622"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1932"/>
+        <location filename="../app/Main.qml" line="1946"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1936"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1950"/>
+        <location filename="../app/Main.qml" line="1964"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1954"/>
+        <location filename="../app/Main.qml" line="1968"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1958"/>
+        <location filename="../app/Main.qml" line="1972"/>
         <source>Retry</source>
         <translation type="unfinished">Wiederholen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1962"/>
+        <location filename="../app/Main.qml" line="1976"/>
         <source>Cancel</source>
         <translation type="unfinished">Abbrechen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2628"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2618"/>
+        <location filename="../app/Main.qml" line="2632"/>
         <source>Loading recently played…</source>
         <translation>Zuletzt gespielte werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2620"/>
+        <location filename="../app/Main.qml" line="2634"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2622"/>
+        <location filename="../app/Main.qml" line="2636"/>
         <source>Loading…</source>
         <translation>Wird geladen…</translation>
     </message>
@@ -864,12 +864,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Wird geladen…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="395"/>
+        <location filename="../screens/MediaListScreen.qml" line="436"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 Einträge</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="396"/>
+        <location filename="../screens/MediaListScreen.qml" line="437"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>Nein</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="246"/>
+        <location filename="../components/Modal.qml" line="256"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
@@ -1262,7 +1262,7 @@ Euskara - devilschile2</source>
         <translation>Stil A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1358"/>
+        <location filename="../screens/SettingsScreen.qml" line="1368"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1406,7 +1406,7 @@ Euskara - devilschile2</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1346"/>
+        <location filename="../screens/SettingsScreen.qml" line="1356"/>
         <source>No settings available on this platform</source>
         <translation>Keine Einstellungen für diese Plattform verfügbar</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="229"/>
-        <location filename="../screens/SystemsScreen.qml" line="329"/>
+        <location filename="../screens/SystemsScreen.qml" line="236"/>
+        <location filename="../screens/SystemsScreen.qml" line="338"/>
         <source>%1 systems</source>
         <translation>%1 Systeme</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="230"/>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="237"/>
+        <location filename="../screens/SystemsScreen.qml" line="355"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="364"/>
+        <location filename="../screens/SystemsScreen.qml" line="373"/>
         <source>No systems in this category</source>
         <translation>Keine Systeme in dieser Kategorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="365"/>
+        <location filename="../screens/SystemsScreen.qml" line="374"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>
@@ -1439,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="475"/>
+        <location filename="../components/Tile.qml" line="539"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -425,34 +425,34 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="116"/>
-        <location filename="../screens/GamesScreen.qml" line="151"/>
+        <location filename="../screens/GamesScreen.qml" line="127"/>
+        <location filename="../screens/GamesScreen.qml" line="162"/>
         <source>%1 files</source>
         <translation>%1 Dateien</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="53"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="125"/>
-        <location filename="../screens/GamesScreen.qml" line="152"/>
+        <location filename="../screens/GamesScreen.qml" line="136"/>
+        <location filename="../screens/GamesScreen.qml" line="163"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="48"/>
+        <location filename="../screens/GamesScreen.qml" line="49"/>
         <source>Loading games…</source>
         <translation>Spiele werden geladen…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="121"/>
+        <location filename="../screens/GamesScreen.qml" line="132"/>
         <source>Loading more…</source>
         <translation>Mehr laden…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="47"/>
+        <location filename="../screens/GamesScreen.qml" line="48"/>
         <source>No games in this system</source>
         <translation>Keine Spiele in diesem System</translation>
     </message>
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="139"/>
+        <location filename="../screens/HubScreen.qml" line="149"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="145"/>
+        <location filename="../screens/HubScreen.qml" line="155"/>
         <source>Favorites</source>
         <translation>Favoriten</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="150"/>
+        <location filename="../screens/HubScreen.qml" line="160"/>
         <source>Recently Played</source>
         <translation>Zuletzt gespielt</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="155"/>
+        <location filename="../screens/HubScreen.qml" line="165"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Einstellungen</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="669"/>
+        <location filename="../screens/HubScreen.qml" line="701"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Keine Systeme verfügbar. Bitte Mediendatenbank unter Einstellungen aktualisieren.</translation>
     </message>
@@ -553,138 +553,138 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1361"/>
+        <location filename="../app/Main.qml" line="1367"/>
         <source>Launch core</source>
         <translation>Core starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1367"/>
-        <location filename="../app/Main.qml" line="1606"/>
+        <location filename="../app/Main.qml" line="1373"/>
+        <location filename="../app/Main.qml" line="1612"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1425"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Remove from favorites</source>
         <translation>Aus Favoriten entfernen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1425"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Add to favorites</source>
         <translation>Zu Favoriten hinzufügen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1430"/>
+        <location filename="../app/Main.qml" line="1436"/>
         <source>Write to NFC token</source>
         <translation>Auf NFC-Token schreiben</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1434"/>
+        <location filename="../app/Main.qml" line="1440"/>
         <source>QR code</source>
         <translation>QR-Code</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1409"/>
-        <location filename="../app/Main.qml" line="1444"/>
+        <location filename="../app/Main.qml" line="1415"/>
+        <location filename="../app/Main.qml" line="1450"/>
         <source>Launch game</source>
         <translation>Spiel starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2604"/>
+        <location filename="../app/Main.qml" line="2610"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2616"/>
         <source>Loading favorites…</source>
         <translation>Favoriten werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2606"/>
+        <location filename="../app/Main.qml" line="2612"/>
         <source>Loading games…</source>
         <translation>Spiele werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1374"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1380"/>
+        <location filename="../app/Main.qml" line="1403"/>
         <source>Update media database</source>
         <translation type="unfinished">Mediendatenbank aktualisieren</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1377"/>
-        <location filename="../app/Main.qml" line="1400"/>
+        <location filename="../app/Main.qml" line="1383"/>
+        <location filename="../app/Main.qml" line="1406"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadaten abrufen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1382"/>
-        <location filename="../app/Main.qml" line="1391"/>
+        <location filename="../app/Main.qml" line="1388"/>
+        <location filename="../app/Main.qml" line="1397"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1382"/>
-        <location filename="../app/Main.qml" line="1391"/>
+        <location filename="../app/Main.qml" line="1388"/>
+        <location filename="../app/Main.qml" line="1397"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1602"/>
+        <location filename="../app/Main.qml" line="1608"/>
         <source>Default</source>
         <translation type="unfinished">Standard</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1602"/>
+        <location filename="../app/Main.qml" line="1608"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1926"/>
+        <location filename="../app/Main.qml" line="1932"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1930"/>
+        <location filename="../app/Main.qml" line="1936"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1944"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1948"/>
+        <location filename="../app/Main.qml" line="1954"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1952"/>
+        <location filename="../app/Main.qml" line="1958"/>
         <source>Retry</source>
         <translation type="unfinished">Wiederholen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1956"/>
+        <location filename="../app/Main.qml" line="1962"/>
         <source>Cancel</source>
         <translation type="unfinished">Abbrechen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2608"/>
+        <location filename="../app/Main.qml" line="2614"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2612"/>
+        <location filename="../app/Main.qml" line="2618"/>
         <source>Loading recently played…</source>
         <translation>Zuletzt gespielte werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2620"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2616"/>
+        <location filename="../app/Main.qml" line="2622"/>
         <source>Loading…</source>
         <translation>Wird geladen…</translation>
     </message>
@@ -692,72 +692,72 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="683"/>
+        <location filename="../app/MainLayout.qml" line="685"/>
         <source>Writing failed</source>
         <translation>Schreiben fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="683"/>
+        <location filename="../app/MainLayout.qml" line="685"/>
         <source>Put a writable card near the reader</source>
         <translation>Beschreibbare Karte an den Leser halten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="811"/>
+        <location filename="../app/MainLayout.qml" line="813"/>
         <source>Are you sure you want to exit?</source>
         <translation>Wirklich beenden?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="894"/>
-        <location filename="../app/MainLayout.qml" line="968"/>
+        <location filename="../app/MainLayout.qml" line="896"/>
+        <location filename="../app/MainLayout.qml" line="970"/>
         <source>Select</source>
         <translation>Auswählen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="902"/>
-        <location filename="../app/MainLayout.qml" line="916"/>
-        <location filename="../app/MainLayout.qml" line="931"/>
-        <location filename="../app/MainLayout.qml" line="942"/>
+        <location filename="../app/MainLayout.qml" line="900"/>
+        <location filename="../app/MainLayout.qml" line="904"/>
+        <location filename="../app/MainLayout.qml" line="918"/>
+        <location filename="../app/MainLayout.qml" line="933"/>
+        <location filename="../app/MainLayout.qml" line="944"/>
         <source>Close</source>
         <translation>Schließen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="909"/>
-        <location filename="../app/MainLayout.qml" line="949"/>
-        <location filename="../app/MainLayout.qml" line="972"/>
-        <location filename="../app/MainLayout.qml" line="983"/>
+        <location filename="../app/MainLayout.qml" line="911"/>
+        <location filename="../app/MainLayout.qml" line="951"/>
+        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="985"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="927"/>
+        <location filename="../app/MainLayout.qml" line="929"/>
         <source>Done</source>
         <translation>Fertig</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="957"/>
+        <location filename="../app/MainLayout.qml" line="959"/>
         <source>I understand</source>
         <translation>Ich verstehe</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="991"/>
+        <location filename="../app/MainLayout.qml" line="993"/>
         <source>Start</source>
         <translation>Starten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1203"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Scroll</source>
         <translation>Scrollen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="890"/>
-        <location filename="../app/MainLayout.qml" line="964"/>
-        <location filename="../app/MainLayout.qml" line="1010"/>
-        <location filename="../app/MainLayout.qml" line="1047"/>
-        <location filename="../app/MainLayout.qml" line="1097"/>
-        <location filename="../app/MainLayout.qml" line="1146"/>
-        <location filename="../app/MainLayout.qml" line="1165"/>
-        <location filename="../app/MainLayout.qml" line="1232"/>
+        <location filename="../app/MainLayout.qml" line="892"/>
+        <location filename="../app/MainLayout.qml" line="966"/>
+        <location filename="../app/MainLayout.qml" line="1012"/>
+        <location filename="../app/MainLayout.qml" line="1049"/>
+        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1148"/>
+        <location filename="../app/MainLayout.qml" line="1167"/>
+        <location filename="../app/MainLayout.qml" line="1234"/>
         <source>Move</source>
         <translation>Bewegen</translation>
     </message>
@@ -777,81 +777,81 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Zuletzt gespielt</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="699"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="700"/>
+        <location filename="../app/MainLayout.qml" line="702"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="810"/>
+        <location filename="../app/MainLayout.qml" line="812"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1014"/>
-        <location filename="../app/MainLayout.qml" line="1057"/>
-        <location filename="../app/MainLayout.qml" line="1107"/>
-        <location filename="../app/MainLayout.qml" line="1151"/>
-        <location filename="../app/MainLayout.qml" line="1242"/>
+        <location filename="../app/MainLayout.qml" line="1016"/>
+        <location filename="../app/MainLayout.qml" line="1059"/>
+        <location filename="../app/MainLayout.qml" line="1109"/>
+        <location filename="../app/MainLayout.qml" line="1153"/>
+        <location filename="../app/MainLayout.qml" line="1244"/>
         <source>Open</source>
         <translation>Öffnen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1024"/>
+        <location filename="../app/MainLayout.qml" line="1026"/>
         <source>Quit</source>
         <translation>Beenden</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1033"/>
-        <location filename="../app/MainLayout.qml" line="1063"/>
-        <location filename="../app/MainLayout.qml" line="1074"/>
-        <location filename="../app/MainLayout.qml" line="1089"/>
-        <location filename="../app/MainLayout.qml" line="1116"/>
-        <location filename="../app/MainLayout.qml" line="1127"/>
-        <location filename="../app/MainLayout.qml" line="1139"/>
-        <location filename="../app/MainLayout.qml" line="1155"/>
-        <location filename="../app/MainLayout.qml" line="1189"/>
-        <location filename="../app/MainLayout.qml" line="1207"/>
-        <location filename="../app/MainLayout.qml" line="1216"/>
-        <location filename="../app/MainLayout.qml" line="1251"/>
-        <location filename="../app/MainLayout.qml" line="1262"/>
+        <location filename="../app/MainLayout.qml" line="1035"/>
+        <location filename="../app/MainLayout.qml" line="1065"/>
+        <location filename="../app/MainLayout.qml" line="1076"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
+        <location filename="../app/MainLayout.qml" line="1118"/>
+        <location filename="../app/MainLayout.qml" line="1129"/>
+        <location filename="../app/MainLayout.qml" line="1141"/>
+        <location filename="../app/MainLayout.qml" line="1157"/>
+        <location filename="../app/MainLayout.qml" line="1191"/>
+        <location filename="../app/MainLayout.qml" line="1209"/>
+        <location filename="../app/MainLayout.qml" line="1218"/>
+        <location filename="../app/MainLayout.qml" line="1253"/>
+        <location filename="../app/MainLayout.qml" line="1264"/>
         <source>Back</source>
         <translation>Zurück</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1053"/>
-        <location filename="../app/MainLayout.qml" line="1103"/>
-        <location filename="../app/MainLayout.qml" line="1238"/>
+        <location filename="../app/MainLayout.qml" line="1055"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
+        <location filename="../app/MainLayout.qml" line="1240"/>
         <source>Page</source>
         <translation>Seite</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1060"/>
-        <location filename="../app/MainLayout.qml" line="1112"/>
-        <location filename="../app/MainLayout.qml" line="1247"/>
+        <location filename="../app/MainLayout.qml" line="1022"/>
+        <location filename="../app/MainLayout.qml" line="1062"/>
+        <location filename="../app/MainLayout.qml" line="1114"/>
+        <location filename="../app/MainLayout.qml" line="1249"/>
         <source>Options</source>
         <translation>Optionen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1070"/>
-        <location filename="../app/MainLayout.qml" line="1123"/>
-        <location filename="../app/MainLayout.qml" line="1258"/>
+        <location filename="../app/MainLayout.qml" line="940"/>
+        <location filename="../app/MainLayout.qml" line="1072"/>
+        <location filename="../app/MainLayout.qml" line="1125"/>
+        <location filename="../app/MainLayout.qml" line="1260"/>
         <source>Retry</source>
         <translation>Wiederholen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1174"/>
+        <location filename="../app/MainLayout.qml" line="1176"/>
         <source>Change</source>
         <translation>Ändern</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1180"/>
+        <location filename="../app/MainLayout.qml" line="1182"/>
         <source>Toggle</source>
         <translation>Umschalten</translation>
     </message>
@@ -864,12 +864,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Wird geladen…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="365"/>
+        <location filename="../screens/MediaListScreen.qml" line="395"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 Einträge</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="366"/>
+        <location filename="../screens/MediaListScreen.qml" line="396"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>Nein</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="198"/>
+        <location filename="../components/Modal.qml" line="246"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
@@ -936,24 +936,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="132"/>
-        <location filename="../screens/SettingsScreen.qml" line="718"/>
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
+        <location filename="../screens/SettingsScreen.qml" line="741"/>
         <source>Language</source>
         <translation>Sprache</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="754"/>
+        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <location filename="../screens/SettingsScreen.qml" line="777"/>
         <source>Browsing layout</source>
         <translation>Darstellungsmodus</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="150"/>
+        <location filename="../screens/SettingsScreen.qml" line="165"/>
         <source>Mouse support</source>
         <translation>Mausunterstützung</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="157"/>
+        <location filename="../screens/SettingsScreen.qml" line="177"/>
         <source>Update media database</source>
         <translation>Mediendatenbank aktualisieren</translation>
     </message>
@@ -962,47 +962,47 @@ Euskara - devilschile2</source>
         <translation type="vanished">Allgemein</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="745"/>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="768"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="145"/>
-        <location filename="../screens/SettingsScreen.qml" line="763"/>
+        <location filename="../screens/SettingsScreen.qml" line="160"/>
+        <location filename="../screens/SettingsScreen.qml" line="786"/>
         <source>Button style</source>
         <translation>Schaltflächenstil</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="772"/>
+        <location filename="../screens/SettingsScreen.qml" line="132"/>
+        <location filename="../screens/SettingsScreen.qml" line="795"/>
         <source>Screensaver</source>
         <translation>Bildschirmschoner</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="80"/>
-        <location filename="../screens/SettingsScreen.qml" line="209"/>
+        <location filename="../screens/SettingsScreen.qml" line="95"/>
+        <location filename="../screens/SettingsScreen.qml" line="229"/>
         <source>Library</source>
         <translation>Bibliothek</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="162"/>
+        <location filename="../screens/SettingsScreen.qml" line="182"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="112"/>
-        <location filename="../screens/SettingsScreen.qml" line="781"/>
+        <location filename="../screens/SettingsScreen.qml" line="127"/>
+        <location filename="../screens/SettingsScreen.qml" line="804"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="167"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
         <source>Scrape metadata</source>
         <translation>Metadaten abrufen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="172"/>
+        <location filename="../screens/SettingsScreen.qml" line="192"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1011,397 +1011,402 @@ Euskara - devilschile2</source>
         <translation type="vanished">Erweitert</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="184"/>
+        <location filename="../screens/SettingsScreen.qml" line="204"/>
         <source>Debug logging</source>
         <translation>Debug-Protokollierung</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="189"/>
+        <location filename="../screens/SettingsScreen.qml" line="209"/>
         <source>Upload log file</source>
         <translation>Protokolldatei hochladen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="179"/>
+        <location filename="../screens/SettingsScreen.qml" line="199"/>
         <source>About / License</source>
         <translation>Über / Lizenz</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
-        <location filename="../screens/SettingsScreen.qml" line="727"/>
+        <location filename="../screens/SettingsScreen.qml" line="137"/>
+        <location filename="../screens/SettingsScreen.qml" line="750"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="127"/>
-        <location filename="../screens/SettingsScreen.qml" line="736"/>
+        <location filename="../screens/SettingsScreen.qml" line="142"/>
+        <location filename="../screens/SettingsScreen.qml" line="759"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="137"/>
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="226"/>
+        <location filename="../screens/SettingsScreen.qml" line="170"/>
+        <source>Reduce motion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
         <source>Optimizing</source>
         <translation>Wird optimiert</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="228"/>
-        <location filename="../screens/SettingsScreen.qml" line="237"/>
+        <location filename="../screens/SettingsScreen.qml" line="248"/>
+        <location filename="../screens/SettingsScreen.qml" line="257"/>
         <source>Paused</source>
         <translation>Pausiert</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="228"/>
-        <location filename="../screens/SettingsScreen.qml" line="237"/>
+        <location filename="../screens/SettingsScreen.qml" line="248"/>
+        <location filename="../screens/SettingsScreen.qml" line="257"/>
         <source>In progress</source>
         <translation>In Bearbeitung</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="231"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>%1 indexed</source>
         <translation>%1 indiziert</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="240"/>
+        <location filename="../screens/SettingsScreen.qml" line="260"/>
         <source>%1 scraped</source>
         <translation>%1 erfasst</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="472"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="472"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Start</source>
         <translation>Starten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="474"/>
+        <location filename="../screens/SettingsScreen.qml" line="497"/>
         <source>Upload</source>
         <translation>Hochladen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Open</source>
         <translation>Öffnen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="556"/>
+        <location filename="../screens/SettingsScreen.qml" line="579"/>
         <source>English</source>
         <translation>Englisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="558"/>
+        <location filename="../screens/SettingsScreen.qml" line="581"/>
         <source>Italian</source>
         <translation>Italienisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="560"/>
+        <location filename="../screens/SettingsScreen.qml" line="583"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="562"/>
+        <location filename="../screens/SettingsScreen.qml" line="585"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="564"/>
+        <location filename="../screens/SettingsScreen.qml" line="587"/>
         <source>German</source>
         <translation>Deutsch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="566"/>
+        <location filename="../screens/SettingsScreen.qml" line="589"/>
         <source>Greek</source>
         <translation>Griechisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="568"/>
+        <location filename="../screens/SettingsScreen.qml" line="591"/>
         <source>Japanese</source>
         <translation>Japanisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="570"/>
+        <location filename="../screens/SettingsScreen.qml" line="593"/>
         <source>Korean</source>
         <translation>Koreanisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="595"/>
         <source>Dutch</source>
         <translation>Niederländisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="597"/>
         <source>Romanian</source>
         <translation>Rumänisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="599"/>
         <source>Slovak</source>
         <translation>Slowakisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="601"/>
         <source>Ukrainian</source>
         <translation>Ukrainisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="603"/>
         <source>Chinese (Simplified)</source>
         <translation>Chinesisch (vereinfacht)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="605"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="607"/>
         <source>Hebrew</source>
         <translation>Hebräisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="588"/>
+        <location filename="../screens/SettingsScreen.qml" line="611"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="589"/>
-        <location filename="../screens/SettingsScreen.qml" line="597"/>
-        <location filename="../screens/SettingsScreen.qml" line="671"/>
+        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="620"/>
+        <location filename="../screens/SettingsScreen.qml" line="694"/>
         <source>Auto</source>
         <translation>Automatisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="594"/>
+        <location filename="../screens/SettingsScreen.qml" line="617"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="596"/>
+        <location filename="../screens/SettingsScreen.qml" line="619"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="607"/>
+        <location filename="../screens/SettingsScreen.qml" line="630"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="632"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="611"/>
+        <location filename="../screens/SettingsScreen.qml" line="634"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="635"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="640"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="619"/>
+        <location filename="../screens/SettingsScreen.qml" line="642"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="620"/>
+        <location filename="../screens/SettingsScreen.qml" line="643"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="625"/>
+        <location filename="../screens/SettingsScreen.qml" line="648"/>
         <source>Detailed list view</source>
         <translation>Detaillierte Listenansicht</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="626"/>
+        <location filename="../screens/SettingsScreen.qml" line="649"/>
         <source>Grid view</source>
         <translation>Rasteransicht</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="631"/>
+        <location filename="../screens/SettingsScreen.qml" line="654"/>
         <source>Style B</source>
         <translation>Stil B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="633"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Style C</source>
         <translation>Stil C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="658"/>
         <source>Style D</source>
         <translation>Stil D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="659"/>
         <source>Style A</source>
         <translation>Stil A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1292"/>
+        <location filename="../screens/SettingsScreen.qml" line="1358"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="526"/>
+        <location filename="../screens/SettingsScreen.qml" line="549"/>
         <source>Default</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="674"/>
         <source>Off</source>
         <translation>Aus</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="653"/>
+        <location filename="../screens/SettingsScreen.qml" line="676"/>
         <source>1 second (testing)</source>
         <translation>1 Sekunde (Test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="655"/>
+        <location filename="../screens/SettingsScreen.qml" line="678"/>
         <source>1 minute</source>
         <translation>1 Minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="657"/>
+        <location filename="../screens/SettingsScreen.qml" line="680"/>
         <source>2 minutes</source>
         <translation>2 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="659"/>
+        <location filename="../screens/SettingsScreen.qml" line="682"/>
         <source>5 minutes</source>
         <translation>5 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="661"/>
+        <location filename="../screens/SettingsScreen.qml" line="684"/>
         <source>10 minutes</source>
         <translation>10 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="663"/>
+        <location filename="../screens/SettingsScreen.qml" line="686"/>
         <source>15 minutes</source>
         <translation>15 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="665"/>
+        <location filename="../screens/SettingsScreen.qml" line="688"/>
         <source>30 minutes</source>
         <translation>30 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="666"/>
+        <location filename="../screens/SettingsScreen.qml" line="689"/>
         <source>%1 seconds</source>
         <translation>%1 Sekunden</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="96"/>
-        <location filename="../screens/SettingsScreen.qml" line="709"/>
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="732"/>
         <source>Resolution</source>
         <translation>Auflösung</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="68"/>
-        <location filename="../screens/SettingsScreen.qml" line="205"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="74"/>
-        <location filename="../screens/SettingsScreen.qml" line="207"/>
+        <location filename="../screens/SettingsScreen.qml" line="89"/>
+        <location filename="../screens/SettingsScreen.qml" line="227"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="86"/>
-        <location filename="../screens/SettingsScreen.qml" line="211"/>
+        <location filename="../screens/SettingsScreen.qml" line="101"/>
+        <location filename="../screens/SettingsScreen.qml" line="231"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="673"/>
+        <location filename="../screens/SettingsScreen.qml" line="696"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="675"/>
+        <location filename="../screens/SettingsScreen.qml" line="698"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="677"/>
+        <location filename="../screens/SettingsScreen.qml" line="700"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="679"/>
+        <location filename="../screens/SettingsScreen.qml" line="702"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="681"/>
+        <location filename="../screens/SettingsScreen.qml" line="704"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="683"/>
+        <location filename="../screens/SettingsScreen.qml" line="706"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="685"/>
+        <location filename="../screens/SettingsScreen.qml" line="708"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="687"/>
+        <location filename="../screens/SettingsScreen.qml" line="710"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="712"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="691"/>
+        <location filename="../screens/SettingsScreen.qml" line="714"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="693"/>
+        <location filename="../screens/SettingsScreen.qml" line="716"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="695"/>
+        <location filename="../screens/SettingsScreen.qml" line="718"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="212"/>
+        <location filename="../screens/SettingsScreen.qml" line="232"/>
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1280"/>
+        <location filename="../screens/SettingsScreen.qml" line="1346"/>
         <source>No settings available on this platform</source>
         <translation>Keine Einstellungen für diese Plattform verfügbar</translation>
     </message>
@@ -1409,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="206"/>
-        <location filename="../screens/SystemsScreen.qml" line="304"/>
+        <location filename="../screens/SystemsScreen.qml" line="229"/>
+        <location filename="../screens/SystemsScreen.qml" line="329"/>
         <source>%1 systems</source>
         <translation>%1 Systeme</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="207"/>
-        <location filename="../screens/SystemsScreen.qml" line="321"/>
+        <location filename="../screens/SystemsScreen.qml" line="230"/>
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="339"/>
+        <location filename="../screens/SystemsScreen.qml" line="364"/>
         <source>No systems in this category</source>
         <translation>Keine Systeme in dieser Kategorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="340"/>
+        <location filename="../screens/SystemsScreen.qml" line="365"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>
@@ -1434,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="364"/>
+        <location filename="../components/Tile.qml" line="475"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="156"/>
+        <location filename="../screens/HubScreen.qml" line="154"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="162"/>
+        <location filename="../screens/HubScreen.qml" line="160"/>
         <source>Favorites</source>
         <translation>Favoriten</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="167"/>
+        <location filename="../screens/HubScreen.qml" line="165"/>
         <source>Recently Played</source>
         <translation>Zuletzt gespielt</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="172"/>
+        <location filename="../screens/HubScreen.qml" line="170"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Einstellungen</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="722"/>
+        <location filename="../screens/HubScreen.qml" line="718"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Keine Systeme verfügbar. Bitte Mediendatenbank unter Einstellungen aktualisieren.</translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>Nein</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="256"/>
+        <location filename="../components/Modal.qml" line="246"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
@@ -936,24 +936,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147"/>
-        <location filename="../screens/SettingsScreen.qml" line="741"/>
+        <location filename="../screens/SettingsScreen.qml" line="141"/>
+        <location filename="../screens/SettingsScreen.qml" line="734"/>
         <source>Language</source>
         <translation>Sprache</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
-        <location filename="../screens/SettingsScreen.qml" line="777"/>
+        <location filename="../screens/SettingsScreen.qml" line="116"/>
+        <location filename="../screens/SettingsScreen.qml" line="770"/>
         <source>Browsing layout</source>
         <translation>Darstellungsmodus</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="165"/>
+        <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>Mouse support</source>
         <translation>Mausunterstützung</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="177"/>
+        <location filename="../screens/SettingsScreen.qml" line="171"/>
         <source>Update media database</source>
         <translation>Mediendatenbank aktualisieren</translation>
     </message>
@@ -962,47 +962,47 @@ Euskara - devilschile2</source>
         <translation type="vanished">Allgemein</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="768"/>
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="761"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="160"/>
-        <location filename="../screens/SettingsScreen.qml" line="786"/>
+        <location filename="../screens/SettingsScreen.qml" line="154"/>
+        <location filename="../screens/SettingsScreen.qml" line="779"/>
         <source>Button style</source>
         <translation>Schaltflächenstil</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="132"/>
-        <location filename="../screens/SettingsScreen.qml" line="795"/>
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
+        <location filename="../screens/SettingsScreen.qml" line="788"/>
         <source>Screensaver</source>
         <translation>Bildschirmschoner</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="95"/>
-        <location filename="../screens/SettingsScreen.qml" line="229"/>
+        <location filename="../screens/SettingsScreen.qml" line="89"/>
+        <location filename="../screens/SettingsScreen.qml" line="223"/>
         <source>Library</source>
         <translation>Bibliothek</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="182"/>
+        <location filename="../screens/SettingsScreen.qml" line="176"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="127"/>
-        <location filename="../screens/SettingsScreen.qml" line="804"/>
+        <location filename="../screens/SettingsScreen.qml" line="121"/>
+        <location filename="../screens/SettingsScreen.qml" line="797"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <location filename="../screens/SettingsScreen.qml" line="181"/>
         <source>Scrape metadata</source>
         <translation>Metadaten abrufen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="192"/>
+        <location filename="../screens/SettingsScreen.qml" line="186"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1011,402 +1011,402 @@ Euskara - devilschile2</source>
         <translation type="vanished">Erweitert</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="204"/>
+        <location filename="../screens/SettingsScreen.qml" line="198"/>
         <source>Debug logging</source>
         <translation>Debug-Protokollierung</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="209"/>
+        <location filename="../screens/SettingsScreen.qml" line="203"/>
         <source>Upload log file</source>
         <translation>Protokolldatei hochladen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="199"/>
+        <location filename="../screens/SettingsScreen.qml" line="193"/>
         <source>About / License</source>
         <translation>Über / Lizenz</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="137"/>
-        <location filename="../screens/SettingsScreen.qml" line="750"/>
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="743"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="142"/>
-        <location filename="../screens/SettingsScreen.qml" line="759"/>
+        <location filename="../screens/SettingsScreen.qml" line="136"/>
+        <location filename="../screens/SettingsScreen.qml" line="752"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152"/>
+        <location filename="../screens/SettingsScreen.qml" line="146"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="170"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
         <source>Reduce motion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="240"/>
         <source>Optimizing</source>
         <translation>Wird optimiert</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="248"/>
-        <location filename="../screens/SettingsScreen.qml" line="257"/>
+        <location filename="../screens/SettingsScreen.qml" line="242"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>Paused</source>
         <translation>Pausiert</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="248"/>
-        <location filename="../screens/SettingsScreen.qml" line="257"/>
+        <location filename="../screens/SettingsScreen.qml" line="242"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>In progress</source>
         <translation>In Bearbeitung</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="245"/>
         <source>%1 indexed</source>
         <translation>%1 indiziert</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="260"/>
+        <location filename="../screens/SettingsScreen.qml" line="254"/>
         <source>%1 scraped</source>
         <translation>%1 erfasst</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="495"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="495"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Start</source>
         <translation>Starten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="497"/>
+        <location filename="../screens/SettingsScreen.qml" line="490"/>
         <source>Upload</source>
         <translation>Hochladen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <location filename="../screens/SettingsScreen.qml" line="491"/>
         <source>Open</source>
         <translation>Öffnen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="579"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>English</source>
         <translation>Englisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="581"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Italian</source>
         <translation>Italienisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="583"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="585"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="587"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>German</source>
         <translation>Deutsch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="589"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Greek</source>
         <translation>Griechisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="591"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Japanese</source>
         <translation>Japanisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="593"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Korean</source>
         <translation>Koreanisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="595"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Dutch</source>
         <translation>Niederländisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="597"/>
+        <location filename="../screens/SettingsScreen.qml" line="590"/>
         <source>Romanian</source>
         <translation>Rumänisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="599"/>
+        <location filename="../screens/SettingsScreen.qml" line="592"/>
         <source>Slovak</source>
         <translation>Slowakisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="601"/>
+        <location filename="../screens/SettingsScreen.qml" line="594"/>
         <source>Ukrainian</source>
         <translation>Ukrainisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="603"/>
+        <location filename="../screens/SettingsScreen.qml" line="596"/>
         <source>Chinese (Simplified)</source>
         <translation>Chinesisch (vereinfacht)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="605"/>
+        <location filename="../screens/SettingsScreen.qml" line="598"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="607"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Hebrew</source>
         <translation>Hebräisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="611"/>
+        <location filename="../screens/SettingsScreen.qml" line="604"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
-        <location filename="../screens/SettingsScreen.qml" line="620"/>
-        <location filename="../screens/SettingsScreen.qml" line="694"/>
+        <location filename="../screens/SettingsScreen.qml" line="605"/>
+        <location filename="../screens/SettingsScreen.qml" line="613"/>
+        <location filename="../screens/SettingsScreen.qml" line="687"/>
         <source>Auto</source>
         <translation>Automatisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="610"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="619"/>
+        <location filename="../screens/SettingsScreen.qml" line="612"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="630"/>
+        <location filename="../screens/SettingsScreen.qml" line="623"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="632"/>
+        <location filename="../screens/SettingsScreen.qml" line="625"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="634"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="628"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="640"/>
+        <location filename="../screens/SettingsScreen.qml" line="633"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="642"/>
+        <location filename="../screens/SettingsScreen.qml" line="635"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="643"/>
+        <location filename="../screens/SettingsScreen.qml" line="636"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="648"/>
+        <location filename="../screens/SettingsScreen.qml" line="641"/>
         <source>Detailed list view</source>
         <translation>Detaillierte Listenansicht</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="642"/>
         <source>Grid view</source>
         <translation>Rasteransicht</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="654"/>
+        <location filename="../screens/SettingsScreen.qml" line="647"/>
         <source>Style B</source>
         <translation>Stil B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="656"/>
+        <location filename="../screens/SettingsScreen.qml" line="649"/>
         <source>Style C</source>
         <translation>Stil C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="658"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
         <source>Style D</source>
         <translation>Stil D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="659"/>
+        <location filename="../screens/SettingsScreen.qml" line="652"/>
         <source>Style A</source>
         <translation>Stil A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1368"/>
+        <location filename="../screens/SettingsScreen.qml" line="1351"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="549"/>
+        <location filename="../screens/SettingsScreen.qml" line="542"/>
         <source>Default</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="674"/>
+        <location filename="../screens/SettingsScreen.qml" line="667"/>
         <source>Off</source>
         <translation>Aus</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="676"/>
+        <location filename="../screens/SettingsScreen.qml" line="669"/>
         <source>1 second (testing)</source>
         <translation>1 Sekunde (Test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="678"/>
+        <location filename="../screens/SettingsScreen.qml" line="671"/>
         <source>1 minute</source>
         <translation>1 Minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="680"/>
+        <location filename="../screens/SettingsScreen.qml" line="673"/>
         <source>2 minutes</source>
         <translation>2 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="682"/>
+        <location filename="../screens/SettingsScreen.qml" line="675"/>
         <source>5 minutes</source>
         <translation>5 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="684"/>
+        <location filename="../screens/SettingsScreen.qml" line="677"/>
         <source>10 minutes</source>
         <translation>10 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="686"/>
+        <location filename="../screens/SettingsScreen.qml" line="679"/>
         <source>15 minutes</source>
         <translation>15 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="688"/>
+        <location filename="../screens/SettingsScreen.qml" line="681"/>
         <source>30 minutes</source>
         <translation>30 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="682"/>
         <source>%1 seconds</source>
         <translation>%1 Sekunden</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
-        <location filename="../screens/SettingsScreen.qml" line="732"/>
+        <location filename="../screens/SettingsScreen.qml" line="105"/>
+        <location filename="../screens/SettingsScreen.qml" line="725"/>
         <source>Resolution</source>
         <translation>Auflösung</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="225"/>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="219"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="89"/>
-        <location filename="../screens/SettingsScreen.qml" line="227"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="221"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="101"/>
-        <location filename="../screens/SettingsScreen.qml" line="231"/>
+        <location filename="../screens/SettingsScreen.qml" line="95"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="696"/>
+        <location filename="../screens/SettingsScreen.qml" line="689"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="698"/>
+        <location filename="../screens/SettingsScreen.qml" line="691"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="700"/>
+        <location filename="../screens/SettingsScreen.qml" line="693"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="702"/>
+        <location filename="../screens/SettingsScreen.qml" line="695"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="704"/>
+        <location filename="../screens/SettingsScreen.qml" line="697"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="706"/>
+        <location filename="../screens/SettingsScreen.qml" line="699"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="708"/>
+        <location filename="../screens/SettingsScreen.qml" line="701"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="710"/>
+        <location filename="../screens/SettingsScreen.qml" line="703"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="712"/>
+        <location filename="../screens/SettingsScreen.qml" line="705"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="714"/>
+        <location filename="../screens/SettingsScreen.qml" line="707"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="716"/>
+        <location filename="../screens/SettingsScreen.qml" line="709"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="718"/>
+        <location filename="../screens/SettingsScreen.qml" line="711"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="232"/>
+        <location filename="../screens/SettingsScreen.qml" line="226"/>
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1356"/>
+        <location filename="../screens/SettingsScreen.qml" line="1339"/>
         <source>No settings available on this platform</source>
         <translation>Keine Einstellungen für diese Plattform verfügbar</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="236"/>
-        <location filename="../screens/SystemsScreen.qml" line="338"/>
+        <location filename="../screens/SystemsScreen.qml" line="242"/>
+        <location filename="../screens/SystemsScreen.qml" line="343"/>
         <source>%1 systems</source>
         <translation>%1 Systeme</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="237"/>
-        <location filename="../screens/SystemsScreen.qml" line="355"/>
+        <location filename="../screens/SystemsScreen.qml" line="243"/>
+        <location filename="../screens/SystemsScreen.qml" line="360"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="373"/>
+        <location filename="../screens/SystemsScreen.qml" line="378"/>
         <source>No systems in this category</source>
         <translation>Keine Systeme in dieser Kategorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="374"/>
+        <location filename="../screens/SystemsScreen.qml" line="379"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>
@@ -1439,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="539"/>
+        <location filename="../components/Tile.qml" line="501"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="156"/>
+        <location filename="../screens/HubScreen.qml" line="154"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="162"/>
+        <location filename="../screens/HubScreen.qml" line="160"/>
         <source>Favorites</source>
         <translation>Αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="167"/>
+        <location filename="../screens/HubScreen.qml" line="165"/>
         <source>Recently Played</source>
         <translation>Πρόσφατα Παιγμένα</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="172"/>
+        <location filename="../screens/HubScreen.qml" line="170"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Ρυθμίσεις</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="722"/>
+        <location filename="../screens/HubScreen.qml" line="718"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Δεν υπάρχουν διαθέσιμα συστήματα. Εκτελέστε Ενημέρωση βάσης δεδομένων από τις Ρυθμίσεις.</translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>Όχι</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="256"/>
+        <location filename="../components/Modal.qml" line="246"/>
         <source>Cancel</source>
         <translation>Ακύρωση</translation>
     </message>
@@ -936,24 +936,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147"/>
-        <location filename="../screens/SettingsScreen.qml" line="741"/>
+        <location filename="../screens/SettingsScreen.qml" line="141"/>
+        <location filename="../screens/SettingsScreen.qml" line="734"/>
         <source>Language</source>
         <translation>Γλώσσα</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
-        <location filename="../screens/SettingsScreen.qml" line="777"/>
+        <location filename="../screens/SettingsScreen.qml" line="116"/>
+        <location filename="../screens/SettingsScreen.qml" line="770"/>
         <source>Browsing layout</source>
         <translation>Διάταξη περιήγησης</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="165"/>
+        <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>Mouse support</source>
         <translation>Υποστήριξη ποντικιού</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="177"/>
+        <location filename="../screens/SettingsScreen.qml" line="171"/>
         <source>Update media database</source>
         <translation>Ενημέρωση βάσης δεδομένων</translation>
     </message>
@@ -962,47 +962,47 @@ Euskara - devilschile2</source>
         <translation type="vanished">Γενικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="768"/>
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="761"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="160"/>
-        <location filename="../screens/SettingsScreen.qml" line="786"/>
+        <location filename="../screens/SettingsScreen.qml" line="154"/>
+        <location filename="../screens/SettingsScreen.qml" line="779"/>
         <source>Button style</source>
         <translation>Στυλ κουμπιών</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="132"/>
-        <location filename="../screens/SettingsScreen.qml" line="795"/>
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
+        <location filename="../screens/SettingsScreen.qml" line="788"/>
         <source>Screensaver</source>
         <translation>Προφύλαξη οθόνης</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="95"/>
-        <location filename="../screens/SettingsScreen.qml" line="229"/>
+        <location filename="../screens/SettingsScreen.qml" line="89"/>
+        <location filename="../screens/SettingsScreen.qml" line="223"/>
         <source>Library</source>
         <translation>Βιβλιοθήκη</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="182"/>
+        <location filename="../screens/SettingsScreen.qml" line="176"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="127"/>
-        <location filename="../screens/SettingsScreen.qml" line="804"/>
+        <location filename="../screens/SettingsScreen.qml" line="121"/>
+        <location filename="../screens/SettingsScreen.qml" line="797"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <location filename="../screens/SettingsScreen.qml" line="181"/>
         <source>Scrape metadata</source>
         <translation>Ανάκτηση μεταδεδομένων</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="192"/>
+        <location filename="../screens/SettingsScreen.qml" line="186"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1011,402 +1011,402 @@ Euskara - devilschile2</source>
         <translation type="vanished">Για προχωρημένους</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="204"/>
+        <location filename="../screens/SettingsScreen.qml" line="198"/>
         <source>Debug logging</source>
         <translation>Καταγραφή εντοπισμού σφαλμάτων</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="209"/>
+        <location filename="../screens/SettingsScreen.qml" line="203"/>
         <source>Upload log file</source>
         <translation>Αποστολή αρχείου καταγραφής</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="199"/>
+        <location filename="../screens/SettingsScreen.qml" line="193"/>
         <source>About / License</source>
         <translation>Σχετικά / Άδεια</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="137"/>
-        <location filename="../screens/SettingsScreen.qml" line="750"/>
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="743"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="142"/>
-        <location filename="../screens/SettingsScreen.qml" line="759"/>
+        <location filename="../screens/SettingsScreen.qml" line="136"/>
+        <location filename="../screens/SettingsScreen.qml" line="752"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152"/>
+        <location filename="../screens/SettingsScreen.qml" line="146"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="170"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
         <source>Reduce motion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="240"/>
         <source>Optimizing</source>
         <translation>Βελτιστοποίηση</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="248"/>
-        <location filename="../screens/SettingsScreen.qml" line="257"/>
+        <location filename="../screens/SettingsScreen.qml" line="242"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>Paused</source>
         <translation>Σε παύση</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="248"/>
-        <location filename="../screens/SettingsScreen.qml" line="257"/>
+        <location filename="../screens/SettingsScreen.qml" line="242"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>In progress</source>
         <translation>Σε εξέλιξη</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="245"/>
         <source>%1 indexed</source>
         <translation>%1 ευρετηριάστηκαν</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="260"/>
+        <location filename="../screens/SettingsScreen.qml" line="254"/>
         <source>%1 scraped</source>
         <translation>%1 συλλέχθηκαν</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="495"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Cancel</source>
         <translation>Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="495"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Start</source>
         <translation>Έναρξη</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="497"/>
+        <location filename="../screens/SettingsScreen.qml" line="490"/>
         <source>Upload</source>
         <translation>Μεταφόρτωση</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <location filename="../screens/SettingsScreen.qml" line="491"/>
         <source>Open</source>
         <translation>Άνοιγμα</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="579"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>English</source>
         <translation>Αγγλικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="581"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Italian</source>
         <translation>Ιταλικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="583"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="585"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="587"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>German</source>
         <translation>Γερμανικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="589"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Greek</source>
         <translation>Ελληνικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="591"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Japanese</source>
         <translation>Ιαπωνικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="593"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Korean</source>
         <translation>Κορεατικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="595"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Dutch</source>
         <translation>Ολλανδικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="597"/>
+        <location filename="../screens/SettingsScreen.qml" line="590"/>
         <source>Romanian</source>
         <translation>Ρουμανικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="599"/>
+        <location filename="../screens/SettingsScreen.qml" line="592"/>
         <source>Slovak</source>
         <translation>Σλοβακικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="601"/>
+        <location filename="../screens/SettingsScreen.qml" line="594"/>
         <source>Ukrainian</source>
         <translation>Ουκρανικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="603"/>
+        <location filename="../screens/SettingsScreen.qml" line="596"/>
         <source>Chinese (Simplified)</source>
         <translation>Κινεζικά (Απλοποιημένα)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="605"/>
+        <location filename="../screens/SettingsScreen.qml" line="598"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="607"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Hebrew</source>
         <translation>Εβραϊκά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="611"/>
+        <location filename="../screens/SettingsScreen.qml" line="604"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
-        <location filename="../screens/SettingsScreen.qml" line="620"/>
-        <location filename="../screens/SettingsScreen.qml" line="694"/>
+        <location filename="../screens/SettingsScreen.qml" line="605"/>
+        <location filename="../screens/SettingsScreen.qml" line="613"/>
+        <location filename="../screens/SettingsScreen.qml" line="687"/>
         <source>Auto</source>
         <translation>Αυτόματο</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="610"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="619"/>
+        <location filename="../screens/SettingsScreen.qml" line="612"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="630"/>
+        <location filename="../screens/SettingsScreen.qml" line="623"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="632"/>
+        <location filename="../screens/SettingsScreen.qml" line="625"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="634"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="628"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="640"/>
+        <location filename="../screens/SettingsScreen.qml" line="633"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="642"/>
+        <location filename="../screens/SettingsScreen.qml" line="635"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="643"/>
+        <location filename="../screens/SettingsScreen.qml" line="636"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="648"/>
+        <location filename="../screens/SettingsScreen.qml" line="641"/>
         <source>Detailed list view</source>
         <translation>Λεπτομερής προβολή λίστας</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="642"/>
         <source>Grid view</source>
         <translation>Προβολή πλέγματος</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="654"/>
+        <location filename="../screens/SettingsScreen.qml" line="647"/>
         <source>Style B</source>
         <translation>Στυλ B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="656"/>
+        <location filename="../screens/SettingsScreen.qml" line="649"/>
         <source>Style C</source>
         <translation>Στυλ C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="658"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
         <source>Style D</source>
         <translation>Στυλ D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="659"/>
+        <location filename="../screens/SettingsScreen.qml" line="652"/>
         <source>Style A</source>
         <translation>Στυλ A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1368"/>
+        <location filename="../screens/SettingsScreen.qml" line="1351"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="549"/>
+        <location filename="../screens/SettingsScreen.qml" line="542"/>
         <source>Default</source>
         <translation>Προεπιλογή</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="674"/>
+        <location filename="../screens/SettingsScreen.qml" line="667"/>
         <source>Off</source>
         <translation>Απενεργοποιημένο</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="676"/>
+        <location filename="../screens/SettingsScreen.qml" line="669"/>
         <source>1 second (testing)</source>
         <translation>1 δευτερόλεπτο (δοκιμή)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="678"/>
+        <location filename="../screens/SettingsScreen.qml" line="671"/>
         <source>1 minute</source>
         <translation>1 λεπτό</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="680"/>
+        <location filename="../screens/SettingsScreen.qml" line="673"/>
         <source>2 minutes</source>
         <translation>2 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="682"/>
+        <location filename="../screens/SettingsScreen.qml" line="675"/>
         <source>5 minutes</source>
         <translation>5 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="684"/>
+        <location filename="../screens/SettingsScreen.qml" line="677"/>
         <source>10 minutes</source>
         <translation>10 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="686"/>
+        <location filename="../screens/SettingsScreen.qml" line="679"/>
         <source>15 minutes</source>
         <translation>15 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="688"/>
+        <location filename="../screens/SettingsScreen.qml" line="681"/>
         <source>30 minutes</source>
         <translation>30 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="682"/>
         <source>%1 seconds</source>
         <translation>%1 δευτερόλεπτα</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
-        <location filename="../screens/SettingsScreen.qml" line="732"/>
+        <location filename="../screens/SettingsScreen.qml" line="105"/>
+        <location filename="../screens/SettingsScreen.qml" line="725"/>
         <source>Resolution</source>
         <translation>Ανάλυση</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="225"/>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="219"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="89"/>
-        <location filename="../screens/SettingsScreen.qml" line="227"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="221"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="101"/>
-        <location filename="../screens/SettingsScreen.qml" line="231"/>
+        <location filename="../screens/SettingsScreen.qml" line="95"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="696"/>
+        <location filename="../screens/SettingsScreen.qml" line="689"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="698"/>
+        <location filename="../screens/SettingsScreen.qml" line="691"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="700"/>
+        <location filename="../screens/SettingsScreen.qml" line="693"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="702"/>
+        <location filename="../screens/SettingsScreen.qml" line="695"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="704"/>
+        <location filename="../screens/SettingsScreen.qml" line="697"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="706"/>
+        <location filename="../screens/SettingsScreen.qml" line="699"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="708"/>
+        <location filename="../screens/SettingsScreen.qml" line="701"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="710"/>
+        <location filename="../screens/SettingsScreen.qml" line="703"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="712"/>
+        <location filename="../screens/SettingsScreen.qml" line="705"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="714"/>
+        <location filename="../screens/SettingsScreen.qml" line="707"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="716"/>
+        <location filename="../screens/SettingsScreen.qml" line="709"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="718"/>
+        <location filename="../screens/SettingsScreen.qml" line="711"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="232"/>
+        <location filename="../screens/SettingsScreen.qml" line="226"/>
         <source>Settings</source>
         <translation>Ρυθμίσεις</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1356"/>
+        <location filename="../screens/SettingsScreen.qml" line="1339"/>
         <source>No settings available on this platform</source>
         <translation>Δεν υπάρχουν διαθέσιμες ρυθμίσεις για αυτή την πλατφόρμα</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="236"/>
-        <location filename="../screens/SystemsScreen.qml" line="338"/>
+        <location filename="../screens/SystemsScreen.qml" line="242"/>
+        <location filename="../screens/SystemsScreen.qml" line="343"/>
         <source>%1 systems</source>
         <translation>%1 συστήματα</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="237"/>
-        <location filename="../screens/SystemsScreen.qml" line="355"/>
+        <location filename="../screens/SystemsScreen.qml" line="243"/>
+        <location filename="../screens/SystemsScreen.qml" line="360"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="373"/>
+        <location filename="../screens/SystemsScreen.qml" line="378"/>
         <source>No systems in this category</source>
         <translation>Δεν υπάρχουν συστήματα σε αυτή την κατηγορία</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="374"/>
+        <location filename="../screens/SystemsScreen.qml" line="379"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>
@@ -1439,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="539"/>
+        <location filename="../components/Tile.qml" line="501"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -97,100 +97,100 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Φόρτωση…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="196"/>
+        <location filename="../components/BrowseDetailPane.qml" line="167"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="196"/>
+        <location filename="../components/BrowseDetailPane.qml" line="167"/>
         <source>Yr</source>
         <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="198"/>
+        <location filename="../components/BrowseDetailPane.qml" line="169"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="198"/>
+        <location filename="../components/BrowseDetailPane.qml" line="169"/>
         <source>Gen</source>
         <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="200"/>
+        <location filename="../components/BrowseDetailPane.qml" line="171"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="200"/>
+        <location filename="../components/BrowseDetailPane.qml" line="171"/>
         <source>Plyr</source>
         <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="202"/>
+        <location filename="../components/BrowseDetailPane.qml" line="173"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="202"/>
+        <location filename="../components/BrowseDetailPane.qml" line="173"/>
         <source>Dev</source>
         <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="204"/>
+        <location filename="../components/BrowseDetailPane.qml" line="175"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="204"/>
+        <location filename="../components/BrowseDetailPane.qml" line="175"/>
         <source>Pub</source>
         <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="206"/>
+        <location filename="../components/BrowseDetailPane.qml" line="177"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="206"/>
+        <location filename="../components/BrowseDetailPane.qml" line="177"/>
         <source>Rtg</source>
         <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="208"/>
+        <location filename="../components/BrowseDetailPane.qml" line="179"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="208"/>
+        <location filename="../components/BrowseDetailPane.qml" line="179"/>
         <source>Cat</source>
         <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="210"/>
+        <location filename="../components/BrowseDetailPane.qml" line="181"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="210"/>
+        <location filename="../components/BrowseDetailPane.qml" line="181"/>
         <source>Date</source>
         <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="212"/>
+        <location filename="../components/BrowseDetailPane.qml" line="183"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="212"/>
+        <location filename="../components/BrowseDetailPane.qml" line="183"/>
         <source>Mfr</source>
         <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
@@ -425,8 +425,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="127"/>
-        <location filename="../screens/GamesScreen.qml" line="162"/>
+        <location filename="../screens/GamesScreen.qml" line="128"/>
+        <location filename="../screens/GamesScreen.qml" line="163"/>
         <source>%1 files</source>
         <translation>%1 αρχεία</translation>
     </message>
@@ -436,8 +436,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="136"/>
-        <location filename="../screens/GamesScreen.qml" line="163"/>
+        <location filename="../screens/GamesScreen.qml" line="137"/>
+        <location filename="../screens/GamesScreen.qml" line="164"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -447,7 +447,7 @@ Euskara - devilschile2</source>
         <translation>Φόρτωση παιχνιδιών…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="132"/>
+        <location filename="../screens/GamesScreen.qml" line="133"/>
         <source>Loading more…</source>
         <translation>Φόρτωση περισσότερων…</translation>
     </message>
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="149"/>
+        <location filename="../screens/HubScreen.qml" line="156"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="155"/>
+        <location filename="../screens/HubScreen.qml" line="162"/>
         <source>Favorites</source>
         <translation>Αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="160"/>
+        <location filename="../screens/HubScreen.qml" line="167"/>
         <source>Recently Played</source>
         <translation>Πρόσφατα Παιγμένα</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="165"/>
+        <location filename="../screens/HubScreen.qml" line="172"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Ρυθμίσεις</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="701"/>
+        <location filename="../screens/HubScreen.qml" line="722"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Δεν υπάρχουν διαθέσιμα συστήματα. Εκτελέστε Ενημέρωση βάσης δεδομένων από τις Ρυθμίσεις.</translation>
     </message>
@@ -553,138 +553,138 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1367"/>
+        <location filename="../app/Main.qml" line="1381"/>
         <source>Launch core</source>
         <translation>Εκκίνηση Core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1373"/>
-        <location filename="../app/Main.qml" line="1612"/>
+        <location filename="../app/Main.qml" line="1387"/>
+        <location filename="../app/Main.qml" line="1626"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1445"/>
         <source>Remove from favorites</source>
         <translation>Αφαίρεση από αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1445"/>
         <source>Add to favorites</source>
         <translation>Προσθήκη στα αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1436"/>
+        <location filename="../app/Main.qml" line="1450"/>
         <source>Write to NFC token</source>
         <translation>Εγγραφή σε NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1440"/>
+        <location filename="../app/Main.qml" line="1454"/>
         <source>QR code</source>
         <translation>Κωδικός QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1415"/>
-        <location filename="../app/Main.qml" line="1450"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1464"/>
         <source>Launch game</source>
         <translation>Εκκίνηση παιχνιδιού</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2624"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2616"/>
+        <location filename="../app/Main.qml" line="2630"/>
         <source>Loading favorites…</source>
         <translation>Φόρτωση αγαπημένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2612"/>
+        <location filename="../app/Main.qml" line="2626"/>
         <source>Loading games…</source>
         <translation>Φόρτωση παιχνιδιών…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1380"/>
-        <location filename="../app/Main.qml" line="1403"/>
+        <location filename="../app/Main.qml" line="1394"/>
+        <location filename="../app/Main.qml" line="1417"/>
         <source>Update media database</source>
         <translation type="unfinished">Ενημέρωση βάσης δεδομένων</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1383"/>
-        <location filename="../app/Main.qml" line="1406"/>
+        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1420"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Ανάκτηση μεταδεδομένων</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1388"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1411"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1388"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1411"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1608"/>
+        <location filename="../app/Main.qml" line="1622"/>
         <source>Default</source>
         <translation type="unfinished">Προεπιλογή</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1608"/>
+        <location filename="../app/Main.qml" line="1622"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1932"/>
+        <location filename="../app/Main.qml" line="1946"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1936"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1950"/>
+        <location filename="../app/Main.qml" line="1964"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1954"/>
+        <location filename="../app/Main.qml" line="1968"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1958"/>
+        <location filename="../app/Main.qml" line="1972"/>
         <source>Retry</source>
         <translation type="unfinished">Επανάληψη</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1962"/>
+        <location filename="../app/Main.qml" line="1976"/>
         <source>Cancel</source>
         <translation type="unfinished">Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2628"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2618"/>
+        <location filename="../app/Main.qml" line="2632"/>
         <source>Loading recently played…</source>
         <translation>Φόρτωση πρόσφατα παιγμένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2620"/>
+        <location filename="../app/Main.qml" line="2634"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2622"/>
+        <location filename="../app/Main.qml" line="2636"/>
         <source>Loading…</source>
         <translation>Φόρτωση…</translation>
     </message>
@@ -864,12 +864,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Φόρτωση…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="395"/>
+        <location filename="../screens/MediaListScreen.qml" line="436"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 εγγραφές</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="396"/>
+        <location filename="../screens/MediaListScreen.qml" line="437"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>Όχι</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="246"/>
+        <location filename="../components/Modal.qml" line="256"/>
         <source>Cancel</source>
         <translation>Ακύρωση</translation>
     </message>
@@ -1262,7 +1262,7 @@ Euskara - devilschile2</source>
         <translation>Στυλ A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1358"/>
+        <location filename="../screens/SettingsScreen.qml" line="1368"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1406,7 +1406,7 @@ Euskara - devilschile2</source>
         <translation>Ρυθμίσεις</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1346"/>
+        <location filename="../screens/SettingsScreen.qml" line="1356"/>
         <source>No settings available on this platform</source>
         <translation>Δεν υπάρχουν διαθέσιμες ρυθμίσεις για αυτή την πλατφόρμα</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="229"/>
-        <location filename="../screens/SystemsScreen.qml" line="329"/>
+        <location filename="../screens/SystemsScreen.qml" line="236"/>
+        <location filename="../screens/SystemsScreen.qml" line="338"/>
         <source>%1 systems</source>
         <translation>%1 συστήματα</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="230"/>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="237"/>
+        <location filename="../screens/SystemsScreen.qml" line="355"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="364"/>
+        <location filename="../screens/SystemsScreen.qml" line="373"/>
         <source>No systems in this category</source>
         <translation>Δεν υπάρχουν συστήματα σε αυτή την κατηγορία</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="365"/>
+        <location filename="../screens/SystemsScreen.qml" line="374"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>
@@ -1439,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="475"/>
+        <location filename="../components/Tile.qml" line="539"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -425,34 +425,34 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="116"/>
-        <location filename="../screens/GamesScreen.qml" line="151"/>
+        <location filename="../screens/GamesScreen.qml" line="127"/>
+        <location filename="../screens/GamesScreen.qml" line="162"/>
         <source>%1 files</source>
         <translation>%1 αρχεία</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="53"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="125"/>
-        <location filename="../screens/GamesScreen.qml" line="152"/>
+        <location filename="../screens/GamesScreen.qml" line="136"/>
+        <location filename="../screens/GamesScreen.qml" line="163"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="48"/>
+        <location filename="../screens/GamesScreen.qml" line="49"/>
         <source>Loading games…</source>
         <translation>Φόρτωση παιχνιδιών…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="121"/>
+        <location filename="../screens/GamesScreen.qml" line="132"/>
         <source>Loading more…</source>
         <translation>Φόρτωση περισσότερων…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="47"/>
+        <location filename="../screens/GamesScreen.qml" line="48"/>
         <source>No games in this system</source>
         <translation>Δεν υπάρχουν παιχνίδια σε αυτό το σύστημα</translation>
     </message>
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="139"/>
+        <location filename="../screens/HubScreen.qml" line="149"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="145"/>
+        <location filename="../screens/HubScreen.qml" line="155"/>
         <source>Favorites</source>
         <translation>Αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="150"/>
+        <location filename="../screens/HubScreen.qml" line="160"/>
         <source>Recently Played</source>
         <translation>Πρόσφατα Παιγμένα</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="155"/>
+        <location filename="../screens/HubScreen.qml" line="165"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Ρυθμίσεις</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="669"/>
+        <location filename="../screens/HubScreen.qml" line="701"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Δεν υπάρχουν διαθέσιμα συστήματα. Εκτελέστε Ενημέρωση βάσης δεδομένων από τις Ρυθμίσεις.</translation>
     </message>
@@ -553,138 +553,138 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1361"/>
+        <location filename="../app/Main.qml" line="1367"/>
         <source>Launch core</source>
         <translation>Εκκίνηση Core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1367"/>
-        <location filename="../app/Main.qml" line="1606"/>
+        <location filename="../app/Main.qml" line="1373"/>
+        <location filename="../app/Main.qml" line="1612"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1425"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Remove from favorites</source>
         <translation>Αφαίρεση από αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1425"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Add to favorites</source>
         <translation>Προσθήκη στα αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1430"/>
+        <location filename="../app/Main.qml" line="1436"/>
         <source>Write to NFC token</source>
         <translation>Εγγραφή σε NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1434"/>
+        <location filename="../app/Main.qml" line="1440"/>
         <source>QR code</source>
         <translation>Κωδικός QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1409"/>
-        <location filename="../app/Main.qml" line="1444"/>
+        <location filename="../app/Main.qml" line="1415"/>
+        <location filename="../app/Main.qml" line="1450"/>
         <source>Launch game</source>
         <translation>Εκκίνηση παιχνιδιού</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2604"/>
+        <location filename="../app/Main.qml" line="2610"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2616"/>
         <source>Loading favorites…</source>
         <translation>Φόρτωση αγαπημένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2606"/>
+        <location filename="../app/Main.qml" line="2612"/>
         <source>Loading games…</source>
         <translation>Φόρτωση παιχνιδιών…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1374"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1380"/>
+        <location filename="../app/Main.qml" line="1403"/>
         <source>Update media database</source>
         <translation type="unfinished">Ενημέρωση βάσης δεδομένων</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1377"/>
-        <location filename="../app/Main.qml" line="1400"/>
+        <location filename="../app/Main.qml" line="1383"/>
+        <location filename="../app/Main.qml" line="1406"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Ανάκτηση μεταδεδομένων</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1382"/>
-        <location filename="../app/Main.qml" line="1391"/>
+        <location filename="../app/Main.qml" line="1388"/>
+        <location filename="../app/Main.qml" line="1397"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1382"/>
-        <location filename="../app/Main.qml" line="1391"/>
+        <location filename="../app/Main.qml" line="1388"/>
+        <location filename="../app/Main.qml" line="1397"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1602"/>
+        <location filename="../app/Main.qml" line="1608"/>
         <source>Default</source>
         <translation type="unfinished">Προεπιλογή</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1602"/>
+        <location filename="../app/Main.qml" line="1608"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1926"/>
+        <location filename="../app/Main.qml" line="1932"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1930"/>
+        <location filename="../app/Main.qml" line="1936"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1944"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1948"/>
+        <location filename="../app/Main.qml" line="1954"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1952"/>
+        <location filename="../app/Main.qml" line="1958"/>
         <source>Retry</source>
         <translation type="unfinished">Επανάληψη</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1956"/>
+        <location filename="../app/Main.qml" line="1962"/>
         <source>Cancel</source>
         <translation type="unfinished">Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2608"/>
+        <location filename="../app/Main.qml" line="2614"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2612"/>
+        <location filename="../app/Main.qml" line="2618"/>
         <source>Loading recently played…</source>
         <translation>Φόρτωση πρόσφατα παιγμένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2620"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2616"/>
+        <location filename="../app/Main.qml" line="2622"/>
         <source>Loading…</source>
         <translation>Φόρτωση…</translation>
     </message>
@@ -692,72 +692,72 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="683"/>
+        <location filename="../app/MainLayout.qml" line="685"/>
         <source>Writing failed</source>
         <translation>Αποτυχία εγγραφής</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="683"/>
+        <location filename="../app/MainLayout.qml" line="685"/>
         <source>Put a writable card near the reader</source>
         <translation>Τοποθετήστε μια εγγράψιμη κάρτα κοντά στον αναγνώστη</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="811"/>
+        <location filename="../app/MainLayout.qml" line="813"/>
         <source>Are you sure you want to exit?</source>
         <translation>Είστε σίγουροι ότι θέλετε να βγείτε;</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="894"/>
-        <location filename="../app/MainLayout.qml" line="968"/>
+        <location filename="../app/MainLayout.qml" line="896"/>
+        <location filename="../app/MainLayout.qml" line="970"/>
         <source>Select</source>
         <translation>Επιλογή</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="902"/>
-        <location filename="../app/MainLayout.qml" line="916"/>
-        <location filename="../app/MainLayout.qml" line="931"/>
-        <location filename="../app/MainLayout.qml" line="942"/>
+        <location filename="../app/MainLayout.qml" line="900"/>
+        <location filename="../app/MainLayout.qml" line="904"/>
+        <location filename="../app/MainLayout.qml" line="918"/>
+        <location filename="../app/MainLayout.qml" line="933"/>
+        <location filename="../app/MainLayout.qml" line="944"/>
         <source>Close</source>
         <translation>Κλείσιμο</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="909"/>
-        <location filename="../app/MainLayout.qml" line="949"/>
-        <location filename="../app/MainLayout.qml" line="972"/>
-        <location filename="../app/MainLayout.qml" line="983"/>
+        <location filename="../app/MainLayout.qml" line="911"/>
+        <location filename="../app/MainLayout.qml" line="951"/>
+        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="985"/>
         <source>Cancel</source>
         <translation>Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="927"/>
+        <location filename="../app/MainLayout.qml" line="929"/>
         <source>Done</source>
         <translation>Ολοκληρώθηκε</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="957"/>
+        <location filename="../app/MainLayout.qml" line="959"/>
         <source>I understand</source>
         <translation>Κατανοώ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="991"/>
+        <location filename="../app/MainLayout.qml" line="993"/>
         <source>Start</source>
         <translation>Έναρξη</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1203"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Scroll</source>
         <translation>Κύλιση</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="890"/>
-        <location filename="../app/MainLayout.qml" line="964"/>
-        <location filename="../app/MainLayout.qml" line="1010"/>
-        <location filename="../app/MainLayout.qml" line="1047"/>
-        <location filename="../app/MainLayout.qml" line="1097"/>
-        <location filename="../app/MainLayout.qml" line="1146"/>
-        <location filename="../app/MainLayout.qml" line="1165"/>
-        <location filename="../app/MainLayout.qml" line="1232"/>
+        <location filename="../app/MainLayout.qml" line="892"/>
+        <location filename="../app/MainLayout.qml" line="966"/>
+        <location filename="../app/MainLayout.qml" line="1012"/>
+        <location filename="../app/MainLayout.qml" line="1049"/>
+        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1148"/>
+        <location filename="../app/MainLayout.qml" line="1167"/>
+        <location filename="../app/MainLayout.qml" line="1234"/>
         <source>Move</source>
         <translation>Μετακίνηση</translation>
     </message>
@@ -777,81 +777,81 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Πρόσφατα Παιγμένα</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="699"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="700"/>
+        <location filename="../app/MainLayout.qml" line="702"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="810"/>
+        <location filename="../app/MainLayout.qml" line="812"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1014"/>
-        <location filename="../app/MainLayout.qml" line="1057"/>
-        <location filename="../app/MainLayout.qml" line="1107"/>
-        <location filename="../app/MainLayout.qml" line="1151"/>
-        <location filename="../app/MainLayout.qml" line="1242"/>
+        <location filename="../app/MainLayout.qml" line="1016"/>
+        <location filename="../app/MainLayout.qml" line="1059"/>
+        <location filename="../app/MainLayout.qml" line="1109"/>
+        <location filename="../app/MainLayout.qml" line="1153"/>
+        <location filename="../app/MainLayout.qml" line="1244"/>
         <source>Open</source>
         <translation>Άνοιγμα</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1024"/>
+        <location filename="../app/MainLayout.qml" line="1026"/>
         <source>Quit</source>
         <translation>Έξοδος</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1033"/>
-        <location filename="../app/MainLayout.qml" line="1063"/>
-        <location filename="../app/MainLayout.qml" line="1074"/>
-        <location filename="../app/MainLayout.qml" line="1089"/>
-        <location filename="../app/MainLayout.qml" line="1116"/>
-        <location filename="../app/MainLayout.qml" line="1127"/>
-        <location filename="../app/MainLayout.qml" line="1139"/>
-        <location filename="../app/MainLayout.qml" line="1155"/>
-        <location filename="../app/MainLayout.qml" line="1189"/>
-        <location filename="../app/MainLayout.qml" line="1207"/>
-        <location filename="../app/MainLayout.qml" line="1216"/>
-        <location filename="../app/MainLayout.qml" line="1251"/>
-        <location filename="../app/MainLayout.qml" line="1262"/>
+        <location filename="../app/MainLayout.qml" line="1035"/>
+        <location filename="../app/MainLayout.qml" line="1065"/>
+        <location filename="../app/MainLayout.qml" line="1076"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
+        <location filename="../app/MainLayout.qml" line="1118"/>
+        <location filename="../app/MainLayout.qml" line="1129"/>
+        <location filename="../app/MainLayout.qml" line="1141"/>
+        <location filename="../app/MainLayout.qml" line="1157"/>
+        <location filename="../app/MainLayout.qml" line="1191"/>
+        <location filename="../app/MainLayout.qml" line="1209"/>
+        <location filename="../app/MainLayout.qml" line="1218"/>
+        <location filename="../app/MainLayout.qml" line="1253"/>
+        <location filename="../app/MainLayout.qml" line="1264"/>
         <source>Back</source>
         <translation>Πίσω</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1053"/>
-        <location filename="../app/MainLayout.qml" line="1103"/>
-        <location filename="../app/MainLayout.qml" line="1238"/>
+        <location filename="../app/MainLayout.qml" line="1055"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
+        <location filename="../app/MainLayout.qml" line="1240"/>
         <source>Page</source>
         <translation>Σελίδα</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1060"/>
-        <location filename="../app/MainLayout.qml" line="1112"/>
-        <location filename="../app/MainLayout.qml" line="1247"/>
+        <location filename="../app/MainLayout.qml" line="1022"/>
+        <location filename="../app/MainLayout.qml" line="1062"/>
+        <location filename="../app/MainLayout.qml" line="1114"/>
+        <location filename="../app/MainLayout.qml" line="1249"/>
         <source>Options</source>
         <translation>Επιλογές</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1070"/>
-        <location filename="../app/MainLayout.qml" line="1123"/>
-        <location filename="../app/MainLayout.qml" line="1258"/>
+        <location filename="../app/MainLayout.qml" line="940"/>
+        <location filename="../app/MainLayout.qml" line="1072"/>
+        <location filename="../app/MainLayout.qml" line="1125"/>
+        <location filename="../app/MainLayout.qml" line="1260"/>
         <source>Retry</source>
         <translation>Επανάληψη</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1174"/>
+        <location filename="../app/MainLayout.qml" line="1176"/>
         <source>Change</source>
         <translation>Αλλαγή</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1180"/>
+        <location filename="../app/MainLayout.qml" line="1182"/>
         <source>Toggle</source>
         <translation>Εναλλαγή</translation>
     </message>
@@ -864,12 +864,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Φόρτωση…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="365"/>
+        <location filename="../screens/MediaListScreen.qml" line="395"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 εγγραφές</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="366"/>
+        <location filename="../screens/MediaListScreen.qml" line="396"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>Όχι</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="198"/>
+        <location filename="../components/Modal.qml" line="246"/>
         <source>Cancel</source>
         <translation>Ακύρωση</translation>
     </message>
@@ -936,24 +936,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="132"/>
-        <location filename="../screens/SettingsScreen.qml" line="718"/>
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
+        <location filename="../screens/SettingsScreen.qml" line="741"/>
         <source>Language</source>
         <translation>Γλώσσα</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="754"/>
+        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <location filename="../screens/SettingsScreen.qml" line="777"/>
         <source>Browsing layout</source>
         <translation>Διάταξη περιήγησης</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="150"/>
+        <location filename="../screens/SettingsScreen.qml" line="165"/>
         <source>Mouse support</source>
         <translation>Υποστήριξη ποντικιού</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="157"/>
+        <location filename="../screens/SettingsScreen.qml" line="177"/>
         <source>Update media database</source>
         <translation>Ενημέρωση βάσης δεδομένων</translation>
     </message>
@@ -962,47 +962,47 @@ Euskara - devilschile2</source>
         <translation type="vanished">Γενικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="745"/>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="768"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="145"/>
-        <location filename="../screens/SettingsScreen.qml" line="763"/>
+        <location filename="../screens/SettingsScreen.qml" line="160"/>
+        <location filename="../screens/SettingsScreen.qml" line="786"/>
         <source>Button style</source>
         <translation>Στυλ κουμπιών</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="772"/>
+        <location filename="../screens/SettingsScreen.qml" line="132"/>
+        <location filename="../screens/SettingsScreen.qml" line="795"/>
         <source>Screensaver</source>
         <translation>Προφύλαξη οθόνης</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="80"/>
-        <location filename="../screens/SettingsScreen.qml" line="209"/>
+        <location filename="../screens/SettingsScreen.qml" line="95"/>
+        <location filename="../screens/SettingsScreen.qml" line="229"/>
         <source>Library</source>
         <translation>Βιβλιοθήκη</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="162"/>
+        <location filename="../screens/SettingsScreen.qml" line="182"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="112"/>
-        <location filename="../screens/SettingsScreen.qml" line="781"/>
+        <location filename="../screens/SettingsScreen.qml" line="127"/>
+        <location filename="../screens/SettingsScreen.qml" line="804"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="167"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
         <source>Scrape metadata</source>
         <translation>Ανάκτηση μεταδεδομένων</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="172"/>
+        <location filename="../screens/SettingsScreen.qml" line="192"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1011,397 +1011,402 @@ Euskara - devilschile2</source>
         <translation type="vanished">Για προχωρημένους</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="184"/>
+        <location filename="../screens/SettingsScreen.qml" line="204"/>
         <source>Debug logging</source>
         <translation>Καταγραφή εντοπισμού σφαλμάτων</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="189"/>
+        <location filename="../screens/SettingsScreen.qml" line="209"/>
         <source>Upload log file</source>
         <translation>Αποστολή αρχείου καταγραφής</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="179"/>
+        <location filename="../screens/SettingsScreen.qml" line="199"/>
         <source>About / License</source>
         <translation>Σχετικά / Άδεια</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
-        <location filename="../screens/SettingsScreen.qml" line="727"/>
+        <location filename="../screens/SettingsScreen.qml" line="137"/>
+        <location filename="../screens/SettingsScreen.qml" line="750"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="127"/>
-        <location filename="../screens/SettingsScreen.qml" line="736"/>
+        <location filename="../screens/SettingsScreen.qml" line="142"/>
+        <location filename="../screens/SettingsScreen.qml" line="759"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="137"/>
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="226"/>
+        <location filename="../screens/SettingsScreen.qml" line="170"/>
+        <source>Reduce motion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
         <source>Optimizing</source>
         <translation>Βελτιστοποίηση</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="228"/>
-        <location filename="../screens/SettingsScreen.qml" line="237"/>
+        <location filename="../screens/SettingsScreen.qml" line="248"/>
+        <location filename="../screens/SettingsScreen.qml" line="257"/>
         <source>Paused</source>
         <translation>Σε παύση</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="228"/>
-        <location filename="../screens/SettingsScreen.qml" line="237"/>
+        <location filename="../screens/SettingsScreen.qml" line="248"/>
+        <location filename="../screens/SettingsScreen.qml" line="257"/>
         <source>In progress</source>
         <translation>Σε εξέλιξη</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="231"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>%1 indexed</source>
         <translation>%1 ευρετηριάστηκαν</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="240"/>
+        <location filename="../screens/SettingsScreen.qml" line="260"/>
         <source>%1 scraped</source>
         <translation>%1 συλλέχθηκαν</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="472"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Cancel</source>
         <translation>Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="472"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Start</source>
         <translation>Έναρξη</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="474"/>
+        <location filename="../screens/SettingsScreen.qml" line="497"/>
         <source>Upload</source>
         <translation>Μεταφόρτωση</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Open</source>
         <translation>Άνοιγμα</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="556"/>
+        <location filename="../screens/SettingsScreen.qml" line="579"/>
         <source>English</source>
         <translation>Αγγλικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="558"/>
+        <location filename="../screens/SettingsScreen.qml" line="581"/>
         <source>Italian</source>
         <translation>Ιταλικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="560"/>
+        <location filename="../screens/SettingsScreen.qml" line="583"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="562"/>
+        <location filename="../screens/SettingsScreen.qml" line="585"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="564"/>
+        <location filename="../screens/SettingsScreen.qml" line="587"/>
         <source>German</source>
         <translation>Γερμανικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="566"/>
+        <location filename="../screens/SettingsScreen.qml" line="589"/>
         <source>Greek</source>
         <translation>Ελληνικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="568"/>
+        <location filename="../screens/SettingsScreen.qml" line="591"/>
         <source>Japanese</source>
         <translation>Ιαπωνικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="570"/>
+        <location filename="../screens/SettingsScreen.qml" line="593"/>
         <source>Korean</source>
         <translation>Κορεατικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="595"/>
         <source>Dutch</source>
         <translation>Ολλανδικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="597"/>
         <source>Romanian</source>
         <translation>Ρουμανικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="599"/>
         <source>Slovak</source>
         <translation>Σλοβακικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="601"/>
         <source>Ukrainian</source>
         <translation>Ουκρανικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="603"/>
         <source>Chinese (Simplified)</source>
         <translation>Κινεζικά (Απλοποιημένα)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="605"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="607"/>
         <source>Hebrew</source>
         <translation>Εβραϊκά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="588"/>
+        <location filename="../screens/SettingsScreen.qml" line="611"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="589"/>
-        <location filename="../screens/SettingsScreen.qml" line="597"/>
-        <location filename="../screens/SettingsScreen.qml" line="671"/>
+        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="620"/>
+        <location filename="../screens/SettingsScreen.qml" line="694"/>
         <source>Auto</source>
         <translation>Αυτόματο</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="594"/>
+        <location filename="../screens/SettingsScreen.qml" line="617"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="596"/>
+        <location filename="../screens/SettingsScreen.qml" line="619"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="607"/>
+        <location filename="../screens/SettingsScreen.qml" line="630"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="632"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="611"/>
+        <location filename="../screens/SettingsScreen.qml" line="634"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="635"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="640"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="619"/>
+        <location filename="../screens/SettingsScreen.qml" line="642"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="620"/>
+        <location filename="../screens/SettingsScreen.qml" line="643"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="625"/>
+        <location filename="../screens/SettingsScreen.qml" line="648"/>
         <source>Detailed list view</source>
         <translation>Λεπτομερής προβολή λίστας</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="626"/>
+        <location filename="../screens/SettingsScreen.qml" line="649"/>
         <source>Grid view</source>
         <translation>Προβολή πλέγματος</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="631"/>
+        <location filename="../screens/SettingsScreen.qml" line="654"/>
         <source>Style B</source>
         <translation>Στυλ B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="633"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Style C</source>
         <translation>Στυλ C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="658"/>
         <source>Style D</source>
         <translation>Στυλ D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="659"/>
         <source>Style A</source>
         <translation>Στυλ A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1292"/>
+        <location filename="../screens/SettingsScreen.qml" line="1358"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="526"/>
+        <location filename="../screens/SettingsScreen.qml" line="549"/>
         <source>Default</source>
         <translation>Προεπιλογή</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="674"/>
         <source>Off</source>
         <translation>Απενεργοποιημένο</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="653"/>
+        <location filename="../screens/SettingsScreen.qml" line="676"/>
         <source>1 second (testing)</source>
         <translation>1 δευτερόλεπτο (δοκιμή)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="655"/>
+        <location filename="../screens/SettingsScreen.qml" line="678"/>
         <source>1 minute</source>
         <translation>1 λεπτό</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="657"/>
+        <location filename="../screens/SettingsScreen.qml" line="680"/>
         <source>2 minutes</source>
         <translation>2 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="659"/>
+        <location filename="../screens/SettingsScreen.qml" line="682"/>
         <source>5 minutes</source>
         <translation>5 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="661"/>
+        <location filename="../screens/SettingsScreen.qml" line="684"/>
         <source>10 minutes</source>
         <translation>10 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="663"/>
+        <location filename="../screens/SettingsScreen.qml" line="686"/>
         <source>15 minutes</source>
         <translation>15 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="665"/>
+        <location filename="../screens/SettingsScreen.qml" line="688"/>
         <source>30 minutes</source>
         <translation>30 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="666"/>
+        <location filename="../screens/SettingsScreen.qml" line="689"/>
         <source>%1 seconds</source>
         <translation>%1 δευτερόλεπτα</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="96"/>
-        <location filename="../screens/SettingsScreen.qml" line="709"/>
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="732"/>
         <source>Resolution</source>
         <translation>Ανάλυση</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="68"/>
-        <location filename="../screens/SettingsScreen.qml" line="205"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="74"/>
-        <location filename="../screens/SettingsScreen.qml" line="207"/>
+        <location filename="../screens/SettingsScreen.qml" line="89"/>
+        <location filename="../screens/SettingsScreen.qml" line="227"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="86"/>
-        <location filename="../screens/SettingsScreen.qml" line="211"/>
+        <location filename="../screens/SettingsScreen.qml" line="101"/>
+        <location filename="../screens/SettingsScreen.qml" line="231"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="673"/>
+        <location filename="../screens/SettingsScreen.qml" line="696"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="675"/>
+        <location filename="../screens/SettingsScreen.qml" line="698"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="677"/>
+        <location filename="../screens/SettingsScreen.qml" line="700"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="679"/>
+        <location filename="../screens/SettingsScreen.qml" line="702"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="681"/>
+        <location filename="../screens/SettingsScreen.qml" line="704"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="683"/>
+        <location filename="../screens/SettingsScreen.qml" line="706"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="685"/>
+        <location filename="../screens/SettingsScreen.qml" line="708"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="687"/>
+        <location filename="../screens/SettingsScreen.qml" line="710"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="712"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="691"/>
+        <location filename="../screens/SettingsScreen.qml" line="714"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="693"/>
+        <location filename="../screens/SettingsScreen.qml" line="716"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="695"/>
+        <location filename="../screens/SettingsScreen.qml" line="718"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="212"/>
+        <location filename="../screens/SettingsScreen.qml" line="232"/>
         <source>Settings</source>
         <translation>Ρυθμίσεις</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1280"/>
+        <location filename="../screens/SettingsScreen.qml" line="1346"/>
         <source>No settings available on this platform</source>
         <translation>Δεν υπάρχουν διαθέσιμες ρυθμίσεις για αυτή την πλατφόρμα</translation>
     </message>
@@ -1409,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="206"/>
-        <location filename="../screens/SystemsScreen.qml" line="304"/>
+        <location filename="../screens/SystemsScreen.qml" line="229"/>
+        <location filename="../screens/SystemsScreen.qml" line="329"/>
         <source>%1 systems</source>
         <translation>%1 συστήματα</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="207"/>
-        <location filename="../screens/SystemsScreen.qml" line="321"/>
+        <location filename="../screens/SystemsScreen.qml" line="230"/>
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="339"/>
+        <location filename="../screens/SystemsScreen.qml" line="364"/>
         <source>No systems in this category</source>
         <translation>Δεν υπάρχουν συστήματα σε αυτή την κατηγορία</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="340"/>
+        <location filename="../screens/SystemsScreen.qml" line="365"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>
@@ -1434,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="364"/>
+        <location filename="../components/Tile.qml" line="475"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -425,8 +425,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="128"/>
-        <location filename="../screens/GamesScreen.qml" line="163"/>
+        <location filename="../screens/GamesScreen.qml" line="131"/>
+        <location filename="../screens/GamesScreen.qml" line="166"/>
         <source>%1 files</source>
         <translation>%1 αρχεία</translation>
     </message>
@@ -436,8 +436,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="137"/>
-        <location filename="../screens/GamesScreen.qml" line="164"/>
+        <location filename="../screens/GamesScreen.qml" line="140"/>
+        <location filename="../screens/GamesScreen.qml" line="167"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -447,7 +447,7 @@ Euskara - devilschile2</source>
         <translation>Φόρτωση παιχνιδιών…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="133"/>
+        <location filename="../screens/GamesScreen.qml" line="136"/>
         <source>Loading more…</source>
         <translation>Φόρτωση περισσότερων…</translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>Όχι</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="246"/>
+        <location filename="../components/Modal.qml" line="250"/>
         <source>Cancel</source>
         <translation>Ακύρωση</translation>
     </message>
@@ -936,24 +936,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="141"/>
-        <location filename="../screens/SettingsScreen.qml" line="734"/>
+        <location filename="../screens/SettingsScreen.qml" line="145"/>
+        <location filename="../screens/SettingsScreen.qml" line="738"/>
         <source>Language</source>
         <translation>Γλώσσα</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116"/>
-        <location filename="../screens/SettingsScreen.qml" line="770"/>
+        <location filename="../screens/SettingsScreen.qml" line="120"/>
+        <location filename="../screens/SettingsScreen.qml" line="774"/>
         <source>Browsing layout</source>
         <translation>Διάταξη περιήγησης</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="159"/>
+        <location filename="../screens/SettingsScreen.qml" line="163"/>
         <source>Mouse support</source>
         <translation>Υποστήριξη ποντικιού</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="171"/>
+        <location filename="../screens/SettingsScreen.qml" line="175"/>
         <source>Update media database</source>
         <translation>Ενημέρωση βάσης δεδομένων</translation>
     </message>
@@ -962,47 +962,47 @@ Euskara - devilschile2</source>
         <translation type="vanished">Γενικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
-        <location filename="../screens/SettingsScreen.qml" line="761"/>
+        <location filename="../screens/SettingsScreen.qml" line="115"/>
+        <location filename="../screens/SettingsScreen.qml" line="765"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="154"/>
-        <location filename="../screens/SettingsScreen.qml" line="779"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="783"/>
         <source>Button style</source>
         <translation>Στυλ κουμπιών</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
-        <location filename="../screens/SettingsScreen.qml" line="788"/>
+        <location filename="../screens/SettingsScreen.qml" line="130"/>
+        <location filename="../screens/SettingsScreen.qml" line="792"/>
         <source>Screensaver</source>
         <translation>Προφύλαξη οθόνης</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="89"/>
-        <location filename="../screens/SettingsScreen.qml" line="223"/>
+        <location filename="../screens/SettingsScreen.qml" line="93"/>
+        <location filename="../screens/SettingsScreen.qml" line="227"/>
         <source>Library</source>
         <translation>Βιβλιοθήκη</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="176"/>
+        <location filename="../screens/SettingsScreen.qml" line="180"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121"/>
-        <location filename="../screens/SettingsScreen.qml" line="797"/>
+        <location filename="../screens/SettingsScreen.qml" line="125"/>
+        <location filename="../screens/SettingsScreen.qml" line="801"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="181"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
         <source>Scrape metadata</source>
         <translation>Ανάκτηση μεταδεδομένων</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="186"/>
+        <location filename="../screens/SettingsScreen.qml" line="190"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1011,402 +1011,402 @@ Euskara - devilschile2</source>
         <translation type="vanished">Για προχωρημένους</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="198"/>
+        <location filename="../screens/SettingsScreen.qml" line="202"/>
         <source>Debug logging</source>
         <translation>Καταγραφή εντοπισμού σφαλμάτων</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="203"/>
+        <location filename="../screens/SettingsScreen.qml" line="207"/>
         <source>Upload log file</source>
         <translation>Αποστολή αρχείου καταγραφής</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="193"/>
+        <location filename="../screens/SettingsScreen.qml" line="197"/>
         <source>About / License</source>
         <translation>Σχετικά / Άδεια</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
-        <location filename="../screens/SettingsScreen.qml" line="743"/>
+        <location filename="../screens/SettingsScreen.qml" line="135"/>
+        <location filename="../screens/SettingsScreen.qml" line="747"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="136"/>
-        <location filename="../screens/SettingsScreen.qml" line="752"/>
+        <location filename="../screens/SettingsScreen.qml" line="140"/>
+        <location filename="../screens/SettingsScreen.qml" line="756"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="146"/>
+        <location filename="../screens/SettingsScreen.qml" line="150"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="168"/>
         <source>Reduce motion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="240"/>
+        <location filename="../screens/SettingsScreen.qml" line="244"/>
         <source>Optimizing</source>
         <translation>Βελτιστοποίηση</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="242"/>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="255"/>
         <source>Paused</source>
         <translation>Σε παύση</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="242"/>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="255"/>
         <source>In progress</source>
         <translation>Σε εξέλιξη</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="245"/>
+        <location filename="../screens/SettingsScreen.qml" line="249"/>
         <source>%1 indexed</source>
         <translation>%1 ευρετηριάστηκαν</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="254"/>
+        <location filename="../screens/SettingsScreen.qml" line="258"/>
         <source>%1 scraped</source>
         <translation>%1 συλλέχθηκαν</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="488"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Cancel</source>
         <translation>Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="488"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Start</source>
         <translation>Έναρξη</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="490"/>
+        <location filename="../screens/SettingsScreen.qml" line="494"/>
         <source>Upload</source>
         <translation>Μεταφόρτωση</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="491"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Open</source>
         <translation>Άνοιγμα</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>English</source>
         <translation>Αγγλικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Italian</source>
         <translation>Ιταλικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>German</source>
         <translation>Γερμανικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Greek</source>
         <translation>Ελληνικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Japanese</source>
         <translation>Ιαπωνικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="590"/>
         <source>Korean</source>
         <translation>Κορεατικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="588"/>
+        <location filename="../screens/SettingsScreen.qml" line="592"/>
         <source>Dutch</source>
         <translation>Ολλανδικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="590"/>
+        <location filename="../screens/SettingsScreen.qml" line="594"/>
         <source>Romanian</source>
         <translation>Ρουμανικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="592"/>
+        <location filename="../screens/SettingsScreen.qml" line="596"/>
         <source>Slovak</source>
         <translation>Σλοβακικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="594"/>
+        <location filename="../screens/SettingsScreen.qml" line="598"/>
         <source>Ukrainian</source>
         <translation>Ουκρανικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="596"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Chinese (Simplified)</source>
         <translation>Κινεζικά (Απλοποιημένα)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="598"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="600"/>
+        <location filename="../screens/SettingsScreen.qml" line="604"/>
         <source>Hebrew</source>
         <translation>Εβραϊκά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="602"/>
+        <location filename="../screens/SettingsScreen.qml" line="606"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="604"/>
+        <location filename="../screens/SettingsScreen.qml" line="608"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="605"/>
-        <location filename="../screens/SettingsScreen.qml" line="613"/>
-        <location filename="../screens/SettingsScreen.qml" line="687"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="691"/>
         <source>Auto</source>
         <translation>Αυτόματο</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="610"/>
+        <location filename="../screens/SettingsScreen.qml" line="614"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="616"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="623"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="625"/>
+        <location filename="../screens/SettingsScreen.qml" line="629"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="627"/>
+        <location filename="../screens/SettingsScreen.qml" line="631"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="628"/>
+        <location filename="../screens/SettingsScreen.qml" line="632"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="633"/>
+        <location filename="../screens/SettingsScreen.qml" line="637"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="639"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="640"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="641"/>
+        <location filename="../screens/SettingsScreen.qml" line="645"/>
         <source>Detailed list view</source>
         <translation>Λεπτομερής προβολή λίστας</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="642"/>
+        <location filename="../screens/SettingsScreen.qml" line="646"/>
         <source>Grid view</source>
         <translation>Προβολή πλέγματος</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
         <source>Style B</source>
         <translation>Στυλ B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Style C</source>
         <translation>Στυλ C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="655"/>
         <source>Style D</source>
         <translation>Στυλ D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="652"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Style A</source>
         <translation>Στυλ A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1351"/>
+        <location filename="../screens/SettingsScreen.qml" line="1382"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="542"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>Default</source>
         <translation>Προεπιλογή</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="667"/>
+        <location filename="../screens/SettingsScreen.qml" line="671"/>
         <source>Off</source>
         <translation>Απενεργοποιημένο</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="669"/>
+        <location filename="../screens/SettingsScreen.qml" line="673"/>
         <source>1 second (testing)</source>
         <translation>1 δευτερόλεπτο (δοκιμή)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="671"/>
+        <location filename="../screens/SettingsScreen.qml" line="675"/>
         <source>1 minute</source>
         <translation>1 λεπτό</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="673"/>
+        <location filename="../screens/SettingsScreen.qml" line="677"/>
         <source>2 minutes</source>
         <translation>2 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="675"/>
+        <location filename="../screens/SettingsScreen.qml" line="679"/>
         <source>5 minutes</source>
         <translation>5 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="677"/>
+        <location filename="../screens/SettingsScreen.qml" line="681"/>
         <source>10 minutes</source>
         <translation>10 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="679"/>
+        <location filename="../screens/SettingsScreen.qml" line="683"/>
         <source>15 minutes</source>
         <translation>15 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="681"/>
+        <location filename="../screens/SettingsScreen.qml" line="685"/>
         <source>30 minutes</source>
         <translation>30 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="682"/>
+        <location filename="../screens/SettingsScreen.qml" line="686"/>
         <source>%1 seconds</source>
         <translation>%1 δευτερόλεπτα</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="105"/>
-        <location filename="../screens/SettingsScreen.qml" line="725"/>
+        <location filename="../screens/SettingsScreen.qml" line="109"/>
+        <location filename="../screens/SettingsScreen.qml" line="729"/>
         <source>Resolution</source>
         <translation>Ανάλυση</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="77"/>
-        <location filename="../screens/SettingsScreen.qml" line="219"/>
+        <location filename="../screens/SettingsScreen.qml" line="81"/>
+        <location filename="../screens/SettingsScreen.qml" line="223"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="221"/>
+        <location filename="../screens/SettingsScreen.qml" line="87"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="95"/>
-        <location filename="../screens/SettingsScreen.qml" line="225"/>
+        <location filename="../screens/SettingsScreen.qml" line="99"/>
+        <location filename="../screens/SettingsScreen.qml" line="229"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="693"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="691"/>
+        <location filename="../screens/SettingsScreen.qml" line="695"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="693"/>
+        <location filename="../screens/SettingsScreen.qml" line="697"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="695"/>
+        <location filename="../screens/SettingsScreen.qml" line="699"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="697"/>
+        <location filename="../screens/SettingsScreen.qml" line="701"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="699"/>
+        <location filename="../screens/SettingsScreen.qml" line="703"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="701"/>
+        <location filename="../screens/SettingsScreen.qml" line="705"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="703"/>
+        <location filename="../screens/SettingsScreen.qml" line="707"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="705"/>
+        <location filename="../screens/SettingsScreen.qml" line="709"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="707"/>
+        <location filename="../screens/SettingsScreen.qml" line="711"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="709"/>
+        <location filename="../screens/SettingsScreen.qml" line="713"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="711"/>
+        <location filename="../screens/SettingsScreen.qml" line="715"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="226"/>
+        <location filename="../screens/SettingsScreen.qml" line="230"/>
         <source>Settings</source>
         <translation>Ρυθμίσεις</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1339"/>
+        <location filename="../screens/SettingsScreen.qml" line="1370"/>
         <source>No settings available on this platform</source>
         <translation>Δεν υπάρχουν διαθέσιμες ρυθμίσεις για αυτή την πλατφόρμα</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="242"/>
-        <location filename="../screens/SystemsScreen.qml" line="343"/>
+        <location filename="../screens/SystemsScreen.qml" line="245"/>
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>%1 systems</source>
         <translation>%1 συστήματα</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="243"/>
-        <location filename="../screens/SystemsScreen.qml" line="360"/>
+        <location filename="../screens/SystemsScreen.qml" line="246"/>
+        <location filename="../screens/SystemsScreen.qml" line="363"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="378"/>
+        <location filename="../screens/SystemsScreen.qml" line="381"/>
         <source>No systems in this category</source>
         <translation>Δεν υπάρχουν συστήματα σε αυτή την κατηγορία</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="379"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -468,22 +468,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="156"/>
+        <location filename="../screens/HubScreen.qml" line="154"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="162"/>
+        <location filename="../screens/HubScreen.qml" line="160"/>
         <source>Favorites</source>
         <translation>Favorites</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="167"/>
+        <location filename="../screens/HubScreen.qml" line="165"/>
         <source>Recently Played</source>
         <translation>Recently Played</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="172"/>
+        <location filename="../screens/HubScreen.qml" line="170"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -492,7 +492,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Settings</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="722"/>
+        <location filename="../screens/HubScreen.qml" line="718"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -880,7 +880,7 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="256"/>
+        <location filename="../components/Modal.qml" line="246"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
@@ -924,469 +924,469 @@ Euskara - devilschile2</source>
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147"/>
-        <location filename="../screens/SettingsScreen.qml" line="741"/>
+        <location filename="../screens/SettingsScreen.qml" line="141"/>
+        <location filename="../screens/SettingsScreen.qml" line="734"/>
         <source>Language</source>
         <translation>Language</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
-        <location filename="../screens/SettingsScreen.qml" line="777"/>
+        <location filename="../screens/SettingsScreen.qml" line="116"/>
+        <location filename="../screens/SettingsScreen.qml" line="770"/>
         <source>Browsing layout</source>
         <translation>Browsing layout</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="165"/>
+        <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>Mouse support</source>
         <translation>Mouse support</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="177"/>
+        <location filename="../screens/SettingsScreen.qml" line="171"/>
         <source>Update media database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="768"/>
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="761"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="160"/>
-        <location filename="../screens/SettingsScreen.qml" line="786"/>
+        <location filename="../screens/SettingsScreen.qml" line="154"/>
+        <location filename="../screens/SettingsScreen.qml" line="779"/>
         <source>Button style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="132"/>
-        <location filename="../screens/SettingsScreen.qml" line="795"/>
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
+        <location filename="../screens/SettingsScreen.qml" line="788"/>
         <source>Screensaver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="182"/>
+        <location filename="../screens/SettingsScreen.qml" line="176"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="127"/>
-        <location filename="../screens/SettingsScreen.qml" line="804"/>
+        <location filename="../screens/SettingsScreen.qml" line="121"/>
+        <location filename="../screens/SettingsScreen.qml" line="797"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <location filename="../screens/SettingsScreen.qml" line="181"/>
         <source>Scrape metadata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="192"/>
+        <location filename="../screens/SettingsScreen.qml" line="186"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="204"/>
+        <location filename="../screens/SettingsScreen.qml" line="198"/>
         <source>Debug logging</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="209"/>
+        <location filename="../screens/SettingsScreen.qml" line="203"/>
         <source>Upload log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="199"/>
+        <location filename="../screens/SettingsScreen.qml" line="193"/>
         <source>About / License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="137"/>
-        <location filename="../screens/SettingsScreen.qml" line="750"/>
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="743"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="142"/>
-        <location filename="../screens/SettingsScreen.qml" line="759"/>
+        <location filename="../screens/SettingsScreen.qml" line="136"/>
+        <location filename="../screens/SettingsScreen.qml" line="752"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152"/>
+        <location filename="../screens/SettingsScreen.qml" line="146"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="170"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
         <source>Reduce motion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="240"/>
         <source>Optimizing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="248"/>
-        <location filename="../screens/SettingsScreen.qml" line="257"/>
+        <location filename="../screens/SettingsScreen.qml" line="242"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>Paused</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="248"/>
-        <location filename="../screens/SettingsScreen.qml" line="257"/>
+        <location filename="../screens/SettingsScreen.qml" line="242"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>In progress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="245"/>
         <source>%1 indexed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="260"/>
+        <location filename="../screens/SettingsScreen.qml" line="254"/>
         <source>%1 scraped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="495"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="495"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="497"/>
+        <location filename="../screens/SettingsScreen.qml" line="490"/>
         <source>Upload</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <location filename="../screens/SettingsScreen.qml" line="491"/>
         <source>Open</source>
         <translation type="unfinished">Open</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="579"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>English</source>
         <translation>English</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="581"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Italian</source>
         <translation>Italian</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="583"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="585"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="587"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>German</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="589"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Greek</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="591"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Japanese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="593"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Korean</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="595"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Dutch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="597"/>
+        <location filename="../screens/SettingsScreen.qml" line="590"/>
         <source>Romanian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="599"/>
+        <location filename="../screens/SettingsScreen.qml" line="592"/>
         <source>Slovak</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="601"/>
+        <location filename="../screens/SettingsScreen.qml" line="594"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="603"/>
+        <location filename="../screens/SettingsScreen.qml" line="596"/>
         <source>Chinese (Simplified)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="605"/>
+        <location filename="../screens/SettingsScreen.qml" line="598"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="607"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Hebrew</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="611"/>
+        <location filename="../screens/SettingsScreen.qml" line="604"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
-        <location filename="../screens/SettingsScreen.qml" line="620"/>
-        <location filename="../screens/SettingsScreen.qml" line="694"/>
+        <location filename="../screens/SettingsScreen.qml" line="605"/>
+        <location filename="../screens/SettingsScreen.qml" line="613"/>
+        <location filename="../screens/SettingsScreen.qml" line="687"/>
         <source>Auto</source>
         <translation>Auto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="610"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="619"/>
+        <location filename="../screens/SettingsScreen.qml" line="612"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="630"/>
+        <location filename="../screens/SettingsScreen.qml" line="623"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="632"/>
+        <location filename="../screens/SettingsScreen.qml" line="625"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="634"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="628"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="640"/>
+        <location filename="../screens/SettingsScreen.qml" line="633"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="642"/>
+        <location filename="../screens/SettingsScreen.qml" line="635"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="643"/>
+        <location filename="../screens/SettingsScreen.qml" line="636"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="648"/>
+        <location filename="../screens/SettingsScreen.qml" line="641"/>
         <source>Detailed list view</source>
         <translation>Detailed list view</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="642"/>
         <source>Grid view</source>
         <translation>Grid view</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="654"/>
+        <location filename="../screens/SettingsScreen.qml" line="647"/>
         <source>Style B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="656"/>
+        <location filename="../screens/SettingsScreen.qml" line="649"/>
         <source>Style C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="658"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
         <source>Style D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="659"/>
+        <location filename="../screens/SettingsScreen.qml" line="652"/>
         <source>Style A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1368"/>
+        <location filename="../screens/SettingsScreen.qml" line="1351"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="549"/>
+        <location filename="../screens/SettingsScreen.qml" line="542"/>
         <source>Default</source>
         <translation>Default</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="674"/>
+        <location filename="../screens/SettingsScreen.qml" line="667"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="676"/>
+        <location filename="../screens/SettingsScreen.qml" line="669"/>
         <source>1 second (testing)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="678"/>
+        <location filename="../screens/SettingsScreen.qml" line="671"/>
         <source>1 minute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="680"/>
+        <location filename="../screens/SettingsScreen.qml" line="673"/>
         <source>2 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="682"/>
+        <location filename="../screens/SettingsScreen.qml" line="675"/>
         <source>5 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="684"/>
+        <location filename="../screens/SettingsScreen.qml" line="677"/>
         <source>10 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="686"/>
+        <location filename="../screens/SettingsScreen.qml" line="679"/>
         <source>15 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="688"/>
+        <location filename="../screens/SettingsScreen.qml" line="681"/>
         <source>30 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="682"/>
         <source>%1 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
-        <location filename="../screens/SettingsScreen.qml" line="732"/>
+        <location filename="../screens/SettingsScreen.qml" line="105"/>
+        <location filename="../screens/SettingsScreen.qml" line="725"/>
         <source>Resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="225"/>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="219"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="89"/>
-        <location filename="../screens/SettingsScreen.qml" line="227"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="221"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="95"/>
-        <location filename="../screens/SettingsScreen.qml" line="229"/>
+        <location filename="../screens/SettingsScreen.qml" line="89"/>
+        <location filename="../screens/SettingsScreen.qml" line="223"/>
         <source>Library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="101"/>
-        <location filename="../screens/SettingsScreen.qml" line="231"/>
+        <location filename="../screens/SettingsScreen.qml" line="95"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="696"/>
+        <location filename="../screens/SettingsScreen.qml" line="689"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="698"/>
+        <location filename="../screens/SettingsScreen.qml" line="691"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="700"/>
+        <location filename="../screens/SettingsScreen.qml" line="693"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="702"/>
+        <location filename="../screens/SettingsScreen.qml" line="695"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="704"/>
+        <location filename="../screens/SettingsScreen.qml" line="697"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="706"/>
+        <location filename="../screens/SettingsScreen.qml" line="699"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="708"/>
+        <location filename="../screens/SettingsScreen.qml" line="701"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="710"/>
+        <location filename="../screens/SettingsScreen.qml" line="703"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="712"/>
+        <location filename="../screens/SettingsScreen.qml" line="705"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="714"/>
+        <location filename="../screens/SettingsScreen.qml" line="707"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="716"/>
+        <location filename="../screens/SettingsScreen.qml" line="709"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="718"/>
+        <location filename="../screens/SettingsScreen.qml" line="711"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="232"/>
+        <location filename="../screens/SettingsScreen.qml" line="226"/>
         <source>Settings</source>
         <translation>Settings</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1356"/>
+        <location filename="../screens/SettingsScreen.qml" line="1339"/>
         <source>No settings available on this platform</source>
         <translation>No settings available on this platform</translation>
     </message>
@@ -1394,24 +1394,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="236"/>
-        <location filename="../screens/SystemsScreen.qml" line="338"/>
+        <location filename="../screens/SystemsScreen.qml" line="242"/>
+        <location filename="../screens/SystemsScreen.qml" line="343"/>
         <source>%1 systems</source>
         <translation>%1 systems</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="237"/>
-        <location filename="../screens/SystemsScreen.qml" line="355"/>
+        <location filename="../screens/SystemsScreen.qml" line="243"/>
+        <location filename="../screens/SystemsScreen.qml" line="360"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="373"/>
+        <location filename="../screens/SystemsScreen.qml" line="378"/>
         <source>No systems in this category</source>
         <translation>No systems in this category</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="374"/>
+        <location filename="../screens/SystemsScreen.qml" line="379"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1419,7 +1419,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="539"/>
+        <location filename="../components/Tile.qml" line="501"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -97,100 +97,100 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Loading…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="196"/>
+        <location filename="../components/BrowseDetailPane.qml" line="167"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="196"/>
+        <location filename="../components/BrowseDetailPane.qml" line="167"/>
         <source>Yr</source>
         <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="198"/>
+        <location filename="../components/BrowseDetailPane.qml" line="169"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="198"/>
+        <location filename="../components/BrowseDetailPane.qml" line="169"/>
         <source>Gen</source>
         <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="200"/>
+        <location filename="../components/BrowseDetailPane.qml" line="171"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="200"/>
+        <location filename="../components/BrowseDetailPane.qml" line="171"/>
         <source>Plyr</source>
         <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="202"/>
+        <location filename="../components/BrowseDetailPane.qml" line="173"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="202"/>
+        <location filename="../components/BrowseDetailPane.qml" line="173"/>
         <source>Dev</source>
         <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="204"/>
+        <location filename="../components/BrowseDetailPane.qml" line="175"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="204"/>
+        <location filename="../components/BrowseDetailPane.qml" line="175"/>
         <source>Pub</source>
         <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="206"/>
+        <location filename="../components/BrowseDetailPane.qml" line="177"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="206"/>
+        <location filename="../components/BrowseDetailPane.qml" line="177"/>
         <source>Rtg</source>
         <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="208"/>
+        <location filename="../components/BrowseDetailPane.qml" line="179"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="208"/>
+        <location filename="../components/BrowseDetailPane.qml" line="179"/>
         <source>Cat</source>
         <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="210"/>
+        <location filename="../components/BrowseDetailPane.qml" line="181"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="210"/>
+        <location filename="../components/BrowseDetailPane.qml" line="181"/>
         <source>Date</source>
         <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="212"/>
+        <location filename="../components/BrowseDetailPane.qml" line="183"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="212"/>
+        <location filename="../components/BrowseDetailPane.qml" line="183"/>
         <source>Mfr</source>
         <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
@@ -405,8 +405,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="127"/>
-        <location filename="../screens/GamesScreen.qml" line="162"/>
+        <location filename="../screens/GamesScreen.qml" line="128"/>
+        <location filename="../screens/GamesScreen.qml" line="163"/>
         <source>%1 files</source>
         <translation>%1 files</translation>
     </message>
@@ -416,8 +416,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="136"/>
-        <location filename="../screens/GamesScreen.qml" line="163"/>
+        <location filename="../screens/GamesScreen.qml" line="137"/>
+        <location filename="../screens/GamesScreen.qml" line="164"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -427,7 +427,7 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="132"/>
+        <location filename="../screens/GamesScreen.qml" line="133"/>
         <source>Loading more…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -468,22 +468,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="149"/>
+        <location filename="../screens/HubScreen.qml" line="156"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="155"/>
+        <location filename="../screens/HubScreen.qml" line="162"/>
         <source>Favorites</source>
         <translation>Favorites</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="160"/>
+        <location filename="../screens/HubScreen.qml" line="167"/>
         <source>Recently Played</source>
         <translation>Recently Played</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="165"/>
+        <location filename="../screens/HubScreen.qml" line="172"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -492,7 +492,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Settings</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="701"/>
+        <location filename="../screens/HubScreen.qml" line="722"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -541,138 +541,138 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1367"/>
+        <location filename="../app/Main.qml" line="1381"/>
         <source>Launch core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1373"/>
-        <location filename="../app/Main.qml" line="1612"/>
+        <location filename="../app/Main.qml" line="1387"/>
+        <location filename="../app/Main.qml" line="1626"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1445"/>
         <source>Remove from favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1445"/>
         <source>Add to favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1436"/>
+        <location filename="../app/Main.qml" line="1450"/>
         <source>Write to NFC token</source>
         <translation type="unfinished">Write to NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1440"/>
+        <location filename="../app/Main.qml" line="1454"/>
         <source>QR code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1415"/>
-        <location filename="../app/Main.qml" line="1450"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1464"/>
         <source>Launch game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2624"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2616"/>
+        <location filename="../app/Main.qml" line="2630"/>
         <source>Loading favorites…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2612"/>
+        <location filename="../app/Main.qml" line="2626"/>
         <source>Loading games…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1380"/>
-        <location filename="../app/Main.qml" line="1403"/>
+        <location filename="../app/Main.qml" line="1394"/>
+        <location filename="../app/Main.qml" line="1417"/>
         <source>Update media database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1383"/>
-        <location filename="../app/Main.qml" line="1406"/>
+        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1420"/>
         <source>Scrape metadata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1388"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1411"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1388"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1411"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1608"/>
+        <location filename="../app/Main.qml" line="1622"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1608"/>
+        <location filename="../app/Main.qml" line="1622"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1932"/>
+        <location filename="../app/Main.qml" line="1946"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1936"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1950"/>
+        <location filename="../app/Main.qml" line="1964"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1954"/>
+        <location filename="../app/Main.qml" line="1968"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1958"/>
+        <location filename="../app/Main.qml" line="1972"/>
         <source>Retry</source>
         <translation type="unfinished">Retry</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1962"/>
+        <location filename="../app/Main.qml" line="1976"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2628"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2618"/>
+        <location filename="../app/Main.qml" line="2632"/>
         <source>Loading recently played…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2620"/>
+        <location filename="../app/Main.qml" line="2634"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2622"/>
+        <location filename="../app/Main.qml" line="2636"/>
         <source>Loading…</source>
         <translation type="unfinished">Loading…</translation>
     </message>
@@ -852,12 +852,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Loading…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="395"/>
+        <location filename="../screens/MediaListScreen.qml" line="436"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 entries</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="396"/>
+        <location filename="../screens/MediaListScreen.qml" line="437"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -880,7 +880,7 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="246"/>
+        <location filename="../components/Modal.qml" line="256"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
@@ -1236,7 +1236,7 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1358"/>
+        <location filename="../screens/SettingsScreen.qml" line="1368"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1386,7 +1386,7 @@ Euskara - devilschile2</source>
         <translation>Settings</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1346"/>
+        <location filename="../screens/SettingsScreen.qml" line="1356"/>
         <source>No settings available on this platform</source>
         <translation>No settings available on this platform</translation>
     </message>
@@ -1394,24 +1394,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="229"/>
-        <location filename="../screens/SystemsScreen.qml" line="329"/>
+        <location filename="../screens/SystemsScreen.qml" line="236"/>
+        <location filename="../screens/SystemsScreen.qml" line="338"/>
         <source>%1 systems</source>
         <translation>%1 systems</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="230"/>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="237"/>
+        <location filename="../screens/SystemsScreen.qml" line="355"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="364"/>
+        <location filename="../screens/SystemsScreen.qml" line="373"/>
         <source>No systems in this category</source>
         <translation>No systems in this category</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="365"/>
+        <location filename="../screens/SystemsScreen.qml" line="374"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1419,7 +1419,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="475"/>
+        <location filename="../components/Tile.qml" line="539"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -405,34 +405,34 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="116"/>
-        <location filename="../screens/GamesScreen.qml" line="151"/>
+        <location filename="../screens/GamesScreen.qml" line="127"/>
+        <location filename="../screens/GamesScreen.qml" line="162"/>
         <source>%1 files</source>
         <translation>%1 files</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="53"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="125"/>
-        <location filename="../screens/GamesScreen.qml" line="152"/>
+        <location filename="../screens/GamesScreen.qml" line="136"/>
+        <location filename="../screens/GamesScreen.qml" line="163"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="48"/>
+        <location filename="../screens/GamesScreen.qml" line="49"/>
         <source>Loading games…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="121"/>
+        <location filename="../screens/GamesScreen.qml" line="132"/>
         <source>Loading more…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="47"/>
+        <location filename="../screens/GamesScreen.qml" line="48"/>
         <source>No games in this system</source>
         <translation>No games in this system</translation>
     </message>
@@ -468,22 +468,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="139"/>
+        <location filename="../screens/HubScreen.qml" line="149"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="145"/>
+        <location filename="../screens/HubScreen.qml" line="155"/>
         <source>Favorites</source>
         <translation>Favorites</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="150"/>
+        <location filename="../screens/HubScreen.qml" line="160"/>
         <source>Recently Played</source>
         <translation>Recently Played</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="155"/>
+        <location filename="../screens/HubScreen.qml" line="165"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -492,7 +492,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Settings</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="669"/>
+        <location filename="../screens/HubScreen.qml" line="701"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -541,138 +541,138 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1361"/>
+        <location filename="../app/Main.qml" line="1367"/>
         <source>Launch core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1367"/>
-        <location filename="../app/Main.qml" line="1606"/>
+        <location filename="../app/Main.qml" line="1373"/>
+        <location filename="../app/Main.qml" line="1612"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1425"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Remove from favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1425"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Add to favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1430"/>
+        <location filename="../app/Main.qml" line="1436"/>
         <source>Write to NFC token</source>
         <translation type="unfinished">Write to NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1434"/>
+        <location filename="../app/Main.qml" line="1440"/>
         <source>QR code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1409"/>
-        <location filename="../app/Main.qml" line="1444"/>
+        <location filename="../app/Main.qml" line="1415"/>
+        <location filename="../app/Main.qml" line="1450"/>
         <source>Launch game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2604"/>
+        <location filename="../app/Main.qml" line="2610"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2616"/>
         <source>Loading favorites…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2606"/>
+        <location filename="../app/Main.qml" line="2612"/>
         <source>Loading games…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1374"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1380"/>
+        <location filename="../app/Main.qml" line="1403"/>
         <source>Update media database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1377"/>
-        <location filename="../app/Main.qml" line="1400"/>
+        <location filename="../app/Main.qml" line="1383"/>
+        <location filename="../app/Main.qml" line="1406"/>
         <source>Scrape metadata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1382"/>
-        <location filename="../app/Main.qml" line="1391"/>
+        <location filename="../app/Main.qml" line="1388"/>
+        <location filename="../app/Main.qml" line="1397"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1382"/>
-        <location filename="../app/Main.qml" line="1391"/>
+        <location filename="../app/Main.qml" line="1388"/>
+        <location filename="../app/Main.qml" line="1397"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1602"/>
+        <location filename="../app/Main.qml" line="1608"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1602"/>
+        <location filename="../app/Main.qml" line="1608"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1926"/>
+        <location filename="../app/Main.qml" line="1932"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1930"/>
+        <location filename="../app/Main.qml" line="1936"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1944"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1948"/>
+        <location filename="../app/Main.qml" line="1954"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1952"/>
+        <location filename="../app/Main.qml" line="1958"/>
         <source>Retry</source>
         <translation type="unfinished">Retry</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1956"/>
+        <location filename="../app/Main.qml" line="1962"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2608"/>
+        <location filename="../app/Main.qml" line="2614"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2612"/>
+        <location filename="../app/Main.qml" line="2618"/>
         <source>Loading recently played…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2620"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2616"/>
+        <location filename="../app/Main.qml" line="2622"/>
         <source>Loading…</source>
         <translation type="unfinished">Loading…</translation>
     </message>
@@ -680,72 +680,72 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="683"/>
+        <location filename="../app/MainLayout.qml" line="685"/>
         <source>Writing failed</source>
         <translation>Writing failed</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="683"/>
+        <location filename="../app/MainLayout.qml" line="685"/>
         <source>Put a writable card near the reader</source>
         <translation>Put a writable card near the reader</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="811"/>
+        <location filename="../app/MainLayout.qml" line="813"/>
         <source>Are you sure you want to exit?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="894"/>
-        <location filename="../app/MainLayout.qml" line="968"/>
+        <location filename="../app/MainLayout.qml" line="896"/>
+        <location filename="../app/MainLayout.qml" line="970"/>
         <source>Select</source>
         <translation>Select</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="902"/>
-        <location filename="../app/MainLayout.qml" line="916"/>
-        <location filename="../app/MainLayout.qml" line="931"/>
-        <location filename="../app/MainLayout.qml" line="942"/>
+        <location filename="../app/MainLayout.qml" line="900"/>
+        <location filename="../app/MainLayout.qml" line="904"/>
+        <location filename="../app/MainLayout.qml" line="918"/>
+        <location filename="../app/MainLayout.qml" line="933"/>
+        <location filename="../app/MainLayout.qml" line="944"/>
         <source>Close</source>
         <translation>Close</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="909"/>
-        <location filename="../app/MainLayout.qml" line="949"/>
-        <location filename="../app/MainLayout.qml" line="972"/>
-        <location filename="../app/MainLayout.qml" line="983"/>
+        <location filename="../app/MainLayout.qml" line="911"/>
+        <location filename="../app/MainLayout.qml" line="951"/>
+        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="985"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="927"/>
+        <location filename="../app/MainLayout.qml" line="929"/>
         <source>Done</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="957"/>
+        <location filename="../app/MainLayout.qml" line="959"/>
         <source>I understand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="991"/>
+        <location filename="../app/MainLayout.qml" line="993"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1203"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Scroll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="890"/>
-        <location filename="../app/MainLayout.qml" line="964"/>
-        <location filename="../app/MainLayout.qml" line="1010"/>
-        <location filename="../app/MainLayout.qml" line="1047"/>
-        <location filename="../app/MainLayout.qml" line="1097"/>
-        <location filename="../app/MainLayout.qml" line="1146"/>
-        <location filename="../app/MainLayout.qml" line="1165"/>
-        <location filename="../app/MainLayout.qml" line="1232"/>
+        <location filename="../app/MainLayout.qml" line="892"/>
+        <location filename="../app/MainLayout.qml" line="966"/>
+        <location filename="../app/MainLayout.qml" line="1012"/>
+        <location filename="../app/MainLayout.qml" line="1049"/>
+        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1148"/>
+        <location filename="../app/MainLayout.qml" line="1167"/>
+        <location filename="../app/MainLayout.qml" line="1234"/>
         <source>Move</source>
         <translation>Move</translation>
     </message>
@@ -765,81 +765,81 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Recently Played</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="699"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="700"/>
+        <location filename="../app/MainLayout.qml" line="702"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="810"/>
+        <location filename="../app/MainLayout.qml" line="812"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1014"/>
-        <location filename="../app/MainLayout.qml" line="1057"/>
-        <location filename="../app/MainLayout.qml" line="1107"/>
-        <location filename="../app/MainLayout.qml" line="1151"/>
-        <location filename="../app/MainLayout.qml" line="1242"/>
+        <location filename="../app/MainLayout.qml" line="1016"/>
+        <location filename="../app/MainLayout.qml" line="1059"/>
+        <location filename="../app/MainLayout.qml" line="1109"/>
+        <location filename="../app/MainLayout.qml" line="1153"/>
+        <location filename="../app/MainLayout.qml" line="1244"/>
         <source>Open</source>
         <translation>Open</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1024"/>
+        <location filename="../app/MainLayout.qml" line="1026"/>
         <source>Quit</source>
         <translation>Quit</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1033"/>
-        <location filename="../app/MainLayout.qml" line="1063"/>
-        <location filename="../app/MainLayout.qml" line="1074"/>
-        <location filename="../app/MainLayout.qml" line="1089"/>
-        <location filename="../app/MainLayout.qml" line="1116"/>
-        <location filename="../app/MainLayout.qml" line="1127"/>
-        <location filename="../app/MainLayout.qml" line="1139"/>
-        <location filename="../app/MainLayout.qml" line="1155"/>
-        <location filename="../app/MainLayout.qml" line="1189"/>
-        <location filename="../app/MainLayout.qml" line="1207"/>
-        <location filename="../app/MainLayout.qml" line="1216"/>
-        <location filename="../app/MainLayout.qml" line="1251"/>
-        <location filename="../app/MainLayout.qml" line="1262"/>
+        <location filename="../app/MainLayout.qml" line="1035"/>
+        <location filename="../app/MainLayout.qml" line="1065"/>
+        <location filename="../app/MainLayout.qml" line="1076"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
+        <location filename="../app/MainLayout.qml" line="1118"/>
+        <location filename="../app/MainLayout.qml" line="1129"/>
+        <location filename="../app/MainLayout.qml" line="1141"/>
+        <location filename="../app/MainLayout.qml" line="1157"/>
+        <location filename="../app/MainLayout.qml" line="1191"/>
+        <location filename="../app/MainLayout.qml" line="1209"/>
+        <location filename="../app/MainLayout.qml" line="1218"/>
+        <location filename="../app/MainLayout.qml" line="1253"/>
+        <location filename="../app/MainLayout.qml" line="1264"/>
         <source>Back</source>
         <translation>Back</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1053"/>
-        <location filename="../app/MainLayout.qml" line="1103"/>
-        <location filename="../app/MainLayout.qml" line="1238"/>
+        <location filename="../app/MainLayout.qml" line="1055"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
+        <location filename="../app/MainLayout.qml" line="1240"/>
         <source>Page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1060"/>
-        <location filename="../app/MainLayout.qml" line="1112"/>
-        <location filename="../app/MainLayout.qml" line="1247"/>
+        <location filename="../app/MainLayout.qml" line="1022"/>
+        <location filename="../app/MainLayout.qml" line="1062"/>
+        <location filename="../app/MainLayout.qml" line="1114"/>
+        <location filename="../app/MainLayout.qml" line="1249"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1070"/>
-        <location filename="../app/MainLayout.qml" line="1123"/>
-        <location filename="../app/MainLayout.qml" line="1258"/>
+        <location filename="../app/MainLayout.qml" line="940"/>
+        <location filename="../app/MainLayout.qml" line="1072"/>
+        <location filename="../app/MainLayout.qml" line="1125"/>
+        <location filename="../app/MainLayout.qml" line="1260"/>
         <source>Retry</source>
         <translation>Retry</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1174"/>
+        <location filename="../app/MainLayout.qml" line="1176"/>
         <source>Change</source>
         <translation>Change</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1180"/>
+        <location filename="../app/MainLayout.qml" line="1182"/>
         <source>Toggle</source>
         <translation>Toggle</translation>
     </message>
@@ -852,12 +852,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Loading…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="365"/>
+        <location filename="../screens/MediaListScreen.qml" line="395"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 entries</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="366"/>
+        <location filename="../screens/MediaListScreen.qml" line="396"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -880,7 +880,7 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="198"/>
+        <location filename="../components/Modal.qml" line="246"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
@@ -924,464 +924,469 @@ Euskara - devilschile2</source>
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="132"/>
-        <location filename="../screens/SettingsScreen.qml" line="718"/>
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
+        <location filename="../screens/SettingsScreen.qml" line="741"/>
         <source>Language</source>
         <translation>Language</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="754"/>
+        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <location filename="../screens/SettingsScreen.qml" line="777"/>
         <source>Browsing layout</source>
         <translation>Browsing layout</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="150"/>
+        <location filename="../screens/SettingsScreen.qml" line="165"/>
         <source>Mouse support</source>
         <translation>Mouse support</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="157"/>
+        <location filename="../screens/SettingsScreen.qml" line="177"/>
         <source>Update media database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="745"/>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="768"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="145"/>
-        <location filename="../screens/SettingsScreen.qml" line="763"/>
+        <location filename="../screens/SettingsScreen.qml" line="160"/>
+        <location filename="../screens/SettingsScreen.qml" line="786"/>
         <source>Button style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="772"/>
+        <location filename="../screens/SettingsScreen.qml" line="132"/>
+        <location filename="../screens/SettingsScreen.qml" line="795"/>
         <source>Screensaver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="162"/>
+        <location filename="../screens/SettingsScreen.qml" line="182"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="112"/>
-        <location filename="../screens/SettingsScreen.qml" line="781"/>
+        <location filename="../screens/SettingsScreen.qml" line="127"/>
+        <location filename="../screens/SettingsScreen.qml" line="804"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="167"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
         <source>Scrape metadata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="172"/>
+        <location filename="../screens/SettingsScreen.qml" line="192"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="184"/>
+        <location filename="../screens/SettingsScreen.qml" line="204"/>
         <source>Debug logging</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="189"/>
+        <location filename="../screens/SettingsScreen.qml" line="209"/>
         <source>Upload log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="179"/>
+        <location filename="../screens/SettingsScreen.qml" line="199"/>
         <source>About / License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
-        <location filename="../screens/SettingsScreen.qml" line="727"/>
+        <location filename="../screens/SettingsScreen.qml" line="137"/>
+        <location filename="../screens/SettingsScreen.qml" line="750"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="127"/>
-        <location filename="../screens/SettingsScreen.qml" line="736"/>
+        <location filename="../screens/SettingsScreen.qml" line="142"/>
+        <location filename="../screens/SettingsScreen.qml" line="759"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="137"/>
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="226"/>
+        <location filename="../screens/SettingsScreen.qml" line="170"/>
+        <source>Reduce motion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
         <source>Optimizing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="228"/>
-        <location filename="../screens/SettingsScreen.qml" line="237"/>
+        <location filename="../screens/SettingsScreen.qml" line="248"/>
+        <location filename="../screens/SettingsScreen.qml" line="257"/>
         <source>Paused</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="228"/>
-        <location filename="../screens/SettingsScreen.qml" line="237"/>
+        <location filename="../screens/SettingsScreen.qml" line="248"/>
+        <location filename="../screens/SettingsScreen.qml" line="257"/>
         <source>In progress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="231"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>%1 indexed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="240"/>
+        <location filename="../screens/SettingsScreen.qml" line="260"/>
         <source>%1 scraped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="472"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="472"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="474"/>
+        <location filename="../screens/SettingsScreen.qml" line="497"/>
         <source>Upload</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Open</source>
         <translation type="unfinished">Open</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="556"/>
+        <location filename="../screens/SettingsScreen.qml" line="579"/>
         <source>English</source>
         <translation>English</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="558"/>
+        <location filename="../screens/SettingsScreen.qml" line="581"/>
         <source>Italian</source>
         <translation>Italian</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="560"/>
+        <location filename="../screens/SettingsScreen.qml" line="583"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="562"/>
+        <location filename="../screens/SettingsScreen.qml" line="585"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="564"/>
+        <location filename="../screens/SettingsScreen.qml" line="587"/>
         <source>German</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="566"/>
+        <location filename="../screens/SettingsScreen.qml" line="589"/>
         <source>Greek</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="568"/>
+        <location filename="../screens/SettingsScreen.qml" line="591"/>
         <source>Japanese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="570"/>
+        <location filename="../screens/SettingsScreen.qml" line="593"/>
         <source>Korean</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="595"/>
         <source>Dutch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="597"/>
         <source>Romanian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="599"/>
         <source>Slovak</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="601"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="603"/>
         <source>Chinese (Simplified)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="605"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="607"/>
         <source>Hebrew</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="588"/>
+        <location filename="../screens/SettingsScreen.qml" line="611"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="589"/>
-        <location filename="../screens/SettingsScreen.qml" line="597"/>
-        <location filename="../screens/SettingsScreen.qml" line="671"/>
+        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="620"/>
+        <location filename="../screens/SettingsScreen.qml" line="694"/>
         <source>Auto</source>
         <translation>Auto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="594"/>
+        <location filename="../screens/SettingsScreen.qml" line="617"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="596"/>
+        <location filename="../screens/SettingsScreen.qml" line="619"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="607"/>
+        <location filename="../screens/SettingsScreen.qml" line="630"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="632"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="611"/>
+        <location filename="../screens/SettingsScreen.qml" line="634"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="635"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="640"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="619"/>
+        <location filename="../screens/SettingsScreen.qml" line="642"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="620"/>
+        <location filename="../screens/SettingsScreen.qml" line="643"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="625"/>
+        <location filename="../screens/SettingsScreen.qml" line="648"/>
         <source>Detailed list view</source>
         <translation>Detailed list view</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="626"/>
+        <location filename="../screens/SettingsScreen.qml" line="649"/>
         <source>Grid view</source>
         <translation>Grid view</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="631"/>
+        <location filename="../screens/SettingsScreen.qml" line="654"/>
         <source>Style B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="633"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Style C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="658"/>
         <source>Style D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="659"/>
         <source>Style A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1292"/>
+        <location filename="../screens/SettingsScreen.qml" line="1358"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="526"/>
+        <location filename="../screens/SettingsScreen.qml" line="549"/>
         <source>Default</source>
         <translation>Default</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="674"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="653"/>
+        <location filename="../screens/SettingsScreen.qml" line="676"/>
         <source>1 second (testing)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="655"/>
+        <location filename="../screens/SettingsScreen.qml" line="678"/>
         <source>1 minute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="657"/>
+        <location filename="../screens/SettingsScreen.qml" line="680"/>
         <source>2 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="659"/>
+        <location filename="../screens/SettingsScreen.qml" line="682"/>
         <source>5 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="661"/>
+        <location filename="../screens/SettingsScreen.qml" line="684"/>
         <source>10 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="663"/>
+        <location filename="../screens/SettingsScreen.qml" line="686"/>
         <source>15 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="665"/>
+        <location filename="../screens/SettingsScreen.qml" line="688"/>
         <source>30 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="666"/>
+        <location filename="../screens/SettingsScreen.qml" line="689"/>
         <source>%1 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="96"/>
-        <location filename="../screens/SettingsScreen.qml" line="709"/>
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="732"/>
         <source>Resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="68"/>
-        <location filename="../screens/SettingsScreen.qml" line="205"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="74"/>
-        <location filename="../screens/SettingsScreen.qml" line="207"/>
+        <location filename="../screens/SettingsScreen.qml" line="89"/>
+        <location filename="../screens/SettingsScreen.qml" line="227"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="80"/>
-        <location filename="../screens/SettingsScreen.qml" line="209"/>
+        <location filename="../screens/SettingsScreen.qml" line="95"/>
+        <location filename="../screens/SettingsScreen.qml" line="229"/>
         <source>Library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="86"/>
-        <location filename="../screens/SettingsScreen.qml" line="211"/>
+        <location filename="../screens/SettingsScreen.qml" line="101"/>
+        <location filename="../screens/SettingsScreen.qml" line="231"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="673"/>
+        <location filename="../screens/SettingsScreen.qml" line="696"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="675"/>
+        <location filename="../screens/SettingsScreen.qml" line="698"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="677"/>
+        <location filename="../screens/SettingsScreen.qml" line="700"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="679"/>
+        <location filename="../screens/SettingsScreen.qml" line="702"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="681"/>
+        <location filename="../screens/SettingsScreen.qml" line="704"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="683"/>
+        <location filename="../screens/SettingsScreen.qml" line="706"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="685"/>
+        <location filename="../screens/SettingsScreen.qml" line="708"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="687"/>
+        <location filename="../screens/SettingsScreen.qml" line="710"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="712"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="691"/>
+        <location filename="../screens/SettingsScreen.qml" line="714"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="693"/>
+        <location filename="../screens/SettingsScreen.qml" line="716"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="695"/>
+        <location filename="../screens/SettingsScreen.qml" line="718"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="212"/>
+        <location filename="../screens/SettingsScreen.qml" line="232"/>
         <source>Settings</source>
         <translation>Settings</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1280"/>
+        <location filename="../screens/SettingsScreen.qml" line="1346"/>
         <source>No settings available on this platform</source>
         <translation>No settings available on this platform</translation>
     </message>
@@ -1389,24 +1394,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="206"/>
-        <location filename="../screens/SystemsScreen.qml" line="304"/>
+        <location filename="../screens/SystemsScreen.qml" line="229"/>
+        <location filename="../screens/SystemsScreen.qml" line="329"/>
         <source>%1 systems</source>
         <translation>%1 systems</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="207"/>
-        <location filename="../screens/SystemsScreen.qml" line="321"/>
+        <location filename="../screens/SystemsScreen.qml" line="230"/>
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="339"/>
+        <location filename="../screens/SystemsScreen.qml" line="364"/>
         <source>No systems in this category</source>
         <translation>No systems in this category</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="340"/>
+        <location filename="../screens/SystemsScreen.qml" line="365"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1414,7 +1419,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="364"/>
+        <location filename="../components/Tile.qml" line="475"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -405,8 +405,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="128"/>
-        <location filename="../screens/GamesScreen.qml" line="163"/>
+        <location filename="../screens/GamesScreen.qml" line="131"/>
+        <location filename="../screens/GamesScreen.qml" line="166"/>
         <source>%1 files</source>
         <translation>%1 files</translation>
     </message>
@@ -416,8 +416,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="137"/>
-        <location filename="../screens/GamesScreen.qml" line="164"/>
+        <location filename="../screens/GamesScreen.qml" line="140"/>
+        <location filename="../screens/GamesScreen.qml" line="167"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -427,7 +427,7 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="133"/>
+        <location filename="../screens/GamesScreen.qml" line="136"/>
         <source>Loading more…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -880,7 +880,7 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="246"/>
+        <location filename="../components/Modal.qml" line="250"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
@@ -924,469 +924,469 @@ Euskara - devilschile2</source>
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="141"/>
-        <location filename="../screens/SettingsScreen.qml" line="734"/>
+        <location filename="../screens/SettingsScreen.qml" line="145"/>
+        <location filename="../screens/SettingsScreen.qml" line="738"/>
         <source>Language</source>
         <translation>Language</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116"/>
-        <location filename="../screens/SettingsScreen.qml" line="770"/>
+        <location filename="../screens/SettingsScreen.qml" line="120"/>
+        <location filename="../screens/SettingsScreen.qml" line="774"/>
         <source>Browsing layout</source>
         <translation>Browsing layout</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="159"/>
+        <location filename="../screens/SettingsScreen.qml" line="163"/>
         <source>Mouse support</source>
         <translation>Mouse support</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="171"/>
+        <location filename="../screens/SettingsScreen.qml" line="175"/>
         <source>Update media database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
-        <location filename="../screens/SettingsScreen.qml" line="761"/>
+        <location filename="../screens/SettingsScreen.qml" line="115"/>
+        <location filename="../screens/SettingsScreen.qml" line="765"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="154"/>
-        <location filename="../screens/SettingsScreen.qml" line="779"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="783"/>
         <source>Button style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
-        <location filename="../screens/SettingsScreen.qml" line="788"/>
+        <location filename="../screens/SettingsScreen.qml" line="130"/>
+        <location filename="../screens/SettingsScreen.qml" line="792"/>
         <source>Screensaver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="176"/>
+        <location filename="../screens/SettingsScreen.qml" line="180"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121"/>
-        <location filename="../screens/SettingsScreen.qml" line="797"/>
+        <location filename="../screens/SettingsScreen.qml" line="125"/>
+        <location filename="../screens/SettingsScreen.qml" line="801"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="181"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
         <source>Scrape metadata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="186"/>
+        <location filename="../screens/SettingsScreen.qml" line="190"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="198"/>
+        <location filename="../screens/SettingsScreen.qml" line="202"/>
         <source>Debug logging</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="203"/>
+        <location filename="../screens/SettingsScreen.qml" line="207"/>
         <source>Upload log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="193"/>
+        <location filename="../screens/SettingsScreen.qml" line="197"/>
         <source>About / License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
-        <location filename="../screens/SettingsScreen.qml" line="743"/>
+        <location filename="../screens/SettingsScreen.qml" line="135"/>
+        <location filename="../screens/SettingsScreen.qml" line="747"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="136"/>
-        <location filename="../screens/SettingsScreen.qml" line="752"/>
+        <location filename="../screens/SettingsScreen.qml" line="140"/>
+        <location filename="../screens/SettingsScreen.qml" line="756"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="146"/>
+        <location filename="../screens/SettingsScreen.qml" line="150"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="168"/>
         <source>Reduce motion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="240"/>
+        <location filename="../screens/SettingsScreen.qml" line="244"/>
         <source>Optimizing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="242"/>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="255"/>
         <source>Paused</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="242"/>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="255"/>
         <source>In progress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="245"/>
+        <location filename="../screens/SettingsScreen.qml" line="249"/>
         <source>%1 indexed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="254"/>
+        <location filename="../screens/SettingsScreen.qml" line="258"/>
         <source>%1 scraped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="488"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="488"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="490"/>
+        <location filename="../screens/SettingsScreen.qml" line="494"/>
         <source>Upload</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="491"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Open</source>
         <translation type="unfinished">Open</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>English</source>
         <translation>English</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Italian</source>
         <translation>Italian</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>German</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Greek</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Japanese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="590"/>
         <source>Korean</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="588"/>
+        <location filename="../screens/SettingsScreen.qml" line="592"/>
         <source>Dutch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="590"/>
+        <location filename="../screens/SettingsScreen.qml" line="594"/>
         <source>Romanian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="592"/>
+        <location filename="../screens/SettingsScreen.qml" line="596"/>
         <source>Slovak</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="594"/>
+        <location filename="../screens/SettingsScreen.qml" line="598"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="596"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Chinese (Simplified)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="598"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="600"/>
+        <location filename="../screens/SettingsScreen.qml" line="604"/>
         <source>Hebrew</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="602"/>
+        <location filename="../screens/SettingsScreen.qml" line="606"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="604"/>
+        <location filename="../screens/SettingsScreen.qml" line="608"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="605"/>
-        <location filename="../screens/SettingsScreen.qml" line="613"/>
-        <location filename="../screens/SettingsScreen.qml" line="687"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="691"/>
         <source>Auto</source>
         <translation>Auto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="610"/>
+        <location filename="../screens/SettingsScreen.qml" line="614"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="616"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="623"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="625"/>
+        <location filename="../screens/SettingsScreen.qml" line="629"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="627"/>
+        <location filename="../screens/SettingsScreen.qml" line="631"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="628"/>
+        <location filename="../screens/SettingsScreen.qml" line="632"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="633"/>
+        <location filename="../screens/SettingsScreen.qml" line="637"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="639"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="640"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="641"/>
+        <location filename="../screens/SettingsScreen.qml" line="645"/>
         <source>Detailed list view</source>
         <translation>Detailed list view</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="642"/>
+        <location filename="../screens/SettingsScreen.qml" line="646"/>
         <source>Grid view</source>
         <translation>Grid view</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
         <source>Style B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Style C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="655"/>
         <source>Style D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="652"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Style A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1351"/>
+        <location filename="../screens/SettingsScreen.qml" line="1382"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="542"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>Default</source>
         <translation>Default</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="667"/>
+        <location filename="../screens/SettingsScreen.qml" line="671"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="669"/>
+        <location filename="../screens/SettingsScreen.qml" line="673"/>
         <source>1 second (testing)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="671"/>
+        <location filename="../screens/SettingsScreen.qml" line="675"/>
         <source>1 minute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="673"/>
+        <location filename="../screens/SettingsScreen.qml" line="677"/>
         <source>2 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="675"/>
+        <location filename="../screens/SettingsScreen.qml" line="679"/>
         <source>5 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="677"/>
+        <location filename="../screens/SettingsScreen.qml" line="681"/>
         <source>10 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="679"/>
+        <location filename="../screens/SettingsScreen.qml" line="683"/>
         <source>15 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="681"/>
+        <location filename="../screens/SettingsScreen.qml" line="685"/>
         <source>30 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="682"/>
+        <location filename="../screens/SettingsScreen.qml" line="686"/>
         <source>%1 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="105"/>
-        <location filename="../screens/SettingsScreen.qml" line="725"/>
+        <location filename="../screens/SettingsScreen.qml" line="109"/>
+        <location filename="../screens/SettingsScreen.qml" line="729"/>
         <source>Resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="77"/>
-        <location filename="../screens/SettingsScreen.qml" line="219"/>
+        <location filename="../screens/SettingsScreen.qml" line="81"/>
+        <location filename="../screens/SettingsScreen.qml" line="223"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="221"/>
+        <location filename="../screens/SettingsScreen.qml" line="87"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="89"/>
-        <location filename="../screens/SettingsScreen.qml" line="223"/>
+        <location filename="../screens/SettingsScreen.qml" line="93"/>
+        <location filename="../screens/SettingsScreen.qml" line="227"/>
         <source>Library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="95"/>
-        <location filename="../screens/SettingsScreen.qml" line="225"/>
+        <location filename="../screens/SettingsScreen.qml" line="99"/>
+        <location filename="../screens/SettingsScreen.qml" line="229"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="693"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="691"/>
+        <location filename="../screens/SettingsScreen.qml" line="695"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="693"/>
+        <location filename="../screens/SettingsScreen.qml" line="697"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="695"/>
+        <location filename="../screens/SettingsScreen.qml" line="699"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="697"/>
+        <location filename="../screens/SettingsScreen.qml" line="701"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="699"/>
+        <location filename="../screens/SettingsScreen.qml" line="703"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="701"/>
+        <location filename="../screens/SettingsScreen.qml" line="705"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="703"/>
+        <location filename="../screens/SettingsScreen.qml" line="707"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="705"/>
+        <location filename="../screens/SettingsScreen.qml" line="709"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="707"/>
+        <location filename="../screens/SettingsScreen.qml" line="711"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="709"/>
+        <location filename="../screens/SettingsScreen.qml" line="713"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="711"/>
+        <location filename="../screens/SettingsScreen.qml" line="715"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="226"/>
+        <location filename="../screens/SettingsScreen.qml" line="230"/>
         <source>Settings</source>
         <translation>Settings</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1339"/>
+        <location filename="../screens/SettingsScreen.qml" line="1370"/>
         <source>No settings available on this platform</source>
         <translation>No settings available on this platform</translation>
     </message>
@@ -1394,24 +1394,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="242"/>
-        <location filename="../screens/SystemsScreen.qml" line="343"/>
+        <location filename="../screens/SystemsScreen.qml" line="245"/>
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>%1 systems</source>
         <translation>%1 systems</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="243"/>
-        <location filename="../screens/SystemsScreen.qml" line="360"/>
+        <location filename="../screens/SystemsScreen.qml" line="246"/>
+        <location filename="../screens/SystemsScreen.qml" line="363"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="378"/>
+        <location filename="../screens/SystemsScreen.qml" line="381"/>
         <source>No systems in this category</source>
         <translation>No systems in this category</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="379"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="156"/>
+        <location filename="../screens/HubScreen.qml" line="154"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="162"/>
+        <location filename="../screens/HubScreen.qml" line="160"/>
         <source>Favorites</source>
         <translation>Favoritos</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="167"/>
+        <location filename="../screens/HubScreen.qml" line="165"/>
         <source>Recently Played</source>
         <translation>Recientemente Jugados</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="172"/>
+        <location filename="../screens/HubScreen.qml" line="170"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Ajustes</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="722"/>
+        <location filename="../screens/HubScreen.qml" line="718"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>No hay sistemas disponibles. Ejecuta Actualizar la base de datos de medios desde Ajustes.</translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>No</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="256"/>
+        <location filename="../components/Modal.qml" line="246"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
@@ -936,18 +936,18 @@ Euskara - devilschile2</source>
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147"/>
-        <location filename="../screens/SettingsScreen.qml" line="741"/>
+        <location filename="../screens/SettingsScreen.qml" line="141"/>
+        <location filename="../screens/SettingsScreen.qml" line="734"/>
         <source>Language</source>
         <translation>Idioma</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="165"/>
+        <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>Mouse support</source>
         <translation>Soporte a ratón</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="177"/>
+        <location filename="../screens/SettingsScreen.qml" line="171"/>
         <source>Update media database</source>
         <translation>Actualizar base de datos de medios</translation>
     </message>
@@ -956,53 +956,53 @@ Euskara - devilschile2</source>
         <translation type="vanished">Ajustes generales</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="768"/>
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="761"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
-        <location filename="../screens/SettingsScreen.qml" line="777"/>
+        <location filename="../screens/SettingsScreen.qml" line="116"/>
+        <location filename="../screens/SettingsScreen.qml" line="770"/>
         <source>Browsing layout</source>
         <translation>Diseño de exploración</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="160"/>
-        <location filename="../screens/SettingsScreen.qml" line="786"/>
+        <location filename="../screens/SettingsScreen.qml" line="154"/>
+        <location filename="../screens/SettingsScreen.qml" line="779"/>
         <source>Button style</source>
         <translation>Estilo de botón</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="132"/>
-        <location filename="../screens/SettingsScreen.qml" line="795"/>
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
+        <location filename="../screens/SettingsScreen.qml" line="788"/>
         <source>Screensaver</source>
         <translation>Salvapantallas</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="95"/>
-        <location filename="../screens/SettingsScreen.qml" line="229"/>
+        <location filename="../screens/SettingsScreen.qml" line="89"/>
+        <location filename="../screens/SettingsScreen.qml" line="223"/>
         <source>Library</source>
         <translation>Biblioteca</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="182"/>
+        <location filename="../screens/SettingsScreen.qml" line="176"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="127"/>
-        <location filename="../screens/SettingsScreen.qml" line="804"/>
+        <location filename="../screens/SettingsScreen.qml" line="121"/>
+        <location filename="../screens/SettingsScreen.qml" line="797"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <location filename="../screens/SettingsScreen.qml" line="181"/>
         <source>Scrape metadata</source>
         <translation>Extraer metadatos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="192"/>
+        <location filename="../screens/SettingsScreen.qml" line="186"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1011,402 +1011,402 @@ Euskara - devilschile2</source>
         <translation type="vanished">Avanzado</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="204"/>
+        <location filename="../screens/SettingsScreen.qml" line="198"/>
         <source>Debug logging</source>
         <translation>Registro de depuración</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="209"/>
+        <location filename="../screens/SettingsScreen.qml" line="203"/>
         <source>Upload log file</source>
         <translation>Subir archivo de registro</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="199"/>
+        <location filename="../screens/SettingsScreen.qml" line="193"/>
         <source>About / License</source>
         <translation>Acerca de / Licencia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="137"/>
-        <location filename="../screens/SettingsScreen.qml" line="750"/>
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="743"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="142"/>
-        <location filename="../screens/SettingsScreen.qml" line="759"/>
+        <location filename="../screens/SettingsScreen.qml" line="136"/>
+        <location filename="../screens/SettingsScreen.qml" line="752"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152"/>
+        <location filename="../screens/SettingsScreen.qml" line="146"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="170"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
         <source>Reduce motion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="240"/>
         <source>Optimizing</source>
         <translation>Optimizando</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="248"/>
-        <location filename="../screens/SettingsScreen.qml" line="257"/>
+        <location filename="../screens/SettingsScreen.qml" line="242"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>Paused</source>
         <translation>Pausado</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="248"/>
-        <location filename="../screens/SettingsScreen.qml" line="257"/>
+        <location filename="../screens/SettingsScreen.qml" line="242"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>In progress</source>
         <translation>En progreso</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="245"/>
         <source>%1 indexed</source>
         <translation>%1 indexados</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="260"/>
+        <location filename="../screens/SettingsScreen.qml" line="254"/>
         <source>%1 scraped</source>
         <translation>%1 extraídos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="495"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="495"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Start</source>
         <translation>Iniciar</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="497"/>
+        <location filename="../screens/SettingsScreen.qml" line="490"/>
         <source>Upload</source>
         <translation>Subir</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <location filename="../screens/SettingsScreen.qml" line="491"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="579"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>English</source>
         <translation>Inglés</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="581"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Italian</source>
         <translation>Italiano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="583"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="585"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="587"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>German</source>
         <translation>Alemán</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="589"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Greek</source>
         <translation>Griego</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="591"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Japanese</source>
         <translation>Japonés</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="593"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Korean</source>
         <translation>Coreano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="595"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Dutch</source>
         <translation>Neerlandés</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="597"/>
+        <location filename="../screens/SettingsScreen.qml" line="590"/>
         <source>Romanian</source>
         <translation>Rumano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="599"/>
+        <location filename="../screens/SettingsScreen.qml" line="592"/>
         <source>Slovak</source>
         <translation>Eslovaco</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="601"/>
+        <location filename="../screens/SettingsScreen.qml" line="594"/>
         <source>Ukrainian</source>
         <translation>Ucraniano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="603"/>
+        <location filename="../screens/SettingsScreen.qml" line="596"/>
         <source>Chinese (Simplified)</source>
         <translation>Chino (simplificado)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="605"/>
+        <location filename="../screens/SettingsScreen.qml" line="598"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="607"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Hebrew</source>
         <translation>Hebreo</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="611"/>
+        <location filename="../screens/SettingsScreen.qml" line="604"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
-        <location filename="../screens/SettingsScreen.qml" line="620"/>
-        <location filename="../screens/SettingsScreen.qml" line="694"/>
+        <location filename="../screens/SettingsScreen.qml" line="605"/>
+        <location filename="../screens/SettingsScreen.qml" line="613"/>
+        <location filename="../screens/SettingsScreen.qml" line="687"/>
         <source>Auto</source>
         <translation>Automático</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="610"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="619"/>
+        <location filename="../screens/SettingsScreen.qml" line="612"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="630"/>
+        <location filename="../screens/SettingsScreen.qml" line="623"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="632"/>
+        <location filename="../screens/SettingsScreen.qml" line="625"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="634"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="628"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="640"/>
+        <location filename="../screens/SettingsScreen.qml" line="633"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="642"/>
+        <location filename="../screens/SettingsScreen.qml" line="635"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="643"/>
+        <location filename="../screens/SettingsScreen.qml" line="636"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="648"/>
+        <location filename="../screens/SettingsScreen.qml" line="641"/>
         <source>Detailed list view</source>
         <translation>Vista de lista detallada</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="642"/>
         <source>Grid view</source>
         <translation>Vista de cuadrícula</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="654"/>
+        <location filename="../screens/SettingsScreen.qml" line="647"/>
         <source>Style B</source>
         <translation>Estilo B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="656"/>
+        <location filename="../screens/SettingsScreen.qml" line="649"/>
         <source>Style C</source>
         <translation>Estilo C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="658"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
         <source>Style D</source>
         <translation>Estilo D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="659"/>
+        <location filename="../screens/SettingsScreen.qml" line="652"/>
         <source>Style A</source>
         <translation>Estilo A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1368"/>
+        <location filename="../screens/SettingsScreen.qml" line="1351"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="549"/>
+        <location filename="../screens/SettingsScreen.qml" line="542"/>
         <source>Default</source>
         <translation>Por defecto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="674"/>
+        <location filename="../screens/SettingsScreen.qml" line="667"/>
         <source>Off</source>
         <translation>Desactivado</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="676"/>
+        <location filename="../screens/SettingsScreen.qml" line="669"/>
         <source>1 second (testing)</source>
         <translation>1 segundo (prueba)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="678"/>
+        <location filename="../screens/SettingsScreen.qml" line="671"/>
         <source>1 minute</source>
         <translation>1 minuto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="680"/>
+        <location filename="../screens/SettingsScreen.qml" line="673"/>
         <source>2 minutes</source>
         <translation>2 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="682"/>
+        <location filename="../screens/SettingsScreen.qml" line="675"/>
         <source>5 minutes</source>
         <translation>5 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="684"/>
+        <location filename="../screens/SettingsScreen.qml" line="677"/>
         <source>10 minutes</source>
         <translation>10 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="686"/>
+        <location filename="../screens/SettingsScreen.qml" line="679"/>
         <source>15 minutes</source>
         <translation>15 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="688"/>
+        <location filename="../screens/SettingsScreen.qml" line="681"/>
         <source>30 minutes</source>
         <translation>30 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="682"/>
         <source>%1 seconds</source>
         <translation>%1 segundos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
-        <location filename="../screens/SettingsScreen.qml" line="732"/>
+        <location filename="../screens/SettingsScreen.qml" line="105"/>
+        <location filename="../screens/SettingsScreen.qml" line="725"/>
         <source>Resolution</source>
         <translation>Resolución</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="225"/>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="219"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="89"/>
-        <location filename="../screens/SettingsScreen.qml" line="227"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="221"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="101"/>
-        <location filename="../screens/SettingsScreen.qml" line="231"/>
+        <location filename="../screens/SettingsScreen.qml" line="95"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="696"/>
+        <location filename="../screens/SettingsScreen.qml" line="689"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="698"/>
+        <location filename="../screens/SettingsScreen.qml" line="691"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="700"/>
+        <location filename="../screens/SettingsScreen.qml" line="693"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="702"/>
+        <location filename="../screens/SettingsScreen.qml" line="695"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="704"/>
+        <location filename="../screens/SettingsScreen.qml" line="697"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="706"/>
+        <location filename="../screens/SettingsScreen.qml" line="699"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="708"/>
+        <location filename="../screens/SettingsScreen.qml" line="701"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="710"/>
+        <location filename="../screens/SettingsScreen.qml" line="703"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="712"/>
+        <location filename="../screens/SettingsScreen.qml" line="705"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="714"/>
+        <location filename="../screens/SettingsScreen.qml" line="707"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="716"/>
+        <location filename="../screens/SettingsScreen.qml" line="709"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="718"/>
+        <location filename="../screens/SettingsScreen.qml" line="711"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="232"/>
+        <location filename="../screens/SettingsScreen.qml" line="226"/>
         <source>Settings</source>
         <translation>Ajustes</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1356"/>
+        <location filename="../screens/SettingsScreen.qml" line="1339"/>
         <source>No settings available on this platform</source>
         <translation>No hay ajustes en esta plataforma</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="236"/>
-        <location filename="../screens/SystemsScreen.qml" line="338"/>
+        <location filename="../screens/SystemsScreen.qml" line="242"/>
+        <location filename="../screens/SystemsScreen.qml" line="343"/>
         <source>%1 systems</source>
         <translation>%1 sistemas</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="237"/>
-        <location filename="../screens/SystemsScreen.qml" line="355"/>
+        <location filename="../screens/SystemsScreen.qml" line="243"/>
+        <location filename="../screens/SystemsScreen.qml" line="360"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="373"/>
+        <location filename="../screens/SystemsScreen.qml" line="378"/>
         <source>No systems in this category</source>
         <translation>No hay sistemas en esta categoría</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="374"/>
+        <location filename="../screens/SystemsScreen.qml" line="379"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>
@@ -1439,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="539"/>
+        <location filename="../components/Tile.qml" line="501"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -97,100 +97,100 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Cargando…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="196"/>
+        <location filename="../components/BrowseDetailPane.qml" line="167"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="196"/>
+        <location filename="../components/BrowseDetailPane.qml" line="167"/>
         <source>Yr</source>
         <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="198"/>
+        <location filename="../components/BrowseDetailPane.qml" line="169"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="198"/>
+        <location filename="../components/BrowseDetailPane.qml" line="169"/>
         <source>Gen</source>
         <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="200"/>
+        <location filename="../components/BrowseDetailPane.qml" line="171"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="200"/>
+        <location filename="../components/BrowseDetailPane.qml" line="171"/>
         <source>Plyr</source>
         <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="202"/>
+        <location filename="../components/BrowseDetailPane.qml" line="173"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="202"/>
+        <location filename="../components/BrowseDetailPane.qml" line="173"/>
         <source>Dev</source>
         <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="204"/>
+        <location filename="../components/BrowseDetailPane.qml" line="175"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="204"/>
+        <location filename="../components/BrowseDetailPane.qml" line="175"/>
         <source>Pub</source>
         <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="206"/>
+        <location filename="../components/BrowseDetailPane.qml" line="177"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="206"/>
+        <location filename="../components/BrowseDetailPane.qml" line="177"/>
         <source>Rtg</source>
         <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="208"/>
+        <location filename="../components/BrowseDetailPane.qml" line="179"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="208"/>
+        <location filename="../components/BrowseDetailPane.qml" line="179"/>
         <source>Cat</source>
         <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="210"/>
+        <location filename="../components/BrowseDetailPane.qml" line="181"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="210"/>
+        <location filename="../components/BrowseDetailPane.qml" line="181"/>
         <source>Date</source>
         <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="212"/>
+        <location filename="../components/BrowseDetailPane.qml" line="183"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="212"/>
+        <location filename="../components/BrowseDetailPane.qml" line="183"/>
         <source>Mfr</source>
         <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
@@ -425,8 +425,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="127"/>
-        <location filename="../screens/GamesScreen.qml" line="162"/>
+        <location filename="../screens/GamesScreen.qml" line="128"/>
+        <location filename="../screens/GamesScreen.qml" line="163"/>
         <source>%1 files</source>
         <translation>%1 archivos</translation>
     </message>
@@ -436,8 +436,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="136"/>
-        <location filename="../screens/GamesScreen.qml" line="163"/>
+        <location filename="../screens/GamesScreen.qml" line="137"/>
+        <location filename="../screens/GamesScreen.qml" line="164"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -447,7 +447,7 @@ Euskara - devilschile2</source>
         <translation>Cargando juegos…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="132"/>
+        <location filename="../screens/GamesScreen.qml" line="133"/>
         <source>Loading more…</source>
         <translation>Cargando más…</translation>
     </message>
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="149"/>
+        <location filename="../screens/HubScreen.qml" line="156"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="155"/>
+        <location filename="../screens/HubScreen.qml" line="162"/>
         <source>Favorites</source>
         <translation>Favoritos</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="160"/>
+        <location filename="../screens/HubScreen.qml" line="167"/>
         <source>Recently Played</source>
         <translation>Recientemente Jugados</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="165"/>
+        <location filename="../screens/HubScreen.qml" line="172"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Ajustes</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="701"/>
+        <location filename="../screens/HubScreen.qml" line="722"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>No hay sistemas disponibles. Ejecuta Actualizar la base de datos de medios desde Ajustes.</translation>
     </message>
@@ -553,138 +553,138 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1367"/>
+        <location filename="../app/Main.qml" line="1381"/>
         <source>Launch core</source>
         <translation>Lanzar core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1373"/>
-        <location filename="../app/Main.qml" line="1612"/>
+        <location filename="../app/Main.qml" line="1387"/>
+        <location filename="../app/Main.qml" line="1626"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1445"/>
         <source>Remove from favorites</source>
         <translation>Eliminar de favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1445"/>
         <source>Add to favorites</source>
         <translation>Agregar a favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1436"/>
+        <location filename="../app/Main.qml" line="1450"/>
         <source>Write to NFC token</source>
         <translation>Escribir en token NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1440"/>
+        <location filename="../app/Main.qml" line="1454"/>
         <source>QR code</source>
         <translation>Código QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1415"/>
-        <location filename="../app/Main.qml" line="1450"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1464"/>
         <source>Launch game</source>
         <translation>Iniciar juego</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2624"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2616"/>
+        <location filename="../app/Main.qml" line="2630"/>
         <source>Loading favorites…</source>
         <translation>Cargando favoritos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2612"/>
+        <location filename="../app/Main.qml" line="2626"/>
         <source>Loading games…</source>
         <translation>Cargando juegos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1380"/>
-        <location filename="../app/Main.qml" line="1403"/>
+        <location filename="../app/Main.qml" line="1394"/>
+        <location filename="../app/Main.qml" line="1417"/>
         <source>Update media database</source>
         <translation type="unfinished">Actualizar base de datos de medios</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1383"/>
-        <location filename="../app/Main.qml" line="1406"/>
+        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1420"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Extraer metadatos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1388"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1411"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1388"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1411"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1608"/>
+        <location filename="../app/Main.qml" line="1622"/>
         <source>Default</source>
         <translation type="unfinished">Por defecto</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1608"/>
+        <location filename="../app/Main.qml" line="1622"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1932"/>
+        <location filename="../app/Main.qml" line="1946"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1936"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1950"/>
+        <location filename="../app/Main.qml" line="1964"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1954"/>
+        <location filename="../app/Main.qml" line="1968"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1958"/>
+        <location filename="../app/Main.qml" line="1972"/>
         <source>Retry</source>
         <translation type="unfinished">Reintentar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1962"/>
+        <location filename="../app/Main.qml" line="1976"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2628"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2618"/>
+        <location filename="../app/Main.qml" line="2632"/>
         <source>Loading recently played…</source>
         <translation>Cargando jugados recientemente…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2620"/>
+        <location filename="../app/Main.qml" line="2634"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2622"/>
+        <location filename="../app/Main.qml" line="2636"/>
         <source>Loading…</source>
         <translation>Cargando…</translation>
     </message>
@@ -864,12 +864,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Cargando…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="395"/>
+        <location filename="../screens/MediaListScreen.qml" line="436"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 entradas</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="396"/>
+        <location filename="../screens/MediaListScreen.qml" line="437"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>No</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="246"/>
+        <location filename="../components/Modal.qml" line="256"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
@@ -1262,7 +1262,7 @@ Euskara - devilschile2</source>
         <translation>Estilo A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1358"/>
+        <location filename="../screens/SettingsScreen.qml" line="1368"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1406,7 +1406,7 @@ Euskara - devilschile2</source>
         <translation>Ajustes</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1346"/>
+        <location filename="../screens/SettingsScreen.qml" line="1356"/>
         <source>No settings available on this platform</source>
         <translation>No hay ajustes en esta plataforma</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="229"/>
-        <location filename="../screens/SystemsScreen.qml" line="329"/>
+        <location filename="../screens/SystemsScreen.qml" line="236"/>
+        <location filename="../screens/SystemsScreen.qml" line="338"/>
         <source>%1 systems</source>
         <translation>%1 sistemas</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="230"/>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="237"/>
+        <location filename="../screens/SystemsScreen.qml" line="355"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="364"/>
+        <location filename="../screens/SystemsScreen.qml" line="373"/>
         <source>No systems in this category</source>
         <translation>No hay sistemas en esta categoría</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="365"/>
+        <location filename="../screens/SystemsScreen.qml" line="374"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>
@@ -1439,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="475"/>
+        <location filename="../components/Tile.qml" line="539"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -425,8 +425,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="128"/>
-        <location filename="../screens/GamesScreen.qml" line="163"/>
+        <location filename="../screens/GamesScreen.qml" line="131"/>
+        <location filename="../screens/GamesScreen.qml" line="166"/>
         <source>%1 files</source>
         <translation>%1 archivos</translation>
     </message>
@@ -436,8 +436,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="137"/>
-        <location filename="../screens/GamesScreen.qml" line="164"/>
+        <location filename="../screens/GamesScreen.qml" line="140"/>
+        <location filename="../screens/GamesScreen.qml" line="167"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -447,7 +447,7 @@ Euskara - devilschile2</source>
         <translation>Cargando juegos…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="133"/>
+        <location filename="../screens/GamesScreen.qml" line="136"/>
         <source>Loading more…</source>
         <translation>Cargando más…</translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>No</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="246"/>
+        <location filename="../components/Modal.qml" line="250"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
@@ -936,18 +936,18 @@ Euskara - devilschile2</source>
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="141"/>
-        <location filename="../screens/SettingsScreen.qml" line="734"/>
+        <location filename="../screens/SettingsScreen.qml" line="145"/>
+        <location filename="../screens/SettingsScreen.qml" line="738"/>
         <source>Language</source>
         <translation>Idioma</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="159"/>
+        <location filename="../screens/SettingsScreen.qml" line="163"/>
         <source>Mouse support</source>
         <translation>Soporte a ratón</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="171"/>
+        <location filename="../screens/SettingsScreen.qml" line="175"/>
         <source>Update media database</source>
         <translation>Actualizar base de datos de medios</translation>
     </message>
@@ -956,53 +956,53 @@ Euskara - devilschile2</source>
         <translation type="vanished">Ajustes generales</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
-        <location filename="../screens/SettingsScreen.qml" line="761"/>
+        <location filename="../screens/SettingsScreen.qml" line="115"/>
+        <location filename="../screens/SettingsScreen.qml" line="765"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116"/>
-        <location filename="../screens/SettingsScreen.qml" line="770"/>
+        <location filename="../screens/SettingsScreen.qml" line="120"/>
+        <location filename="../screens/SettingsScreen.qml" line="774"/>
         <source>Browsing layout</source>
         <translation>Diseño de exploración</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="154"/>
-        <location filename="../screens/SettingsScreen.qml" line="779"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="783"/>
         <source>Button style</source>
         <translation>Estilo de botón</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
-        <location filename="../screens/SettingsScreen.qml" line="788"/>
+        <location filename="../screens/SettingsScreen.qml" line="130"/>
+        <location filename="../screens/SettingsScreen.qml" line="792"/>
         <source>Screensaver</source>
         <translation>Salvapantallas</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="89"/>
-        <location filename="../screens/SettingsScreen.qml" line="223"/>
+        <location filename="../screens/SettingsScreen.qml" line="93"/>
+        <location filename="../screens/SettingsScreen.qml" line="227"/>
         <source>Library</source>
         <translation>Biblioteca</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="176"/>
+        <location filename="../screens/SettingsScreen.qml" line="180"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121"/>
-        <location filename="../screens/SettingsScreen.qml" line="797"/>
+        <location filename="../screens/SettingsScreen.qml" line="125"/>
+        <location filename="../screens/SettingsScreen.qml" line="801"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="181"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
         <source>Scrape metadata</source>
         <translation>Extraer metadatos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="186"/>
+        <location filename="../screens/SettingsScreen.qml" line="190"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1011,402 +1011,402 @@ Euskara - devilschile2</source>
         <translation type="vanished">Avanzado</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="198"/>
+        <location filename="../screens/SettingsScreen.qml" line="202"/>
         <source>Debug logging</source>
         <translation>Registro de depuración</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="203"/>
+        <location filename="../screens/SettingsScreen.qml" line="207"/>
         <source>Upload log file</source>
         <translation>Subir archivo de registro</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="193"/>
+        <location filename="../screens/SettingsScreen.qml" line="197"/>
         <source>About / License</source>
         <translation>Acerca de / Licencia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
-        <location filename="../screens/SettingsScreen.qml" line="743"/>
+        <location filename="../screens/SettingsScreen.qml" line="135"/>
+        <location filename="../screens/SettingsScreen.qml" line="747"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="136"/>
-        <location filename="../screens/SettingsScreen.qml" line="752"/>
+        <location filename="../screens/SettingsScreen.qml" line="140"/>
+        <location filename="../screens/SettingsScreen.qml" line="756"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="146"/>
+        <location filename="../screens/SettingsScreen.qml" line="150"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="168"/>
         <source>Reduce motion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="240"/>
+        <location filename="../screens/SettingsScreen.qml" line="244"/>
         <source>Optimizing</source>
         <translation>Optimizando</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="242"/>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="255"/>
         <source>Paused</source>
         <translation>Pausado</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="242"/>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="255"/>
         <source>In progress</source>
         <translation>En progreso</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="245"/>
+        <location filename="../screens/SettingsScreen.qml" line="249"/>
         <source>%1 indexed</source>
         <translation>%1 indexados</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="254"/>
+        <location filename="../screens/SettingsScreen.qml" line="258"/>
         <source>%1 scraped</source>
         <translation>%1 extraídos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="488"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="488"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Start</source>
         <translation>Iniciar</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="490"/>
+        <location filename="../screens/SettingsScreen.qml" line="494"/>
         <source>Upload</source>
         <translation>Subir</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="491"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>English</source>
         <translation>Inglés</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Italian</source>
         <translation>Italiano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>German</source>
         <translation>Alemán</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Greek</source>
         <translation>Griego</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Japanese</source>
         <translation>Japonés</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="590"/>
         <source>Korean</source>
         <translation>Coreano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="588"/>
+        <location filename="../screens/SettingsScreen.qml" line="592"/>
         <source>Dutch</source>
         <translation>Neerlandés</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="590"/>
+        <location filename="../screens/SettingsScreen.qml" line="594"/>
         <source>Romanian</source>
         <translation>Rumano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="592"/>
+        <location filename="../screens/SettingsScreen.qml" line="596"/>
         <source>Slovak</source>
         <translation>Eslovaco</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="594"/>
+        <location filename="../screens/SettingsScreen.qml" line="598"/>
         <source>Ukrainian</source>
         <translation>Ucraniano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="596"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Chinese (Simplified)</source>
         <translation>Chino (simplificado)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="598"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="600"/>
+        <location filename="../screens/SettingsScreen.qml" line="604"/>
         <source>Hebrew</source>
         <translation>Hebreo</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="602"/>
+        <location filename="../screens/SettingsScreen.qml" line="606"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="604"/>
+        <location filename="../screens/SettingsScreen.qml" line="608"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="605"/>
-        <location filename="../screens/SettingsScreen.qml" line="613"/>
-        <location filename="../screens/SettingsScreen.qml" line="687"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="691"/>
         <source>Auto</source>
         <translation>Automático</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="610"/>
+        <location filename="../screens/SettingsScreen.qml" line="614"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="616"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="623"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="625"/>
+        <location filename="../screens/SettingsScreen.qml" line="629"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="627"/>
+        <location filename="../screens/SettingsScreen.qml" line="631"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="628"/>
+        <location filename="../screens/SettingsScreen.qml" line="632"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="633"/>
+        <location filename="../screens/SettingsScreen.qml" line="637"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="639"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="640"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="641"/>
+        <location filename="../screens/SettingsScreen.qml" line="645"/>
         <source>Detailed list view</source>
         <translation>Vista de lista detallada</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="642"/>
+        <location filename="../screens/SettingsScreen.qml" line="646"/>
         <source>Grid view</source>
         <translation>Vista de cuadrícula</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
         <source>Style B</source>
         <translation>Estilo B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Style C</source>
         <translation>Estilo C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="655"/>
         <source>Style D</source>
         <translation>Estilo D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="652"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Style A</source>
         <translation>Estilo A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1351"/>
+        <location filename="../screens/SettingsScreen.qml" line="1382"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="542"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>Default</source>
         <translation>Por defecto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="667"/>
+        <location filename="../screens/SettingsScreen.qml" line="671"/>
         <source>Off</source>
         <translation>Desactivado</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="669"/>
+        <location filename="../screens/SettingsScreen.qml" line="673"/>
         <source>1 second (testing)</source>
         <translation>1 segundo (prueba)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="671"/>
+        <location filename="../screens/SettingsScreen.qml" line="675"/>
         <source>1 minute</source>
         <translation>1 minuto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="673"/>
+        <location filename="../screens/SettingsScreen.qml" line="677"/>
         <source>2 minutes</source>
         <translation>2 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="675"/>
+        <location filename="../screens/SettingsScreen.qml" line="679"/>
         <source>5 minutes</source>
         <translation>5 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="677"/>
+        <location filename="../screens/SettingsScreen.qml" line="681"/>
         <source>10 minutes</source>
         <translation>10 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="679"/>
+        <location filename="../screens/SettingsScreen.qml" line="683"/>
         <source>15 minutes</source>
         <translation>15 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="681"/>
+        <location filename="../screens/SettingsScreen.qml" line="685"/>
         <source>30 minutes</source>
         <translation>30 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="682"/>
+        <location filename="../screens/SettingsScreen.qml" line="686"/>
         <source>%1 seconds</source>
         <translation>%1 segundos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="105"/>
-        <location filename="../screens/SettingsScreen.qml" line="725"/>
+        <location filename="../screens/SettingsScreen.qml" line="109"/>
+        <location filename="../screens/SettingsScreen.qml" line="729"/>
         <source>Resolution</source>
         <translation>Resolución</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="77"/>
-        <location filename="../screens/SettingsScreen.qml" line="219"/>
+        <location filename="../screens/SettingsScreen.qml" line="81"/>
+        <location filename="../screens/SettingsScreen.qml" line="223"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="221"/>
+        <location filename="../screens/SettingsScreen.qml" line="87"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="95"/>
-        <location filename="../screens/SettingsScreen.qml" line="225"/>
+        <location filename="../screens/SettingsScreen.qml" line="99"/>
+        <location filename="../screens/SettingsScreen.qml" line="229"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="693"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="691"/>
+        <location filename="../screens/SettingsScreen.qml" line="695"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="693"/>
+        <location filename="../screens/SettingsScreen.qml" line="697"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="695"/>
+        <location filename="../screens/SettingsScreen.qml" line="699"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="697"/>
+        <location filename="../screens/SettingsScreen.qml" line="701"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="699"/>
+        <location filename="../screens/SettingsScreen.qml" line="703"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="701"/>
+        <location filename="../screens/SettingsScreen.qml" line="705"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="703"/>
+        <location filename="../screens/SettingsScreen.qml" line="707"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="705"/>
+        <location filename="../screens/SettingsScreen.qml" line="709"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="707"/>
+        <location filename="../screens/SettingsScreen.qml" line="711"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="709"/>
+        <location filename="../screens/SettingsScreen.qml" line="713"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="711"/>
+        <location filename="../screens/SettingsScreen.qml" line="715"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="226"/>
+        <location filename="../screens/SettingsScreen.qml" line="230"/>
         <source>Settings</source>
         <translation>Ajustes</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1339"/>
+        <location filename="../screens/SettingsScreen.qml" line="1370"/>
         <source>No settings available on this platform</source>
         <translation>No hay ajustes en esta plataforma</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="242"/>
-        <location filename="../screens/SystemsScreen.qml" line="343"/>
+        <location filename="../screens/SystemsScreen.qml" line="245"/>
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>%1 systems</source>
         <translation>%1 sistemas</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="243"/>
-        <location filename="../screens/SystemsScreen.qml" line="360"/>
+        <location filename="../screens/SystemsScreen.qml" line="246"/>
+        <location filename="../screens/SystemsScreen.qml" line="363"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="378"/>
+        <location filename="../screens/SystemsScreen.qml" line="381"/>
         <source>No systems in this category</source>
         <translation>No hay sistemas en esta categoría</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="379"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -425,34 +425,34 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="116"/>
-        <location filename="../screens/GamesScreen.qml" line="151"/>
+        <location filename="../screens/GamesScreen.qml" line="127"/>
+        <location filename="../screens/GamesScreen.qml" line="162"/>
         <source>%1 files</source>
         <translation>%1 archivos</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="53"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="125"/>
-        <location filename="../screens/GamesScreen.qml" line="152"/>
+        <location filename="../screens/GamesScreen.qml" line="136"/>
+        <location filename="../screens/GamesScreen.qml" line="163"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="48"/>
+        <location filename="../screens/GamesScreen.qml" line="49"/>
         <source>Loading games…</source>
         <translation>Cargando juegos…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="121"/>
+        <location filename="../screens/GamesScreen.qml" line="132"/>
         <source>Loading more…</source>
         <translation>Cargando más…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="47"/>
+        <location filename="../screens/GamesScreen.qml" line="48"/>
         <source>No games in this system</source>
         <translation>No hay juegos en este sistema</translation>
     </message>
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="139"/>
+        <location filename="../screens/HubScreen.qml" line="149"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="145"/>
+        <location filename="../screens/HubScreen.qml" line="155"/>
         <source>Favorites</source>
         <translation>Favoritos</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="150"/>
+        <location filename="../screens/HubScreen.qml" line="160"/>
         <source>Recently Played</source>
         <translation>Recientemente Jugados</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="155"/>
+        <location filename="../screens/HubScreen.qml" line="165"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Ajustes</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="669"/>
+        <location filename="../screens/HubScreen.qml" line="701"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>No hay sistemas disponibles. Ejecuta Actualizar la base de datos de medios desde Ajustes.</translation>
     </message>
@@ -553,138 +553,138 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1361"/>
+        <location filename="../app/Main.qml" line="1367"/>
         <source>Launch core</source>
         <translation>Lanzar core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1367"/>
-        <location filename="../app/Main.qml" line="1606"/>
+        <location filename="../app/Main.qml" line="1373"/>
+        <location filename="../app/Main.qml" line="1612"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1425"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Remove from favorites</source>
         <translation>Eliminar de favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1425"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Add to favorites</source>
         <translation>Agregar a favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1430"/>
+        <location filename="../app/Main.qml" line="1436"/>
         <source>Write to NFC token</source>
         <translation>Escribir en token NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1434"/>
+        <location filename="../app/Main.qml" line="1440"/>
         <source>QR code</source>
         <translation>Código QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1409"/>
-        <location filename="../app/Main.qml" line="1444"/>
+        <location filename="../app/Main.qml" line="1415"/>
+        <location filename="../app/Main.qml" line="1450"/>
         <source>Launch game</source>
         <translation>Iniciar juego</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2604"/>
+        <location filename="../app/Main.qml" line="2610"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2616"/>
         <source>Loading favorites…</source>
         <translation>Cargando favoritos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2606"/>
+        <location filename="../app/Main.qml" line="2612"/>
         <source>Loading games…</source>
         <translation>Cargando juegos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1374"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1380"/>
+        <location filename="../app/Main.qml" line="1403"/>
         <source>Update media database</source>
         <translation type="unfinished">Actualizar base de datos de medios</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1377"/>
-        <location filename="../app/Main.qml" line="1400"/>
+        <location filename="../app/Main.qml" line="1383"/>
+        <location filename="../app/Main.qml" line="1406"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Extraer metadatos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1382"/>
-        <location filename="../app/Main.qml" line="1391"/>
+        <location filename="../app/Main.qml" line="1388"/>
+        <location filename="../app/Main.qml" line="1397"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1382"/>
-        <location filename="../app/Main.qml" line="1391"/>
+        <location filename="../app/Main.qml" line="1388"/>
+        <location filename="../app/Main.qml" line="1397"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1602"/>
+        <location filename="../app/Main.qml" line="1608"/>
         <source>Default</source>
         <translation type="unfinished">Por defecto</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1602"/>
+        <location filename="../app/Main.qml" line="1608"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1926"/>
+        <location filename="../app/Main.qml" line="1932"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1930"/>
+        <location filename="../app/Main.qml" line="1936"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1944"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1948"/>
+        <location filename="../app/Main.qml" line="1954"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1952"/>
+        <location filename="../app/Main.qml" line="1958"/>
         <source>Retry</source>
         <translation type="unfinished">Reintentar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1956"/>
+        <location filename="../app/Main.qml" line="1962"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2608"/>
+        <location filename="../app/Main.qml" line="2614"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2612"/>
+        <location filename="../app/Main.qml" line="2618"/>
         <source>Loading recently played…</source>
         <translation>Cargando jugados recientemente…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2620"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2616"/>
+        <location filename="../app/Main.qml" line="2622"/>
         <source>Loading…</source>
         <translation>Cargando…</translation>
     </message>
@@ -692,72 +692,72 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="683"/>
+        <location filename="../app/MainLayout.qml" line="685"/>
         <source>Writing failed</source>
         <translation>Error de escritura</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="683"/>
+        <location filename="../app/MainLayout.qml" line="685"/>
         <source>Put a writable card near the reader</source>
         <translation>Pon una tarjeta escribible junto al lector</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="811"/>
+        <location filename="../app/MainLayout.qml" line="813"/>
         <source>Are you sure you want to exit?</source>
         <translation>¿Seguro que quieres salir?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="894"/>
-        <location filename="../app/MainLayout.qml" line="968"/>
+        <location filename="../app/MainLayout.qml" line="896"/>
+        <location filename="../app/MainLayout.qml" line="970"/>
         <source>Select</source>
         <translation>Seleccionar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="902"/>
-        <location filename="../app/MainLayout.qml" line="916"/>
-        <location filename="../app/MainLayout.qml" line="931"/>
-        <location filename="../app/MainLayout.qml" line="942"/>
+        <location filename="../app/MainLayout.qml" line="900"/>
+        <location filename="../app/MainLayout.qml" line="904"/>
+        <location filename="../app/MainLayout.qml" line="918"/>
+        <location filename="../app/MainLayout.qml" line="933"/>
+        <location filename="../app/MainLayout.qml" line="944"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="909"/>
-        <location filename="../app/MainLayout.qml" line="949"/>
-        <location filename="../app/MainLayout.qml" line="972"/>
-        <location filename="../app/MainLayout.qml" line="983"/>
+        <location filename="../app/MainLayout.qml" line="911"/>
+        <location filename="../app/MainLayout.qml" line="951"/>
+        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="985"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="927"/>
+        <location filename="../app/MainLayout.qml" line="929"/>
         <source>Done</source>
         <translation>Hecho</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="957"/>
+        <location filename="../app/MainLayout.qml" line="959"/>
         <source>I understand</source>
         <translation>Entendido</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="991"/>
+        <location filename="../app/MainLayout.qml" line="993"/>
         <source>Start</source>
         <translation>Iniciar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1203"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Scroll</source>
         <translation>Desplazar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="890"/>
-        <location filename="../app/MainLayout.qml" line="964"/>
-        <location filename="../app/MainLayout.qml" line="1010"/>
-        <location filename="../app/MainLayout.qml" line="1047"/>
-        <location filename="../app/MainLayout.qml" line="1097"/>
-        <location filename="../app/MainLayout.qml" line="1146"/>
-        <location filename="../app/MainLayout.qml" line="1165"/>
-        <location filename="../app/MainLayout.qml" line="1232"/>
+        <location filename="../app/MainLayout.qml" line="892"/>
+        <location filename="../app/MainLayout.qml" line="966"/>
+        <location filename="../app/MainLayout.qml" line="1012"/>
+        <location filename="../app/MainLayout.qml" line="1049"/>
+        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1148"/>
+        <location filename="../app/MainLayout.qml" line="1167"/>
+        <location filename="../app/MainLayout.qml" line="1234"/>
         <source>Move</source>
         <translation>Mover</translation>
     </message>
@@ -777,81 +777,81 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="699"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="700"/>
+        <location filename="../app/MainLayout.qml" line="702"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="810"/>
+        <location filename="../app/MainLayout.qml" line="812"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1014"/>
-        <location filename="../app/MainLayout.qml" line="1057"/>
-        <location filename="../app/MainLayout.qml" line="1107"/>
-        <location filename="../app/MainLayout.qml" line="1151"/>
-        <location filename="../app/MainLayout.qml" line="1242"/>
+        <location filename="../app/MainLayout.qml" line="1016"/>
+        <location filename="../app/MainLayout.qml" line="1059"/>
+        <location filename="../app/MainLayout.qml" line="1109"/>
+        <location filename="../app/MainLayout.qml" line="1153"/>
+        <location filename="../app/MainLayout.qml" line="1244"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1024"/>
+        <location filename="../app/MainLayout.qml" line="1026"/>
         <source>Quit</source>
         <translation>Salir</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1033"/>
-        <location filename="../app/MainLayout.qml" line="1063"/>
-        <location filename="../app/MainLayout.qml" line="1074"/>
-        <location filename="../app/MainLayout.qml" line="1089"/>
-        <location filename="../app/MainLayout.qml" line="1116"/>
-        <location filename="../app/MainLayout.qml" line="1127"/>
-        <location filename="../app/MainLayout.qml" line="1139"/>
-        <location filename="../app/MainLayout.qml" line="1155"/>
-        <location filename="../app/MainLayout.qml" line="1189"/>
-        <location filename="../app/MainLayout.qml" line="1207"/>
-        <location filename="../app/MainLayout.qml" line="1216"/>
-        <location filename="../app/MainLayout.qml" line="1251"/>
-        <location filename="../app/MainLayout.qml" line="1262"/>
+        <location filename="../app/MainLayout.qml" line="1035"/>
+        <location filename="../app/MainLayout.qml" line="1065"/>
+        <location filename="../app/MainLayout.qml" line="1076"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
+        <location filename="../app/MainLayout.qml" line="1118"/>
+        <location filename="../app/MainLayout.qml" line="1129"/>
+        <location filename="../app/MainLayout.qml" line="1141"/>
+        <location filename="../app/MainLayout.qml" line="1157"/>
+        <location filename="../app/MainLayout.qml" line="1191"/>
+        <location filename="../app/MainLayout.qml" line="1209"/>
+        <location filename="../app/MainLayout.qml" line="1218"/>
+        <location filename="../app/MainLayout.qml" line="1253"/>
+        <location filename="../app/MainLayout.qml" line="1264"/>
         <source>Back</source>
         <translation>Atrás</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1053"/>
-        <location filename="../app/MainLayout.qml" line="1103"/>
-        <location filename="../app/MainLayout.qml" line="1238"/>
+        <location filename="../app/MainLayout.qml" line="1055"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
+        <location filename="../app/MainLayout.qml" line="1240"/>
         <source>Page</source>
         <translation>Página</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1060"/>
-        <location filename="../app/MainLayout.qml" line="1112"/>
-        <location filename="../app/MainLayout.qml" line="1247"/>
+        <location filename="../app/MainLayout.qml" line="1022"/>
+        <location filename="../app/MainLayout.qml" line="1062"/>
+        <location filename="../app/MainLayout.qml" line="1114"/>
+        <location filename="../app/MainLayout.qml" line="1249"/>
         <source>Options</source>
         <translation>Opciones</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1070"/>
-        <location filename="../app/MainLayout.qml" line="1123"/>
-        <location filename="../app/MainLayout.qml" line="1258"/>
+        <location filename="../app/MainLayout.qml" line="940"/>
+        <location filename="../app/MainLayout.qml" line="1072"/>
+        <location filename="../app/MainLayout.qml" line="1125"/>
+        <location filename="../app/MainLayout.qml" line="1260"/>
         <source>Retry</source>
         <translation>Reintentar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1174"/>
+        <location filename="../app/MainLayout.qml" line="1176"/>
         <source>Change</source>
         <translation>Cambiar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1180"/>
+        <location filename="../app/MainLayout.qml" line="1182"/>
         <source>Toggle</source>
         <translation>Alternar</translation>
     </message>
@@ -864,12 +864,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Cargando…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="365"/>
+        <location filename="../screens/MediaListScreen.qml" line="395"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 entradas</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="366"/>
+        <location filename="../screens/MediaListScreen.qml" line="396"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>No</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="198"/>
+        <location filename="../components/Modal.qml" line="246"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
@@ -936,18 +936,18 @@ Euskara - devilschile2</source>
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="132"/>
-        <location filename="../screens/SettingsScreen.qml" line="718"/>
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
+        <location filename="../screens/SettingsScreen.qml" line="741"/>
         <source>Language</source>
         <translation>Idioma</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="150"/>
+        <location filename="../screens/SettingsScreen.qml" line="165"/>
         <source>Mouse support</source>
         <translation>Soporte a ratón</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="157"/>
+        <location filename="../screens/SettingsScreen.qml" line="177"/>
         <source>Update media database</source>
         <translation>Actualizar base de datos de medios</translation>
     </message>
@@ -956,53 +956,53 @@ Euskara - devilschile2</source>
         <translation type="vanished">Ajustes generales</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="745"/>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="768"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="754"/>
+        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <location filename="../screens/SettingsScreen.qml" line="777"/>
         <source>Browsing layout</source>
         <translation>Diseño de exploración</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="145"/>
-        <location filename="../screens/SettingsScreen.qml" line="763"/>
+        <location filename="../screens/SettingsScreen.qml" line="160"/>
+        <location filename="../screens/SettingsScreen.qml" line="786"/>
         <source>Button style</source>
         <translation>Estilo de botón</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="772"/>
+        <location filename="../screens/SettingsScreen.qml" line="132"/>
+        <location filename="../screens/SettingsScreen.qml" line="795"/>
         <source>Screensaver</source>
         <translation>Salvapantallas</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="80"/>
-        <location filename="../screens/SettingsScreen.qml" line="209"/>
+        <location filename="../screens/SettingsScreen.qml" line="95"/>
+        <location filename="../screens/SettingsScreen.qml" line="229"/>
         <source>Library</source>
         <translation>Biblioteca</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="162"/>
+        <location filename="../screens/SettingsScreen.qml" line="182"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="112"/>
-        <location filename="../screens/SettingsScreen.qml" line="781"/>
+        <location filename="../screens/SettingsScreen.qml" line="127"/>
+        <location filename="../screens/SettingsScreen.qml" line="804"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="167"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
         <source>Scrape metadata</source>
         <translation>Extraer metadatos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="172"/>
+        <location filename="../screens/SettingsScreen.qml" line="192"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1011,397 +1011,402 @@ Euskara - devilschile2</source>
         <translation type="vanished">Avanzado</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="184"/>
+        <location filename="../screens/SettingsScreen.qml" line="204"/>
         <source>Debug logging</source>
         <translation>Registro de depuración</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="189"/>
+        <location filename="../screens/SettingsScreen.qml" line="209"/>
         <source>Upload log file</source>
         <translation>Subir archivo de registro</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="179"/>
+        <location filename="../screens/SettingsScreen.qml" line="199"/>
         <source>About / License</source>
         <translation>Acerca de / Licencia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
-        <location filename="../screens/SettingsScreen.qml" line="727"/>
+        <location filename="../screens/SettingsScreen.qml" line="137"/>
+        <location filename="../screens/SettingsScreen.qml" line="750"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="127"/>
-        <location filename="../screens/SettingsScreen.qml" line="736"/>
+        <location filename="../screens/SettingsScreen.qml" line="142"/>
+        <location filename="../screens/SettingsScreen.qml" line="759"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="137"/>
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="226"/>
+        <location filename="../screens/SettingsScreen.qml" line="170"/>
+        <source>Reduce motion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
         <source>Optimizing</source>
         <translation>Optimizando</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="228"/>
-        <location filename="../screens/SettingsScreen.qml" line="237"/>
+        <location filename="../screens/SettingsScreen.qml" line="248"/>
+        <location filename="../screens/SettingsScreen.qml" line="257"/>
         <source>Paused</source>
         <translation>Pausado</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="228"/>
-        <location filename="../screens/SettingsScreen.qml" line="237"/>
+        <location filename="../screens/SettingsScreen.qml" line="248"/>
+        <location filename="../screens/SettingsScreen.qml" line="257"/>
         <source>In progress</source>
         <translation>En progreso</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="231"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>%1 indexed</source>
         <translation>%1 indexados</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="240"/>
+        <location filename="../screens/SettingsScreen.qml" line="260"/>
         <source>%1 scraped</source>
         <translation>%1 extraídos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="472"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="472"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Start</source>
         <translation>Iniciar</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="474"/>
+        <location filename="../screens/SettingsScreen.qml" line="497"/>
         <source>Upload</source>
         <translation>Subir</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="556"/>
+        <location filename="../screens/SettingsScreen.qml" line="579"/>
         <source>English</source>
         <translation>Inglés</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="558"/>
+        <location filename="../screens/SettingsScreen.qml" line="581"/>
         <source>Italian</source>
         <translation>Italiano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="560"/>
+        <location filename="../screens/SettingsScreen.qml" line="583"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="562"/>
+        <location filename="../screens/SettingsScreen.qml" line="585"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="564"/>
+        <location filename="../screens/SettingsScreen.qml" line="587"/>
         <source>German</source>
         <translation>Alemán</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="566"/>
+        <location filename="../screens/SettingsScreen.qml" line="589"/>
         <source>Greek</source>
         <translation>Griego</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="568"/>
+        <location filename="../screens/SettingsScreen.qml" line="591"/>
         <source>Japanese</source>
         <translation>Japonés</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="570"/>
+        <location filename="../screens/SettingsScreen.qml" line="593"/>
         <source>Korean</source>
         <translation>Coreano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="595"/>
         <source>Dutch</source>
         <translation>Neerlandés</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="597"/>
         <source>Romanian</source>
         <translation>Rumano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="599"/>
         <source>Slovak</source>
         <translation>Eslovaco</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="601"/>
         <source>Ukrainian</source>
         <translation>Ucraniano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="603"/>
         <source>Chinese (Simplified)</source>
         <translation>Chino (simplificado)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="605"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="607"/>
         <source>Hebrew</source>
         <translation>Hebreo</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="588"/>
+        <location filename="../screens/SettingsScreen.qml" line="611"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="589"/>
-        <location filename="../screens/SettingsScreen.qml" line="597"/>
-        <location filename="../screens/SettingsScreen.qml" line="671"/>
+        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="620"/>
+        <location filename="../screens/SettingsScreen.qml" line="694"/>
         <source>Auto</source>
         <translation>Automático</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="594"/>
+        <location filename="../screens/SettingsScreen.qml" line="617"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="596"/>
+        <location filename="../screens/SettingsScreen.qml" line="619"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="607"/>
+        <location filename="../screens/SettingsScreen.qml" line="630"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="632"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="611"/>
+        <location filename="../screens/SettingsScreen.qml" line="634"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="635"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="640"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="619"/>
+        <location filename="../screens/SettingsScreen.qml" line="642"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="620"/>
+        <location filename="../screens/SettingsScreen.qml" line="643"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="625"/>
+        <location filename="../screens/SettingsScreen.qml" line="648"/>
         <source>Detailed list view</source>
         <translation>Vista de lista detallada</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="626"/>
+        <location filename="../screens/SettingsScreen.qml" line="649"/>
         <source>Grid view</source>
         <translation>Vista de cuadrícula</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="631"/>
+        <location filename="../screens/SettingsScreen.qml" line="654"/>
         <source>Style B</source>
         <translation>Estilo B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="633"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Style C</source>
         <translation>Estilo C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="658"/>
         <source>Style D</source>
         <translation>Estilo D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="659"/>
         <source>Style A</source>
         <translation>Estilo A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1292"/>
+        <location filename="../screens/SettingsScreen.qml" line="1358"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="526"/>
+        <location filename="../screens/SettingsScreen.qml" line="549"/>
         <source>Default</source>
         <translation>Por defecto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="674"/>
         <source>Off</source>
         <translation>Desactivado</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="653"/>
+        <location filename="../screens/SettingsScreen.qml" line="676"/>
         <source>1 second (testing)</source>
         <translation>1 segundo (prueba)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="655"/>
+        <location filename="../screens/SettingsScreen.qml" line="678"/>
         <source>1 minute</source>
         <translation>1 minuto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="657"/>
+        <location filename="../screens/SettingsScreen.qml" line="680"/>
         <source>2 minutes</source>
         <translation>2 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="659"/>
+        <location filename="../screens/SettingsScreen.qml" line="682"/>
         <source>5 minutes</source>
         <translation>5 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="661"/>
+        <location filename="../screens/SettingsScreen.qml" line="684"/>
         <source>10 minutes</source>
         <translation>10 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="663"/>
+        <location filename="../screens/SettingsScreen.qml" line="686"/>
         <source>15 minutes</source>
         <translation>15 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="665"/>
+        <location filename="../screens/SettingsScreen.qml" line="688"/>
         <source>30 minutes</source>
         <translation>30 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="666"/>
+        <location filename="../screens/SettingsScreen.qml" line="689"/>
         <source>%1 seconds</source>
         <translation>%1 segundos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="96"/>
-        <location filename="../screens/SettingsScreen.qml" line="709"/>
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="732"/>
         <source>Resolution</source>
         <translation>Resolución</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="68"/>
-        <location filename="../screens/SettingsScreen.qml" line="205"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="74"/>
-        <location filename="../screens/SettingsScreen.qml" line="207"/>
+        <location filename="../screens/SettingsScreen.qml" line="89"/>
+        <location filename="../screens/SettingsScreen.qml" line="227"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="86"/>
-        <location filename="../screens/SettingsScreen.qml" line="211"/>
+        <location filename="../screens/SettingsScreen.qml" line="101"/>
+        <location filename="../screens/SettingsScreen.qml" line="231"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="673"/>
+        <location filename="../screens/SettingsScreen.qml" line="696"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="675"/>
+        <location filename="../screens/SettingsScreen.qml" line="698"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="677"/>
+        <location filename="../screens/SettingsScreen.qml" line="700"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="679"/>
+        <location filename="../screens/SettingsScreen.qml" line="702"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="681"/>
+        <location filename="../screens/SettingsScreen.qml" line="704"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="683"/>
+        <location filename="../screens/SettingsScreen.qml" line="706"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="685"/>
+        <location filename="../screens/SettingsScreen.qml" line="708"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="687"/>
+        <location filename="../screens/SettingsScreen.qml" line="710"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="712"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="691"/>
+        <location filename="../screens/SettingsScreen.qml" line="714"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="693"/>
+        <location filename="../screens/SettingsScreen.qml" line="716"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="695"/>
+        <location filename="../screens/SettingsScreen.qml" line="718"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="212"/>
+        <location filename="../screens/SettingsScreen.qml" line="232"/>
         <source>Settings</source>
         <translation>Ajustes</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1280"/>
+        <location filename="../screens/SettingsScreen.qml" line="1346"/>
         <source>No settings available on this platform</source>
         <translation>No hay ajustes en esta plataforma</translation>
     </message>
@@ -1409,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="206"/>
-        <location filename="../screens/SystemsScreen.qml" line="304"/>
+        <location filename="../screens/SystemsScreen.qml" line="229"/>
+        <location filename="../screens/SystemsScreen.qml" line="329"/>
         <source>%1 systems</source>
         <translation>%1 sistemas</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="207"/>
-        <location filename="../screens/SystemsScreen.qml" line="321"/>
+        <location filename="../screens/SystemsScreen.qml" line="230"/>
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="339"/>
+        <location filename="../screens/SystemsScreen.qml" line="364"/>
         <source>No systems in this category</source>
         <translation>No hay sistemas en esta categoría</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="340"/>
+        <location filename="../screens/SystemsScreen.qml" line="365"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>
@@ -1434,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="364"/>
+        <location filename="../components/Tile.qml" line="475"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -425,8 +425,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="128"/>
-        <location filename="../screens/GamesScreen.qml" line="163"/>
+        <location filename="../screens/GamesScreen.qml" line="131"/>
+        <location filename="../screens/GamesScreen.qml" line="166"/>
         <source>%1 files</source>
         <translation>%1 fitxategi</translation>
     </message>
@@ -436,8 +436,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Jokua kargatzen...</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="137"/>
-        <location filename="../screens/GamesScreen.qml" line="164"/>
+        <location filename="../screens/GamesScreen.qml" line="140"/>
+        <location filename="../screens/GamesScreen.qml" line="167"/>
         <source>%1 / %2</source>
         <translation type="unfinished">%1 / %2</translation>
     </message>
@@ -447,7 +447,7 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Jokuak kargatzen</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="133"/>
+        <location filename="../screens/GamesScreen.qml" line="136"/>
         <source>Loading more…</source>
         <translation type="unfinished">Gehiago kargatzen...</translation>
     </message>
@@ -900,7 +900,7 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Ez</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="246"/>
+        <location filename="../components/Modal.qml" line="250"/>
         <source>Cancel</source>
         <translation>Utzi</translation>
     </message>
@@ -944,24 +944,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="141"/>
-        <location filename="../screens/SettingsScreen.qml" line="734"/>
+        <location filename="../screens/SettingsScreen.qml" line="145"/>
+        <location filename="../screens/SettingsScreen.qml" line="738"/>
         <source>Language</source>
         <translation>Hizkuntza</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116"/>
-        <location filename="../screens/SettingsScreen.qml" line="770"/>
+        <location filename="../screens/SettingsScreen.qml" line="120"/>
+        <location filename="../screens/SettingsScreen.qml" line="774"/>
         <source>Browsing layout</source>
         <translation>Nabigazio diseinua</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="159"/>
+        <location filename="../screens/SettingsScreen.qml" line="163"/>
         <source>Mouse support</source>
         <translation>Saguaren euskarria</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="171"/>
+        <location filename="../screens/SettingsScreen.qml" line="175"/>
         <source>Update media database</source>
         <translation type="unfinished">Eguneratu multimedia datu-basea</translation>
     </message>
@@ -970,47 +970,47 @@ Euskara - devilschile2</source>
         <translation type="obsolete">Orokorra</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
-        <location filename="../screens/SettingsScreen.qml" line="761"/>
+        <location filename="../screens/SettingsScreen.qml" line="115"/>
+        <location filename="../screens/SettingsScreen.qml" line="765"/>
         <source>Orientation</source>
         <translation type="unfinished">Orientazioa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="154"/>
-        <location filename="../screens/SettingsScreen.qml" line="779"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="783"/>
         <source>Button style</source>
         <translation type="unfinished">Botoi estiloa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
-        <location filename="../screens/SettingsScreen.qml" line="788"/>
+        <location filename="../screens/SettingsScreen.qml" line="130"/>
+        <location filename="../screens/SettingsScreen.qml" line="792"/>
         <source>Screensaver</source>
         <translation type="unfinished">Pantaila babeslea</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="89"/>
-        <location filename="../screens/SettingsScreen.qml" line="223"/>
+        <location filename="../screens/SettingsScreen.qml" line="93"/>
+        <location filename="../screens/SettingsScreen.qml" line="227"/>
         <source>Library</source>
         <translation type="unfinished">Liburutegia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="176"/>
+        <location filename="../screens/SettingsScreen.qml" line="180"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished">Aurkitu arcade bertsio alternatiboak</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121"/>
-        <location filename="../screens/SettingsScreen.qml" line="797"/>
+        <location filename="../screens/SettingsScreen.qml" line="125"/>
+        <location filename="../screens/SettingsScreen.qml" line="801"/>
         <source>Preferred artwork</source>
         <translation type="unfinished">Hobetsitako artelana</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="181"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadatuak scrapeatu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="186"/>
+        <location filename="../screens/SettingsScreen.qml" line="190"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished">Berriro scrapeatzea existitzen da</translation>
     </message>
@@ -1019,402 +1019,402 @@ Euskara - devilschile2</source>
         <translation type="obsolete">Aurreratua</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="198"/>
+        <location filename="../screens/SettingsScreen.qml" line="202"/>
         <source>Debug logging</source>
         <translation type="unfinished">Arazte erregistroa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="203"/>
+        <location filename="../screens/SettingsScreen.qml" line="207"/>
         <source>Upload log file</source>
         <translation type="unfinished">Igo erregistro fitxategia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="193"/>
+        <location filename="../screens/SettingsScreen.qml" line="197"/>
         <source>About / License</source>
         <translation type="unfinished">Buruz / Lizentzia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
-        <location filename="../screens/SettingsScreen.qml" line="743"/>
+        <location filename="../screens/SettingsScreen.qml" line="135"/>
+        <location filename="../screens/SettingsScreen.qml" line="747"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="136"/>
-        <location filename="../screens/SettingsScreen.qml" line="752"/>
+        <location filename="../screens/SettingsScreen.qml" line="140"/>
+        <location filename="../screens/SettingsScreen.qml" line="756"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="146"/>
+        <location filename="../screens/SettingsScreen.qml" line="150"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="168"/>
         <source>Reduce motion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="240"/>
+        <location filename="../screens/SettingsScreen.qml" line="244"/>
         <source>Optimizing</source>
         <translation type="unfinished">Optimizatzen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="242"/>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="255"/>
         <source>Paused</source>
         <translation type="unfinished">Geldituta</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="242"/>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="255"/>
         <source>In progress</source>
         <translation type="unfinished">Abian</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="245"/>
+        <location filename="../screens/SettingsScreen.qml" line="249"/>
         <source>%1 indexed</source>
         <translation type="unfinished">%1 indexatuta</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="254"/>
+        <location filename="../screens/SettingsScreen.qml" line="258"/>
         <source>%1 scraped</source>
         <translation type="unfinished">%1 scrapetatuta</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="488"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Cancel</source>
         <translation type="unfinished">Utzi</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="488"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Start</source>
         <translation type="unfinished">Hasi</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="490"/>
+        <location filename="../screens/SettingsScreen.qml" line="494"/>
         <source>Upload</source>
         <translation type="unfinished">Igo</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="491"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Open</source>
         <translation type="unfinished">Ireki</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>English</source>
         <translation>Ingelera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Italian</source>
         <translation>Italiera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>German</source>
         <translation type="unfinished">Alemaniera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Greek</source>
         <translation type="unfinished">Grekoa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Japanese</source>
         <translation type="unfinished">Japoniera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="590"/>
         <source>Korean</source>
         <translation type="unfinished">Koreera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="588"/>
+        <location filename="../screens/SettingsScreen.qml" line="592"/>
         <source>Dutch</source>
         <translation type="unfinished">Holandera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="590"/>
+        <location filename="../screens/SettingsScreen.qml" line="594"/>
         <source>Romanian</source>
         <translation type="unfinished">Errumaniera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="592"/>
+        <location filename="../screens/SettingsScreen.qml" line="596"/>
         <source>Slovak</source>
         <translation type="unfinished">eslovakiera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="594"/>
+        <location filename="../screens/SettingsScreen.qml" line="598"/>
         <source>Ukrainian</source>
         <translation type="unfinished">Ukraniera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="596"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Chinese (Simplified)</source>
         <translation type="unfinished">Txinera (sinplifikatua)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="598"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="600"/>
+        <location filename="../screens/SettingsScreen.qml" line="604"/>
         <source>Hebrew</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="602"/>
+        <location filename="../screens/SettingsScreen.qml" line="606"/>
         <source>Arabic</source>
         <translation type="unfinished">Arabiera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="604"/>
+        <location filename="../screens/SettingsScreen.qml" line="608"/>
         <source>Hindi</source>
         <translation type="unfinished">HIndia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="605"/>
-        <location filename="../screens/SettingsScreen.qml" line="613"/>
-        <location filename="../screens/SettingsScreen.qml" line="687"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="691"/>
         <source>Auto</source>
         <translation>Auto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="610"/>
+        <location filename="../screens/SettingsScreen.qml" line="614"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="616"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="623"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="625"/>
+        <location filename="../screens/SettingsScreen.qml" line="629"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="627"/>
+        <location filename="../screens/SettingsScreen.qml" line="631"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="628"/>
+        <location filename="../screens/SettingsScreen.qml" line="632"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="633"/>
+        <location filename="../screens/SettingsScreen.qml" line="637"/>
         <source>Rotated CW</source>
         <translation type="unfinished">CW biratua</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="639"/>
         <source>Rotated CCW</source>
         <translation type="unfinished">CCW biratua</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="640"/>
         <source>Horizontal</source>
         <translation type="unfinished">Horizontala</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="641"/>
+        <location filename="../screens/SettingsScreen.qml" line="645"/>
         <source>Detailed list view</source>
         <translation>Xehetasun listaren ikuspegia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="642"/>
+        <location filename="../screens/SettingsScreen.qml" line="646"/>
         <source>Grid view</source>
         <translation>Sarearen ikuspegia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
         <source>Style B</source>
         <translation type="unfinished">B estiloa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Style C</source>
         <translation type="unfinished">C estiloa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="655"/>
         <source>Style D</source>
         <translation type="unfinished">D estiloa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="652"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Style A</source>
         <translation type="unfinished">A estiloa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1351"/>
+        <location filename="../screens/SettingsScreen.qml" line="1382"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="542"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>Default</source>
         <translation>Lehenetsia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="667"/>
+        <location filename="../screens/SettingsScreen.qml" line="671"/>
         <source>Off</source>
         <translation type="unfinished">Desaktibatuta</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="669"/>
+        <location filename="../screens/SettingsScreen.qml" line="673"/>
         <source>1 second (testing)</source>
         <translation type="unfinished">segundu 1 (frogatzen)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="671"/>
+        <location filename="../screens/SettingsScreen.qml" line="675"/>
         <source>1 minute</source>
         <translation type="unfinished">minutu 1</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="673"/>
+        <location filename="../screens/SettingsScreen.qml" line="677"/>
         <source>2 minutes</source>
         <translation type="unfinished">2 minutu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="675"/>
+        <location filename="../screens/SettingsScreen.qml" line="679"/>
         <source>5 minutes</source>
         <translation type="unfinished">5 minutu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="677"/>
+        <location filename="../screens/SettingsScreen.qml" line="681"/>
         <source>10 minutes</source>
         <translation type="unfinished">10 minutu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="679"/>
+        <location filename="../screens/SettingsScreen.qml" line="683"/>
         <source>15 minutes</source>
         <translation type="unfinished">15 minutu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="681"/>
+        <location filename="../screens/SettingsScreen.qml" line="685"/>
         <source>30 minutes</source>
         <translation type="unfinished">30 minutu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="682"/>
+        <location filename="../screens/SettingsScreen.qml" line="686"/>
         <source>%1 seconds</source>
         <translation type="unfinished">%1 segundu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="105"/>
-        <location filename="../screens/SettingsScreen.qml" line="725"/>
+        <location filename="../screens/SettingsScreen.qml" line="109"/>
+        <location filename="../screens/SettingsScreen.qml" line="729"/>
         <source>Resolution</source>
         <translation type="unfinished">Bereizmena</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="77"/>
-        <location filename="../screens/SettingsScreen.qml" line="219"/>
+        <location filename="../screens/SettingsScreen.qml" line="81"/>
+        <location filename="../screens/SettingsScreen.qml" line="223"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="221"/>
+        <location filename="../screens/SettingsScreen.qml" line="87"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="95"/>
-        <location filename="../screens/SettingsScreen.qml" line="225"/>
+        <location filename="../screens/SettingsScreen.qml" line="99"/>
+        <location filename="../screens/SettingsScreen.qml" line="229"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="693"/>
         <source>Image</source>
         <translation type="unfinished">Irudia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="691"/>
+        <location filename="../screens/SettingsScreen.qml" line="695"/>
         <source>Thumbnail</source>
         <translation type="unfinished">Miniatura</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="693"/>
+        <location filename="../screens/SettingsScreen.qml" line="697"/>
         <source>Box art</source>
         <translation type="unfinished">Kaxaren artelana</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="695"/>
+        <location filename="../screens/SettingsScreen.qml" line="699"/>
         <source>3D box art</source>
         <translation type="unfinished">Kaxaren 3D artelana</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="697"/>
+        <location filename="../screens/SettingsScreen.qml" line="701"/>
         <source>Screenshot</source>
         <translation type="unfinished">Pantaila argazkoa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="699"/>
+        <location filename="../screens/SettingsScreen.qml" line="703"/>
         <source>Wheel</source>
         <translation type="unfinished">Gurpila</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="701"/>
+        <location filename="../screens/SettingsScreen.qml" line="705"/>
         <source>Title screen</source>
         <translation type="unfinished">Izenburu pantaila</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="703"/>
+        <location filename="../screens/SettingsScreen.qml" line="707"/>
         <source>Map</source>
         <translation type="unfinished">Mapa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="705"/>
+        <location filename="../screens/SettingsScreen.qml" line="709"/>
         <source>Marquee</source>
         <translation type="unfinished">Karpa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="707"/>
+        <location filename="../screens/SettingsScreen.qml" line="711"/>
         <source>Fan art</source>
         <translation type="unfinished">Fan artelana</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="709"/>
+        <location filename="../screens/SettingsScreen.qml" line="713"/>
         <source>Box side</source>
         <translation type="unfinished">Kaxa alboa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="711"/>
+        <location filename="../screens/SettingsScreen.qml" line="715"/>
         <source>Box back</source>
         <translation type="unfinished">Kaxa atzekaldea</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="226"/>
+        <location filename="../screens/SettingsScreen.qml" line="230"/>
         <source>Settings</source>
         <translation>Ezarpenak</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1339"/>
+        <location filename="../screens/SettingsScreen.qml" line="1370"/>
         <source>No settings available on this platform</source>
         <translation>Ez dago ezarpenik plataforma honetan</translation>
     </message>
@@ -1422,24 +1422,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="242"/>
-        <location filename="../screens/SystemsScreen.qml" line="343"/>
+        <location filename="../screens/SystemsScreen.qml" line="245"/>
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>%1 systems</source>
         <translation>%1 sistema</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="243"/>
-        <location filename="../screens/SystemsScreen.qml" line="360"/>
+        <location filename="../screens/SystemsScreen.qml" line="246"/>
+        <location filename="../screens/SystemsScreen.qml" line="363"/>
         <source>%1 / %2</source>
         <translation type="unfinished">%1 / %2</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="378"/>
+        <location filename="../screens/SystemsScreen.qml" line="381"/>
         <source>No systems in this category</source>
         <translation>Ez dago sistemarik kategoria honetan</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="379"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>Loading systems…</source>
         <translation type="unfinished">Sistemak kargatzen</translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -488,22 +488,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="156"/>
+        <location filename="../screens/HubScreen.qml" line="154"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="162"/>
+        <location filename="../screens/HubScreen.qml" line="160"/>
         <source>Favorites</source>
         <translation>Gogokoak</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="167"/>
+        <location filename="../screens/HubScreen.qml" line="165"/>
         <source>Recently Played</source>
         <translation>Duela gutxi jolastuta</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="172"/>
+        <location filename="../screens/HubScreen.qml" line="170"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -512,7 +512,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Ezarpenak</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="722"/>
+        <location filename="../screens/HubScreen.qml" line="718"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation type="unfinished">Ez dago sistemarik eskuragarri. Exekutatu Eguneratu baliabide datubasea Aukeretatik</translation>
     </message>
@@ -900,7 +900,7 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Ez</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="256"/>
+        <location filename="../components/Modal.qml" line="246"/>
         <source>Cancel</source>
         <translation>Utzi</translation>
     </message>
@@ -944,24 +944,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147"/>
-        <location filename="../screens/SettingsScreen.qml" line="741"/>
+        <location filename="../screens/SettingsScreen.qml" line="141"/>
+        <location filename="../screens/SettingsScreen.qml" line="734"/>
         <source>Language</source>
         <translation>Hizkuntza</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
-        <location filename="../screens/SettingsScreen.qml" line="777"/>
+        <location filename="../screens/SettingsScreen.qml" line="116"/>
+        <location filename="../screens/SettingsScreen.qml" line="770"/>
         <source>Browsing layout</source>
         <translation>Nabigazio diseinua</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="165"/>
+        <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>Mouse support</source>
         <translation>Saguaren euskarria</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="177"/>
+        <location filename="../screens/SettingsScreen.qml" line="171"/>
         <source>Update media database</source>
         <translation type="unfinished">Eguneratu multimedia datu-basea</translation>
     </message>
@@ -970,47 +970,47 @@ Euskara - devilschile2</source>
         <translation type="obsolete">Orokorra</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="768"/>
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="761"/>
         <source>Orientation</source>
         <translation type="unfinished">Orientazioa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="160"/>
-        <location filename="../screens/SettingsScreen.qml" line="786"/>
+        <location filename="../screens/SettingsScreen.qml" line="154"/>
+        <location filename="../screens/SettingsScreen.qml" line="779"/>
         <source>Button style</source>
         <translation type="unfinished">Botoi estiloa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="132"/>
-        <location filename="../screens/SettingsScreen.qml" line="795"/>
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
+        <location filename="../screens/SettingsScreen.qml" line="788"/>
         <source>Screensaver</source>
         <translation type="unfinished">Pantaila babeslea</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="95"/>
-        <location filename="../screens/SettingsScreen.qml" line="229"/>
+        <location filename="../screens/SettingsScreen.qml" line="89"/>
+        <location filename="../screens/SettingsScreen.qml" line="223"/>
         <source>Library</source>
         <translation type="unfinished">Liburutegia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="182"/>
+        <location filename="../screens/SettingsScreen.qml" line="176"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished">Aurkitu arcade bertsio alternatiboak</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="127"/>
-        <location filename="../screens/SettingsScreen.qml" line="804"/>
+        <location filename="../screens/SettingsScreen.qml" line="121"/>
+        <location filename="../screens/SettingsScreen.qml" line="797"/>
         <source>Preferred artwork</source>
         <translation type="unfinished">Hobetsitako artelana</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <location filename="../screens/SettingsScreen.qml" line="181"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadatuak scrapeatu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="192"/>
+        <location filename="../screens/SettingsScreen.qml" line="186"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished">Berriro scrapeatzea existitzen da</translation>
     </message>
@@ -1019,402 +1019,402 @@ Euskara - devilschile2</source>
         <translation type="obsolete">Aurreratua</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="204"/>
+        <location filename="../screens/SettingsScreen.qml" line="198"/>
         <source>Debug logging</source>
         <translation type="unfinished">Arazte erregistroa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="209"/>
+        <location filename="../screens/SettingsScreen.qml" line="203"/>
         <source>Upload log file</source>
         <translation type="unfinished">Igo erregistro fitxategia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="199"/>
+        <location filename="../screens/SettingsScreen.qml" line="193"/>
         <source>About / License</source>
         <translation type="unfinished">Buruz / Lizentzia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="137"/>
-        <location filename="../screens/SettingsScreen.qml" line="750"/>
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="743"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="142"/>
-        <location filename="../screens/SettingsScreen.qml" line="759"/>
+        <location filename="../screens/SettingsScreen.qml" line="136"/>
+        <location filename="../screens/SettingsScreen.qml" line="752"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152"/>
+        <location filename="../screens/SettingsScreen.qml" line="146"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="170"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
         <source>Reduce motion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="240"/>
         <source>Optimizing</source>
         <translation type="unfinished">Optimizatzen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="248"/>
-        <location filename="../screens/SettingsScreen.qml" line="257"/>
+        <location filename="../screens/SettingsScreen.qml" line="242"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>Paused</source>
         <translation type="unfinished">Geldituta</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="248"/>
-        <location filename="../screens/SettingsScreen.qml" line="257"/>
+        <location filename="../screens/SettingsScreen.qml" line="242"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>In progress</source>
         <translation type="unfinished">Abian</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="245"/>
         <source>%1 indexed</source>
         <translation type="unfinished">%1 indexatuta</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="260"/>
+        <location filename="../screens/SettingsScreen.qml" line="254"/>
         <source>%1 scraped</source>
         <translation type="unfinished">%1 scrapetatuta</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="495"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Cancel</source>
         <translation type="unfinished">Utzi</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="495"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Start</source>
         <translation type="unfinished">Hasi</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="497"/>
+        <location filename="../screens/SettingsScreen.qml" line="490"/>
         <source>Upload</source>
         <translation type="unfinished">Igo</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <location filename="../screens/SettingsScreen.qml" line="491"/>
         <source>Open</source>
         <translation type="unfinished">Ireki</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="579"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>English</source>
         <translation>Ingelera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="581"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Italian</source>
         <translation>Italiera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="583"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="585"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="587"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>German</source>
         <translation type="unfinished">Alemaniera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="589"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Greek</source>
         <translation type="unfinished">Grekoa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="591"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Japanese</source>
         <translation type="unfinished">Japoniera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="593"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Korean</source>
         <translation type="unfinished">Koreera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="595"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Dutch</source>
         <translation type="unfinished">Holandera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="597"/>
+        <location filename="../screens/SettingsScreen.qml" line="590"/>
         <source>Romanian</source>
         <translation type="unfinished">Errumaniera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="599"/>
+        <location filename="../screens/SettingsScreen.qml" line="592"/>
         <source>Slovak</source>
         <translation type="unfinished">eslovakiera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="601"/>
+        <location filename="../screens/SettingsScreen.qml" line="594"/>
         <source>Ukrainian</source>
         <translation type="unfinished">Ukraniera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="603"/>
+        <location filename="../screens/SettingsScreen.qml" line="596"/>
         <source>Chinese (Simplified)</source>
         <translation type="unfinished">Txinera (sinplifikatua)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="605"/>
+        <location filename="../screens/SettingsScreen.qml" line="598"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="607"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Hebrew</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Arabic</source>
         <translation type="unfinished">Arabiera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="611"/>
+        <location filename="../screens/SettingsScreen.qml" line="604"/>
         <source>Hindi</source>
         <translation type="unfinished">HIndia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
-        <location filename="../screens/SettingsScreen.qml" line="620"/>
-        <location filename="../screens/SettingsScreen.qml" line="694"/>
+        <location filename="../screens/SettingsScreen.qml" line="605"/>
+        <location filename="../screens/SettingsScreen.qml" line="613"/>
+        <location filename="../screens/SettingsScreen.qml" line="687"/>
         <source>Auto</source>
         <translation>Auto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="610"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="619"/>
+        <location filename="../screens/SettingsScreen.qml" line="612"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="630"/>
+        <location filename="../screens/SettingsScreen.qml" line="623"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="632"/>
+        <location filename="../screens/SettingsScreen.qml" line="625"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="634"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="628"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="640"/>
+        <location filename="../screens/SettingsScreen.qml" line="633"/>
         <source>Rotated CW</source>
         <translation type="unfinished">CW biratua</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="642"/>
+        <location filename="../screens/SettingsScreen.qml" line="635"/>
         <source>Rotated CCW</source>
         <translation type="unfinished">CCW biratua</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="643"/>
+        <location filename="../screens/SettingsScreen.qml" line="636"/>
         <source>Horizontal</source>
         <translation type="unfinished">Horizontala</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="648"/>
+        <location filename="../screens/SettingsScreen.qml" line="641"/>
         <source>Detailed list view</source>
         <translation>Xehetasun listaren ikuspegia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="642"/>
         <source>Grid view</source>
         <translation>Sarearen ikuspegia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="654"/>
+        <location filename="../screens/SettingsScreen.qml" line="647"/>
         <source>Style B</source>
         <translation type="unfinished">B estiloa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="656"/>
+        <location filename="../screens/SettingsScreen.qml" line="649"/>
         <source>Style C</source>
         <translation type="unfinished">C estiloa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="658"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
         <source>Style D</source>
         <translation type="unfinished">D estiloa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="659"/>
+        <location filename="../screens/SettingsScreen.qml" line="652"/>
         <source>Style A</source>
         <translation type="unfinished">A estiloa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1368"/>
+        <location filename="../screens/SettingsScreen.qml" line="1351"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="549"/>
+        <location filename="../screens/SettingsScreen.qml" line="542"/>
         <source>Default</source>
         <translation>Lehenetsia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="674"/>
+        <location filename="../screens/SettingsScreen.qml" line="667"/>
         <source>Off</source>
         <translation type="unfinished">Desaktibatuta</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="676"/>
+        <location filename="../screens/SettingsScreen.qml" line="669"/>
         <source>1 second (testing)</source>
         <translation type="unfinished">segundu 1 (frogatzen)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="678"/>
+        <location filename="../screens/SettingsScreen.qml" line="671"/>
         <source>1 minute</source>
         <translation type="unfinished">minutu 1</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="680"/>
+        <location filename="../screens/SettingsScreen.qml" line="673"/>
         <source>2 minutes</source>
         <translation type="unfinished">2 minutu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="682"/>
+        <location filename="../screens/SettingsScreen.qml" line="675"/>
         <source>5 minutes</source>
         <translation type="unfinished">5 minutu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="684"/>
+        <location filename="../screens/SettingsScreen.qml" line="677"/>
         <source>10 minutes</source>
         <translation type="unfinished">10 minutu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="686"/>
+        <location filename="../screens/SettingsScreen.qml" line="679"/>
         <source>15 minutes</source>
         <translation type="unfinished">15 minutu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="688"/>
+        <location filename="../screens/SettingsScreen.qml" line="681"/>
         <source>30 minutes</source>
         <translation type="unfinished">30 minutu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="682"/>
         <source>%1 seconds</source>
         <translation type="unfinished">%1 segundu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
-        <location filename="../screens/SettingsScreen.qml" line="732"/>
+        <location filename="../screens/SettingsScreen.qml" line="105"/>
+        <location filename="../screens/SettingsScreen.qml" line="725"/>
         <source>Resolution</source>
         <translation type="unfinished">Bereizmena</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="225"/>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="219"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="89"/>
-        <location filename="../screens/SettingsScreen.qml" line="227"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="221"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="101"/>
-        <location filename="../screens/SettingsScreen.qml" line="231"/>
+        <location filename="../screens/SettingsScreen.qml" line="95"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="696"/>
+        <location filename="../screens/SettingsScreen.qml" line="689"/>
         <source>Image</source>
         <translation type="unfinished">Irudia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="698"/>
+        <location filename="../screens/SettingsScreen.qml" line="691"/>
         <source>Thumbnail</source>
         <translation type="unfinished">Miniatura</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="700"/>
+        <location filename="../screens/SettingsScreen.qml" line="693"/>
         <source>Box art</source>
         <translation type="unfinished">Kaxaren artelana</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="702"/>
+        <location filename="../screens/SettingsScreen.qml" line="695"/>
         <source>3D box art</source>
         <translation type="unfinished">Kaxaren 3D artelana</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="704"/>
+        <location filename="../screens/SettingsScreen.qml" line="697"/>
         <source>Screenshot</source>
         <translation type="unfinished">Pantaila argazkoa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="706"/>
+        <location filename="../screens/SettingsScreen.qml" line="699"/>
         <source>Wheel</source>
         <translation type="unfinished">Gurpila</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="708"/>
+        <location filename="../screens/SettingsScreen.qml" line="701"/>
         <source>Title screen</source>
         <translation type="unfinished">Izenburu pantaila</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="710"/>
+        <location filename="../screens/SettingsScreen.qml" line="703"/>
         <source>Map</source>
         <translation type="unfinished">Mapa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="712"/>
+        <location filename="../screens/SettingsScreen.qml" line="705"/>
         <source>Marquee</source>
         <translation type="unfinished">Karpa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="714"/>
+        <location filename="../screens/SettingsScreen.qml" line="707"/>
         <source>Fan art</source>
         <translation type="unfinished">Fan artelana</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="716"/>
+        <location filename="../screens/SettingsScreen.qml" line="709"/>
         <source>Box side</source>
         <translation type="unfinished">Kaxa alboa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="718"/>
+        <location filename="../screens/SettingsScreen.qml" line="711"/>
         <source>Box back</source>
         <translation type="unfinished">Kaxa atzekaldea</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="232"/>
+        <location filename="../screens/SettingsScreen.qml" line="226"/>
         <source>Settings</source>
         <translation>Ezarpenak</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1356"/>
+        <location filename="../screens/SettingsScreen.qml" line="1339"/>
         <source>No settings available on this platform</source>
         <translation>Ez dago ezarpenik plataforma honetan</translation>
     </message>
@@ -1422,24 +1422,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="236"/>
-        <location filename="../screens/SystemsScreen.qml" line="338"/>
+        <location filename="../screens/SystemsScreen.qml" line="242"/>
+        <location filename="../screens/SystemsScreen.qml" line="343"/>
         <source>%1 systems</source>
         <translation>%1 sistema</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="237"/>
-        <location filename="../screens/SystemsScreen.qml" line="355"/>
+        <location filename="../screens/SystemsScreen.qml" line="243"/>
+        <location filename="../screens/SystemsScreen.qml" line="360"/>
         <source>%1 / %2</source>
         <translation type="unfinished">%1 / %2</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="373"/>
+        <location filename="../screens/SystemsScreen.qml" line="378"/>
         <source>No systems in this category</source>
         <translation>Ez dago sistemarik kategoria honetan</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="374"/>
+        <location filename="../screens/SystemsScreen.qml" line="379"/>
         <source>Loading systems…</source>
         <translation type="unfinished">Sistemak kargatzen</translation>
     </message>
@@ -1447,7 +1447,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="539"/>
+        <location filename="../components/Tile.qml" line="501"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -97,100 +97,100 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Kargatzen…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="196"/>
+        <location filename="../components/BrowseDetailPane.qml" line="167"/>
         <source>Year</source>
         <translation type="unfinished">Urtea</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="196"/>
+        <location filename="../components/BrowseDetailPane.qml" line="167"/>
         <source>Yr</source>
         <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="198"/>
+        <location filename="../components/BrowseDetailPane.qml" line="169"/>
         <source>Genre</source>
         <translation type="unfinished">Mota</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="198"/>
+        <location filename="../components/BrowseDetailPane.qml" line="169"/>
         <source>Gen</source>
         <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="200"/>
+        <location filename="../components/BrowseDetailPane.qml" line="171"/>
         <source>Players</source>
         <translation type="unfinished">Jokalariak</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="200"/>
+        <location filename="../components/BrowseDetailPane.qml" line="171"/>
         <source>Plyr</source>
         <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="202"/>
+        <location filename="../components/BrowseDetailPane.qml" line="173"/>
         <source>Developer</source>
         <translation type="unfinished">Garatzailea</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="202"/>
+        <location filename="../components/BrowseDetailPane.qml" line="173"/>
         <source>Dev</source>
         <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="204"/>
+        <location filename="../components/BrowseDetailPane.qml" line="175"/>
         <source>Publisher</source>
         <translation type="unfinished">Argitaratzailea</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="204"/>
+        <location filename="../components/BrowseDetailPane.qml" line="175"/>
         <source>Pub</source>
         <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="206"/>
+        <location filename="../components/BrowseDetailPane.qml" line="177"/>
         <source>Rating</source>
         <translation type="unfinished">Balorazioa</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="206"/>
+        <location filename="../components/BrowseDetailPane.qml" line="177"/>
         <source>Rtg</source>
         <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="208"/>
+        <location filename="../components/BrowseDetailPane.qml" line="179"/>
         <source>Category</source>
         <translation type="unfinished">Kategoria</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="208"/>
+        <location filename="../components/BrowseDetailPane.qml" line="179"/>
         <source>Cat</source>
         <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="210"/>
+        <location filename="../components/BrowseDetailPane.qml" line="181"/>
         <source>Release date</source>
         <translation type="unfinished">Argitaratze data</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="210"/>
+        <location filename="../components/BrowseDetailPane.qml" line="181"/>
         <source>Date</source>
         <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="212"/>
+        <location filename="../components/BrowseDetailPane.qml" line="183"/>
         <source>Manufacturer</source>
         <translation type="unfinished">Fabrikatzailea</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="212"/>
+        <location filename="../components/BrowseDetailPane.qml" line="183"/>
         <source>Mfr</source>
         <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
@@ -425,8 +425,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="127"/>
-        <location filename="../screens/GamesScreen.qml" line="162"/>
+        <location filename="../screens/GamesScreen.qml" line="128"/>
+        <location filename="../screens/GamesScreen.qml" line="163"/>
         <source>%1 files</source>
         <translation>%1 fitxategi</translation>
     </message>
@@ -436,8 +436,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Jokua kargatzen...</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="136"/>
-        <location filename="../screens/GamesScreen.qml" line="163"/>
+        <location filename="../screens/GamesScreen.qml" line="137"/>
+        <location filename="../screens/GamesScreen.qml" line="164"/>
         <source>%1 / %2</source>
         <translation type="unfinished">%1 / %2</translation>
     </message>
@@ -447,7 +447,7 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Jokuak kargatzen</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="132"/>
+        <location filename="../screens/GamesScreen.qml" line="133"/>
         <source>Loading more…</source>
         <translation type="unfinished">Gehiago kargatzen...</translation>
     </message>
@@ -488,22 +488,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="149"/>
+        <location filename="../screens/HubScreen.qml" line="156"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="155"/>
+        <location filename="../screens/HubScreen.qml" line="162"/>
         <source>Favorites</source>
         <translation>Gogokoak</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="160"/>
+        <location filename="../screens/HubScreen.qml" line="167"/>
         <source>Recently Played</source>
         <translation>Duela gutxi jolastuta</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="165"/>
+        <location filename="../screens/HubScreen.qml" line="172"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -512,7 +512,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Ezarpenak</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="701"/>
+        <location filename="../screens/HubScreen.qml" line="722"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation type="unfinished">Ez dago sistemarik eskuragarri. Exekutatu Eguneratu baliabide datubasea Aukeretatik</translation>
     </message>
@@ -561,138 +561,138 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1367"/>
+        <location filename="../app/Main.qml" line="1381"/>
         <source>Launch core</source>
         <translation type="unfinished">Exekutatu nukleoa</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1373"/>
-        <location filename="../app/Main.qml" line="1612"/>
+        <location filename="../app/Main.qml" line="1387"/>
+        <location filename="../app/Main.qml" line="1626"/>
         <source>Change launcher</source>
         <translation type="unfinished">Aldatu abiarazlea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1445"/>
         <source>Remove from favorites</source>
         <translation type="unfinished">Kendu gogokoetatik</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1445"/>
         <source>Add to favorites</source>
         <translation type="unfinished">Gehitu gogokoetan</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1436"/>
+        <location filename="../app/Main.qml" line="1450"/>
         <source>Write to NFC token</source>
         <translation type="unfinished">Idatzi NFC token-a</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1440"/>
+        <location filename="../app/Main.qml" line="1454"/>
         <source>QR code</source>
         <translation type="unfinished">QR kodea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1415"/>
-        <location filename="../app/Main.qml" line="1450"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1464"/>
         <source>Launch game</source>
         <translation type="unfinished">Abiarazi jokua</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2624"/>
         <source>Loading systems…</source>
         <translation type="unfinished">Sistemak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2616"/>
+        <location filename="../app/Main.qml" line="2630"/>
         <source>Loading favorites…</source>
         <translation type="unfinished">Gogokoak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2612"/>
+        <location filename="../app/Main.qml" line="2626"/>
         <source>Loading games…</source>
         <translation type="unfinished">Jokoak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1380"/>
-        <location filename="../app/Main.qml" line="1403"/>
+        <location filename="../app/Main.qml" line="1394"/>
+        <location filename="../app/Main.qml" line="1417"/>
         <source>Update media database</source>
         <translation type="unfinished">Eguneratu multimedia datu-basea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1383"/>
-        <location filename="../app/Main.qml" line="1406"/>
+        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1420"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadatuak scrapeatu</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1388"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1411"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1388"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1411"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1608"/>
+        <location filename="../app/Main.qml" line="1622"/>
         <source>Default</source>
         <translation type="unfinished">Lehenetsia</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1608"/>
+        <location filename="../app/Main.qml" line="1622"/>
         <source>Current: %1</source>
         <translation type="unfinished">Unekoa: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1932"/>
+        <location filename="../app/Main.qml" line="1946"/>
         <source>Saving launcher</source>
         <translation type="unfinished">Abiarazlea gordetzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1936"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>Saving…</source>
         <translation type="unfinished">Gordetzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1950"/>
+        <location filename="../app/Main.qml" line="1964"/>
         <source>Launcher update failed</source>
         <translation type="unfinished">Abiarazle egukeraketak huts egin du</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1954"/>
+        <location filename="../app/Main.qml" line="1968"/>
         <source>Error: %1</source>
         <translation type="unfinished">Errorea: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1958"/>
+        <location filename="../app/Main.qml" line="1972"/>
         <source>Retry</source>
         <translation type="unfinished">Berriro saiatu</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1962"/>
+        <location filename="../app/Main.qml" line="1976"/>
         <source>Cancel</source>
         <translation type="unfinished">Utzi</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2628"/>
         <source>Loading game…</source>
         <translation type="unfinished">Jokua kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2618"/>
+        <location filename="../app/Main.qml" line="2632"/>
         <source>Loading recently played…</source>
         <translation type="unfinished">Duela gutxi jokatutakoak kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2620"/>
+        <location filename="../app/Main.qml" line="2634"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2622"/>
+        <location filename="../app/Main.qml" line="2636"/>
         <source>Loading…</source>
         <translation type="unfinished">Kargatzen…</translation>
     </message>
@@ -872,12 +872,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Kargatzen…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="395"/>
+        <location filename="../screens/MediaListScreen.qml" line="436"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 sarrera</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="396"/>
+        <location filename="../screens/MediaListScreen.qml" line="437"/>
         <source>%1 / %2</source>
         <translation type="unfinished">%1 / %2</translation>
     </message>
@@ -900,7 +900,7 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Ez</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="246"/>
+        <location filename="../components/Modal.qml" line="256"/>
         <source>Cancel</source>
         <translation>Utzi</translation>
     </message>
@@ -1270,7 +1270,7 @@ Euskara - devilschile2</source>
         <translation type="unfinished">A estiloa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1358"/>
+        <location filename="../screens/SettingsScreen.qml" line="1368"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1414,7 +1414,7 @@ Euskara - devilschile2</source>
         <translation>Ezarpenak</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1346"/>
+        <location filename="../screens/SettingsScreen.qml" line="1356"/>
         <source>No settings available on this platform</source>
         <translation>Ez dago ezarpenik plataforma honetan</translation>
     </message>
@@ -1422,24 +1422,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="229"/>
-        <location filename="../screens/SystemsScreen.qml" line="329"/>
+        <location filename="../screens/SystemsScreen.qml" line="236"/>
+        <location filename="../screens/SystemsScreen.qml" line="338"/>
         <source>%1 systems</source>
         <translation>%1 sistema</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="230"/>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="237"/>
+        <location filename="../screens/SystemsScreen.qml" line="355"/>
         <source>%1 / %2</source>
         <translation type="unfinished">%1 / %2</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="364"/>
+        <location filename="../screens/SystemsScreen.qml" line="373"/>
         <source>No systems in this category</source>
         <translation>Ez dago sistemarik kategoria honetan</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="365"/>
+        <location filename="../screens/SystemsScreen.qml" line="374"/>
         <source>Loading systems…</source>
         <translation type="unfinished">Sistemak kargatzen</translation>
     </message>
@@ -1447,7 +1447,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="475"/>
+        <location filename="../components/Tile.qml" line="539"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -425,34 +425,34 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="116"/>
-        <location filename="../screens/GamesScreen.qml" line="151"/>
+        <location filename="../screens/GamesScreen.qml" line="127"/>
+        <location filename="../screens/GamesScreen.qml" line="162"/>
         <source>%1 files</source>
         <translation>%1 fitxategi</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="53"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading game…</source>
         <translation type="unfinished">Jokua kargatzen...</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="125"/>
-        <location filename="../screens/GamesScreen.qml" line="152"/>
+        <location filename="../screens/GamesScreen.qml" line="136"/>
+        <location filename="../screens/GamesScreen.qml" line="163"/>
         <source>%1 / %2</source>
         <translation type="unfinished">%1 / %2</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="48"/>
+        <location filename="../screens/GamesScreen.qml" line="49"/>
         <source>Loading games…</source>
         <translation type="unfinished">Jokuak kargatzen</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="121"/>
+        <location filename="../screens/GamesScreen.qml" line="132"/>
         <source>Loading more…</source>
         <translation type="unfinished">Gehiago kargatzen...</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="47"/>
+        <location filename="../screens/GamesScreen.qml" line="48"/>
         <source>No games in this system</source>
         <translation>Sistema honek ez du jokurik</translation>
     </message>
@@ -488,22 +488,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="139"/>
+        <location filename="../screens/HubScreen.qml" line="149"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="145"/>
+        <location filename="../screens/HubScreen.qml" line="155"/>
         <source>Favorites</source>
         <translation>Gogokoak</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="150"/>
+        <location filename="../screens/HubScreen.qml" line="160"/>
         <source>Recently Played</source>
         <translation>Duela gutxi jolastuta</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="155"/>
+        <location filename="../screens/HubScreen.qml" line="165"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -512,7 +512,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Ezarpenak</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="669"/>
+        <location filename="../screens/HubScreen.qml" line="701"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation type="unfinished">Ez dago sistemarik eskuragarri. Exekutatu Eguneratu baliabide datubasea Aukeretatik</translation>
     </message>
@@ -561,138 +561,138 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1361"/>
+        <location filename="../app/Main.qml" line="1367"/>
         <source>Launch core</source>
         <translation type="unfinished">Exekutatu nukleoa</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1367"/>
-        <location filename="../app/Main.qml" line="1606"/>
+        <location filename="../app/Main.qml" line="1373"/>
+        <location filename="../app/Main.qml" line="1612"/>
         <source>Change launcher</source>
         <translation type="unfinished">Aldatu abiarazlea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1425"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Remove from favorites</source>
         <translation type="unfinished">Kendu gogokoetatik</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1425"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Add to favorites</source>
         <translation type="unfinished">Gehitu gogokoetan</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1430"/>
+        <location filename="../app/Main.qml" line="1436"/>
         <source>Write to NFC token</source>
         <translation type="unfinished">Idatzi NFC token-a</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1434"/>
+        <location filename="../app/Main.qml" line="1440"/>
         <source>QR code</source>
         <translation type="unfinished">QR kodea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1409"/>
-        <location filename="../app/Main.qml" line="1444"/>
+        <location filename="../app/Main.qml" line="1415"/>
+        <location filename="../app/Main.qml" line="1450"/>
         <source>Launch game</source>
         <translation type="unfinished">Abiarazi jokua</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2604"/>
+        <location filename="../app/Main.qml" line="2610"/>
         <source>Loading systems…</source>
         <translation type="unfinished">Sistemak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2616"/>
         <source>Loading favorites…</source>
         <translation type="unfinished">Gogokoak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2606"/>
+        <location filename="../app/Main.qml" line="2612"/>
         <source>Loading games…</source>
         <translation type="unfinished">Jokoak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1374"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1380"/>
+        <location filename="../app/Main.qml" line="1403"/>
         <source>Update media database</source>
         <translation type="unfinished">Eguneratu multimedia datu-basea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1377"/>
-        <location filename="../app/Main.qml" line="1400"/>
+        <location filename="../app/Main.qml" line="1383"/>
+        <location filename="../app/Main.qml" line="1406"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadatuak scrapeatu</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1382"/>
-        <location filename="../app/Main.qml" line="1391"/>
+        <location filename="../app/Main.qml" line="1388"/>
+        <location filename="../app/Main.qml" line="1397"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1382"/>
-        <location filename="../app/Main.qml" line="1391"/>
+        <location filename="../app/Main.qml" line="1388"/>
+        <location filename="../app/Main.qml" line="1397"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1602"/>
+        <location filename="../app/Main.qml" line="1608"/>
         <source>Default</source>
         <translation type="unfinished">Lehenetsia</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1602"/>
+        <location filename="../app/Main.qml" line="1608"/>
         <source>Current: %1</source>
         <translation type="unfinished">Unekoa: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1926"/>
+        <location filename="../app/Main.qml" line="1932"/>
         <source>Saving launcher</source>
         <translation type="unfinished">Abiarazlea gordetzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1930"/>
+        <location filename="../app/Main.qml" line="1936"/>
         <source>Saving…</source>
         <translation type="unfinished">Gordetzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1944"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>Launcher update failed</source>
         <translation type="unfinished">Abiarazle egukeraketak huts egin du</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1948"/>
+        <location filename="../app/Main.qml" line="1954"/>
         <source>Error: %1</source>
         <translation type="unfinished">Errorea: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1952"/>
+        <location filename="../app/Main.qml" line="1958"/>
         <source>Retry</source>
         <translation type="unfinished">Berriro saiatu</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1956"/>
+        <location filename="../app/Main.qml" line="1962"/>
         <source>Cancel</source>
         <translation type="unfinished">Utzi</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2608"/>
+        <location filename="../app/Main.qml" line="2614"/>
         <source>Loading game…</source>
         <translation type="unfinished">Jokua kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2612"/>
+        <location filename="../app/Main.qml" line="2618"/>
         <source>Loading recently played…</source>
         <translation type="unfinished">Duela gutxi jokatutakoak kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2620"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2616"/>
+        <location filename="../app/Main.qml" line="2622"/>
         <source>Loading…</source>
         <translation type="unfinished">Kargatzen…</translation>
     </message>
@@ -700,72 +700,72 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="683"/>
+        <location filename="../app/MainLayout.qml" line="685"/>
         <source>Writing failed</source>
         <translation>Idazketak huts egin du</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="683"/>
+        <location filename="../app/MainLayout.qml" line="685"/>
         <source>Put a writable card near the reader</source>
         <translation>Jarri idatzi daitekeen txartel bat irakurlearen ondoan</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="811"/>
+        <location filename="../app/MainLayout.qml" line="813"/>
         <source>Are you sure you want to exit?</source>
         <translation type="unfinished">Ziur zaude irten nahi duzula?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="894"/>
-        <location filename="../app/MainLayout.qml" line="968"/>
+        <location filename="../app/MainLayout.qml" line="896"/>
+        <location filename="../app/MainLayout.qml" line="970"/>
         <source>Select</source>
         <translation>Aukeratu</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="902"/>
-        <location filename="../app/MainLayout.qml" line="916"/>
-        <location filename="../app/MainLayout.qml" line="931"/>
-        <location filename="../app/MainLayout.qml" line="942"/>
+        <location filename="../app/MainLayout.qml" line="900"/>
+        <location filename="../app/MainLayout.qml" line="904"/>
+        <location filename="../app/MainLayout.qml" line="918"/>
+        <location filename="../app/MainLayout.qml" line="933"/>
+        <location filename="../app/MainLayout.qml" line="944"/>
         <source>Close</source>
         <translation>Itxi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="909"/>
-        <location filename="../app/MainLayout.qml" line="949"/>
-        <location filename="../app/MainLayout.qml" line="972"/>
-        <location filename="../app/MainLayout.qml" line="983"/>
+        <location filename="../app/MainLayout.qml" line="911"/>
+        <location filename="../app/MainLayout.qml" line="951"/>
+        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="985"/>
         <source>Cancel</source>
         <translation>Utzi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="927"/>
+        <location filename="../app/MainLayout.qml" line="929"/>
         <source>Done</source>
         <translation type="unfinished">Eginda</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="957"/>
+        <location filename="../app/MainLayout.qml" line="959"/>
         <source>I understand</source>
         <translation type="unfinished">Ulertzen dut</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="991"/>
+        <location filename="../app/MainLayout.qml" line="993"/>
         <source>Start</source>
         <translation type="unfinished">Hasi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1203"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Scroll</source>
         <translation type="unfinished">Scroll-a egin</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="890"/>
-        <location filename="../app/MainLayout.qml" line="964"/>
-        <location filename="../app/MainLayout.qml" line="1010"/>
-        <location filename="../app/MainLayout.qml" line="1047"/>
-        <location filename="../app/MainLayout.qml" line="1097"/>
-        <location filename="../app/MainLayout.qml" line="1146"/>
-        <location filename="../app/MainLayout.qml" line="1165"/>
-        <location filename="../app/MainLayout.qml" line="1232"/>
+        <location filename="../app/MainLayout.qml" line="892"/>
+        <location filename="../app/MainLayout.qml" line="966"/>
+        <location filename="../app/MainLayout.qml" line="1012"/>
+        <location filename="../app/MainLayout.qml" line="1049"/>
+        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1148"/>
+        <location filename="../app/MainLayout.qml" line="1167"/>
+        <location filename="../app/MainLayout.qml" line="1234"/>
         <source>Move</source>
         <translation>Mugitu</translation>
     </message>
@@ -785,81 +785,81 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Duela gutxi jokatuak</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="699"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished">Itxi eta Zaparoo Frontend berabiarazi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="700"/>
+        <location filename="../app/MainLayout.qml" line="702"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished">Ezarpenak indarrean jartzeko frontend-a berrabiarazi behar dugu</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="810"/>
+        <location filename="../app/MainLayout.qml" line="812"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished">Itxi Zaparoo Frontend?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1014"/>
-        <location filename="../app/MainLayout.qml" line="1057"/>
-        <location filename="../app/MainLayout.qml" line="1107"/>
-        <location filename="../app/MainLayout.qml" line="1151"/>
-        <location filename="../app/MainLayout.qml" line="1242"/>
+        <location filename="../app/MainLayout.qml" line="1016"/>
+        <location filename="../app/MainLayout.qml" line="1059"/>
+        <location filename="../app/MainLayout.qml" line="1109"/>
+        <location filename="../app/MainLayout.qml" line="1153"/>
+        <location filename="../app/MainLayout.qml" line="1244"/>
         <source>Open</source>
         <translation>Ireki</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1024"/>
+        <location filename="../app/MainLayout.qml" line="1026"/>
         <source>Quit</source>
         <translation>Irten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1033"/>
-        <location filename="../app/MainLayout.qml" line="1063"/>
-        <location filename="../app/MainLayout.qml" line="1074"/>
-        <location filename="../app/MainLayout.qml" line="1089"/>
-        <location filename="../app/MainLayout.qml" line="1116"/>
-        <location filename="../app/MainLayout.qml" line="1127"/>
-        <location filename="../app/MainLayout.qml" line="1139"/>
-        <location filename="../app/MainLayout.qml" line="1155"/>
-        <location filename="../app/MainLayout.qml" line="1189"/>
-        <location filename="../app/MainLayout.qml" line="1207"/>
-        <location filename="../app/MainLayout.qml" line="1216"/>
-        <location filename="../app/MainLayout.qml" line="1251"/>
-        <location filename="../app/MainLayout.qml" line="1262"/>
+        <location filename="../app/MainLayout.qml" line="1035"/>
+        <location filename="../app/MainLayout.qml" line="1065"/>
+        <location filename="../app/MainLayout.qml" line="1076"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
+        <location filename="../app/MainLayout.qml" line="1118"/>
+        <location filename="../app/MainLayout.qml" line="1129"/>
+        <location filename="../app/MainLayout.qml" line="1141"/>
+        <location filename="../app/MainLayout.qml" line="1157"/>
+        <location filename="../app/MainLayout.qml" line="1191"/>
+        <location filename="../app/MainLayout.qml" line="1209"/>
+        <location filename="../app/MainLayout.qml" line="1218"/>
+        <location filename="../app/MainLayout.qml" line="1253"/>
+        <location filename="../app/MainLayout.qml" line="1264"/>
         <source>Back</source>
         <translation>Atzera</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1053"/>
-        <location filename="../app/MainLayout.qml" line="1103"/>
-        <location filename="../app/MainLayout.qml" line="1238"/>
+        <location filename="../app/MainLayout.qml" line="1055"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
+        <location filename="../app/MainLayout.qml" line="1240"/>
         <source>Page</source>
         <translation type="unfinished">Orria</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1060"/>
-        <location filename="../app/MainLayout.qml" line="1112"/>
-        <location filename="../app/MainLayout.qml" line="1247"/>
+        <location filename="../app/MainLayout.qml" line="1022"/>
+        <location filename="../app/MainLayout.qml" line="1062"/>
+        <location filename="../app/MainLayout.qml" line="1114"/>
+        <location filename="../app/MainLayout.qml" line="1249"/>
         <source>Options</source>
         <translation type="unfinished">Aukerak</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1070"/>
-        <location filename="../app/MainLayout.qml" line="1123"/>
-        <location filename="../app/MainLayout.qml" line="1258"/>
+        <location filename="../app/MainLayout.qml" line="940"/>
+        <location filename="../app/MainLayout.qml" line="1072"/>
+        <location filename="../app/MainLayout.qml" line="1125"/>
+        <location filename="../app/MainLayout.qml" line="1260"/>
         <source>Retry</source>
         <translation>Berriro saiatu</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1174"/>
+        <location filename="../app/MainLayout.qml" line="1176"/>
         <source>Change</source>
         <translation>Aldatu</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1180"/>
+        <location filename="../app/MainLayout.qml" line="1182"/>
         <source>Toggle</source>
         <translation>Txandakatu</translation>
     </message>
@@ -872,12 +872,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Kargatzen…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="365"/>
+        <location filename="../screens/MediaListScreen.qml" line="395"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 sarrera</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="366"/>
+        <location filename="../screens/MediaListScreen.qml" line="396"/>
         <source>%1 / %2</source>
         <translation type="unfinished">%1 / %2</translation>
     </message>
@@ -900,7 +900,7 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Ez</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="198"/>
+        <location filename="../components/Modal.qml" line="246"/>
         <source>Cancel</source>
         <translation>Utzi</translation>
     </message>
@@ -944,24 +944,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="132"/>
-        <location filename="../screens/SettingsScreen.qml" line="718"/>
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
+        <location filename="../screens/SettingsScreen.qml" line="741"/>
         <source>Language</source>
         <translation>Hizkuntza</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="754"/>
+        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <location filename="../screens/SettingsScreen.qml" line="777"/>
         <source>Browsing layout</source>
         <translation>Nabigazio diseinua</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="150"/>
+        <location filename="../screens/SettingsScreen.qml" line="165"/>
         <source>Mouse support</source>
         <translation>Saguaren euskarria</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="157"/>
+        <location filename="../screens/SettingsScreen.qml" line="177"/>
         <source>Update media database</source>
         <translation type="unfinished">Eguneratu multimedia datu-basea</translation>
     </message>
@@ -970,47 +970,47 @@ Euskara - devilschile2</source>
         <translation type="obsolete">Orokorra</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="745"/>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="768"/>
         <source>Orientation</source>
         <translation type="unfinished">Orientazioa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="145"/>
-        <location filename="../screens/SettingsScreen.qml" line="763"/>
+        <location filename="../screens/SettingsScreen.qml" line="160"/>
+        <location filename="../screens/SettingsScreen.qml" line="786"/>
         <source>Button style</source>
         <translation type="unfinished">Botoi estiloa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="772"/>
+        <location filename="../screens/SettingsScreen.qml" line="132"/>
+        <location filename="../screens/SettingsScreen.qml" line="795"/>
         <source>Screensaver</source>
         <translation type="unfinished">Pantaila babeslea</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="80"/>
-        <location filename="../screens/SettingsScreen.qml" line="209"/>
+        <location filename="../screens/SettingsScreen.qml" line="95"/>
+        <location filename="../screens/SettingsScreen.qml" line="229"/>
         <source>Library</source>
         <translation type="unfinished">Liburutegia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="162"/>
+        <location filename="../screens/SettingsScreen.qml" line="182"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished">Aurkitu arcade bertsio alternatiboak</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="112"/>
-        <location filename="../screens/SettingsScreen.qml" line="781"/>
+        <location filename="../screens/SettingsScreen.qml" line="127"/>
+        <location filename="../screens/SettingsScreen.qml" line="804"/>
         <source>Preferred artwork</source>
         <translation type="unfinished">Hobetsitako artelana</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="167"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadatuak scrapeatu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="172"/>
+        <location filename="../screens/SettingsScreen.qml" line="192"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished">Berriro scrapeatzea existitzen da</translation>
     </message>
@@ -1019,397 +1019,402 @@ Euskara - devilschile2</source>
         <translation type="obsolete">Aurreratua</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="184"/>
+        <location filename="../screens/SettingsScreen.qml" line="204"/>
         <source>Debug logging</source>
         <translation type="unfinished">Arazte erregistroa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="189"/>
+        <location filename="../screens/SettingsScreen.qml" line="209"/>
         <source>Upload log file</source>
         <translation type="unfinished">Igo erregistro fitxategia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="179"/>
+        <location filename="../screens/SettingsScreen.qml" line="199"/>
         <source>About / License</source>
         <translation type="unfinished">Buruz / Lizentzia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
-        <location filename="../screens/SettingsScreen.qml" line="727"/>
+        <location filename="../screens/SettingsScreen.qml" line="137"/>
+        <location filename="../screens/SettingsScreen.qml" line="750"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="127"/>
-        <location filename="../screens/SettingsScreen.qml" line="736"/>
+        <location filename="../screens/SettingsScreen.qml" line="142"/>
+        <location filename="../screens/SettingsScreen.qml" line="759"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="137"/>
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="226"/>
+        <location filename="../screens/SettingsScreen.qml" line="170"/>
+        <source>Reduce motion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
         <source>Optimizing</source>
         <translation type="unfinished">Optimizatzen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="228"/>
-        <location filename="../screens/SettingsScreen.qml" line="237"/>
+        <location filename="../screens/SettingsScreen.qml" line="248"/>
+        <location filename="../screens/SettingsScreen.qml" line="257"/>
         <source>Paused</source>
         <translation type="unfinished">Geldituta</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="228"/>
-        <location filename="../screens/SettingsScreen.qml" line="237"/>
+        <location filename="../screens/SettingsScreen.qml" line="248"/>
+        <location filename="../screens/SettingsScreen.qml" line="257"/>
         <source>In progress</source>
         <translation type="unfinished">Abian</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="231"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>%1 indexed</source>
         <translation type="unfinished">%1 indexatuta</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="240"/>
+        <location filename="../screens/SettingsScreen.qml" line="260"/>
         <source>%1 scraped</source>
         <translation type="unfinished">%1 scrapetatuta</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="472"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Cancel</source>
         <translation type="unfinished">Utzi</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="472"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Start</source>
         <translation type="unfinished">Hasi</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="474"/>
+        <location filename="../screens/SettingsScreen.qml" line="497"/>
         <source>Upload</source>
         <translation type="unfinished">Igo</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Open</source>
         <translation type="unfinished">Ireki</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="556"/>
+        <location filename="../screens/SettingsScreen.qml" line="579"/>
         <source>English</source>
         <translation>Ingelera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="558"/>
+        <location filename="../screens/SettingsScreen.qml" line="581"/>
         <source>Italian</source>
         <translation>Italiera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="560"/>
+        <location filename="../screens/SettingsScreen.qml" line="583"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="562"/>
+        <location filename="../screens/SettingsScreen.qml" line="585"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="564"/>
+        <location filename="../screens/SettingsScreen.qml" line="587"/>
         <source>German</source>
         <translation type="unfinished">Alemaniera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="566"/>
+        <location filename="../screens/SettingsScreen.qml" line="589"/>
         <source>Greek</source>
         <translation type="unfinished">Grekoa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="568"/>
+        <location filename="../screens/SettingsScreen.qml" line="591"/>
         <source>Japanese</source>
         <translation type="unfinished">Japoniera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="570"/>
+        <location filename="../screens/SettingsScreen.qml" line="593"/>
         <source>Korean</source>
         <translation type="unfinished">Koreera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="595"/>
         <source>Dutch</source>
         <translation type="unfinished">Holandera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="597"/>
         <source>Romanian</source>
         <translation type="unfinished">Errumaniera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="599"/>
         <source>Slovak</source>
         <translation type="unfinished">eslovakiera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="601"/>
         <source>Ukrainian</source>
         <translation type="unfinished">Ukraniera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="603"/>
         <source>Chinese (Simplified)</source>
         <translation type="unfinished">Txinera (sinplifikatua)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="605"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="607"/>
         <source>Hebrew</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
         <source>Arabic</source>
         <translation type="unfinished">Arabiera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="588"/>
+        <location filename="../screens/SettingsScreen.qml" line="611"/>
         <source>Hindi</source>
         <translation type="unfinished">HIndia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="589"/>
-        <location filename="../screens/SettingsScreen.qml" line="597"/>
-        <location filename="../screens/SettingsScreen.qml" line="671"/>
+        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="620"/>
+        <location filename="../screens/SettingsScreen.qml" line="694"/>
         <source>Auto</source>
         <translation>Auto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="594"/>
+        <location filename="../screens/SettingsScreen.qml" line="617"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="596"/>
+        <location filename="../screens/SettingsScreen.qml" line="619"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="607"/>
+        <location filename="../screens/SettingsScreen.qml" line="630"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="632"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="611"/>
+        <location filename="../screens/SettingsScreen.qml" line="634"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="635"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="640"/>
         <source>Rotated CW</source>
         <translation type="unfinished">CW biratua</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="619"/>
+        <location filename="../screens/SettingsScreen.qml" line="642"/>
         <source>Rotated CCW</source>
         <translation type="unfinished">CCW biratua</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="620"/>
+        <location filename="../screens/SettingsScreen.qml" line="643"/>
         <source>Horizontal</source>
         <translation type="unfinished">Horizontala</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="625"/>
+        <location filename="../screens/SettingsScreen.qml" line="648"/>
         <source>Detailed list view</source>
         <translation>Xehetasun listaren ikuspegia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="626"/>
+        <location filename="../screens/SettingsScreen.qml" line="649"/>
         <source>Grid view</source>
         <translation>Sarearen ikuspegia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="631"/>
+        <location filename="../screens/SettingsScreen.qml" line="654"/>
         <source>Style B</source>
         <translation type="unfinished">B estiloa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="633"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Style C</source>
         <translation type="unfinished">C estiloa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="658"/>
         <source>Style D</source>
         <translation type="unfinished">D estiloa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="659"/>
         <source>Style A</source>
         <translation type="unfinished">A estiloa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1292"/>
+        <location filename="../screens/SettingsScreen.qml" line="1358"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="526"/>
+        <location filename="../screens/SettingsScreen.qml" line="549"/>
         <source>Default</source>
         <translation>Lehenetsia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="674"/>
         <source>Off</source>
         <translation type="unfinished">Desaktibatuta</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="653"/>
+        <location filename="../screens/SettingsScreen.qml" line="676"/>
         <source>1 second (testing)</source>
         <translation type="unfinished">segundu 1 (frogatzen)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="655"/>
+        <location filename="../screens/SettingsScreen.qml" line="678"/>
         <source>1 minute</source>
         <translation type="unfinished">minutu 1</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="657"/>
+        <location filename="../screens/SettingsScreen.qml" line="680"/>
         <source>2 minutes</source>
         <translation type="unfinished">2 minutu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="659"/>
+        <location filename="../screens/SettingsScreen.qml" line="682"/>
         <source>5 minutes</source>
         <translation type="unfinished">5 minutu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="661"/>
+        <location filename="../screens/SettingsScreen.qml" line="684"/>
         <source>10 minutes</source>
         <translation type="unfinished">10 minutu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="663"/>
+        <location filename="../screens/SettingsScreen.qml" line="686"/>
         <source>15 minutes</source>
         <translation type="unfinished">15 minutu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="665"/>
+        <location filename="../screens/SettingsScreen.qml" line="688"/>
         <source>30 minutes</source>
         <translation type="unfinished">30 minutu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="666"/>
+        <location filename="../screens/SettingsScreen.qml" line="689"/>
         <source>%1 seconds</source>
         <translation type="unfinished">%1 segundu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="96"/>
-        <location filename="../screens/SettingsScreen.qml" line="709"/>
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="732"/>
         <source>Resolution</source>
         <translation type="unfinished">Bereizmena</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="68"/>
-        <location filename="../screens/SettingsScreen.qml" line="205"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="74"/>
-        <location filename="../screens/SettingsScreen.qml" line="207"/>
+        <location filename="../screens/SettingsScreen.qml" line="89"/>
+        <location filename="../screens/SettingsScreen.qml" line="227"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="86"/>
-        <location filename="../screens/SettingsScreen.qml" line="211"/>
+        <location filename="../screens/SettingsScreen.qml" line="101"/>
+        <location filename="../screens/SettingsScreen.qml" line="231"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="673"/>
+        <location filename="../screens/SettingsScreen.qml" line="696"/>
         <source>Image</source>
         <translation type="unfinished">Irudia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="675"/>
+        <location filename="../screens/SettingsScreen.qml" line="698"/>
         <source>Thumbnail</source>
         <translation type="unfinished">Miniatura</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="677"/>
+        <location filename="../screens/SettingsScreen.qml" line="700"/>
         <source>Box art</source>
         <translation type="unfinished">Kaxaren artelana</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="679"/>
+        <location filename="../screens/SettingsScreen.qml" line="702"/>
         <source>3D box art</source>
         <translation type="unfinished">Kaxaren 3D artelana</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="681"/>
+        <location filename="../screens/SettingsScreen.qml" line="704"/>
         <source>Screenshot</source>
         <translation type="unfinished">Pantaila argazkoa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="683"/>
+        <location filename="../screens/SettingsScreen.qml" line="706"/>
         <source>Wheel</source>
         <translation type="unfinished">Gurpila</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="685"/>
+        <location filename="../screens/SettingsScreen.qml" line="708"/>
         <source>Title screen</source>
         <translation type="unfinished">Izenburu pantaila</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="687"/>
+        <location filename="../screens/SettingsScreen.qml" line="710"/>
         <source>Map</source>
         <translation type="unfinished">Mapa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="712"/>
         <source>Marquee</source>
         <translation type="unfinished">Karpa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="691"/>
+        <location filename="../screens/SettingsScreen.qml" line="714"/>
         <source>Fan art</source>
         <translation type="unfinished">Fan artelana</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="693"/>
+        <location filename="../screens/SettingsScreen.qml" line="716"/>
         <source>Box side</source>
         <translation type="unfinished">Kaxa alboa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="695"/>
+        <location filename="../screens/SettingsScreen.qml" line="718"/>
         <source>Box back</source>
         <translation type="unfinished">Kaxa atzekaldea</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="212"/>
+        <location filename="../screens/SettingsScreen.qml" line="232"/>
         <source>Settings</source>
         <translation>Ezarpenak</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1280"/>
+        <location filename="../screens/SettingsScreen.qml" line="1346"/>
         <source>No settings available on this platform</source>
         <translation>Ez dago ezarpenik plataforma honetan</translation>
     </message>
@@ -1417,24 +1422,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="206"/>
-        <location filename="../screens/SystemsScreen.qml" line="304"/>
+        <location filename="../screens/SystemsScreen.qml" line="229"/>
+        <location filename="../screens/SystemsScreen.qml" line="329"/>
         <source>%1 systems</source>
         <translation>%1 sistema</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="207"/>
-        <location filename="../screens/SystemsScreen.qml" line="321"/>
+        <location filename="../screens/SystemsScreen.qml" line="230"/>
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>%1 / %2</source>
         <translation type="unfinished">%1 / %2</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="339"/>
+        <location filename="../screens/SystemsScreen.qml" line="364"/>
         <source>No systems in this category</source>
         <translation>Ez dago sistemarik kategoria honetan</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="340"/>
+        <location filename="../screens/SystemsScreen.qml" line="365"/>
         <source>Loading systems…</source>
         <translation type="unfinished">Sistemak kargatzen</translation>
     </message>
@@ -1442,7 +1447,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="364"/>
+        <location filename="../components/Tile.qml" line="475"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="156"/>
+        <location filename="../screens/HubScreen.qml" line="154"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="162"/>
+        <location filename="../screens/HubScreen.qml" line="160"/>
         <source>Favorites</source>
         <translation>מועדפים</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="167"/>
+        <location filename="../screens/HubScreen.qml" line="165"/>
         <source>Recently Played</source>
         <translation>שוחקו לאחרונה</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="172"/>
+        <location filename="../screens/HubScreen.qml" line="170"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">הגדרות</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="722"/>
+        <location filename="../screens/HubScreen.qml" line="718"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>אין מערכות זמינות. הפעילו &quot;עדכון מסד נתוני מדיה&quot; מההגדרות.</translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>לא</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="256"/>
+        <location filename="../components/Modal.qml" line="246"/>
         <source>Cancel</source>
         <translation>ביטול</translation>
     </message>
@@ -940,64 +940,64 @@ Euskara - devilschile2</source>
         <translation type="vanished">כללי</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147"/>
-        <location filename="../screens/SettingsScreen.qml" line="741"/>
+        <location filename="../screens/SettingsScreen.qml" line="141"/>
+        <location filename="../screens/SettingsScreen.qml" line="734"/>
         <source>Language</source>
         <translation>שפה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="768"/>
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="761"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
-        <location filename="../screens/SettingsScreen.qml" line="777"/>
+        <location filename="../screens/SettingsScreen.qml" line="116"/>
+        <location filename="../screens/SettingsScreen.qml" line="770"/>
         <source>Browsing layout</source>
         <translation>פריסת עיון</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="160"/>
-        <location filename="../screens/SettingsScreen.qml" line="786"/>
+        <location filename="../screens/SettingsScreen.qml" line="154"/>
+        <location filename="../screens/SettingsScreen.qml" line="779"/>
         <source>Button style</source>
         <translation>סגנון כפתורים</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="132"/>
-        <location filename="../screens/SettingsScreen.qml" line="795"/>
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
+        <location filename="../screens/SettingsScreen.qml" line="788"/>
         <source>Screensaver</source>
         <translation>שומר מסך</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="95"/>
-        <location filename="../screens/SettingsScreen.qml" line="229"/>
+        <location filename="../screens/SettingsScreen.qml" line="89"/>
+        <location filename="../screens/SettingsScreen.qml" line="223"/>
         <source>Library</source>
         <translation>ספרייה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="182"/>
+        <location filename="../screens/SettingsScreen.qml" line="176"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="127"/>
-        <location filename="../screens/SettingsScreen.qml" line="804"/>
+        <location filename="../screens/SettingsScreen.qml" line="121"/>
+        <location filename="../screens/SettingsScreen.qml" line="797"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="177"/>
+        <location filename="../screens/SettingsScreen.qml" line="171"/>
         <source>Update media database</source>
         <translation>עדכון מסד נתוני המדיה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <location filename="../screens/SettingsScreen.qml" line="181"/>
         <source>Scrape metadata</source>
         <translation>איסוף מטא-נתונים</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="192"/>
+        <location filename="../screens/SettingsScreen.qml" line="186"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1006,407 +1006,407 @@ Euskara - devilschile2</source>
         <translation type="vanished">מתקדם</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="165"/>
+        <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>Mouse support</source>
         <translation>תמיכת עכבר</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="204"/>
+        <location filename="../screens/SettingsScreen.qml" line="198"/>
         <source>Debug logging</source>
         <translation>רישום ניפוי שגיאות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="209"/>
+        <location filename="../screens/SettingsScreen.qml" line="203"/>
         <source>Upload log file</source>
         <translation>העלאת קובץ יומן</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="199"/>
+        <location filename="../screens/SettingsScreen.qml" line="193"/>
         <source>About / License</source>
         <translation>אודות / רישיון</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="137"/>
-        <location filename="../screens/SettingsScreen.qml" line="750"/>
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="743"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="142"/>
-        <location filename="../screens/SettingsScreen.qml" line="759"/>
+        <location filename="../screens/SettingsScreen.qml" line="136"/>
+        <location filename="../screens/SettingsScreen.qml" line="752"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152"/>
+        <location filename="../screens/SettingsScreen.qml" line="146"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="170"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
         <source>Reduce motion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="240"/>
         <source>Optimizing</source>
         <translation>מבצע אופטימיזציה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="248"/>
-        <location filename="../screens/SettingsScreen.qml" line="257"/>
+        <location filename="../screens/SettingsScreen.qml" line="242"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>Paused</source>
         <translation>מושהה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="248"/>
-        <location filename="../screens/SettingsScreen.qml" line="257"/>
+        <location filename="../screens/SettingsScreen.qml" line="242"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>In progress</source>
         <translation>בתהליך</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="245"/>
         <source>%1 indexed</source>
         <translation>%1 אונדקסו</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="260"/>
+        <location filename="../screens/SettingsScreen.qml" line="254"/>
         <source>%1 scraped</source>
         <translation>%1 נאספו</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="495"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Cancel</source>
         <translation>ביטול</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="495"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Start</source>
         <translation>התחל</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="497"/>
+        <location filename="../screens/SettingsScreen.qml" line="490"/>
         <source>Upload</source>
         <translation>העלאה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <location filename="../screens/SettingsScreen.qml" line="491"/>
         <source>Open</source>
         <translation>פתח</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="549"/>
+        <location filename="../screens/SettingsScreen.qml" line="542"/>
         <source>Default</source>
         <translation>ברירת מחדל</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="579"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>English</source>
         <translation>אנגלית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="581"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Italian</source>
         <translation>איטלקית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="583"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="585"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="587"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>German</source>
         <translation>גרמנית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="589"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Greek</source>
         <translation>יוונית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="591"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Japanese</source>
         <translation>יפנית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="593"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Korean</source>
         <translation>קוריאנית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="595"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Dutch</source>
         <translation>הולנדית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="597"/>
+        <location filename="../screens/SettingsScreen.qml" line="590"/>
         <source>Romanian</source>
         <translation>רומנית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="599"/>
+        <location filename="../screens/SettingsScreen.qml" line="592"/>
         <source>Slovak</source>
         <translation>סלובקית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="601"/>
+        <location filename="../screens/SettingsScreen.qml" line="594"/>
         <source>Ukrainian</source>
         <translation>אוקראינית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="603"/>
+        <location filename="../screens/SettingsScreen.qml" line="596"/>
         <source>Chinese (Simplified)</source>
         <translation>סינית (מפושטת)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="605"/>
+        <location filename="../screens/SettingsScreen.qml" line="598"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="607"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Hebrew</source>
         <translation>עברית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="611"/>
+        <location filename="../screens/SettingsScreen.qml" line="604"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
-        <location filename="../screens/SettingsScreen.qml" line="620"/>
-        <location filename="../screens/SettingsScreen.qml" line="694"/>
+        <location filename="../screens/SettingsScreen.qml" line="605"/>
+        <location filename="../screens/SettingsScreen.qml" line="613"/>
+        <location filename="../screens/SettingsScreen.qml" line="687"/>
         <source>Auto</source>
         <translation>אוטומטי</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="610"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="619"/>
+        <location filename="../screens/SettingsScreen.qml" line="612"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="630"/>
+        <location filename="../screens/SettingsScreen.qml" line="623"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="632"/>
+        <location filename="../screens/SettingsScreen.qml" line="625"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="634"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="628"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="640"/>
+        <location filename="../screens/SettingsScreen.qml" line="633"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="642"/>
+        <location filename="../screens/SettingsScreen.qml" line="635"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="643"/>
+        <location filename="../screens/SettingsScreen.qml" line="636"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="648"/>
+        <location filename="../screens/SettingsScreen.qml" line="641"/>
         <source>Detailed list view</source>
         <translation>תצוגת רשימה מפורטת</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="642"/>
         <source>Grid view</source>
         <translation>תצוגת רשת</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="654"/>
+        <location filename="../screens/SettingsScreen.qml" line="647"/>
         <source>Style B</source>
         <translation>סגנון B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="656"/>
+        <location filename="../screens/SettingsScreen.qml" line="649"/>
         <source>Style C</source>
         <translation>סגנון C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="658"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
         <source>Style D</source>
         <translation>סגנון D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="659"/>
+        <location filename="../screens/SettingsScreen.qml" line="652"/>
         <source>Style A</source>
         <translation>סגנון A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="674"/>
+        <location filename="../screens/SettingsScreen.qml" line="667"/>
         <source>Off</source>
         <translation>כבוי</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="676"/>
+        <location filename="../screens/SettingsScreen.qml" line="669"/>
         <source>1 second (testing)</source>
         <translation>שנייה אחת (לבדיקה)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="678"/>
+        <location filename="../screens/SettingsScreen.qml" line="671"/>
         <source>1 minute</source>
         <translation>דקה אחת</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="680"/>
+        <location filename="../screens/SettingsScreen.qml" line="673"/>
         <source>2 minutes</source>
         <translation>2 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="682"/>
+        <location filename="../screens/SettingsScreen.qml" line="675"/>
         <source>5 minutes</source>
         <translation>5 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="684"/>
+        <location filename="../screens/SettingsScreen.qml" line="677"/>
         <source>10 minutes</source>
         <translation>10 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="686"/>
+        <location filename="../screens/SettingsScreen.qml" line="679"/>
         <source>15 minutes</source>
         <translation>15 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="688"/>
+        <location filename="../screens/SettingsScreen.qml" line="681"/>
         <source>30 minutes</source>
         <translation>30 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="682"/>
         <source>%1 seconds</source>
         <translation>%1 שניות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1368"/>
+        <location filename="../screens/SettingsScreen.qml" line="1351"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
-        <location filename="../screens/SettingsScreen.qml" line="732"/>
+        <location filename="../screens/SettingsScreen.qml" line="105"/>
+        <location filename="../screens/SettingsScreen.qml" line="725"/>
         <source>Resolution</source>
         <translation>רזולוציה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="225"/>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="219"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="89"/>
-        <location filename="../screens/SettingsScreen.qml" line="227"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="221"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="101"/>
-        <location filename="../screens/SettingsScreen.qml" line="231"/>
+        <location filename="../screens/SettingsScreen.qml" line="95"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="696"/>
+        <location filename="../screens/SettingsScreen.qml" line="689"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="698"/>
+        <location filename="../screens/SettingsScreen.qml" line="691"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="700"/>
+        <location filename="../screens/SettingsScreen.qml" line="693"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="702"/>
+        <location filename="../screens/SettingsScreen.qml" line="695"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="704"/>
+        <location filename="../screens/SettingsScreen.qml" line="697"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="706"/>
+        <location filename="../screens/SettingsScreen.qml" line="699"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="708"/>
+        <location filename="../screens/SettingsScreen.qml" line="701"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="710"/>
+        <location filename="../screens/SettingsScreen.qml" line="703"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="712"/>
+        <location filename="../screens/SettingsScreen.qml" line="705"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="714"/>
+        <location filename="../screens/SettingsScreen.qml" line="707"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="716"/>
+        <location filename="../screens/SettingsScreen.qml" line="709"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="718"/>
+        <location filename="../screens/SettingsScreen.qml" line="711"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="232"/>
+        <location filename="../screens/SettingsScreen.qml" line="226"/>
         <source>Settings</source>
         <translation>הגדרות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1356"/>
+        <location filename="../screens/SettingsScreen.qml" line="1339"/>
         <source>No settings available on this platform</source>
         <translation>אין הגדרות זמינות בפלטפורמה זו</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="236"/>
-        <location filename="../screens/SystemsScreen.qml" line="338"/>
+        <location filename="../screens/SystemsScreen.qml" line="242"/>
+        <location filename="../screens/SystemsScreen.qml" line="343"/>
         <source>%1 systems</source>
         <translation>%1 מערכות</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="237"/>
-        <location filename="../screens/SystemsScreen.qml" line="355"/>
+        <location filename="../screens/SystemsScreen.qml" line="243"/>
+        <location filename="../screens/SystemsScreen.qml" line="360"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="373"/>
+        <location filename="../screens/SystemsScreen.qml" line="378"/>
         <source>No systems in this category</source>
         <translation>אין מערכות בקטגוריה זו</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="374"/>
+        <location filename="../screens/SystemsScreen.qml" line="379"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>
@@ -1439,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="539"/>
+        <location filename="../components/Tile.qml" line="501"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -425,34 +425,34 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="116"/>
-        <location filename="../screens/GamesScreen.qml" line="151"/>
+        <location filename="../screens/GamesScreen.qml" line="127"/>
+        <location filename="../screens/GamesScreen.qml" line="162"/>
         <source>%1 files</source>
         <translation>%1 קבצים</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="53"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="125"/>
-        <location filename="../screens/GamesScreen.qml" line="152"/>
+        <location filename="../screens/GamesScreen.qml" line="136"/>
+        <location filename="../screens/GamesScreen.qml" line="163"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="47"/>
+        <location filename="../screens/GamesScreen.qml" line="48"/>
         <source>No games in this system</source>
         <translation>אין משחקים במערכת זו</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="48"/>
+        <location filename="../screens/GamesScreen.qml" line="49"/>
         <source>Loading games…</source>
         <translation>טוען משחקים…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="121"/>
+        <location filename="../screens/GamesScreen.qml" line="132"/>
         <source>Loading more…</source>
         <translation>טוען עוד…</translation>
     </message>
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="139"/>
+        <location filename="../screens/HubScreen.qml" line="149"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="145"/>
+        <location filename="../screens/HubScreen.qml" line="155"/>
         <source>Favorites</source>
         <translation>מועדפים</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="150"/>
+        <location filename="../screens/HubScreen.qml" line="160"/>
         <source>Recently Played</source>
         <translation>שוחקו לאחרונה</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="155"/>
+        <location filename="../screens/HubScreen.qml" line="165"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">הגדרות</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="669"/>
+        <location filename="../screens/HubScreen.qml" line="701"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>אין מערכות זמינות. הפעילו &quot;עדכון מסד נתוני מדיה&quot; מההגדרות.</translation>
     </message>
@@ -553,138 +553,138 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1361"/>
+        <location filename="../app/Main.qml" line="1367"/>
         <source>Launch core</source>
         <translation>הפעל את הליבה</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1367"/>
-        <location filename="../app/Main.qml" line="1606"/>
+        <location filename="../app/Main.qml" line="1373"/>
+        <location filename="../app/Main.qml" line="1612"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1374"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1380"/>
+        <location filename="../app/Main.qml" line="1403"/>
         <source>Update media database</source>
         <translation type="unfinished">עדכון מסד נתוני המדיה</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1377"/>
-        <location filename="../app/Main.qml" line="1400"/>
+        <location filename="../app/Main.qml" line="1383"/>
+        <location filename="../app/Main.qml" line="1406"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">איסוף מטא-נתונים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1382"/>
-        <location filename="../app/Main.qml" line="1391"/>
+        <location filename="../app/Main.qml" line="1388"/>
+        <location filename="../app/Main.qml" line="1397"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1382"/>
-        <location filename="../app/Main.qml" line="1391"/>
+        <location filename="../app/Main.qml" line="1388"/>
+        <location filename="../app/Main.qml" line="1397"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1409"/>
-        <location filename="../app/Main.qml" line="1444"/>
+        <location filename="../app/Main.qml" line="1415"/>
+        <location filename="../app/Main.qml" line="1450"/>
         <source>Launch game</source>
         <translation>הפעל משחק</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1425"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Remove from favorites</source>
         <translation>הסר מהמועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1425"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Add to favorites</source>
         <translation>הוסף למועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1430"/>
+        <location filename="../app/Main.qml" line="1436"/>
         <source>Write to NFC token</source>
         <translation>כתוב לטוקן NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1434"/>
+        <location filename="../app/Main.qml" line="1440"/>
         <source>QR code</source>
         <translation>קוד QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1602"/>
+        <location filename="../app/Main.qml" line="1608"/>
         <source>Default</source>
         <translation type="unfinished">ברירת מחדל</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1602"/>
+        <location filename="../app/Main.qml" line="1608"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1926"/>
+        <location filename="../app/Main.qml" line="1932"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1930"/>
+        <location filename="../app/Main.qml" line="1936"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1944"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1948"/>
+        <location filename="../app/Main.qml" line="1954"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1952"/>
+        <location filename="../app/Main.qml" line="1958"/>
         <source>Retry</source>
         <translation type="unfinished">נסה שוב</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1956"/>
+        <location filename="../app/Main.qml" line="1962"/>
         <source>Cancel</source>
         <translation type="unfinished">ביטול</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2604"/>
+        <location filename="../app/Main.qml" line="2610"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2606"/>
+        <location filename="../app/Main.qml" line="2612"/>
         <source>Loading games…</source>
         <translation>טוען משחקים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2608"/>
+        <location filename="../app/Main.qml" line="2614"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2616"/>
         <source>Loading favorites…</source>
         <translation>טוען מועדפים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2612"/>
+        <location filename="../app/Main.qml" line="2618"/>
         <source>Loading recently played…</source>
         <translation>טוען את הפריטים ששוחקו לאחרונה…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2620"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2616"/>
+        <location filename="../app/Main.qml" line="2622"/>
         <source>Loading…</source>
         <translation>טוען…</translation>
     </message>
@@ -692,12 +692,12 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="683"/>
+        <location filename="../app/MainLayout.qml" line="685"/>
         <source>Writing failed</source>
         <translation>הכתיבה נכשלה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="683"/>
+        <location filename="../app/MainLayout.qml" line="685"/>
         <source>Put a writable card near the reader</source>
         <translation>הניחו כרטיס הניתן לכתיבה ליד הקורא</translation>
     </message>
@@ -717,141 +717,141 @@ Euskara - devilschile2</source>
         <translation type="unfinished">שוחקו לאחרונה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="699"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="700"/>
+        <location filename="../app/MainLayout.qml" line="702"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="810"/>
+        <location filename="../app/MainLayout.qml" line="812"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="811"/>
+        <location filename="../app/MainLayout.qml" line="813"/>
         <source>Are you sure you want to exit?</source>
         <translation>האם אתה בטוח שברצונך לצאת?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="890"/>
-        <location filename="../app/MainLayout.qml" line="964"/>
-        <location filename="../app/MainLayout.qml" line="1010"/>
-        <location filename="../app/MainLayout.qml" line="1047"/>
-        <location filename="../app/MainLayout.qml" line="1097"/>
-        <location filename="../app/MainLayout.qml" line="1146"/>
-        <location filename="../app/MainLayout.qml" line="1165"/>
-        <location filename="../app/MainLayout.qml" line="1232"/>
+        <location filename="../app/MainLayout.qml" line="892"/>
+        <location filename="../app/MainLayout.qml" line="966"/>
+        <location filename="../app/MainLayout.qml" line="1012"/>
+        <location filename="../app/MainLayout.qml" line="1049"/>
+        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1148"/>
+        <location filename="../app/MainLayout.qml" line="1167"/>
+        <location filename="../app/MainLayout.qml" line="1234"/>
         <source>Move</source>
         <translation>הזזה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="894"/>
-        <location filename="../app/MainLayout.qml" line="968"/>
+        <location filename="../app/MainLayout.qml" line="896"/>
+        <location filename="../app/MainLayout.qml" line="970"/>
         <source>Select</source>
         <translation>בחירה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="902"/>
-        <location filename="../app/MainLayout.qml" line="916"/>
-        <location filename="../app/MainLayout.qml" line="931"/>
-        <location filename="../app/MainLayout.qml" line="942"/>
+        <location filename="../app/MainLayout.qml" line="900"/>
+        <location filename="../app/MainLayout.qml" line="904"/>
+        <location filename="../app/MainLayout.qml" line="918"/>
+        <location filename="../app/MainLayout.qml" line="933"/>
+        <location filename="../app/MainLayout.qml" line="944"/>
         <source>Close</source>
         <translation>סגור</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="909"/>
-        <location filename="../app/MainLayout.qml" line="949"/>
-        <location filename="../app/MainLayout.qml" line="972"/>
-        <location filename="../app/MainLayout.qml" line="983"/>
+        <location filename="../app/MainLayout.qml" line="911"/>
+        <location filename="../app/MainLayout.qml" line="951"/>
+        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="985"/>
         <source>Cancel</source>
         <translation>ביטול</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="927"/>
+        <location filename="../app/MainLayout.qml" line="929"/>
         <source>Done</source>
         <translation>הושלם</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1070"/>
-        <location filename="../app/MainLayout.qml" line="1123"/>
-        <location filename="../app/MainLayout.qml" line="1258"/>
+        <location filename="../app/MainLayout.qml" line="940"/>
+        <location filename="../app/MainLayout.qml" line="1072"/>
+        <location filename="../app/MainLayout.qml" line="1125"/>
+        <location filename="../app/MainLayout.qml" line="1260"/>
         <source>Retry</source>
         <translation>נסה שוב</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="957"/>
+        <location filename="../app/MainLayout.qml" line="959"/>
         <source>I understand</source>
         <translation>הבנתי</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="991"/>
+        <location filename="../app/MainLayout.qml" line="993"/>
         <source>Start</source>
         <translation>התחל</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1014"/>
-        <location filename="../app/MainLayout.qml" line="1057"/>
-        <location filename="../app/MainLayout.qml" line="1107"/>
-        <location filename="../app/MainLayout.qml" line="1151"/>
-        <location filename="../app/MainLayout.qml" line="1242"/>
+        <location filename="../app/MainLayout.qml" line="1016"/>
+        <location filename="../app/MainLayout.qml" line="1059"/>
+        <location filename="../app/MainLayout.qml" line="1109"/>
+        <location filename="../app/MainLayout.qml" line="1153"/>
+        <location filename="../app/MainLayout.qml" line="1244"/>
         <source>Open</source>
         <translation>פתח</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1024"/>
+        <location filename="../app/MainLayout.qml" line="1026"/>
         <source>Quit</source>
         <translation>יציאה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1033"/>
-        <location filename="../app/MainLayout.qml" line="1063"/>
-        <location filename="../app/MainLayout.qml" line="1074"/>
-        <location filename="../app/MainLayout.qml" line="1089"/>
-        <location filename="../app/MainLayout.qml" line="1116"/>
-        <location filename="../app/MainLayout.qml" line="1127"/>
-        <location filename="../app/MainLayout.qml" line="1139"/>
-        <location filename="../app/MainLayout.qml" line="1155"/>
-        <location filename="../app/MainLayout.qml" line="1189"/>
-        <location filename="../app/MainLayout.qml" line="1207"/>
-        <location filename="../app/MainLayout.qml" line="1216"/>
-        <location filename="../app/MainLayout.qml" line="1251"/>
-        <location filename="../app/MainLayout.qml" line="1262"/>
+        <location filename="../app/MainLayout.qml" line="1035"/>
+        <location filename="../app/MainLayout.qml" line="1065"/>
+        <location filename="../app/MainLayout.qml" line="1076"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
+        <location filename="../app/MainLayout.qml" line="1118"/>
+        <location filename="../app/MainLayout.qml" line="1129"/>
+        <location filename="../app/MainLayout.qml" line="1141"/>
+        <location filename="../app/MainLayout.qml" line="1157"/>
+        <location filename="../app/MainLayout.qml" line="1191"/>
+        <location filename="../app/MainLayout.qml" line="1209"/>
+        <location filename="../app/MainLayout.qml" line="1218"/>
+        <location filename="../app/MainLayout.qml" line="1253"/>
+        <location filename="../app/MainLayout.qml" line="1264"/>
         <source>Back</source>
         <translation>חזרה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1053"/>
-        <location filename="../app/MainLayout.qml" line="1103"/>
-        <location filename="../app/MainLayout.qml" line="1238"/>
+        <location filename="../app/MainLayout.qml" line="1055"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
+        <location filename="../app/MainLayout.qml" line="1240"/>
         <source>Page</source>
         <translation>עמוד</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1060"/>
-        <location filename="../app/MainLayout.qml" line="1112"/>
-        <location filename="../app/MainLayout.qml" line="1247"/>
+        <location filename="../app/MainLayout.qml" line="1022"/>
+        <location filename="../app/MainLayout.qml" line="1062"/>
+        <location filename="../app/MainLayout.qml" line="1114"/>
+        <location filename="../app/MainLayout.qml" line="1249"/>
         <source>Options</source>
         <translation>אפשרויות</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1174"/>
+        <location filename="../app/MainLayout.qml" line="1176"/>
         <source>Change</source>
         <translation>שינוי</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1180"/>
+        <location filename="../app/MainLayout.qml" line="1182"/>
         <source>Toggle</source>
         <translation>החלף</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1203"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Scroll</source>
         <translation>גלילה</translation>
     </message>
@@ -864,12 +864,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">טוען…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="365"/>
+        <location filename="../screens/MediaListScreen.qml" line="395"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 פריטים</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="366"/>
+        <location filename="../screens/MediaListScreen.qml" line="396"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>לא</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="198"/>
+        <location filename="../components/Modal.qml" line="246"/>
         <source>Cancel</source>
         <translation>ביטול</translation>
     </message>
@@ -940,64 +940,64 @@ Euskara - devilschile2</source>
         <translation type="vanished">כללי</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="132"/>
-        <location filename="../screens/SettingsScreen.qml" line="718"/>
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
+        <location filename="../screens/SettingsScreen.qml" line="741"/>
         <source>Language</source>
         <translation>שפה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="745"/>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="768"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="754"/>
+        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <location filename="../screens/SettingsScreen.qml" line="777"/>
         <source>Browsing layout</source>
         <translation>פריסת עיון</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="145"/>
-        <location filename="../screens/SettingsScreen.qml" line="763"/>
+        <location filename="../screens/SettingsScreen.qml" line="160"/>
+        <location filename="../screens/SettingsScreen.qml" line="786"/>
         <source>Button style</source>
         <translation>סגנון כפתורים</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="772"/>
+        <location filename="../screens/SettingsScreen.qml" line="132"/>
+        <location filename="../screens/SettingsScreen.qml" line="795"/>
         <source>Screensaver</source>
         <translation>שומר מסך</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="80"/>
-        <location filename="../screens/SettingsScreen.qml" line="209"/>
+        <location filename="../screens/SettingsScreen.qml" line="95"/>
+        <location filename="../screens/SettingsScreen.qml" line="229"/>
         <source>Library</source>
         <translation>ספרייה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="162"/>
+        <location filename="../screens/SettingsScreen.qml" line="182"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="112"/>
-        <location filename="../screens/SettingsScreen.qml" line="781"/>
+        <location filename="../screens/SettingsScreen.qml" line="127"/>
+        <location filename="../screens/SettingsScreen.qml" line="804"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="157"/>
+        <location filename="../screens/SettingsScreen.qml" line="177"/>
         <source>Update media database</source>
         <translation>עדכון מסד נתוני המדיה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="167"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
         <source>Scrape metadata</source>
         <translation>איסוף מטא-נתונים</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="172"/>
+        <location filename="../screens/SettingsScreen.qml" line="192"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1006,402 +1006,407 @@ Euskara - devilschile2</source>
         <translation type="vanished">מתקדם</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="150"/>
+        <location filename="../screens/SettingsScreen.qml" line="165"/>
         <source>Mouse support</source>
         <translation>תמיכת עכבר</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="184"/>
+        <location filename="../screens/SettingsScreen.qml" line="204"/>
         <source>Debug logging</source>
         <translation>רישום ניפוי שגיאות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="189"/>
+        <location filename="../screens/SettingsScreen.qml" line="209"/>
         <source>Upload log file</source>
         <translation>העלאת קובץ יומן</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="179"/>
+        <location filename="../screens/SettingsScreen.qml" line="199"/>
         <source>About / License</source>
         <translation>אודות / רישיון</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
-        <location filename="../screens/SettingsScreen.qml" line="727"/>
+        <location filename="../screens/SettingsScreen.qml" line="137"/>
+        <location filename="../screens/SettingsScreen.qml" line="750"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="127"/>
-        <location filename="../screens/SettingsScreen.qml" line="736"/>
+        <location filename="../screens/SettingsScreen.qml" line="142"/>
+        <location filename="../screens/SettingsScreen.qml" line="759"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="137"/>
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="226"/>
+        <location filename="../screens/SettingsScreen.qml" line="170"/>
+        <source>Reduce motion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
         <source>Optimizing</source>
         <translation>מבצע אופטימיזציה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="228"/>
-        <location filename="../screens/SettingsScreen.qml" line="237"/>
+        <location filename="../screens/SettingsScreen.qml" line="248"/>
+        <location filename="../screens/SettingsScreen.qml" line="257"/>
         <source>Paused</source>
         <translation>מושהה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="228"/>
-        <location filename="../screens/SettingsScreen.qml" line="237"/>
+        <location filename="../screens/SettingsScreen.qml" line="248"/>
+        <location filename="../screens/SettingsScreen.qml" line="257"/>
         <source>In progress</source>
         <translation>בתהליך</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="231"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>%1 indexed</source>
         <translation>%1 אונדקסו</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="240"/>
+        <location filename="../screens/SettingsScreen.qml" line="260"/>
         <source>%1 scraped</source>
         <translation>%1 נאספו</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="472"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Cancel</source>
         <translation>ביטול</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="472"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Start</source>
         <translation>התחל</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="474"/>
+        <location filename="../screens/SettingsScreen.qml" line="497"/>
         <source>Upload</source>
         <translation>העלאה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Open</source>
         <translation>פתח</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="526"/>
+        <location filename="../screens/SettingsScreen.qml" line="549"/>
         <source>Default</source>
         <translation>ברירת מחדל</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="556"/>
+        <location filename="../screens/SettingsScreen.qml" line="579"/>
         <source>English</source>
         <translation>אנגלית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="558"/>
+        <location filename="../screens/SettingsScreen.qml" line="581"/>
         <source>Italian</source>
         <translation>איטלקית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="560"/>
+        <location filename="../screens/SettingsScreen.qml" line="583"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="562"/>
+        <location filename="../screens/SettingsScreen.qml" line="585"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="564"/>
+        <location filename="../screens/SettingsScreen.qml" line="587"/>
         <source>German</source>
         <translation>גרמנית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="566"/>
+        <location filename="../screens/SettingsScreen.qml" line="589"/>
         <source>Greek</source>
         <translation>יוונית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="568"/>
+        <location filename="../screens/SettingsScreen.qml" line="591"/>
         <source>Japanese</source>
         <translation>יפנית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="570"/>
+        <location filename="../screens/SettingsScreen.qml" line="593"/>
         <source>Korean</source>
         <translation>קוריאנית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="595"/>
         <source>Dutch</source>
         <translation>הולנדית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="597"/>
         <source>Romanian</source>
         <translation>רומנית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="599"/>
         <source>Slovak</source>
         <translation>סלובקית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="601"/>
         <source>Ukrainian</source>
         <translation>אוקראינית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="603"/>
         <source>Chinese (Simplified)</source>
         <translation>סינית (מפושטת)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="605"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="607"/>
         <source>Hebrew</source>
         <translation>עברית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="588"/>
+        <location filename="../screens/SettingsScreen.qml" line="611"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="589"/>
-        <location filename="../screens/SettingsScreen.qml" line="597"/>
-        <location filename="../screens/SettingsScreen.qml" line="671"/>
+        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="620"/>
+        <location filename="../screens/SettingsScreen.qml" line="694"/>
         <source>Auto</source>
         <translation>אוטומטי</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="594"/>
+        <location filename="../screens/SettingsScreen.qml" line="617"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="596"/>
+        <location filename="../screens/SettingsScreen.qml" line="619"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="607"/>
+        <location filename="../screens/SettingsScreen.qml" line="630"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="632"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="611"/>
+        <location filename="../screens/SettingsScreen.qml" line="634"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="635"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="640"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="619"/>
+        <location filename="../screens/SettingsScreen.qml" line="642"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="620"/>
+        <location filename="../screens/SettingsScreen.qml" line="643"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="625"/>
+        <location filename="../screens/SettingsScreen.qml" line="648"/>
         <source>Detailed list view</source>
         <translation>תצוגת רשימה מפורטת</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="626"/>
+        <location filename="../screens/SettingsScreen.qml" line="649"/>
         <source>Grid view</source>
         <translation>תצוגת רשת</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="631"/>
+        <location filename="../screens/SettingsScreen.qml" line="654"/>
         <source>Style B</source>
         <translation>סגנון B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="633"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Style C</source>
         <translation>סגנון C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="658"/>
         <source>Style D</source>
         <translation>סגנון D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="659"/>
         <source>Style A</source>
         <translation>סגנון A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="674"/>
         <source>Off</source>
         <translation>כבוי</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="653"/>
+        <location filename="../screens/SettingsScreen.qml" line="676"/>
         <source>1 second (testing)</source>
         <translation>שנייה אחת (לבדיקה)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="655"/>
+        <location filename="../screens/SettingsScreen.qml" line="678"/>
         <source>1 minute</source>
         <translation>דקה אחת</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="657"/>
+        <location filename="../screens/SettingsScreen.qml" line="680"/>
         <source>2 minutes</source>
         <translation>2 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="659"/>
+        <location filename="../screens/SettingsScreen.qml" line="682"/>
         <source>5 minutes</source>
         <translation>5 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="661"/>
+        <location filename="../screens/SettingsScreen.qml" line="684"/>
         <source>10 minutes</source>
         <translation>10 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="663"/>
+        <location filename="../screens/SettingsScreen.qml" line="686"/>
         <source>15 minutes</source>
         <translation>15 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="665"/>
+        <location filename="../screens/SettingsScreen.qml" line="688"/>
         <source>30 minutes</source>
         <translation>30 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="666"/>
+        <location filename="../screens/SettingsScreen.qml" line="689"/>
         <source>%1 seconds</source>
         <translation>%1 שניות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1292"/>
+        <location filename="../screens/SettingsScreen.qml" line="1358"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="96"/>
-        <location filename="../screens/SettingsScreen.qml" line="709"/>
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="732"/>
         <source>Resolution</source>
         <translation>רזולוציה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="68"/>
-        <location filename="../screens/SettingsScreen.qml" line="205"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="74"/>
-        <location filename="../screens/SettingsScreen.qml" line="207"/>
+        <location filename="../screens/SettingsScreen.qml" line="89"/>
+        <location filename="../screens/SettingsScreen.qml" line="227"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="86"/>
-        <location filename="../screens/SettingsScreen.qml" line="211"/>
+        <location filename="../screens/SettingsScreen.qml" line="101"/>
+        <location filename="../screens/SettingsScreen.qml" line="231"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="673"/>
+        <location filename="../screens/SettingsScreen.qml" line="696"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="675"/>
+        <location filename="../screens/SettingsScreen.qml" line="698"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="677"/>
+        <location filename="../screens/SettingsScreen.qml" line="700"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="679"/>
+        <location filename="../screens/SettingsScreen.qml" line="702"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="681"/>
+        <location filename="../screens/SettingsScreen.qml" line="704"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="683"/>
+        <location filename="../screens/SettingsScreen.qml" line="706"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="685"/>
+        <location filename="../screens/SettingsScreen.qml" line="708"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="687"/>
+        <location filename="../screens/SettingsScreen.qml" line="710"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="712"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="691"/>
+        <location filename="../screens/SettingsScreen.qml" line="714"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="693"/>
+        <location filename="../screens/SettingsScreen.qml" line="716"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="695"/>
+        <location filename="../screens/SettingsScreen.qml" line="718"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="212"/>
+        <location filename="../screens/SettingsScreen.qml" line="232"/>
         <source>Settings</source>
         <translation>הגדרות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1280"/>
+        <location filename="../screens/SettingsScreen.qml" line="1346"/>
         <source>No settings available on this platform</source>
         <translation>אין הגדרות זמינות בפלטפורמה זו</translation>
     </message>
@@ -1409,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="206"/>
-        <location filename="../screens/SystemsScreen.qml" line="304"/>
+        <location filename="../screens/SystemsScreen.qml" line="229"/>
+        <location filename="../screens/SystemsScreen.qml" line="329"/>
         <source>%1 systems</source>
         <translation>%1 מערכות</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="207"/>
-        <location filename="../screens/SystemsScreen.qml" line="321"/>
+        <location filename="../screens/SystemsScreen.qml" line="230"/>
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="339"/>
+        <location filename="../screens/SystemsScreen.qml" line="364"/>
         <source>No systems in this category</source>
         <translation>אין מערכות בקטגוריה זו</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="340"/>
+        <location filename="../screens/SystemsScreen.qml" line="365"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>
@@ -1434,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="364"/>
+        <location filename="../components/Tile.qml" line="475"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -425,8 +425,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="128"/>
-        <location filename="../screens/GamesScreen.qml" line="163"/>
+        <location filename="../screens/GamesScreen.qml" line="131"/>
+        <location filename="../screens/GamesScreen.qml" line="166"/>
         <source>%1 files</source>
         <translation>%1 קבצים</translation>
     </message>
@@ -436,8 +436,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="137"/>
-        <location filename="../screens/GamesScreen.qml" line="164"/>
+        <location filename="../screens/GamesScreen.qml" line="140"/>
+        <location filename="../screens/GamesScreen.qml" line="167"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -452,7 +452,7 @@ Euskara - devilschile2</source>
         <translation>טוען משחקים…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="133"/>
+        <location filename="../screens/GamesScreen.qml" line="136"/>
         <source>Loading more…</source>
         <translation>טוען עוד…</translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>לא</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="246"/>
+        <location filename="../components/Modal.qml" line="250"/>
         <source>Cancel</source>
         <translation>ביטול</translation>
     </message>
@@ -940,64 +940,64 @@ Euskara - devilschile2</source>
         <translation type="vanished">כללי</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="141"/>
-        <location filename="../screens/SettingsScreen.qml" line="734"/>
+        <location filename="../screens/SettingsScreen.qml" line="145"/>
+        <location filename="../screens/SettingsScreen.qml" line="738"/>
         <source>Language</source>
         <translation>שפה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
-        <location filename="../screens/SettingsScreen.qml" line="761"/>
+        <location filename="../screens/SettingsScreen.qml" line="115"/>
+        <location filename="../screens/SettingsScreen.qml" line="765"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116"/>
-        <location filename="../screens/SettingsScreen.qml" line="770"/>
+        <location filename="../screens/SettingsScreen.qml" line="120"/>
+        <location filename="../screens/SettingsScreen.qml" line="774"/>
         <source>Browsing layout</source>
         <translation>פריסת עיון</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="154"/>
-        <location filename="../screens/SettingsScreen.qml" line="779"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="783"/>
         <source>Button style</source>
         <translation>סגנון כפתורים</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
-        <location filename="../screens/SettingsScreen.qml" line="788"/>
+        <location filename="../screens/SettingsScreen.qml" line="130"/>
+        <location filename="../screens/SettingsScreen.qml" line="792"/>
         <source>Screensaver</source>
         <translation>שומר מסך</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="89"/>
-        <location filename="../screens/SettingsScreen.qml" line="223"/>
+        <location filename="../screens/SettingsScreen.qml" line="93"/>
+        <location filename="../screens/SettingsScreen.qml" line="227"/>
         <source>Library</source>
         <translation>ספרייה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="176"/>
+        <location filename="../screens/SettingsScreen.qml" line="180"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121"/>
-        <location filename="../screens/SettingsScreen.qml" line="797"/>
+        <location filename="../screens/SettingsScreen.qml" line="125"/>
+        <location filename="../screens/SettingsScreen.qml" line="801"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="171"/>
+        <location filename="../screens/SettingsScreen.qml" line="175"/>
         <source>Update media database</source>
         <translation>עדכון מסד נתוני המדיה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="181"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
         <source>Scrape metadata</source>
         <translation>איסוף מטא-נתונים</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="186"/>
+        <location filename="../screens/SettingsScreen.qml" line="190"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1006,407 +1006,407 @@ Euskara - devilschile2</source>
         <translation type="vanished">מתקדם</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="159"/>
+        <location filename="../screens/SettingsScreen.qml" line="163"/>
         <source>Mouse support</source>
         <translation>תמיכת עכבר</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="198"/>
+        <location filename="../screens/SettingsScreen.qml" line="202"/>
         <source>Debug logging</source>
         <translation>רישום ניפוי שגיאות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="203"/>
+        <location filename="../screens/SettingsScreen.qml" line="207"/>
         <source>Upload log file</source>
         <translation>העלאת קובץ יומן</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="193"/>
+        <location filename="../screens/SettingsScreen.qml" line="197"/>
         <source>About / License</source>
         <translation>אודות / רישיון</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
-        <location filename="../screens/SettingsScreen.qml" line="743"/>
+        <location filename="../screens/SettingsScreen.qml" line="135"/>
+        <location filename="../screens/SettingsScreen.qml" line="747"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="136"/>
-        <location filename="../screens/SettingsScreen.qml" line="752"/>
+        <location filename="../screens/SettingsScreen.qml" line="140"/>
+        <location filename="../screens/SettingsScreen.qml" line="756"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="146"/>
+        <location filename="../screens/SettingsScreen.qml" line="150"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="168"/>
         <source>Reduce motion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="240"/>
+        <location filename="../screens/SettingsScreen.qml" line="244"/>
         <source>Optimizing</source>
         <translation>מבצע אופטימיזציה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="242"/>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="255"/>
         <source>Paused</source>
         <translation>מושהה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="242"/>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="255"/>
         <source>In progress</source>
         <translation>בתהליך</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="245"/>
+        <location filename="../screens/SettingsScreen.qml" line="249"/>
         <source>%1 indexed</source>
         <translation>%1 אונדקסו</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="254"/>
+        <location filename="../screens/SettingsScreen.qml" line="258"/>
         <source>%1 scraped</source>
         <translation>%1 נאספו</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="488"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Cancel</source>
         <translation>ביטול</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="488"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Start</source>
         <translation>התחל</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="490"/>
+        <location filename="../screens/SettingsScreen.qml" line="494"/>
         <source>Upload</source>
         <translation>העלאה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="491"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Open</source>
         <translation>פתח</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="542"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>Default</source>
         <translation>ברירת מחדל</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>English</source>
         <translation>אנגלית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Italian</source>
         <translation>איטלקית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>German</source>
         <translation>גרמנית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Greek</source>
         <translation>יוונית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Japanese</source>
         <translation>יפנית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="590"/>
         <source>Korean</source>
         <translation>קוריאנית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="588"/>
+        <location filename="../screens/SettingsScreen.qml" line="592"/>
         <source>Dutch</source>
         <translation>הולנדית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="590"/>
+        <location filename="../screens/SettingsScreen.qml" line="594"/>
         <source>Romanian</source>
         <translation>רומנית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="592"/>
+        <location filename="../screens/SettingsScreen.qml" line="596"/>
         <source>Slovak</source>
         <translation>סלובקית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="594"/>
+        <location filename="../screens/SettingsScreen.qml" line="598"/>
         <source>Ukrainian</source>
         <translation>אוקראינית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="596"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Chinese (Simplified)</source>
         <translation>סינית (מפושטת)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="598"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="600"/>
+        <location filename="../screens/SettingsScreen.qml" line="604"/>
         <source>Hebrew</source>
         <translation>עברית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="602"/>
+        <location filename="../screens/SettingsScreen.qml" line="606"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="604"/>
+        <location filename="../screens/SettingsScreen.qml" line="608"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="605"/>
-        <location filename="../screens/SettingsScreen.qml" line="613"/>
-        <location filename="../screens/SettingsScreen.qml" line="687"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="691"/>
         <source>Auto</source>
         <translation>אוטומטי</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="610"/>
+        <location filename="../screens/SettingsScreen.qml" line="614"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="616"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="623"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="625"/>
+        <location filename="../screens/SettingsScreen.qml" line="629"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="627"/>
+        <location filename="../screens/SettingsScreen.qml" line="631"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="628"/>
+        <location filename="../screens/SettingsScreen.qml" line="632"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="633"/>
+        <location filename="../screens/SettingsScreen.qml" line="637"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="639"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="640"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="641"/>
+        <location filename="../screens/SettingsScreen.qml" line="645"/>
         <source>Detailed list view</source>
         <translation>תצוגת רשימה מפורטת</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="642"/>
+        <location filename="../screens/SettingsScreen.qml" line="646"/>
         <source>Grid view</source>
         <translation>תצוגת רשת</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
         <source>Style B</source>
         <translation>סגנון B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Style C</source>
         <translation>סגנון C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="655"/>
         <source>Style D</source>
         <translation>סגנון D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="652"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Style A</source>
         <translation>סגנון A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="667"/>
+        <location filename="../screens/SettingsScreen.qml" line="671"/>
         <source>Off</source>
         <translation>כבוי</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="669"/>
+        <location filename="../screens/SettingsScreen.qml" line="673"/>
         <source>1 second (testing)</source>
         <translation>שנייה אחת (לבדיקה)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="671"/>
+        <location filename="../screens/SettingsScreen.qml" line="675"/>
         <source>1 minute</source>
         <translation>דקה אחת</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="673"/>
+        <location filename="../screens/SettingsScreen.qml" line="677"/>
         <source>2 minutes</source>
         <translation>2 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="675"/>
+        <location filename="../screens/SettingsScreen.qml" line="679"/>
         <source>5 minutes</source>
         <translation>5 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="677"/>
+        <location filename="../screens/SettingsScreen.qml" line="681"/>
         <source>10 minutes</source>
         <translation>10 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="679"/>
+        <location filename="../screens/SettingsScreen.qml" line="683"/>
         <source>15 minutes</source>
         <translation>15 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="681"/>
+        <location filename="../screens/SettingsScreen.qml" line="685"/>
         <source>30 minutes</source>
         <translation>30 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="682"/>
+        <location filename="../screens/SettingsScreen.qml" line="686"/>
         <source>%1 seconds</source>
         <translation>%1 שניות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1351"/>
+        <location filename="../screens/SettingsScreen.qml" line="1382"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="105"/>
-        <location filename="../screens/SettingsScreen.qml" line="725"/>
+        <location filename="../screens/SettingsScreen.qml" line="109"/>
+        <location filename="../screens/SettingsScreen.qml" line="729"/>
         <source>Resolution</source>
         <translation>רזולוציה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="77"/>
-        <location filename="../screens/SettingsScreen.qml" line="219"/>
+        <location filename="../screens/SettingsScreen.qml" line="81"/>
+        <location filename="../screens/SettingsScreen.qml" line="223"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="221"/>
+        <location filename="../screens/SettingsScreen.qml" line="87"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="95"/>
-        <location filename="../screens/SettingsScreen.qml" line="225"/>
+        <location filename="../screens/SettingsScreen.qml" line="99"/>
+        <location filename="../screens/SettingsScreen.qml" line="229"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="693"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="691"/>
+        <location filename="../screens/SettingsScreen.qml" line="695"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="693"/>
+        <location filename="../screens/SettingsScreen.qml" line="697"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="695"/>
+        <location filename="../screens/SettingsScreen.qml" line="699"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="697"/>
+        <location filename="../screens/SettingsScreen.qml" line="701"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="699"/>
+        <location filename="../screens/SettingsScreen.qml" line="703"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="701"/>
+        <location filename="../screens/SettingsScreen.qml" line="705"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="703"/>
+        <location filename="../screens/SettingsScreen.qml" line="707"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="705"/>
+        <location filename="../screens/SettingsScreen.qml" line="709"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="707"/>
+        <location filename="../screens/SettingsScreen.qml" line="711"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="709"/>
+        <location filename="../screens/SettingsScreen.qml" line="713"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="711"/>
+        <location filename="../screens/SettingsScreen.qml" line="715"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="226"/>
+        <location filename="../screens/SettingsScreen.qml" line="230"/>
         <source>Settings</source>
         <translation>הגדרות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1339"/>
+        <location filename="../screens/SettingsScreen.qml" line="1370"/>
         <source>No settings available on this platform</source>
         <translation>אין הגדרות זמינות בפלטפורמה זו</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="242"/>
-        <location filename="../screens/SystemsScreen.qml" line="343"/>
+        <location filename="../screens/SystemsScreen.qml" line="245"/>
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>%1 systems</source>
         <translation>%1 מערכות</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="243"/>
-        <location filename="../screens/SystemsScreen.qml" line="360"/>
+        <location filename="../screens/SystemsScreen.qml" line="246"/>
+        <location filename="../screens/SystemsScreen.qml" line="363"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="378"/>
+        <location filename="../screens/SystemsScreen.qml" line="381"/>
         <source>No systems in this category</source>
         <translation>אין מערכות בקטגוריה זו</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="379"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -97,100 +97,100 @@ Euskara - devilschile2</source>
         <translation type="unfinished">טוען…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="196"/>
+        <location filename="../components/BrowseDetailPane.qml" line="167"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="196"/>
+        <location filename="../components/BrowseDetailPane.qml" line="167"/>
         <source>Yr</source>
         <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="198"/>
+        <location filename="../components/BrowseDetailPane.qml" line="169"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="198"/>
+        <location filename="../components/BrowseDetailPane.qml" line="169"/>
         <source>Gen</source>
         <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="200"/>
+        <location filename="../components/BrowseDetailPane.qml" line="171"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="200"/>
+        <location filename="../components/BrowseDetailPane.qml" line="171"/>
         <source>Plyr</source>
         <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="202"/>
+        <location filename="../components/BrowseDetailPane.qml" line="173"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="202"/>
+        <location filename="../components/BrowseDetailPane.qml" line="173"/>
         <source>Dev</source>
         <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="204"/>
+        <location filename="../components/BrowseDetailPane.qml" line="175"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="204"/>
+        <location filename="../components/BrowseDetailPane.qml" line="175"/>
         <source>Pub</source>
         <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="206"/>
+        <location filename="../components/BrowseDetailPane.qml" line="177"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="206"/>
+        <location filename="../components/BrowseDetailPane.qml" line="177"/>
         <source>Rtg</source>
         <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="208"/>
+        <location filename="../components/BrowseDetailPane.qml" line="179"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="208"/>
+        <location filename="../components/BrowseDetailPane.qml" line="179"/>
         <source>Cat</source>
         <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="210"/>
+        <location filename="../components/BrowseDetailPane.qml" line="181"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="210"/>
+        <location filename="../components/BrowseDetailPane.qml" line="181"/>
         <source>Date</source>
         <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="212"/>
+        <location filename="../components/BrowseDetailPane.qml" line="183"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="212"/>
+        <location filename="../components/BrowseDetailPane.qml" line="183"/>
         <source>Mfr</source>
         <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
@@ -425,8 +425,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="127"/>
-        <location filename="../screens/GamesScreen.qml" line="162"/>
+        <location filename="../screens/GamesScreen.qml" line="128"/>
+        <location filename="../screens/GamesScreen.qml" line="163"/>
         <source>%1 files</source>
         <translation>%1 קבצים</translation>
     </message>
@@ -436,8 +436,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="136"/>
-        <location filename="../screens/GamesScreen.qml" line="163"/>
+        <location filename="../screens/GamesScreen.qml" line="137"/>
+        <location filename="../screens/GamesScreen.qml" line="164"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -452,7 +452,7 @@ Euskara - devilschile2</source>
         <translation>טוען משחקים…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="132"/>
+        <location filename="../screens/GamesScreen.qml" line="133"/>
         <source>Loading more…</source>
         <translation>טוען עוד…</translation>
     </message>
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="149"/>
+        <location filename="../screens/HubScreen.qml" line="156"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="155"/>
+        <location filename="../screens/HubScreen.qml" line="162"/>
         <source>Favorites</source>
         <translation>מועדפים</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="160"/>
+        <location filename="../screens/HubScreen.qml" line="167"/>
         <source>Recently Played</source>
         <translation>שוחקו לאחרונה</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="165"/>
+        <location filename="../screens/HubScreen.qml" line="172"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">הגדרות</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="701"/>
+        <location filename="../screens/HubScreen.qml" line="722"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>אין מערכות זמינות. הפעילו &quot;עדכון מסד נתוני מדיה&quot; מההגדרות.</translation>
     </message>
@@ -553,138 +553,138 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1367"/>
+        <location filename="../app/Main.qml" line="1381"/>
         <source>Launch core</source>
         <translation>הפעל את הליבה</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1373"/>
-        <location filename="../app/Main.qml" line="1612"/>
+        <location filename="../app/Main.qml" line="1387"/>
+        <location filename="../app/Main.qml" line="1626"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1380"/>
-        <location filename="../app/Main.qml" line="1403"/>
+        <location filename="../app/Main.qml" line="1394"/>
+        <location filename="../app/Main.qml" line="1417"/>
         <source>Update media database</source>
         <translation type="unfinished">עדכון מסד נתוני המדיה</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1383"/>
-        <location filename="../app/Main.qml" line="1406"/>
+        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1420"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">איסוף מטא-נתונים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1388"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1411"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1388"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1411"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1415"/>
-        <location filename="../app/Main.qml" line="1450"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1464"/>
         <source>Launch game</source>
         <translation>הפעל משחק</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1445"/>
         <source>Remove from favorites</source>
         <translation>הסר מהמועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1445"/>
         <source>Add to favorites</source>
         <translation>הוסף למועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1436"/>
+        <location filename="../app/Main.qml" line="1450"/>
         <source>Write to NFC token</source>
         <translation>כתוב לטוקן NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1440"/>
+        <location filename="../app/Main.qml" line="1454"/>
         <source>QR code</source>
         <translation>קוד QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1608"/>
+        <location filename="../app/Main.qml" line="1622"/>
         <source>Default</source>
         <translation type="unfinished">ברירת מחדל</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1608"/>
+        <location filename="../app/Main.qml" line="1622"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1932"/>
+        <location filename="../app/Main.qml" line="1946"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1936"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1950"/>
+        <location filename="../app/Main.qml" line="1964"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1954"/>
+        <location filename="../app/Main.qml" line="1968"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1958"/>
+        <location filename="../app/Main.qml" line="1972"/>
         <source>Retry</source>
         <translation type="unfinished">נסה שוב</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1962"/>
+        <location filename="../app/Main.qml" line="1976"/>
         <source>Cancel</source>
         <translation type="unfinished">ביטול</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2624"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2612"/>
+        <location filename="../app/Main.qml" line="2626"/>
         <source>Loading games…</source>
         <translation>טוען משחקים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2628"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2616"/>
+        <location filename="../app/Main.qml" line="2630"/>
         <source>Loading favorites…</source>
         <translation>טוען מועדפים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2618"/>
+        <location filename="../app/Main.qml" line="2632"/>
         <source>Loading recently played…</source>
         <translation>טוען את הפריטים ששוחקו לאחרונה…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2620"/>
+        <location filename="../app/Main.qml" line="2634"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2622"/>
+        <location filename="../app/Main.qml" line="2636"/>
         <source>Loading…</source>
         <translation>טוען…</translation>
     </message>
@@ -864,12 +864,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">טוען…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="395"/>
+        <location filename="../screens/MediaListScreen.qml" line="436"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 פריטים</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="396"/>
+        <location filename="../screens/MediaListScreen.qml" line="437"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>לא</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="246"/>
+        <location filename="../components/Modal.qml" line="256"/>
         <source>Cancel</source>
         <translation>ביטול</translation>
     </message>
@@ -1312,7 +1312,7 @@ Euskara - devilschile2</source>
         <translation>%1 שניות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1358"/>
+        <location filename="../screens/SettingsScreen.qml" line="1368"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1406,7 +1406,7 @@ Euskara - devilschile2</source>
         <translation>הגדרות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1346"/>
+        <location filename="../screens/SettingsScreen.qml" line="1356"/>
         <source>No settings available on this platform</source>
         <translation>אין הגדרות זמינות בפלטפורמה זו</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="229"/>
-        <location filename="../screens/SystemsScreen.qml" line="329"/>
+        <location filename="../screens/SystemsScreen.qml" line="236"/>
+        <location filename="../screens/SystemsScreen.qml" line="338"/>
         <source>%1 systems</source>
         <translation>%1 מערכות</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="230"/>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="237"/>
+        <location filename="../screens/SystemsScreen.qml" line="355"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="364"/>
+        <location filename="../screens/SystemsScreen.qml" line="373"/>
         <source>No systems in this category</source>
         <translation>אין מערכות בקטגוריה זו</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="365"/>
+        <location filename="../screens/SystemsScreen.qml" line="374"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>
@@ -1439,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="475"/>
+        <location filename="../components/Tile.qml" line="539"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="156"/>
+        <location filename="../screens/HubScreen.qml" line="154"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="162"/>
+        <location filename="../screens/HubScreen.qml" line="160"/>
         <source>Favorites</source>
         <translation>पसंदीदा</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="167"/>
+        <location filename="../screens/HubScreen.qml" line="165"/>
         <source>Recently Played</source>
         <translation>हाल ही में खेले गए</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="172"/>
+        <location filename="../screens/HubScreen.qml" line="170"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">सेटिंग्स</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="722"/>
+        <location filename="../screens/HubScreen.qml" line="718"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>कोई सिस्टम उपलब्ध नहीं है। सेटिंग्स से मीडिया डेटाबेस अपडेट चलाएँ।</translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>नहीं</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="256"/>
+        <location filename="../components/Modal.qml" line="246"/>
         <source>Cancel</source>
         <translation>रद्द करें</translation>
     </message>
@@ -940,64 +940,64 @@ Euskara - devilschile2</source>
         <translation type="vanished">सामान्य</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147"/>
-        <location filename="../screens/SettingsScreen.qml" line="741"/>
+        <location filename="../screens/SettingsScreen.qml" line="141"/>
+        <location filename="../screens/SettingsScreen.qml" line="734"/>
         <source>Language</source>
         <translation>भाषा</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="768"/>
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="761"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
-        <location filename="../screens/SettingsScreen.qml" line="777"/>
+        <location filename="../screens/SettingsScreen.qml" line="116"/>
+        <location filename="../screens/SettingsScreen.qml" line="770"/>
         <source>Browsing layout</source>
         <translation>ब्राउज़िंग लेआउट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="160"/>
-        <location filename="../screens/SettingsScreen.qml" line="786"/>
+        <location filename="../screens/SettingsScreen.qml" line="154"/>
+        <location filename="../screens/SettingsScreen.qml" line="779"/>
         <source>Button style</source>
         <translation>बटन शैली</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="132"/>
-        <location filename="../screens/SettingsScreen.qml" line="795"/>
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
+        <location filename="../screens/SettingsScreen.qml" line="788"/>
         <source>Screensaver</source>
         <translation>स्क्रीनसेवर</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="95"/>
-        <location filename="../screens/SettingsScreen.qml" line="229"/>
+        <location filename="../screens/SettingsScreen.qml" line="89"/>
+        <location filename="../screens/SettingsScreen.qml" line="223"/>
         <source>Library</source>
         <translation>लाइब्रेरी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="182"/>
+        <location filename="../screens/SettingsScreen.qml" line="176"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="127"/>
-        <location filename="../screens/SettingsScreen.qml" line="804"/>
+        <location filename="../screens/SettingsScreen.qml" line="121"/>
+        <location filename="../screens/SettingsScreen.qml" line="797"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="177"/>
+        <location filename="../screens/SettingsScreen.qml" line="171"/>
         <source>Update media database</source>
         <translation>मीडिया डेटाबेस अपडेट करें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <location filename="../screens/SettingsScreen.qml" line="181"/>
         <source>Scrape metadata</source>
         <translation>मेटाडेटा स्क्रैप करें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="192"/>
+        <location filename="../screens/SettingsScreen.qml" line="186"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1006,407 +1006,407 @@ Euskara - devilschile2</source>
         <translation type="vanished">उन्नत</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="165"/>
+        <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>Mouse support</source>
         <translation>माउस समर्थन</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="204"/>
+        <location filename="../screens/SettingsScreen.qml" line="198"/>
         <source>Debug logging</source>
         <translation>डीबग लॉगिंग</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="209"/>
+        <location filename="../screens/SettingsScreen.qml" line="203"/>
         <source>Upload log file</source>
         <translation>लॉग फ़ाइल अपलोड करें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="199"/>
+        <location filename="../screens/SettingsScreen.qml" line="193"/>
         <source>About / License</source>
         <translation>परिचय / लाइसेंस</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="137"/>
-        <location filename="../screens/SettingsScreen.qml" line="750"/>
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="743"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="142"/>
-        <location filename="../screens/SettingsScreen.qml" line="759"/>
+        <location filename="../screens/SettingsScreen.qml" line="136"/>
+        <location filename="../screens/SettingsScreen.qml" line="752"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152"/>
+        <location filename="../screens/SettingsScreen.qml" line="146"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="170"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
         <source>Reduce motion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="240"/>
         <source>Optimizing</source>
         <translation>अनुकूलित किया जा रहा है</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="248"/>
-        <location filename="../screens/SettingsScreen.qml" line="257"/>
+        <location filename="../screens/SettingsScreen.qml" line="242"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>Paused</source>
         <translation>रोक दिया गया</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="248"/>
-        <location filename="../screens/SettingsScreen.qml" line="257"/>
+        <location filename="../screens/SettingsScreen.qml" line="242"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>In progress</source>
         <translation>प्रगति पर</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="245"/>
         <source>%1 indexed</source>
         <translation>%1 इंडेक्स किए गए</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="260"/>
+        <location filename="../screens/SettingsScreen.qml" line="254"/>
         <source>%1 scraped</source>
         <translation>%1 स्क्रैप किए गए</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="495"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Cancel</source>
         <translation>रद्द करें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="495"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Start</source>
         <translation>शुरू करें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="497"/>
+        <location filename="../screens/SettingsScreen.qml" line="490"/>
         <source>Upload</source>
         <translation>अपलोड</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <location filename="../screens/SettingsScreen.qml" line="491"/>
         <source>Open</source>
         <translation>खोलें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="549"/>
+        <location filename="../screens/SettingsScreen.qml" line="542"/>
         <source>Default</source>
         <translation>डिफ़ॉल्ट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="579"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>English</source>
         <translation>अंग्रेज़ी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="581"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Italian</source>
         <translation>इतालवी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="583"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="585"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="587"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>German</source>
         <translation>जर्मन</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="589"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Greek</source>
         <translation>ग्रीक</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="591"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Japanese</source>
         <translation>जापानी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="593"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Korean</source>
         <translation>कोरियाई</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="595"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Dutch</source>
         <translation>डच</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="597"/>
+        <location filename="../screens/SettingsScreen.qml" line="590"/>
         <source>Romanian</source>
         <translation>रोमानियाई</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="599"/>
+        <location filename="../screens/SettingsScreen.qml" line="592"/>
         <source>Slovak</source>
         <translation>स्लोवाक</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="601"/>
+        <location filename="../screens/SettingsScreen.qml" line="594"/>
         <source>Ukrainian</source>
         <translation>यूक्रेनी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="603"/>
+        <location filename="../screens/SettingsScreen.qml" line="596"/>
         <source>Chinese (Simplified)</source>
         <translation>चीनी (सरलीकृत)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="605"/>
+        <location filename="../screens/SettingsScreen.qml" line="598"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="607"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Hebrew</source>
         <translation>हिब्रू</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Arabic</source>
         <translation>अरबी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="611"/>
+        <location filename="../screens/SettingsScreen.qml" line="604"/>
         <source>Hindi</source>
         <translation>हिंदी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
-        <location filename="../screens/SettingsScreen.qml" line="620"/>
-        <location filename="../screens/SettingsScreen.qml" line="694"/>
+        <location filename="../screens/SettingsScreen.qml" line="605"/>
+        <location filename="../screens/SettingsScreen.qml" line="613"/>
+        <location filename="../screens/SettingsScreen.qml" line="687"/>
         <source>Auto</source>
         <translation>स्वचालित</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="610"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="619"/>
+        <location filename="../screens/SettingsScreen.qml" line="612"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="630"/>
+        <location filename="../screens/SettingsScreen.qml" line="623"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="632"/>
+        <location filename="../screens/SettingsScreen.qml" line="625"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="634"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="628"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="640"/>
+        <location filename="../screens/SettingsScreen.qml" line="633"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="642"/>
+        <location filename="../screens/SettingsScreen.qml" line="635"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="643"/>
+        <location filename="../screens/SettingsScreen.qml" line="636"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="648"/>
+        <location filename="../screens/SettingsScreen.qml" line="641"/>
         <source>Detailed list view</source>
         <translation>विस्तृत सूची दृश्य</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="642"/>
         <source>Grid view</source>
         <translation>ग्रिड दृश्य</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="654"/>
+        <location filename="../screens/SettingsScreen.qml" line="647"/>
         <source>Style B</source>
         <translation>शैली B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="656"/>
+        <location filename="../screens/SettingsScreen.qml" line="649"/>
         <source>Style C</source>
         <translation>शैली C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="658"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
         <source>Style D</source>
         <translation>शैली D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="659"/>
+        <location filename="../screens/SettingsScreen.qml" line="652"/>
         <source>Style A</source>
         <translation>शैली A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="674"/>
+        <location filename="../screens/SettingsScreen.qml" line="667"/>
         <source>Off</source>
         <translation>बंद</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="676"/>
+        <location filename="../screens/SettingsScreen.qml" line="669"/>
         <source>1 second (testing)</source>
         <translation>1 सेकंड (परीक्षण)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="678"/>
+        <location filename="../screens/SettingsScreen.qml" line="671"/>
         <source>1 minute</source>
         <translation>1 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="680"/>
+        <location filename="../screens/SettingsScreen.qml" line="673"/>
         <source>2 minutes</source>
         <translation>2 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="682"/>
+        <location filename="../screens/SettingsScreen.qml" line="675"/>
         <source>5 minutes</source>
         <translation>5 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="684"/>
+        <location filename="../screens/SettingsScreen.qml" line="677"/>
         <source>10 minutes</source>
         <translation>10 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="686"/>
+        <location filename="../screens/SettingsScreen.qml" line="679"/>
         <source>15 minutes</source>
         <translation>15 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="688"/>
+        <location filename="../screens/SettingsScreen.qml" line="681"/>
         <source>30 minutes</source>
         <translation>30 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="682"/>
         <source>%1 seconds</source>
         <translation>%1 सेकंड</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1368"/>
+        <location filename="../screens/SettingsScreen.qml" line="1351"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
-        <location filename="../screens/SettingsScreen.qml" line="732"/>
+        <location filename="../screens/SettingsScreen.qml" line="105"/>
+        <location filename="../screens/SettingsScreen.qml" line="725"/>
         <source>Resolution</source>
         <translation>रिज़ॉल्यूशन</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="225"/>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="219"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="89"/>
-        <location filename="../screens/SettingsScreen.qml" line="227"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="221"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="101"/>
-        <location filename="../screens/SettingsScreen.qml" line="231"/>
+        <location filename="../screens/SettingsScreen.qml" line="95"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="696"/>
+        <location filename="../screens/SettingsScreen.qml" line="689"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="698"/>
+        <location filename="../screens/SettingsScreen.qml" line="691"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="700"/>
+        <location filename="../screens/SettingsScreen.qml" line="693"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="702"/>
+        <location filename="../screens/SettingsScreen.qml" line="695"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="704"/>
+        <location filename="../screens/SettingsScreen.qml" line="697"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="706"/>
+        <location filename="../screens/SettingsScreen.qml" line="699"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="708"/>
+        <location filename="../screens/SettingsScreen.qml" line="701"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="710"/>
+        <location filename="../screens/SettingsScreen.qml" line="703"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="712"/>
+        <location filename="../screens/SettingsScreen.qml" line="705"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="714"/>
+        <location filename="../screens/SettingsScreen.qml" line="707"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="716"/>
+        <location filename="../screens/SettingsScreen.qml" line="709"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="718"/>
+        <location filename="../screens/SettingsScreen.qml" line="711"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="232"/>
+        <location filename="../screens/SettingsScreen.qml" line="226"/>
         <source>Settings</source>
         <translation>सेटिंग्स</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1356"/>
+        <location filename="../screens/SettingsScreen.qml" line="1339"/>
         <source>No settings available on this platform</source>
         <translation>इस प्लेटफ़ॉर्म पर कोई सेटिंग उपलब्ध नहीं है</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="236"/>
-        <location filename="../screens/SystemsScreen.qml" line="338"/>
+        <location filename="../screens/SystemsScreen.qml" line="242"/>
+        <location filename="../screens/SystemsScreen.qml" line="343"/>
         <source>%1 systems</source>
         <translation>%1 सिस्टम</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="237"/>
-        <location filename="../screens/SystemsScreen.qml" line="355"/>
+        <location filename="../screens/SystemsScreen.qml" line="243"/>
+        <location filename="../screens/SystemsScreen.qml" line="360"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="373"/>
+        <location filename="../screens/SystemsScreen.qml" line="378"/>
         <source>No systems in this category</source>
         <translation>इस श्रेणी में कोई सिस्टम नहीं है</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="374"/>
+        <location filename="../screens/SystemsScreen.qml" line="379"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>
@@ -1439,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="539"/>
+        <location filename="../components/Tile.qml" line="501"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -97,100 +97,100 @@ Euskara - devilschile2</source>
         <translation type="unfinished">लोड हो रहा है…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="196"/>
+        <location filename="../components/BrowseDetailPane.qml" line="167"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="196"/>
+        <location filename="../components/BrowseDetailPane.qml" line="167"/>
         <source>Yr</source>
         <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="198"/>
+        <location filename="../components/BrowseDetailPane.qml" line="169"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="198"/>
+        <location filename="../components/BrowseDetailPane.qml" line="169"/>
         <source>Gen</source>
         <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="200"/>
+        <location filename="../components/BrowseDetailPane.qml" line="171"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="200"/>
+        <location filename="../components/BrowseDetailPane.qml" line="171"/>
         <source>Plyr</source>
         <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="202"/>
+        <location filename="../components/BrowseDetailPane.qml" line="173"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="202"/>
+        <location filename="../components/BrowseDetailPane.qml" line="173"/>
         <source>Dev</source>
         <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="204"/>
+        <location filename="../components/BrowseDetailPane.qml" line="175"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="204"/>
+        <location filename="../components/BrowseDetailPane.qml" line="175"/>
         <source>Pub</source>
         <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="206"/>
+        <location filename="../components/BrowseDetailPane.qml" line="177"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="206"/>
+        <location filename="../components/BrowseDetailPane.qml" line="177"/>
         <source>Rtg</source>
         <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="208"/>
+        <location filename="../components/BrowseDetailPane.qml" line="179"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="208"/>
+        <location filename="../components/BrowseDetailPane.qml" line="179"/>
         <source>Cat</source>
         <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="210"/>
+        <location filename="../components/BrowseDetailPane.qml" line="181"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="210"/>
+        <location filename="../components/BrowseDetailPane.qml" line="181"/>
         <source>Date</source>
         <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="212"/>
+        <location filename="../components/BrowseDetailPane.qml" line="183"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="212"/>
+        <location filename="../components/BrowseDetailPane.qml" line="183"/>
         <source>Mfr</source>
         <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
@@ -425,8 +425,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="127"/>
-        <location filename="../screens/GamesScreen.qml" line="162"/>
+        <location filename="../screens/GamesScreen.qml" line="128"/>
+        <location filename="../screens/GamesScreen.qml" line="163"/>
         <source>%1 files</source>
         <translation>%1 फ़ाइलें</translation>
     </message>
@@ -436,8 +436,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="136"/>
-        <location filename="../screens/GamesScreen.qml" line="163"/>
+        <location filename="../screens/GamesScreen.qml" line="137"/>
+        <location filename="../screens/GamesScreen.qml" line="164"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -452,7 +452,7 @@ Euskara - devilschile2</source>
         <translation>गेम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="132"/>
+        <location filename="../screens/GamesScreen.qml" line="133"/>
         <source>Loading more…</source>
         <translation>और लोड हो रहा है…</translation>
     </message>
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="149"/>
+        <location filename="../screens/HubScreen.qml" line="156"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="155"/>
+        <location filename="../screens/HubScreen.qml" line="162"/>
         <source>Favorites</source>
         <translation>पसंदीदा</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="160"/>
+        <location filename="../screens/HubScreen.qml" line="167"/>
         <source>Recently Played</source>
         <translation>हाल ही में खेले गए</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="165"/>
+        <location filename="../screens/HubScreen.qml" line="172"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">सेटिंग्स</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="701"/>
+        <location filename="../screens/HubScreen.qml" line="722"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>कोई सिस्टम उपलब्ध नहीं है। सेटिंग्स से मीडिया डेटाबेस अपडेट चलाएँ।</translation>
     </message>
@@ -553,138 +553,138 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1367"/>
+        <location filename="../app/Main.qml" line="1381"/>
         <source>Launch core</source>
         <translation>कोर चलाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1373"/>
-        <location filename="../app/Main.qml" line="1612"/>
+        <location filename="../app/Main.qml" line="1387"/>
+        <location filename="../app/Main.qml" line="1626"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1380"/>
-        <location filename="../app/Main.qml" line="1403"/>
+        <location filename="../app/Main.qml" line="1394"/>
+        <location filename="../app/Main.qml" line="1417"/>
         <source>Update media database</source>
         <translation type="unfinished">मीडिया डेटाबेस अपडेट करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1383"/>
-        <location filename="../app/Main.qml" line="1406"/>
+        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1420"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">मेटाडेटा स्क्रैप करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1388"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1411"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1388"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1411"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1415"/>
-        <location filename="../app/Main.qml" line="1450"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1464"/>
         <source>Launch game</source>
         <translation>गेम चलाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1445"/>
         <source>Remove from favorites</source>
         <translation>पसंदीदा से हटाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1445"/>
         <source>Add to favorites</source>
         <translation>पसंदीदा में जोड़ें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1436"/>
+        <location filename="../app/Main.qml" line="1450"/>
         <source>Write to NFC token</source>
         <translation>NFC टोकन पर लिखें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1440"/>
+        <location filename="../app/Main.qml" line="1454"/>
         <source>QR code</source>
         <translation>QR कोड</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1608"/>
+        <location filename="../app/Main.qml" line="1622"/>
         <source>Default</source>
         <translation type="unfinished">डिफ़ॉल्ट</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1608"/>
+        <location filename="../app/Main.qml" line="1622"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1932"/>
+        <location filename="../app/Main.qml" line="1946"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1936"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1950"/>
+        <location filename="../app/Main.qml" line="1964"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1954"/>
+        <location filename="../app/Main.qml" line="1968"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1958"/>
+        <location filename="../app/Main.qml" line="1972"/>
         <source>Retry</source>
         <translation type="unfinished">फिर से प्रयास करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1962"/>
+        <location filename="../app/Main.qml" line="1976"/>
         <source>Cancel</source>
         <translation type="unfinished">रद्द करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2624"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2612"/>
+        <location filename="../app/Main.qml" line="2626"/>
         <source>Loading games…</source>
         <translation>गेम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2628"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2616"/>
+        <location filename="../app/Main.qml" line="2630"/>
         <source>Loading favorites…</source>
         <translation>पसंदीदा लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2618"/>
+        <location filename="../app/Main.qml" line="2632"/>
         <source>Loading recently played…</source>
         <translation>हाल ही में खेले गए लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2620"/>
+        <location filename="../app/Main.qml" line="2634"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2622"/>
+        <location filename="../app/Main.qml" line="2636"/>
         <source>Loading…</source>
         <translation>लोड हो रहा है…</translation>
     </message>
@@ -864,12 +864,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">लोड हो रहा है…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="395"/>
+        <location filename="../screens/MediaListScreen.qml" line="436"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 प्रविष्टियाँ</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="396"/>
+        <location filename="../screens/MediaListScreen.qml" line="437"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>नहीं</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="246"/>
+        <location filename="../components/Modal.qml" line="256"/>
         <source>Cancel</source>
         <translation>रद्द करें</translation>
     </message>
@@ -1312,7 +1312,7 @@ Euskara - devilschile2</source>
         <translation>%1 सेकंड</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1358"/>
+        <location filename="../screens/SettingsScreen.qml" line="1368"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1406,7 +1406,7 @@ Euskara - devilschile2</source>
         <translation>सेटिंग्स</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1346"/>
+        <location filename="../screens/SettingsScreen.qml" line="1356"/>
         <source>No settings available on this platform</source>
         <translation>इस प्लेटफ़ॉर्म पर कोई सेटिंग उपलब्ध नहीं है</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="229"/>
-        <location filename="../screens/SystemsScreen.qml" line="329"/>
+        <location filename="../screens/SystemsScreen.qml" line="236"/>
+        <location filename="../screens/SystemsScreen.qml" line="338"/>
         <source>%1 systems</source>
         <translation>%1 सिस्टम</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="230"/>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="237"/>
+        <location filename="../screens/SystemsScreen.qml" line="355"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="364"/>
+        <location filename="../screens/SystemsScreen.qml" line="373"/>
         <source>No systems in this category</source>
         <translation>इस श्रेणी में कोई सिस्टम नहीं है</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="365"/>
+        <location filename="../screens/SystemsScreen.qml" line="374"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>
@@ -1439,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="475"/>
+        <location filename="../components/Tile.qml" line="539"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -425,34 +425,34 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="116"/>
-        <location filename="../screens/GamesScreen.qml" line="151"/>
+        <location filename="../screens/GamesScreen.qml" line="127"/>
+        <location filename="../screens/GamesScreen.qml" line="162"/>
         <source>%1 files</source>
         <translation>%1 फ़ाइलें</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="53"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="125"/>
-        <location filename="../screens/GamesScreen.qml" line="152"/>
+        <location filename="../screens/GamesScreen.qml" line="136"/>
+        <location filename="../screens/GamesScreen.qml" line="163"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="47"/>
+        <location filename="../screens/GamesScreen.qml" line="48"/>
         <source>No games in this system</source>
         <translation>इस सिस्टम में कोई गेम नहीं है</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="48"/>
+        <location filename="../screens/GamesScreen.qml" line="49"/>
         <source>Loading games…</source>
         <translation>गेम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="121"/>
+        <location filename="../screens/GamesScreen.qml" line="132"/>
         <source>Loading more…</source>
         <translation>और लोड हो रहा है…</translation>
     </message>
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="139"/>
+        <location filename="../screens/HubScreen.qml" line="149"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="145"/>
+        <location filename="../screens/HubScreen.qml" line="155"/>
         <source>Favorites</source>
         <translation>पसंदीदा</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="150"/>
+        <location filename="../screens/HubScreen.qml" line="160"/>
         <source>Recently Played</source>
         <translation>हाल ही में खेले गए</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="155"/>
+        <location filename="../screens/HubScreen.qml" line="165"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">सेटिंग्स</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="669"/>
+        <location filename="../screens/HubScreen.qml" line="701"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>कोई सिस्टम उपलब्ध नहीं है। सेटिंग्स से मीडिया डेटाबेस अपडेट चलाएँ।</translation>
     </message>
@@ -553,138 +553,138 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1361"/>
+        <location filename="../app/Main.qml" line="1367"/>
         <source>Launch core</source>
         <translation>कोर चलाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1367"/>
-        <location filename="../app/Main.qml" line="1606"/>
+        <location filename="../app/Main.qml" line="1373"/>
+        <location filename="../app/Main.qml" line="1612"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1374"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1380"/>
+        <location filename="../app/Main.qml" line="1403"/>
         <source>Update media database</source>
         <translation type="unfinished">मीडिया डेटाबेस अपडेट करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1377"/>
-        <location filename="../app/Main.qml" line="1400"/>
+        <location filename="../app/Main.qml" line="1383"/>
+        <location filename="../app/Main.qml" line="1406"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">मेटाडेटा स्क्रैप करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1382"/>
-        <location filename="../app/Main.qml" line="1391"/>
+        <location filename="../app/Main.qml" line="1388"/>
+        <location filename="../app/Main.qml" line="1397"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1382"/>
-        <location filename="../app/Main.qml" line="1391"/>
+        <location filename="../app/Main.qml" line="1388"/>
+        <location filename="../app/Main.qml" line="1397"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1409"/>
-        <location filename="../app/Main.qml" line="1444"/>
+        <location filename="../app/Main.qml" line="1415"/>
+        <location filename="../app/Main.qml" line="1450"/>
         <source>Launch game</source>
         <translation>गेम चलाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1425"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Remove from favorites</source>
         <translation>पसंदीदा से हटाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1425"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Add to favorites</source>
         <translation>पसंदीदा में जोड़ें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1430"/>
+        <location filename="../app/Main.qml" line="1436"/>
         <source>Write to NFC token</source>
         <translation>NFC टोकन पर लिखें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1434"/>
+        <location filename="../app/Main.qml" line="1440"/>
         <source>QR code</source>
         <translation>QR कोड</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1602"/>
+        <location filename="../app/Main.qml" line="1608"/>
         <source>Default</source>
         <translation type="unfinished">डिफ़ॉल्ट</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1602"/>
+        <location filename="../app/Main.qml" line="1608"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1926"/>
+        <location filename="../app/Main.qml" line="1932"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1930"/>
+        <location filename="../app/Main.qml" line="1936"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1944"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1948"/>
+        <location filename="../app/Main.qml" line="1954"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1952"/>
+        <location filename="../app/Main.qml" line="1958"/>
         <source>Retry</source>
         <translation type="unfinished">फिर से प्रयास करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1956"/>
+        <location filename="../app/Main.qml" line="1962"/>
         <source>Cancel</source>
         <translation type="unfinished">रद्द करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2604"/>
+        <location filename="../app/Main.qml" line="2610"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2606"/>
+        <location filename="../app/Main.qml" line="2612"/>
         <source>Loading games…</source>
         <translation>गेम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2608"/>
+        <location filename="../app/Main.qml" line="2614"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2616"/>
         <source>Loading favorites…</source>
         <translation>पसंदीदा लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2612"/>
+        <location filename="../app/Main.qml" line="2618"/>
         <source>Loading recently played…</source>
         <translation>हाल ही में खेले गए लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2620"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2616"/>
+        <location filename="../app/Main.qml" line="2622"/>
         <source>Loading…</source>
         <translation>लोड हो रहा है…</translation>
     </message>
@@ -692,12 +692,12 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="683"/>
+        <location filename="../app/MainLayout.qml" line="685"/>
         <source>Writing failed</source>
         <translation>लिखना विफल हुआ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="683"/>
+        <location filename="../app/MainLayout.qml" line="685"/>
         <source>Put a writable card near the reader</source>
         <translation>रीडर के पास लिखने योग्य कार्ड रखें</translation>
     </message>
@@ -717,141 +717,141 @@ Euskara - devilschile2</source>
         <translation type="unfinished">हाल ही में खेले गए</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="699"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="700"/>
+        <location filename="../app/MainLayout.qml" line="702"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="810"/>
+        <location filename="../app/MainLayout.qml" line="812"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="811"/>
+        <location filename="../app/MainLayout.qml" line="813"/>
         <source>Are you sure you want to exit?</source>
         <translation>क्या आप वाकई बाहर निकलना चाहते हैं?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="890"/>
-        <location filename="../app/MainLayout.qml" line="964"/>
-        <location filename="../app/MainLayout.qml" line="1010"/>
-        <location filename="../app/MainLayout.qml" line="1047"/>
-        <location filename="../app/MainLayout.qml" line="1097"/>
-        <location filename="../app/MainLayout.qml" line="1146"/>
-        <location filename="../app/MainLayout.qml" line="1165"/>
-        <location filename="../app/MainLayout.qml" line="1232"/>
+        <location filename="../app/MainLayout.qml" line="892"/>
+        <location filename="../app/MainLayout.qml" line="966"/>
+        <location filename="../app/MainLayout.qml" line="1012"/>
+        <location filename="../app/MainLayout.qml" line="1049"/>
+        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1148"/>
+        <location filename="../app/MainLayout.qml" line="1167"/>
+        <location filename="../app/MainLayout.qml" line="1234"/>
         <source>Move</source>
         <translation>स्थानांतरित करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="894"/>
-        <location filename="../app/MainLayout.qml" line="968"/>
+        <location filename="../app/MainLayout.qml" line="896"/>
+        <location filename="../app/MainLayout.qml" line="970"/>
         <source>Select</source>
         <translation>चुनें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="902"/>
-        <location filename="../app/MainLayout.qml" line="916"/>
-        <location filename="../app/MainLayout.qml" line="931"/>
-        <location filename="../app/MainLayout.qml" line="942"/>
+        <location filename="../app/MainLayout.qml" line="900"/>
+        <location filename="../app/MainLayout.qml" line="904"/>
+        <location filename="../app/MainLayout.qml" line="918"/>
+        <location filename="../app/MainLayout.qml" line="933"/>
+        <location filename="../app/MainLayout.qml" line="944"/>
         <source>Close</source>
         <translation>बंद करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="909"/>
-        <location filename="../app/MainLayout.qml" line="949"/>
-        <location filename="../app/MainLayout.qml" line="972"/>
-        <location filename="../app/MainLayout.qml" line="983"/>
+        <location filename="../app/MainLayout.qml" line="911"/>
+        <location filename="../app/MainLayout.qml" line="951"/>
+        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="985"/>
         <source>Cancel</source>
         <translation>रद्द करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="927"/>
+        <location filename="../app/MainLayout.qml" line="929"/>
         <source>Done</source>
         <translation>पूरा</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1070"/>
-        <location filename="../app/MainLayout.qml" line="1123"/>
-        <location filename="../app/MainLayout.qml" line="1258"/>
+        <location filename="../app/MainLayout.qml" line="940"/>
+        <location filename="../app/MainLayout.qml" line="1072"/>
+        <location filename="../app/MainLayout.qml" line="1125"/>
+        <location filename="../app/MainLayout.qml" line="1260"/>
         <source>Retry</source>
         <translation>फिर से प्रयास करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="957"/>
+        <location filename="../app/MainLayout.qml" line="959"/>
         <source>I understand</source>
         <translation>मैं समझ गया</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="991"/>
+        <location filename="../app/MainLayout.qml" line="993"/>
         <source>Start</source>
         <translation>शुरू करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1014"/>
-        <location filename="../app/MainLayout.qml" line="1057"/>
-        <location filename="../app/MainLayout.qml" line="1107"/>
-        <location filename="../app/MainLayout.qml" line="1151"/>
-        <location filename="../app/MainLayout.qml" line="1242"/>
+        <location filename="../app/MainLayout.qml" line="1016"/>
+        <location filename="../app/MainLayout.qml" line="1059"/>
+        <location filename="../app/MainLayout.qml" line="1109"/>
+        <location filename="../app/MainLayout.qml" line="1153"/>
+        <location filename="../app/MainLayout.qml" line="1244"/>
         <source>Open</source>
         <translation>खोलें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1024"/>
+        <location filename="../app/MainLayout.qml" line="1026"/>
         <source>Quit</source>
         <translation>बंद करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1033"/>
-        <location filename="../app/MainLayout.qml" line="1063"/>
-        <location filename="../app/MainLayout.qml" line="1074"/>
-        <location filename="../app/MainLayout.qml" line="1089"/>
-        <location filename="../app/MainLayout.qml" line="1116"/>
-        <location filename="../app/MainLayout.qml" line="1127"/>
-        <location filename="../app/MainLayout.qml" line="1139"/>
-        <location filename="../app/MainLayout.qml" line="1155"/>
-        <location filename="../app/MainLayout.qml" line="1189"/>
-        <location filename="../app/MainLayout.qml" line="1207"/>
-        <location filename="../app/MainLayout.qml" line="1216"/>
-        <location filename="../app/MainLayout.qml" line="1251"/>
-        <location filename="../app/MainLayout.qml" line="1262"/>
+        <location filename="../app/MainLayout.qml" line="1035"/>
+        <location filename="../app/MainLayout.qml" line="1065"/>
+        <location filename="../app/MainLayout.qml" line="1076"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
+        <location filename="../app/MainLayout.qml" line="1118"/>
+        <location filename="../app/MainLayout.qml" line="1129"/>
+        <location filename="../app/MainLayout.qml" line="1141"/>
+        <location filename="../app/MainLayout.qml" line="1157"/>
+        <location filename="../app/MainLayout.qml" line="1191"/>
+        <location filename="../app/MainLayout.qml" line="1209"/>
+        <location filename="../app/MainLayout.qml" line="1218"/>
+        <location filename="../app/MainLayout.qml" line="1253"/>
+        <location filename="../app/MainLayout.qml" line="1264"/>
         <source>Back</source>
         <translation>वापस</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1053"/>
-        <location filename="../app/MainLayout.qml" line="1103"/>
-        <location filename="../app/MainLayout.qml" line="1238"/>
+        <location filename="../app/MainLayout.qml" line="1055"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
+        <location filename="../app/MainLayout.qml" line="1240"/>
         <source>Page</source>
         <translation>पृष्ठ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1060"/>
-        <location filename="../app/MainLayout.qml" line="1112"/>
-        <location filename="../app/MainLayout.qml" line="1247"/>
+        <location filename="../app/MainLayout.qml" line="1022"/>
+        <location filename="../app/MainLayout.qml" line="1062"/>
+        <location filename="../app/MainLayout.qml" line="1114"/>
+        <location filename="../app/MainLayout.qml" line="1249"/>
         <source>Options</source>
         <translation>विकल्प</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1174"/>
+        <location filename="../app/MainLayout.qml" line="1176"/>
         <source>Change</source>
         <translation>बदलें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1180"/>
+        <location filename="../app/MainLayout.qml" line="1182"/>
         <source>Toggle</source>
         <translation>टॉगल</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1203"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Scroll</source>
         <translation>स्क्रॉल</translation>
     </message>
@@ -864,12 +864,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">लोड हो रहा है…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="365"/>
+        <location filename="../screens/MediaListScreen.qml" line="395"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 प्रविष्टियाँ</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="366"/>
+        <location filename="../screens/MediaListScreen.qml" line="396"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>नहीं</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="198"/>
+        <location filename="../components/Modal.qml" line="246"/>
         <source>Cancel</source>
         <translation>रद्द करें</translation>
     </message>
@@ -940,64 +940,64 @@ Euskara - devilschile2</source>
         <translation type="vanished">सामान्य</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="132"/>
-        <location filename="../screens/SettingsScreen.qml" line="718"/>
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
+        <location filename="../screens/SettingsScreen.qml" line="741"/>
         <source>Language</source>
         <translation>भाषा</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="745"/>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="768"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="754"/>
+        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <location filename="../screens/SettingsScreen.qml" line="777"/>
         <source>Browsing layout</source>
         <translation>ब्राउज़िंग लेआउट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="145"/>
-        <location filename="../screens/SettingsScreen.qml" line="763"/>
+        <location filename="../screens/SettingsScreen.qml" line="160"/>
+        <location filename="../screens/SettingsScreen.qml" line="786"/>
         <source>Button style</source>
         <translation>बटन शैली</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="772"/>
+        <location filename="../screens/SettingsScreen.qml" line="132"/>
+        <location filename="../screens/SettingsScreen.qml" line="795"/>
         <source>Screensaver</source>
         <translation>स्क्रीनसेवर</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="80"/>
-        <location filename="../screens/SettingsScreen.qml" line="209"/>
+        <location filename="../screens/SettingsScreen.qml" line="95"/>
+        <location filename="../screens/SettingsScreen.qml" line="229"/>
         <source>Library</source>
         <translation>लाइब्रेरी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="162"/>
+        <location filename="../screens/SettingsScreen.qml" line="182"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="112"/>
-        <location filename="../screens/SettingsScreen.qml" line="781"/>
+        <location filename="../screens/SettingsScreen.qml" line="127"/>
+        <location filename="../screens/SettingsScreen.qml" line="804"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="157"/>
+        <location filename="../screens/SettingsScreen.qml" line="177"/>
         <source>Update media database</source>
         <translation>मीडिया डेटाबेस अपडेट करें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="167"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
         <source>Scrape metadata</source>
         <translation>मेटाडेटा स्क्रैप करें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="172"/>
+        <location filename="../screens/SettingsScreen.qml" line="192"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1006,402 +1006,407 @@ Euskara - devilschile2</source>
         <translation type="vanished">उन्नत</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="150"/>
+        <location filename="../screens/SettingsScreen.qml" line="165"/>
         <source>Mouse support</source>
         <translation>माउस समर्थन</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="184"/>
+        <location filename="../screens/SettingsScreen.qml" line="204"/>
         <source>Debug logging</source>
         <translation>डीबग लॉगिंग</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="189"/>
+        <location filename="../screens/SettingsScreen.qml" line="209"/>
         <source>Upload log file</source>
         <translation>लॉग फ़ाइल अपलोड करें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="179"/>
+        <location filename="../screens/SettingsScreen.qml" line="199"/>
         <source>About / License</source>
         <translation>परिचय / लाइसेंस</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
-        <location filename="../screens/SettingsScreen.qml" line="727"/>
+        <location filename="../screens/SettingsScreen.qml" line="137"/>
+        <location filename="../screens/SettingsScreen.qml" line="750"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="127"/>
-        <location filename="../screens/SettingsScreen.qml" line="736"/>
+        <location filename="../screens/SettingsScreen.qml" line="142"/>
+        <location filename="../screens/SettingsScreen.qml" line="759"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="137"/>
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="226"/>
+        <location filename="../screens/SettingsScreen.qml" line="170"/>
+        <source>Reduce motion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
         <source>Optimizing</source>
         <translation>अनुकूलित किया जा रहा है</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="228"/>
-        <location filename="../screens/SettingsScreen.qml" line="237"/>
+        <location filename="../screens/SettingsScreen.qml" line="248"/>
+        <location filename="../screens/SettingsScreen.qml" line="257"/>
         <source>Paused</source>
         <translation>रोक दिया गया</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="228"/>
-        <location filename="../screens/SettingsScreen.qml" line="237"/>
+        <location filename="../screens/SettingsScreen.qml" line="248"/>
+        <location filename="../screens/SettingsScreen.qml" line="257"/>
         <source>In progress</source>
         <translation>प्रगति पर</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="231"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>%1 indexed</source>
         <translation>%1 इंडेक्स किए गए</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="240"/>
+        <location filename="../screens/SettingsScreen.qml" line="260"/>
         <source>%1 scraped</source>
         <translation>%1 स्क्रैप किए गए</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="472"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Cancel</source>
         <translation>रद्द करें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="472"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Start</source>
         <translation>शुरू करें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="474"/>
+        <location filename="../screens/SettingsScreen.qml" line="497"/>
         <source>Upload</source>
         <translation>अपलोड</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Open</source>
         <translation>खोलें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="526"/>
+        <location filename="../screens/SettingsScreen.qml" line="549"/>
         <source>Default</source>
         <translation>डिफ़ॉल्ट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="556"/>
+        <location filename="../screens/SettingsScreen.qml" line="579"/>
         <source>English</source>
         <translation>अंग्रेज़ी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="558"/>
+        <location filename="../screens/SettingsScreen.qml" line="581"/>
         <source>Italian</source>
         <translation>इतालवी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="560"/>
+        <location filename="../screens/SettingsScreen.qml" line="583"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="562"/>
+        <location filename="../screens/SettingsScreen.qml" line="585"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="564"/>
+        <location filename="../screens/SettingsScreen.qml" line="587"/>
         <source>German</source>
         <translation>जर्मन</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="566"/>
+        <location filename="../screens/SettingsScreen.qml" line="589"/>
         <source>Greek</source>
         <translation>ग्रीक</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="568"/>
+        <location filename="../screens/SettingsScreen.qml" line="591"/>
         <source>Japanese</source>
         <translation>जापानी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="570"/>
+        <location filename="../screens/SettingsScreen.qml" line="593"/>
         <source>Korean</source>
         <translation>कोरियाई</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="595"/>
         <source>Dutch</source>
         <translation>डच</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="597"/>
         <source>Romanian</source>
         <translation>रोमानियाई</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="599"/>
         <source>Slovak</source>
         <translation>स्लोवाक</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="601"/>
         <source>Ukrainian</source>
         <translation>यूक्रेनी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="603"/>
         <source>Chinese (Simplified)</source>
         <translation>चीनी (सरलीकृत)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="605"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="607"/>
         <source>Hebrew</source>
         <translation>हिब्रू</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
         <source>Arabic</source>
         <translation>अरबी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="588"/>
+        <location filename="../screens/SettingsScreen.qml" line="611"/>
         <source>Hindi</source>
         <translation>हिंदी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="589"/>
-        <location filename="../screens/SettingsScreen.qml" line="597"/>
-        <location filename="../screens/SettingsScreen.qml" line="671"/>
+        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="620"/>
+        <location filename="../screens/SettingsScreen.qml" line="694"/>
         <source>Auto</source>
         <translation>स्वचालित</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="594"/>
+        <location filename="../screens/SettingsScreen.qml" line="617"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="596"/>
+        <location filename="../screens/SettingsScreen.qml" line="619"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="607"/>
+        <location filename="../screens/SettingsScreen.qml" line="630"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="632"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="611"/>
+        <location filename="../screens/SettingsScreen.qml" line="634"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="635"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="640"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="619"/>
+        <location filename="../screens/SettingsScreen.qml" line="642"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="620"/>
+        <location filename="../screens/SettingsScreen.qml" line="643"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="625"/>
+        <location filename="../screens/SettingsScreen.qml" line="648"/>
         <source>Detailed list view</source>
         <translation>विस्तृत सूची दृश्य</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="626"/>
+        <location filename="../screens/SettingsScreen.qml" line="649"/>
         <source>Grid view</source>
         <translation>ग्रिड दृश्य</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="631"/>
+        <location filename="../screens/SettingsScreen.qml" line="654"/>
         <source>Style B</source>
         <translation>शैली B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="633"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Style C</source>
         <translation>शैली C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="658"/>
         <source>Style D</source>
         <translation>शैली D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="659"/>
         <source>Style A</source>
         <translation>शैली A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="674"/>
         <source>Off</source>
         <translation>बंद</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="653"/>
+        <location filename="../screens/SettingsScreen.qml" line="676"/>
         <source>1 second (testing)</source>
         <translation>1 सेकंड (परीक्षण)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="655"/>
+        <location filename="../screens/SettingsScreen.qml" line="678"/>
         <source>1 minute</source>
         <translation>1 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="657"/>
+        <location filename="../screens/SettingsScreen.qml" line="680"/>
         <source>2 minutes</source>
         <translation>2 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="659"/>
+        <location filename="../screens/SettingsScreen.qml" line="682"/>
         <source>5 minutes</source>
         <translation>5 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="661"/>
+        <location filename="../screens/SettingsScreen.qml" line="684"/>
         <source>10 minutes</source>
         <translation>10 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="663"/>
+        <location filename="../screens/SettingsScreen.qml" line="686"/>
         <source>15 minutes</source>
         <translation>15 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="665"/>
+        <location filename="../screens/SettingsScreen.qml" line="688"/>
         <source>30 minutes</source>
         <translation>30 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="666"/>
+        <location filename="../screens/SettingsScreen.qml" line="689"/>
         <source>%1 seconds</source>
         <translation>%1 सेकंड</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1292"/>
+        <location filename="../screens/SettingsScreen.qml" line="1358"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="96"/>
-        <location filename="../screens/SettingsScreen.qml" line="709"/>
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="732"/>
         <source>Resolution</source>
         <translation>रिज़ॉल्यूशन</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="68"/>
-        <location filename="../screens/SettingsScreen.qml" line="205"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="74"/>
-        <location filename="../screens/SettingsScreen.qml" line="207"/>
+        <location filename="../screens/SettingsScreen.qml" line="89"/>
+        <location filename="../screens/SettingsScreen.qml" line="227"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="86"/>
-        <location filename="../screens/SettingsScreen.qml" line="211"/>
+        <location filename="../screens/SettingsScreen.qml" line="101"/>
+        <location filename="../screens/SettingsScreen.qml" line="231"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="673"/>
+        <location filename="../screens/SettingsScreen.qml" line="696"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="675"/>
+        <location filename="../screens/SettingsScreen.qml" line="698"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="677"/>
+        <location filename="../screens/SettingsScreen.qml" line="700"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="679"/>
+        <location filename="../screens/SettingsScreen.qml" line="702"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="681"/>
+        <location filename="../screens/SettingsScreen.qml" line="704"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="683"/>
+        <location filename="../screens/SettingsScreen.qml" line="706"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="685"/>
+        <location filename="../screens/SettingsScreen.qml" line="708"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="687"/>
+        <location filename="../screens/SettingsScreen.qml" line="710"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="712"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="691"/>
+        <location filename="../screens/SettingsScreen.qml" line="714"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="693"/>
+        <location filename="../screens/SettingsScreen.qml" line="716"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="695"/>
+        <location filename="../screens/SettingsScreen.qml" line="718"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="212"/>
+        <location filename="../screens/SettingsScreen.qml" line="232"/>
         <source>Settings</source>
         <translation>सेटिंग्स</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1280"/>
+        <location filename="../screens/SettingsScreen.qml" line="1346"/>
         <source>No settings available on this platform</source>
         <translation>इस प्लेटफ़ॉर्म पर कोई सेटिंग उपलब्ध नहीं है</translation>
     </message>
@@ -1409,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="206"/>
-        <location filename="../screens/SystemsScreen.qml" line="304"/>
+        <location filename="../screens/SystemsScreen.qml" line="229"/>
+        <location filename="../screens/SystemsScreen.qml" line="329"/>
         <source>%1 systems</source>
         <translation>%1 सिस्टम</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="207"/>
-        <location filename="../screens/SystemsScreen.qml" line="321"/>
+        <location filename="../screens/SystemsScreen.qml" line="230"/>
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="339"/>
+        <location filename="../screens/SystemsScreen.qml" line="364"/>
         <source>No systems in this category</source>
         <translation>इस श्रेणी में कोई सिस्टम नहीं है</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="340"/>
+        <location filename="../screens/SystemsScreen.qml" line="365"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>
@@ -1434,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="364"/>
+        <location filename="../components/Tile.qml" line="475"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -425,8 +425,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="128"/>
-        <location filename="../screens/GamesScreen.qml" line="163"/>
+        <location filename="../screens/GamesScreen.qml" line="131"/>
+        <location filename="../screens/GamesScreen.qml" line="166"/>
         <source>%1 files</source>
         <translation>%1 फ़ाइलें</translation>
     </message>
@@ -436,8 +436,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="137"/>
-        <location filename="../screens/GamesScreen.qml" line="164"/>
+        <location filename="../screens/GamesScreen.qml" line="140"/>
+        <location filename="../screens/GamesScreen.qml" line="167"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -452,7 +452,7 @@ Euskara - devilschile2</source>
         <translation>गेम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="133"/>
+        <location filename="../screens/GamesScreen.qml" line="136"/>
         <source>Loading more…</source>
         <translation>और लोड हो रहा है…</translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>नहीं</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="246"/>
+        <location filename="../components/Modal.qml" line="250"/>
         <source>Cancel</source>
         <translation>रद्द करें</translation>
     </message>
@@ -940,64 +940,64 @@ Euskara - devilschile2</source>
         <translation type="vanished">सामान्य</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="141"/>
-        <location filename="../screens/SettingsScreen.qml" line="734"/>
+        <location filename="../screens/SettingsScreen.qml" line="145"/>
+        <location filename="../screens/SettingsScreen.qml" line="738"/>
         <source>Language</source>
         <translation>भाषा</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
-        <location filename="../screens/SettingsScreen.qml" line="761"/>
+        <location filename="../screens/SettingsScreen.qml" line="115"/>
+        <location filename="../screens/SettingsScreen.qml" line="765"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116"/>
-        <location filename="../screens/SettingsScreen.qml" line="770"/>
+        <location filename="../screens/SettingsScreen.qml" line="120"/>
+        <location filename="../screens/SettingsScreen.qml" line="774"/>
         <source>Browsing layout</source>
         <translation>ब्राउज़िंग लेआउट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="154"/>
-        <location filename="../screens/SettingsScreen.qml" line="779"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="783"/>
         <source>Button style</source>
         <translation>बटन शैली</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
-        <location filename="../screens/SettingsScreen.qml" line="788"/>
+        <location filename="../screens/SettingsScreen.qml" line="130"/>
+        <location filename="../screens/SettingsScreen.qml" line="792"/>
         <source>Screensaver</source>
         <translation>स्क्रीनसेवर</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="89"/>
-        <location filename="../screens/SettingsScreen.qml" line="223"/>
+        <location filename="../screens/SettingsScreen.qml" line="93"/>
+        <location filename="../screens/SettingsScreen.qml" line="227"/>
         <source>Library</source>
         <translation>लाइब्रेरी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="176"/>
+        <location filename="../screens/SettingsScreen.qml" line="180"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121"/>
-        <location filename="../screens/SettingsScreen.qml" line="797"/>
+        <location filename="../screens/SettingsScreen.qml" line="125"/>
+        <location filename="../screens/SettingsScreen.qml" line="801"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="171"/>
+        <location filename="../screens/SettingsScreen.qml" line="175"/>
         <source>Update media database</source>
         <translation>मीडिया डेटाबेस अपडेट करें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="181"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
         <source>Scrape metadata</source>
         <translation>मेटाडेटा स्क्रैप करें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="186"/>
+        <location filename="../screens/SettingsScreen.qml" line="190"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1006,407 +1006,407 @@ Euskara - devilschile2</source>
         <translation type="vanished">उन्नत</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="159"/>
+        <location filename="../screens/SettingsScreen.qml" line="163"/>
         <source>Mouse support</source>
         <translation>माउस समर्थन</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="198"/>
+        <location filename="../screens/SettingsScreen.qml" line="202"/>
         <source>Debug logging</source>
         <translation>डीबग लॉगिंग</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="203"/>
+        <location filename="../screens/SettingsScreen.qml" line="207"/>
         <source>Upload log file</source>
         <translation>लॉग फ़ाइल अपलोड करें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="193"/>
+        <location filename="../screens/SettingsScreen.qml" line="197"/>
         <source>About / License</source>
         <translation>परिचय / लाइसेंस</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
-        <location filename="../screens/SettingsScreen.qml" line="743"/>
+        <location filename="../screens/SettingsScreen.qml" line="135"/>
+        <location filename="../screens/SettingsScreen.qml" line="747"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="136"/>
-        <location filename="../screens/SettingsScreen.qml" line="752"/>
+        <location filename="../screens/SettingsScreen.qml" line="140"/>
+        <location filename="../screens/SettingsScreen.qml" line="756"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="146"/>
+        <location filename="../screens/SettingsScreen.qml" line="150"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="168"/>
         <source>Reduce motion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="240"/>
+        <location filename="../screens/SettingsScreen.qml" line="244"/>
         <source>Optimizing</source>
         <translation>अनुकूलित किया जा रहा है</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="242"/>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="255"/>
         <source>Paused</source>
         <translation>रोक दिया गया</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="242"/>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="255"/>
         <source>In progress</source>
         <translation>प्रगति पर</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="245"/>
+        <location filename="../screens/SettingsScreen.qml" line="249"/>
         <source>%1 indexed</source>
         <translation>%1 इंडेक्स किए गए</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="254"/>
+        <location filename="../screens/SettingsScreen.qml" line="258"/>
         <source>%1 scraped</source>
         <translation>%1 स्क्रैप किए गए</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="488"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Cancel</source>
         <translation>रद्द करें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="488"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Start</source>
         <translation>शुरू करें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="490"/>
+        <location filename="../screens/SettingsScreen.qml" line="494"/>
         <source>Upload</source>
         <translation>अपलोड</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="491"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Open</source>
         <translation>खोलें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="542"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>Default</source>
         <translation>डिफ़ॉल्ट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>English</source>
         <translation>अंग्रेज़ी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Italian</source>
         <translation>इतालवी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>German</source>
         <translation>जर्मन</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Greek</source>
         <translation>ग्रीक</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Japanese</source>
         <translation>जापानी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="590"/>
         <source>Korean</source>
         <translation>कोरियाई</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="588"/>
+        <location filename="../screens/SettingsScreen.qml" line="592"/>
         <source>Dutch</source>
         <translation>डच</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="590"/>
+        <location filename="../screens/SettingsScreen.qml" line="594"/>
         <source>Romanian</source>
         <translation>रोमानियाई</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="592"/>
+        <location filename="../screens/SettingsScreen.qml" line="596"/>
         <source>Slovak</source>
         <translation>स्लोवाक</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="594"/>
+        <location filename="../screens/SettingsScreen.qml" line="598"/>
         <source>Ukrainian</source>
         <translation>यूक्रेनी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="596"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Chinese (Simplified)</source>
         <translation>चीनी (सरलीकृत)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="598"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="600"/>
+        <location filename="../screens/SettingsScreen.qml" line="604"/>
         <source>Hebrew</source>
         <translation>हिब्रू</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="602"/>
+        <location filename="../screens/SettingsScreen.qml" line="606"/>
         <source>Arabic</source>
         <translation>अरबी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="604"/>
+        <location filename="../screens/SettingsScreen.qml" line="608"/>
         <source>Hindi</source>
         <translation>हिंदी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="605"/>
-        <location filename="../screens/SettingsScreen.qml" line="613"/>
-        <location filename="../screens/SettingsScreen.qml" line="687"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="691"/>
         <source>Auto</source>
         <translation>स्वचालित</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="610"/>
+        <location filename="../screens/SettingsScreen.qml" line="614"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="616"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="623"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="625"/>
+        <location filename="../screens/SettingsScreen.qml" line="629"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="627"/>
+        <location filename="../screens/SettingsScreen.qml" line="631"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="628"/>
+        <location filename="../screens/SettingsScreen.qml" line="632"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="633"/>
+        <location filename="../screens/SettingsScreen.qml" line="637"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="639"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="640"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="641"/>
+        <location filename="../screens/SettingsScreen.qml" line="645"/>
         <source>Detailed list view</source>
         <translation>विस्तृत सूची दृश्य</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="642"/>
+        <location filename="../screens/SettingsScreen.qml" line="646"/>
         <source>Grid view</source>
         <translation>ग्रिड दृश्य</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
         <source>Style B</source>
         <translation>शैली B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Style C</source>
         <translation>शैली C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="655"/>
         <source>Style D</source>
         <translation>शैली D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="652"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Style A</source>
         <translation>शैली A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="667"/>
+        <location filename="../screens/SettingsScreen.qml" line="671"/>
         <source>Off</source>
         <translation>बंद</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="669"/>
+        <location filename="../screens/SettingsScreen.qml" line="673"/>
         <source>1 second (testing)</source>
         <translation>1 सेकंड (परीक्षण)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="671"/>
+        <location filename="../screens/SettingsScreen.qml" line="675"/>
         <source>1 minute</source>
         <translation>1 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="673"/>
+        <location filename="../screens/SettingsScreen.qml" line="677"/>
         <source>2 minutes</source>
         <translation>2 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="675"/>
+        <location filename="../screens/SettingsScreen.qml" line="679"/>
         <source>5 minutes</source>
         <translation>5 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="677"/>
+        <location filename="../screens/SettingsScreen.qml" line="681"/>
         <source>10 minutes</source>
         <translation>10 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="679"/>
+        <location filename="../screens/SettingsScreen.qml" line="683"/>
         <source>15 minutes</source>
         <translation>15 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="681"/>
+        <location filename="../screens/SettingsScreen.qml" line="685"/>
         <source>30 minutes</source>
         <translation>30 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="682"/>
+        <location filename="../screens/SettingsScreen.qml" line="686"/>
         <source>%1 seconds</source>
         <translation>%1 सेकंड</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1351"/>
+        <location filename="../screens/SettingsScreen.qml" line="1382"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="105"/>
-        <location filename="../screens/SettingsScreen.qml" line="725"/>
+        <location filename="../screens/SettingsScreen.qml" line="109"/>
+        <location filename="../screens/SettingsScreen.qml" line="729"/>
         <source>Resolution</source>
         <translation>रिज़ॉल्यूशन</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="77"/>
-        <location filename="../screens/SettingsScreen.qml" line="219"/>
+        <location filename="../screens/SettingsScreen.qml" line="81"/>
+        <location filename="../screens/SettingsScreen.qml" line="223"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="221"/>
+        <location filename="../screens/SettingsScreen.qml" line="87"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="95"/>
-        <location filename="../screens/SettingsScreen.qml" line="225"/>
+        <location filename="../screens/SettingsScreen.qml" line="99"/>
+        <location filename="../screens/SettingsScreen.qml" line="229"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="693"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="691"/>
+        <location filename="../screens/SettingsScreen.qml" line="695"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="693"/>
+        <location filename="../screens/SettingsScreen.qml" line="697"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="695"/>
+        <location filename="../screens/SettingsScreen.qml" line="699"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="697"/>
+        <location filename="../screens/SettingsScreen.qml" line="701"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="699"/>
+        <location filename="../screens/SettingsScreen.qml" line="703"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="701"/>
+        <location filename="../screens/SettingsScreen.qml" line="705"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="703"/>
+        <location filename="../screens/SettingsScreen.qml" line="707"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="705"/>
+        <location filename="../screens/SettingsScreen.qml" line="709"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="707"/>
+        <location filename="../screens/SettingsScreen.qml" line="711"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="709"/>
+        <location filename="../screens/SettingsScreen.qml" line="713"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="711"/>
+        <location filename="../screens/SettingsScreen.qml" line="715"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="226"/>
+        <location filename="../screens/SettingsScreen.qml" line="230"/>
         <source>Settings</source>
         <translation>सेटिंग्स</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1339"/>
+        <location filename="../screens/SettingsScreen.qml" line="1370"/>
         <source>No settings available on this platform</source>
         <translation>इस प्लेटफ़ॉर्म पर कोई सेटिंग उपलब्ध नहीं है</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="242"/>
-        <location filename="../screens/SystemsScreen.qml" line="343"/>
+        <location filename="../screens/SystemsScreen.qml" line="245"/>
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>%1 systems</source>
         <translation>%1 सिस्टम</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="243"/>
-        <location filename="../screens/SystemsScreen.qml" line="360"/>
+        <location filename="../screens/SystemsScreen.qml" line="246"/>
+        <location filename="../screens/SystemsScreen.qml" line="363"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="378"/>
+        <location filename="../screens/SystemsScreen.qml" line="381"/>
         <source>No systems in this category</source>
         <translation>इस श्रेणी में कोई सिस्टम नहीं है</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="379"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -97,100 +97,100 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Caricamento…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="196"/>
+        <location filename="../components/BrowseDetailPane.qml" line="167"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="196"/>
+        <location filename="../components/BrowseDetailPane.qml" line="167"/>
         <source>Yr</source>
         <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="198"/>
+        <location filename="../components/BrowseDetailPane.qml" line="169"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="198"/>
+        <location filename="../components/BrowseDetailPane.qml" line="169"/>
         <source>Gen</source>
         <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="200"/>
+        <location filename="../components/BrowseDetailPane.qml" line="171"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="200"/>
+        <location filename="../components/BrowseDetailPane.qml" line="171"/>
         <source>Plyr</source>
         <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="202"/>
+        <location filename="../components/BrowseDetailPane.qml" line="173"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="202"/>
+        <location filename="../components/BrowseDetailPane.qml" line="173"/>
         <source>Dev</source>
         <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="204"/>
+        <location filename="../components/BrowseDetailPane.qml" line="175"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="204"/>
+        <location filename="../components/BrowseDetailPane.qml" line="175"/>
         <source>Pub</source>
         <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="206"/>
+        <location filename="../components/BrowseDetailPane.qml" line="177"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="206"/>
+        <location filename="../components/BrowseDetailPane.qml" line="177"/>
         <source>Rtg</source>
         <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="208"/>
+        <location filename="../components/BrowseDetailPane.qml" line="179"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="208"/>
+        <location filename="../components/BrowseDetailPane.qml" line="179"/>
         <source>Cat</source>
         <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="210"/>
+        <location filename="../components/BrowseDetailPane.qml" line="181"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="210"/>
+        <location filename="../components/BrowseDetailPane.qml" line="181"/>
         <source>Date</source>
         <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="212"/>
+        <location filename="../components/BrowseDetailPane.qml" line="183"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="212"/>
+        <location filename="../components/BrowseDetailPane.qml" line="183"/>
         <source>Mfr</source>
         <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
@@ -425,8 +425,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="127"/>
-        <location filename="../screens/GamesScreen.qml" line="162"/>
+        <location filename="../screens/GamesScreen.qml" line="128"/>
+        <location filename="../screens/GamesScreen.qml" line="163"/>
         <source>%1 files</source>
         <translation>%1 file</translation>
     </message>
@@ -436,8 +436,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="136"/>
-        <location filename="../screens/GamesScreen.qml" line="163"/>
+        <location filename="../screens/GamesScreen.qml" line="137"/>
+        <location filename="../screens/GamesScreen.qml" line="164"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -447,7 +447,7 @@ Euskara - devilschile2</source>
         <translation>Caricamento giochi…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="132"/>
+        <location filename="../screens/GamesScreen.qml" line="133"/>
         <source>Loading more…</source>
         <translation>Caricamento altro…</translation>
     </message>
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="149"/>
+        <location filename="../screens/HubScreen.qml" line="156"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="155"/>
+        <location filename="../screens/HubScreen.qml" line="162"/>
         <source>Favorites</source>
         <translation>Preferiti</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="160"/>
+        <location filename="../screens/HubScreen.qml" line="167"/>
         <source>Recently Played</source>
         <translation>Giocati di recente</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="165"/>
+        <location filename="../screens/HubScreen.qml" line="172"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Impostazioni</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="701"/>
+        <location filename="../screens/HubScreen.qml" line="722"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Nessun sistema disponibile. Esegui Aggiorna database multimediale dalle Impostazioni.</translation>
     </message>
@@ -553,138 +553,138 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1367"/>
+        <location filename="../app/Main.qml" line="1381"/>
         <source>Launch core</source>
         <translation>Avvia core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1373"/>
-        <location filename="../app/Main.qml" line="1612"/>
+        <location filename="../app/Main.qml" line="1387"/>
+        <location filename="../app/Main.qml" line="1626"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1445"/>
         <source>Remove from favorites</source>
         <translation>Rimuovi dai preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1445"/>
         <source>Add to favorites</source>
         <translation>Aggiungi ai preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1436"/>
+        <location filename="../app/Main.qml" line="1450"/>
         <source>Write to NFC token</source>
         <translation>Scrivi sul token NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1440"/>
+        <location filename="../app/Main.qml" line="1454"/>
         <source>QR code</source>
         <translation>Codice QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1415"/>
-        <location filename="../app/Main.qml" line="1450"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1464"/>
         <source>Launch game</source>
         <translation>Avvia gioco</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2624"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2616"/>
+        <location filename="../app/Main.qml" line="2630"/>
         <source>Loading favorites…</source>
         <translation>Caricamento preferiti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2612"/>
+        <location filename="../app/Main.qml" line="2626"/>
         <source>Loading games…</source>
         <translation>Caricamento giochi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1380"/>
-        <location filename="../app/Main.qml" line="1403"/>
+        <location filename="../app/Main.qml" line="1394"/>
+        <location filename="../app/Main.qml" line="1417"/>
         <source>Update media database</source>
         <translation type="unfinished">Aggiorna database multimediale</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1383"/>
-        <location filename="../app/Main.qml" line="1406"/>
+        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1420"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Recupera metadati</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1388"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1411"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1388"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1411"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1608"/>
+        <location filename="../app/Main.qml" line="1622"/>
         <source>Default</source>
         <translation type="unfinished">Predefinito</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1608"/>
+        <location filename="../app/Main.qml" line="1622"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1932"/>
+        <location filename="../app/Main.qml" line="1946"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1936"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1950"/>
+        <location filename="../app/Main.qml" line="1964"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1954"/>
+        <location filename="../app/Main.qml" line="1968"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1958"/>
+        <location filename="../app/Main.qml" line="1972"/>
         <source>Retry</source>
         <translation type="unfinished">Riprova</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1962"/>
+        <location filename="../app/Main.qml" line="1976"/>
         <source>Cancel</source>
         <translation type="unfinished">Annulla</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2628"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2618"/>
+        <location filename="../app/Main.qml" line="2632"/>
         <source>Loading recently played…</source>
         <translation>Caricamento recenti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2620"/>
+        <location filename="../app/Main.qml" line="2634"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2622"/>
+        <location filename="../app/Main.qml" line="2636"/>
         <source>Loading…</source>
         <translation>Caricamento…</translation>
     </message>
@@ -864,12 +864,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Caricamento…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="395"/>
+        <location filename="../screens/MediaListScreen.qml" line="436"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 elementi</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="396"/>
+        <location filename="../screens/MediaListScreen.qml" line="437"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>No</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="246"/>
+        <location filename="../components/Modal.qml" line="256"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
@@ -1262,7 +1262,7 @@ Euskara - devilschile2</source>
         <translation>Stile A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1358"/>
+        <location filename="../screens/SettingsScreen.qml" line="1368"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1406,7 +1406,7 @@ Euskara - devilschile2</source>
         <translation>Impostazioni</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1346"/>
+        <location filename="../screens/SettingsScreen.qml" line="1356"/>
         <source>No settings available on this platform</source>
         <translation>Nessuna impostazione disponibile su questa piattaforma</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="229"/>
-        <location filename="../screens/SystemsScreen.qml" line="329"/>
+        <location filename="../screens/SystemsScreen.qml" line="236"/>
+        <location filename="../screens/SystemsScreen.qml" line="338"/>
         <source>%1 systems</source>
         <translation>%1 sistemi</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="230"/>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="237"/>
+        <location filename="../screens/SystemsScreen.qml" line="355"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="364"/>
+        <location filename="../screens/SystemsScreen.qml" line="373"/>
         <source>No systems in this category</source>
         <translation>Nessun sistema in questa categoria</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="365"/>
+        <location filename="../screens/SystemsScreen.qml" line="374"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>
@@ -1439,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="475"/>
+        <location filename="../components/Tile.qml" line="539"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -425,34 +425,34 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="116"/>
-        <location filename="../screens/GamesScreen.qml" line="151"/>
+        <location filename="../screens/GamesScreen.qml" line="127"/>
+        <location filename="../screens/GamesScreen.qml" line="162"/>
         <source>%1 files</source>
         <translation>%1 file</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="53"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="125"/>
-        <location filename="../screens/GamesScreen.qml" line="152"/>
+        <location filename="../screens/GamesScreen.qml" line="136"/>
+        <location filename="../screens/GamesScreen.qml" line="163"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="48"/>
+        <location filename="../screens/GamesScreen.qml" line="49"/>
         <source>Loading games…</source>
         <translation>Caricamento giochi…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="121"/>
+        <location filename="../screens/GamesScreen.qml" line="132"/>
         <source>Loading more…</source>
         <translation>Caricamento altro…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="47"/>
+        <location filename="../screens/GamesScreen.qml" line="48"/>
         <source>No games in this system</source>
         <translation>Nessun gioco in questo sistema</translation>
     </message>
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="139"/>
+        <location filename="../screens/HubScreen.qml" line="149"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="145"/>
+        <location filename="../screens/HubScreen.qml" line="155"/>
         <source>Favorites</source>
         <translation>Preferiti</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="150"/>
+        <location filename="../screens/HubScreen.qml" line="160"/>
         <source>Recently Played</source>
         <translation>Giocati di recente</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="155"/>
+        <location filename="../screens/HubScreen.qml" line="165"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Impostazioni</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="669"/>
+        <location filename="../screens/HubScreen.qml" line="701"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Nessun sistema disponibile. Esegui Aggiorna database multimediale dalle Impostazioni.</translation>
     </message>
@@ -553,138 +553,138 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1361"/>
+        <location filename="../app/Main.qml" line="1367"/>
         <source>Launch core</source>
         <translation>Avvia core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1367"/>
-        <location filename="../app/Main.qml" line="1606"/>
+        <location filename="../app/Main.qml" line="1373"/>
+        <location filename="../app/Main.qml" line="1612"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1425"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Remove from favorites</source>
         <translation>Rimuovi dai preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1425"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Add to favorites</source>
         <translation>Aggiungi ai preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1430"/>
+        <location filename="../app/Main.qml" line="1436"/>
         <source>Write to NFC token</source>
         <translation>Scrivi sul token NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1434"/>
+        <location filename="../app/Main.qml" line="1440"/>
         <source>QR code</source>
         <translation>Codice QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1409"/>
-        <location filename="../app/Main.qml" line="1444"/>
+        <location filename="../app/Main.qml" line="1415"/>
+        <location filename="../app/Main.qml" line="1450"/>
         <source>Launch game</source>
         <translation>Avvia gioco</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2604"/>
+        <location filename="../app/Main.qml" line="2610"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2616"/>
         <source>Loading favorites…</source>
         <translation>Caricamento preferiti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2606"/>
+        <location filename="../app/Main.qml" line="2612"/>
         <source>Loading games…</source>
         <translation>Caricamento giochi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1374"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1380"/>
+        <location filename="../app/Main.qml" line="1403"/>
         <source>Update media database</source>
         <translation type="unfinished">Aggiorna database multimediale</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1377"/>
-        <location filename="../app/Main.qml" line="1400"/>
+        <location filename="../app/Main.qml" line="1383"/>
+        <location filename="../app/Main.qml" line="1406"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Recupera metadati</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1382"/>
-        <location filename="../app/Main.qml" line="1391"/>
+        <location filename="../app/Main.qml" line="1388"/>
+        <location filename="../app/Main.qml" line="1397"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1382"/>
-        <location filename="../app/Main.qml" line="1391"/>
+        <location filename="../app/Main.qml" line="1388"/>
+        <location filename="../app/Main.qml" line="1397"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1602"/>
+        <location filename="../app/Main.qml" line="1608"/>
         <source>Default</source>
         <translation type="unfinished">Predefinito</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1602"/>
+        <location filename="../app/Main.qml" line="1608"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1926"/>
+        <location filename="../app/Main.qml" line="1932"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1930"/>
+        <location filename="../app/Main.qml" line="1936"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1944"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1948"/>
+        <location filename="../app/Main.qml" line="1954"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1952"/>
+        <location filename="../app/Main.qml" line="1958"/>
         <source>Retry</source>
         <translation type="unfinished">Riprova</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1956"/>
+        <location filename="../app/Main.qml" line="1962"/>
         <source>Cancel</source>
         <translation type="unfinished">Annulla</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2608"/>
+        <location filename="../app/Main.qml" line="2614"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2612"/>
+        <location filename="../app/Main.qml" line="2618"/>
         <source>Loading recently played…</source>
         <translation>Caricamento recenti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2620"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2616"/>
+        <location filename="../app/Main.qml" line="2622"/>
         <source>Loading…</source>
         <translation>Caricamento…</translation>
     </message>
@@ -692,72 +692,72 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="683"/>
+        <location filename="../app/MainLayout.qml" line="685"/>
         <source>Writing failed</source>
         <translation>Scrittura non riuscita</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="683"/>
+        <location filename="../app/MainLayout.qml" line="685"/>
         <source>Put a writable card near the reader</source>
         <translation>Avvicina una scheda scrivibile al lettore</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="811"/>
+        <location filename="../app/MainLayout.qml" line="813"/>
         <source>Are you sure you want to exit?</source>
         <translation>Sei sicuro di voler uscire?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="894"/>
-        <location filename="../app/MainLayout.qml" line="968"/>
+        <location filename="../app/MainLayout.qml" line="896"/>
+        <location filename="../app/MainLayout.qml" line="970"/>
         <source>Select</source>
         <translation>Seleziona</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="902"/>
-        <location filename="../app/MainLayout.qml" line="916"/>
-        <location filename="../app/MainLayout.qml" line="931"/>
-        <location filename="../app/MainLayout.qml" line="942"/>
+        <location filename="../app/MainLayout.qml" line="900"/>
+        <location filename="../app/MainLayout.qml" line="904"/>
+        <location filename="../app/MainLayout.qml" line="918"/>
+        <location filename="../app/MainLayout.qml" line="933"/>
+        <location filename="../app/MainLayout.qml" line="944"/>
         <source>Close</source>
         <translation>Chiudi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="909"/>
-        <location filename="../app/MainLayout.qml" line="949"/>
-        <location filename="../app/MainLayout.qml" line="972"/>
-        <location filename="../app/MainLayout.qml" line="983"/>
+        <location filename="../app/MainLayout.qml" line="911"/>
+        <location filename="../app/MainLayout.qml" line="951"/>
+        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="985"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="927"/>
+        <location filename="../app/MainLayout.qml" line="929"/>
         <source>Done</source>
         <translation>Fatto</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="957"/>
+        <location filename="../app/MainLayout.qml" line="959"/>
         <source>I understand</source>
         <translation>Ho capito</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="991"/>
+        <location filename="../app/MainLayout.qml" line="993"/>
         <source>Start</source>
         <translation>Avvia</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1203"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Scroll</source>
         <translation>Scorri</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="890"/>
-        <location filename="../app/MainLayout.qml" line="964"/>
-        <location filename="../app/MainLayout.qml" line="1010"/>
-        <location filename="../app/MainLayout.qml" line="1047"/>
-        <location filename="../app/MainLayout.qml" line="1097"/>
-        <location filename="../app/MainLayout.qml" line="1146"/>
-        <location filename="../app/MainLayout.qml" line="1165"/>
-        <location filename="../app/MainLayout.qml" line="1232"/>
+        <location filename="../app/MainLayout.qml" line="892"/>
+        <location filename="../app/MainLayout.qml" line="966"/>
+        <location filename="../app/MainLayout.qml" line="1012"/>
+        <location filename="../app/MainLayout.qml" line="1049"/>
+        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1148"/>
+        <location filename="../app/MainLayout.qml" line="1167"/>
+        <location filename="../app/MainLayout.qml" line="1234"/>
         <source>Move</source>
         <translation>Muovi</translation>
     </message>
@@ -777,81 +777,81 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Giocati di recente</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="699"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="700"/>
+        <location filename="../app/MainLayout.qml" line="702"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="810"/>
+        <location filename="../app/MainLayout.qml" line="812"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1014"/>
-        <location filename="../app/MainLayout.qml" line="1057"/>
-        <location filename="../app/MainLayout.qml" line="1107"/>
-        <location filename="../app/MainLayout.qml" line="1151"/>
-        <location filename="../app/MainLayout.qml" line="1242"/>
+        <location filename="../app/MainLayout.qml" line="1016"/>
+        <location filename="../app/MainLayout.qml" line="1059"/>
+        <location filename="../app/MainLayout.qml" line="1109"/>
+        <location filename="../app/MainLayout.qml" line="1153"/>
+        <location filename="../app/MainLayout.qml" line="1244"/>
         <source>Open</source>
         <translation>Apri</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1024"/>
+        <location filename="../app/MainLayout.qml" line="1026"/>
         <source>Quit</source>
         <translation>Esci</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1033"/>
-        <location filename="../app/MainLayout.qml" line="1063"/>
-        <location filename="../app/MainLayout.qml" line="1074"/>
-        <location filename="../app/MainLayout.qml" line="1089"/>
-        <location filename="../app/MainLayout.qml" line="1116"/>
-        <location filename="../app/MainLayout.qml" line="1127"/>
-        <location filename="../app/MainLayout.qml" line="1139"/>
-        <location filename="../app/MainLayout.qml" line="1155"/>
-        <location filename="../app/MainLayout.qml" line="1189"/>
-        <location filename="../app/MainLayout.qml" line="1207"/>
-        <location filename="../app/MainLayout.qml" line="1216"/>
-        <location filename="../app/MainLayout.qml" line="1251"/>
-        <location filename="../app/MainLayout.qml" line="1262"/>
+        <location filename="../app/MainLayout.qml" line="1035"/>
+        <location filename="../app/MainLayout.qml" line="1065"/>
+        <location filename="../app/MainLayout.qml" line="1076"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
+        <location filename="../app/MainLayout.qml" line="1118"/>
+        <location filename="../app/MainLayout.qml" line="1129"/>
+        <location filename="../app/MainLayout.qml" line="1141"/>
+        <location filename="../app/MainLayout.qml" line="1157"/>
+        <location filename="../app/MainLayout.qml" line="1191"/>
+        <location filename="../app/MainLayout.qml" line="1209"/>
+        <location filename="../app/MainLayout.qml" line="1218"/>
+        <location filename="../app/MainLayout.qml" line="1253"/>
+        <location filename="../app/MainLayout.qml" line="1264"/>
         <source>Back</source>
         <translation>Indietro</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1053"/>
-        <location filename="../app/MainLayout.qml" line="1103"/>
-        <location filename="../app/MainLayout.qml" line="1238"/>
+        <location filename="../app/MainLayout.qml" line="1055"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
+        <location filename="../app/MainLayout.qml" line="1240"/>
         <source>Page</source>
         <translation>Pagina</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1060"/>
-        <location filename="../app/MainLayout.qml" line="1112"/>
-        <location filename="../app/MainLayout.qml" line="1247"/>
+        <location filename="../app/MainLayout.qml" line="1022"/>
+        <location filename="../app/MainLayout.qml" line="1062"/>
+        <location filename="../app/MainLayout.qml" line="1114"/>
+        <location filename="../app/MainLayout.qml" line="1249"/>
         <source>Options</source>
         <translation>Opzioni</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1070"/>
-        <location filename="../app/MainLayout.qml" line="1123"/>
-        <location filename="../app/MainLayout.qml" line="1258"/>
+        <location filename="../app/MainLayout.qml" line="940"/>
+        <location filename="../app/MainLayout.qml" line="1072"/>
+        <location filename="../app/MainLayout.qml" line="1125"/>
+        <location filename="../app/MainLayout.qml" line="1260"/>
         <source>Retry</source>
         <translation>Riprova</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1174"/>
+        <location filename="../app/MainLayout.qml" line="1176"/>
         <source>Change</source>
         <translation>Cambia</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1180"/>
+        <location filename="../app/MainLayout.qml" line="1182"/>
         <source>Toggle</source>
         <translation>Alterna</translation>
     </message>
@@ -864,12 +864,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Caricamento…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="365"/>
+        <location filename="../screens/MediaListScreen.qml" line="395"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 elementi</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="366"/>
+        <location filename="../screens/MediaListScreen.qml" line="396"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>No</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="198"/>
+        <location filename="../components/Modal.qml" line="246"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
@@ -936,24 +936,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="132"/>
-        <location filename="../screens/SettingsScreen.qml" line="718"/>
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
+        <location filename="../screens/SettingsScreen.qml" line="741"/>
         <source>Language</source>
         <translation>Lingua</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="754"/>
+        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <location filename="../screens/SettingsScreen.qml" line="777"/>
         <source>Browsing layout</source>
         <translation>Layout navigazione</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="150"/>
+        <location filename="../screens/SettingsScreen.qml" line="165"/>
         <source>Mouse support</source>
         <translation>Supporto mouse</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="157"/>
+        <location filename="../screens/SettingsScreen.qml" line="177"/>
         <source>Update media database</source>
         <translation>Aggiorna database multimediale</translation>
     </message>
@@ -962,47 +962,47 @@ Euskara - devilschile2</source>
         <translation type="vanished">Generale</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="745"/>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="768"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="145"/>
-        <location filename="../screens/SettingsScreen.qml" line="763"/>
+        <location filename="../screens/SettingsScreen.qml" line="160"/>
+        <location filename="../screens/SettingsScreen.qml" line="786"/>
         <source>Button style</source>
         <translation>Stile pulsanti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="772"/>
+        <location filename="../screens/SettingsScreen.qml" line="132"/>
+        <location filename="../screens/SettingsScreen.qml" line="795"/>
         <source>Screensaver</source>
         <translation>Salvaschermo</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="80"/>
-        <location filename="../screens/SettingsScreen.qml" line="209"/>
+        <location filename="../screens/SettingsScreen.qml" line="95"/>
+        <location filename="../screens/SettingsScreen.qml" line="229"/>
         <source>Library</source>
         <translation>Libreria</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="162"/>
+        <location filename="../screens/SettingsScreen.qml" line="182"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="112"/>
-        <location filename="../screens/SettingsScreen.qml" line="781"/>
+        <location filename="../screens/SettingsScreen.qml" line="127"/>
+        <location filename="../screens/SettingsScreen.qml" line="804"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="167"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
         <source>Scrape metadata</source>
         <translation>Recupera metadati</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="172"/>
+        <location filename="../screens/SettingsScreen.qml" line="192"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1011,397 +1011,402 @@ Euskara - devilschile2</source>
         <translation type="vanished">Avanzate</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="184"/>
+        <location filename="../screens/SettingsScreen.qml" line="204"/>
         <source>Debug logging</source>
         <translation>Log di debug</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="189"/>
+        <location filename="../screens/SettingsScreen.qml" line="209"/>
         <source>Upload log file</source>
         <translation>Carica file di log</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="179"/>
+        <location filename="../screens/SettingsScreen.qml" line="199"/>
         <source>About / License</source>
         <translation>Informazioni / Licenza</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
-        <location filename="../screens/SettingsScreen.qml" line="727"/>
+        <location filename="../screens/SettingsScreen.qml" line="137"/>
+        <location filename="../screens/SettingsScreen.qml" line="750"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="127"/>
-        <location filename="../screens/SettingsScreen.qml" line="736"/>
+        <location filename="../screens/SettingsScreen.qml" line="142"/>
+        <location filename="../screens/SettingsScreen.qml" line="759"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="137"/>
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="226"/>
+        <location filename="../screens/SettingsScreen.qml" line="170"/>
+        <source>Reduce motion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
         <source>Optimizing</source>
         <translation>Ottimizzazione</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="228"/>
-        <location filename="../screens/SettingsScreen.qml" line="237"/>
+        <location filename="../screens/SettingsScreen.qml" line="248"/>
+        <location filename="../screens/SettingsScreen.qml" line="257"/>
         <source>Paused</source>
         <translation>In pausa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="228"/>
-        <location filename="../screens/SettingsScreen.qml" line="237"/>
+        <location filename="../screens/SettingsScreen.qml" line="248"/>
+        <location filename="../screens/SettingsScreen.qml" line="257"/>
         <source>In progress</source>
         <translation>In corso</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="231"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>%1 indexed</source>
         <translation>%1 indicizzati</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="240"/>
+        <location filename="../screens/SettingsScreen.qml" line="260"/>
         <source>%1 scraped</source>
         <translation>%1 recuperati</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="472"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="472"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Start</source>
         <translation>Avvia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="474"/>
+        <location filename="../screens/SettingsScreen.qml" line="497"/>
         <source>Upload</source>
         <translation>Carica</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Open</source>
         <translation>Apri</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="556"/>
+        <location filename="../screens/SettingsScreen.qml" line="579"/>
         <source>English</source>
         <translation>Inglese</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="558"/>
+        <location filename="../screens/SettingsScreen.qml" line="581"/>
         <source>Italian</source>
         <translation>Italiano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="560"/>
+        <location filename="../screens/SettingsScreen.qml" line="583"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="562"/>
+        <location filename="../screens/SettingsScreen.qml" line="585"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="564"/>
+        <location filename="../screens/SettingsScreen.qml" line="587"/>
         <source>German</source>
         <translation>Tedesco</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="566"/>
+        <location filename="../screens/SettingsScreen.qml" line="589"/>
         <source>Greek</source>
         <translation>Greco</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="568"/>
+        <location filename="../screens/SettingsScreen.qml" line="591"/>
         <source>Japanese</source>
         <translation>Giapponese</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="570"/>
+        <location filename="../screens/SettingsScreen.qml" line="593"/>
         <source>Korean</source>
         <translation>Coreano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="595"/>
         <source>Dutch</source>
         <translation>Olandese</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="597"/>
         <source>Romanian</source>
         <translation>Rumeno</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="599"/>
         <source>Slovak</source>
         <translation>Slovacco</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="601"/>
         <source>Ukrainian</source>
         <translation>Ucraino</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="603"/>
         <source>Chinese (Simplified)</source>
         <translation>Cinese (semplificato)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="605"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="607"/>
         <source>Hebrew</source>
         <translation>Ebraico</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="588"/>
+        <location filename="../screens/SettingsScreen.qml" line="611"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="589"/>
-        <location filename="../screens/SettingsScreen.qml" line="597"/>
-        <location filename="../screens/SettingsScreen.qml" line="671"/>
+        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="620"/>
+        <location filename="../screens/SettingsScreen.qml" line="694"/>
         <source>Auto</source>
         <translation>Automatico</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="594"/>
+        <location filename="../screens/SettingsScreen.qml" line="617"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="596"/>
+        <location filename="../screens/SettingsScreen.qml" line="619"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="607"/>
+        <location filename="../screens/SettingsScreen.qml" line="630"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="632"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="611"/>
+        <location filename="../screens/SettingsScreen.qml" line="634"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="635"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="640"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="619"/>
+        <location filename="../screens/SettingsScreen.qml" line="642"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="620"/>
+        <location filename="../screens/SettingsScreen.qml" line="643"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="625"/>
+        <location filename="../screens/SettingsScreen.qml" line="648"/>
         <source>Detailed list view</source>
         <translation>Vista elenco dettagliata</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="626"/>
+        <location filename="../screens/SettingsScreen.qml" line="649"/>
         <source>Grid view</source>
         <translation>Vista griglia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="631"/>
+        <location filename="../screens/SettingsScreen.qml" line="654"/>
         <source>Style B</source>
         <translation>Stile B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="633"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Style C</source>
         <translation>Stile C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="658"/>
         <source>Style D</source>
         <translation>Stile D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="659"/>
         <source>Style A</source>
         <translation>Stile A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1292"/>
+        <location filename="../screens/SettingsScreen.qml" line="1358"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="526"/>
+        <location filename="../screens/SettingsScreen.qml" line="549"/>
         <source>Default</source>
         <translation>Predefinito</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="674"/>
         <source>Off</source>
         <translation>Disattivato</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="653"/>
+        <location filename="../screens/SettingsScreen.qml" line="676"/>
         <source>1 second (testing)</source>
         <translation>1 secondo (test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="655"/>
+        <location filename="../screens/SettingsScreen.qml" line="678"/>
         <source>1 minute</source>
         <translation>1 minuto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="657"/>
+        <location filename="../screens/SettingsScreen.qml" line="680"/>
         <source>2 minutes</source>
         <translation>2 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="659"/>
+        <location filename="../screens/SettingsScreen.qml" line="682"/>
         <source>5 minutes</source>
         <translation>5 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="661"/>
+        <location filename="../screens/SettingsScreen.qml" line="684"/>
         <source>10 minutes</source>
         <translation>10 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="663"/>
+        <location filename="../screens/SettingsScreen.qml" line="686"/>
         <source>15 minutes</source>
         <translation>15 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="665"/>
+        <location filename="../screens/SettingsScreen.qml" line="688"/>
         <source>30 minutes</source>
         <translation>30 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="666"/>
+        <location filename="../screens/SettingsScreen.qml" line="689"/>
         <source>%1 seconds</source>
         <translation>%1 secondi</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="96"/>
-        <location filename="../screens/SettingsScreen.qml" line="709"/>
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="732"/>
         <source>Resolution</source>
         <translation>Risoluzione</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="68"/>
-        <location filename="../screens/SettingsScreen.qml" line="205"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="74"/>
-        <location filename="../screens/SettingsScreen.qml" line="207"/>
+        <location filename="../screens/SettingsScreen.qml" line="89"/>
+        <location filename="../screens/SettingsScreen.qml" line="227"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="86"/>
-        <location filename="../screens/SettingsScreen.qml" line="211"/>
+        <location filename="../screens/SettingsScreen.qml" line="101"/>
+        <location filename="../screens/SettingsScreen.qml" line="231"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="673"/>
+        <location filename="../screens/SettingsScreen.qml" line="696"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="675"/>
+        <location filename="../screens/SettingsScreen.qml" line="698"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="677"/>
+        <location filename="../screens/SettingsScreen.qml" line="700"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="679"/>
+        <location filename="../screens/SettingsScreen.qml" line="702"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="681"/>
+        <location filename="../screens/SettingsScreen.qml" line="704"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="683"/>
+        <location filename="../screens/SettingsScreen.qml" line="706"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="685"/>
+        <location filename="../screens/SettingsScreen.qml" line="708"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="687"/>
+        <location filename="../screens/SettingsScreen.qml" line="710"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="712"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="691"/>
+        <location filename="../screens/SettingsScreen.qml" line="714"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="693"/>
+        <location filename="../screens/SettingsScreen.qml" line="716"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="695"/>
+        <location filename="../screens/SettingsScreen.qml" line="718"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="212"/>
+        <location filename="../screens/SettingsScreen.qml" line="232"/>
         <source>Settings</source>
         <translation>Impostazioni</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1280"/>
+        <location filename="../screens/SettingsScreen.qml" line="1346"/>
         <source>No settings available on this platform</source>
         <translation>Nessuna impostazione disponibile su questa piattaforma</translation>
     </message>
@@ -1409,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="206"/>
-        <location filename="../screens/SystemsScreen.qml" line="304"/>
+        <location filename="../screens/SystemsScreen.qml" line="229"/>
+        <location filename="../screens/SystemsScreen.qml" line="329"/>
         <source>%1 systems</source>
         <translation>%1 sistemi</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="207"/>
-        <location filename="../screens/SystemsScreen.qml" line="321"/>
+        <location filename="../screens/SystemsScreen.qml" line="230"/>
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="339"/>
+        <location filename="../screens/SystemsScreen.qml" line="364"/>
         <source>No systems in this category</source>
         <translation>Nessun sistema in questa categoria</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="340"/>
+        <location filename="../screens/SystemsScreen.qml" line="365"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>
@@ -1434,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="364"/>
+        <location filename="../components/Tile.qml" line="475"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -425,8 +425,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="128"/>
-        <location filename="../screens/GamesScreen.qml" line="163"/>
+        <location filename="../screens/GamesScreen.qml" line="131"/>
+        <location filename="../screens/GamesScreen.qml" line="166"/>
         <source>%1 files</source>
         <translation>%1 file</translation>
     </message>
@@ -436,8 +436,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="137"/>
-        <location filename="../screens/GamesScreen.qml" line="164"/>
+        <location filename="../screens/GamesScreen.qml" line="140"/>
+        <location filename="../screens/GamesScreen.qml" line="167"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -447,7 +447,7 @@ Euskara - devilschile2</source>
         <translation>Caricamento giochi…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="133"/>
+        <location filename="../screens/GamesScreen.qml" line="136"/>
         <source>Loading more…</source>
         <translation>Caricamento altro…</translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>No</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="246"/>
+        <location filename="../components/Modal.qml" line="250"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
@@ -936,24 +936,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="141"/>
-        <location filename="../screens/SettingsScreen.qml" line="734"/>
+        <location filename="../screens/SettingsScreen.qml" line="145"/>
+        <location filename="../screens/SettingsScreen.qml" line="738"/>
         <source>Language</source>
         <translation>Lingua</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116"/>
-        <location filename="../screens/SettingsScreen.qml" line="770"/>
+        <location filename="../screens/SettingsScreen.qml" line="120"/>
+        <location filename="../screens/SettingsScreen.qml" line="774"/>
         <source>Browsing layout</source>
         <translation>Layout navigazione</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="159"/>
+        <location filename="../screens/SettingsScreen.qml" line="163"/>
         <source>Mouse support</source>
         <translation>Supporto mouse</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="171"/>
+        <location filename="../screens/SettingsScreen.qml" line="175"/>
         <source>Update media database</source>
         <translation>Aggiorna database multimediale</translation>
     </message>
@@ -962,47 +962,47 @@ Euskara - devilschile2</source>
         <translation type="vanished">Generale</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
-        <location filename="../screens/SettingsScreen.qml" line="761"/>
+        <location filename="../screens/SettingsScreen.qml" line="115"/>
+        <location filename="../screens/SettingsScreen.qml" line="765"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="154"/>
-        <location filename="../screens/SettingsScreen.qml" line="779"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="783"/>
         <source>Button style</source>
         <translation>Stile pulsanti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
-        <location filename="../screens/SettingsScreen.qml" line="788"/>
+        <location filename="../screens/SettingsScreen.qml" line="130"/>
+        <location filename="../screens/SettingsScreen.qml" line="792"/>
         <source>Screensaver</source>
         <translation>Salvaschermo</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="89"/>
-        <location filename="../screens/SettingsScreen.qml" line="223"/>
+        <location filename="../screens/SettingsScreen.qml" line="93"/>
+        <location filename="../screens/SettingsScreen.qml" line="227"/>
         <source>Library</source>
         <translation>Libreria</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="176"/>
+        <location filename="../screens/SettingsScreen.qml" line="180"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121"/>
-        <location filename="../screens/SettingsScreen.qml" line="797"/>
+        <location filename="../screens/SettingsScreen.qml" line="125"/>
+        <location filename="../screens/SettingsScreen.qml" line="801"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="181"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
         <source>Scrape metadata</source>
         <translation>Recupera metadati</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="186"/>
+        <location filename="../screens/SettingsScreen.qml" line="190"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1011,402 +1011,402 @@ Euskara - devilschile2</source>
         <translation type="vanished">Avanzate</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="198"/>
+        <location filename="../screens/SettingsScreen.qml" line="202"/>
         <source>Debug logging</source>
         <translation>Log di debug</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="203"/>
+        <location filename="../screens/SettingsScreen.qml" line="207"/>
         <source>Upload log file</source>
         <translation>Carica file di log</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="193"/>
+        <location filename="../screens/SettingsScreen.qml" line="197"/>
         <source>About / License</source>
         <translation>Informazioni / Licenza</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
-        <location filename="../screens/SettingsScreen.qml" line="743"/>
+        <location filename="../screens/SettingsScreen.qml" line="135"/>
+        <location filename="../screens/SettingsScreen.qml" line="747"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="136"/>
-        <location filename="../screens/SettingsScreen.qml" line="752"/>
+        <location filename="../screens/SettingsScreen.qml" line="140"/>
+        <location filename="../screens/SettingsScreen.qml" line="756"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="146"/>
+        <location filename="../screens/SettingsScreen.qml" line="150"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="168"/>
         <source>Reduce motion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="240"/>
+        <location filename="../screens/SettingsScreen.qml" line="244"/>
         <source>Optimizing</source>
         <translation>Ottimizzazione</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="242"/>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="255"/>
         <source>Paused</source>
         <translation>In pausa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="242"/>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="255"/>
         <source>In progress</source>
         <translation>In corso</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="245"/>
+        <location filename="../screens/SettingsScreen.qml" line="249"/>
         <source>%1 indexed</source>
         <translation>%1 indicizzati</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="254"/>
+        <location filename="../screens/SettingsScreen.qml" line="258"/>
         <source>%1 scraped</source>
         <translation>%1 recuperati</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="488"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="488"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Start</source>
         <translation>Avvia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="490"/>
+        <location filename="../screens/SettingsScreen.qml" line="494"/>
         <source>Upload</source>
         <translation>Carica</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="491"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Open</source>
         <translation>Apri</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>English</source>
         <translation>Inglese</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Italian</source>
         <translation>Italiano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>German</source>
         <translation>Tedesco</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Greek</source>
         <translation>Greco</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Japanese</source>
         <translation>Giapponese</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="590"/>
         <source>Korean</source>
         <translation>Coreano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="588"/>
+        <location filename="../screens/SettingsScreen.qml" line="592"/>
         <source>Dutch</source>
         <translation>Olandese</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="590"/>
+        <location filename="../screens/SettingsScreen.qml" line="594"/>
         <source>Romanian</source>
         <translation>Rumeno</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="592"/>
+        <location filename="../screens/SettingsScreen.qml" line="596"/>
         <source>Slovak</source>
         <translation>Slovacco</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="594"/>
+        <location filename="../screens/SettingsScreen.qml" line="598"/>
         <source>Ukrainian</source>
         <translation>Ucraino</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="596"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Chinese (Simplified)</source>
         <translation>Cinese (semplificato)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="598"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="600"/>
+        <location filename="../screens/SettingsScreen.qml" line="604"/>
         <source>Hebrew</source>
         <translation>Ebraico</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="602"/>
+        <location filename="../screens/SettingsScreen.qml" line="606"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="604"/>
+        <location filename="../screens/SettingsScreen.qml" line="608"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="605"/>
-        <location filename="../screens/SettingsScreen.qml" line="613"/>
-        <location filename="../screens/SettingsScreen.qml" line="687"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="691"/>
         <source>Auto</source>
         <translation>Automatico</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="610"/>
+        <location filename="../screens/SettingsScreen.qml" line="614"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="616"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="623"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="625"/>
+        <location filename="../screens/SettingsScreen.qml" line="629"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="627"/>
+        <location filename="../screens/SettingsScreen.qml" line="631"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="628"/>
+        <location filename="../screens/SettingsScreen.qml" line="632"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="633"/>
+        <location filename="../screens/SettingsScreen.qml" line="637"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="639"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="640"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="641"/>
+        <location filename="../screens/SettingsScreen.qml" line="645"/>
         <source>Detailed list view</source>
         <translation>Vista elenco dettagliata</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="642"/>
+        <location filename="../screens/SettingsScreen.qml" line="646"/>
         <source>Grid view</source>
         <translation>Vista griglia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
         <source>Style B</source>
         <translation>Stile B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Style C</source>
         <translation>Stile C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="655"/>
         <source>Style D</source>
         <translation>Stile D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="652"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Style A</source>
         <translation>Stile A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1351"/>
+        <location filename="../screens/SettingsScreen.qml" line="1382"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="542"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>Default</source>
         <translation>Predefinito</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="667"/>
+        <location filename="../screens/SettingsScreen.qml" line="671"/>
         <source>Off</source>
         <translation>Disattivato</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="669"/>
+        <location filename="../screens/SettingsScreen.qml" line="673"/>
         <source>1 second (testing)</source>
         <translation>1 secondo (test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="671"/>
+        <location filename="../screens/SettingsScreen.qml" line="675"/>
         <source>1 minute</source>
         <translation>1 minuto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="673"/>
+        <location filename="../screens/SettingsScreen.qml" line="677"/>
         <source>2 minutes</source>
         <translation>2 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="675"/>
+        <location filename="../screens/SettingsScreen.qml" line="679"/>
         <source>5 minutes</source>
         <translation>5 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="677"/>
+        <location filename="../screens/SettingsScreen.qml" line="681"/>
         <source>10 minutes</source>
         <translation>10 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="679"/>
+        <location filename="../screens/SettingsScreen.qml" line="683"/>
         <source>15 minutes</source>
         <translation>15 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="681"/>
+        <location filename="../screens/SettingsScreen.qml" line="685"/>
         <source>30 minutes</source>
         <translation>30 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="682"/>
+        <location filename="../screens/SettingsScreen.qml" line="686"/>
         <source>%1 seconds</source>
         <translation>%1 secondi</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="105"/>
-        <location filename="../screens/SettingsScreen.qml" line="725"/>
+        <location filename="../screens/SettingsScreen.qml" line="109"/>
+        <location filename="../screens/SettingsScreen.qml" line="729"/>
         <source>Resolution</source>
         <translation>Risoluzione</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="77"/>
-        <location filename="../screens/SettingsScreen.qml" line="219"/>
+        <location filename="../screens/SettingsScreen.qml" line="81"/>
+        <location filename="../screens/SettingsScreen.qml" line="223"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="221"/>
+        <location filename="../screens/SettingsScreen.qml" line="87"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="95"/>
-        <location filename="../screens/SettingsScreen.qml" line="225"/>
+        <location filename="../screens/SettingsScreen.qml" line="99"/>
+        <location filename="../screens/SettingsScreen.qml" line="229"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="693"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="691"/>
+        <location filename="../screens/SettingsScreen.qml" line="695"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="693"/>
+        <location filename="../screens/SettingsScreen.qml" line="697"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="695"/>
+        <location filename="../screens/SettingsScreen.qml" line="699"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="697"/>
+        <location filename="../screens/SettingsScreen.qml" line="701"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="699"/>
+        <location filename="../screens/SettingsScreen.qml" line="703"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="701"/>
+        <location filename="../screens/SettingsScreen.qml" line="705"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="703"/>
+        <location filename="../screens/SettingsScreen.qml" line="707"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="705"/>
+        <location filename="../screens/SettingsScreen.qml" line="709"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="707"/>
+        <location filename="../screens/SettingsScreen.qml" line="711"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="709"/>
+        <location filename="../screens/SettingsScreen.qml" line="713"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="711"/>
+        <location filename="../screens/SettingsScreen.qml" line="715"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="226"/>
+        <location filename="../screens/SettingsScreen.qml" line="230"/>
         <source>Settings</source>
         <translation>Impostazioni</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1339"/>
+        <location filename="../screens/SettingsScreen.qml" line="1370"/>
         <source>No settings available on this platform</source>
         <translation>Nessuna impostazione disponibile su questa piattaforma</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="242"/>
-        <location filename="../screens/SystemsScreen.qml" line="343"/>
+        <location filename="../screens/SystemsScreen.qml" line="245"/>
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>%1 systems</source>
         <translation>%1 sistemi</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="243"/>
-        <location filename="../screens/SystemsScreen.qml" line="360"/>
+        <location filename="../screens/SystemsScreen.qml" line="246"/>
+        <location filename="../screens/SystemsScreen.qml" line="363"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="378"/>
+        <location filename="../screens/SystemsScreen.qml" line="381"/>
         <source>No systems in this category</source>
         <translation>Nessun sistema in questa categoria</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="379"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="156"/>
+        <location filename="../screens/HubScreen.qml" line="154"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="162"/>
+        <location filename="../screens/HubScreen.qml" line="160"/>
         <source>Favorites</source>
         <translation>Preferiti</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="167"/>
+        <location filename="../screens/HubScreen.qml" line="165"/>
         <source>Recently Played</source>
         <translation>Giocati di recente</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="172"/>
+        <location filename="../screens/HubScreen.qml" line="170"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Impostazioni</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="722"/>
+        <location filename="../screens/HubScreen.qml" line="718"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Nessun sistema disponibile. Esegui Aggiorna database multimediale dalle Impostazioni.</translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>No</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="256"/>
+        <location filename="../components/Modal.qml" line="246"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
@@ -936,24 +936,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147"/>
-        <location filename="../screens/SettingsScreen.qml" line="741"/>
+        <location filename="../screens/SettingsScreen.qml" line="141"/>
+        <location filename="../screens/SettingsScreen.qml" line="734"/>
         <source>Language</source>
         <translation>Lingua</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
-        <location filename="../screens/SettingsScreen.qml" line="777"/>
+        <location filename="../screens/SettingsScreen.qml" line="116"/>
+        <location filename="../screens/SettingsScreen.qml" line="770"/>
         <source>Browsing layout</source>
         <translation>Layout navigazione</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="165"/>
+        <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>Mouse support</source>
         <translation>Supporto mouse</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="177"/>
+        <location filename="../screens/SettingsScreen.qml" line="171"/>
         <source>Update media database</source>
         <translation>Aggiorna database multimediale</translation>
     </message>
@@ -962,47 +962,47 @@ Euskara - devilschile2</source>
         <translation type="vanished">Generale</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="768"/>
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="761"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="160"/>
-        <location filename="../screens/SettingsScreen.qml" line="786"/>
+        <location filename="../screens/SettingsScreen.qml" line="154"/>
+        <location filename="../screens/SettingsScreen.qml" line="779"/>
         <source>Button style</source>
         <translation>Stile pulsanti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="132"/>
-        <location filename="../screens/SettingsScreen.qml" line="795"/>
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
+        <location filename="../screens/SettingsScreen.qml" line="788"/>
         <source>Screensaver</source>
         <translation>Salvaschermo</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="95"/>
-        <location filename="../screens/SettingsScreen.qml" line="229"/>
+        <location filename="../screens/SettingsScreen.qml" line="89"/>
+        <location filename="../screens/SettingsScreen.qml" line="223"/>
         <source>Library</source>
         <translation>Libreria</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="182"/>
+        <location filename="../screens/SettingsScreen.qml" line="176"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="127"/>
-        <location filename="../screens/SettingsScreen.qml" line="804"/>
+        <location filename="../screens/SettingsScreen.qml" line="121"/>
+        <location filename="../screens/SettingsScreen.qml" line="797"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <location filename="../screens/SettingsScreen.qml" line="181"/>
         <source>Scrape metadata</source>
         <translation>Recupera metadati</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="192"/>
+        <location filename="../screens/SettingsScreen.qml" line="186"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1011,402 +1011,402 @@ Euskara - devilschile2</source>
         <translation type="vanished">Avanzate</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="204"/>
+        <location filename="../screens/SettingsScreen.qml" line="198"/>
         <source>Debug logging</source>
         <translation>Log di debug</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="209"/>
+        <location filename="../screens/SettingsScreen.qml" line="203"/>
         <source>Upload log file</source>
         <translation>Carica file di log</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="199"/>
+        <location filename="../screens/SettingsScreen.qml" line="193"/>
         <source>About / License</source>
         <translation>Informazioni / Licenza</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="137"/>
-        <location filename="../screens/SettingsScreen.qml" line="750"/>
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="743"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="142"/>
-        <location filename="../screens/SettingsScreen.qml" line="759"/>
+        <location filename="../screens/SettingsScreen.qml" line="136"/>
+        <location filename="../screens/SettingsScreen.qml" line="752"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152"/>
+        <location filename="../screens/SettingsScreen.qml" line="146"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="170"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
         <source>Reduce motion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="240"/>
         <source>Optimizing</source>
         <translation>Ottimizzazione</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="248"/>
-        <location filename="../screens/SettingsScreen.qml" line="257"/>
+        <location filename="../screens/SettingsScreen.qml" line="242"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>Paused</source>
         <translation>In pausa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="248"/>
-        <location filename="../screens/SettingsScreen.qml" line="257"/>
+        <location filename="../screens/SettingsScreen.qml" line="242"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>In progress</source>
         <translation>In corso</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="245"/>
         <source>%1 indexed</source>
         <translation>%1 indicizzati</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="260"/>
+        <location filename="../screens/SettingsScreen.qml" line="254"/>
         <source>%1 scraped</source>
         <translation>%1 recuperati</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="495"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="495"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Start</source>
         <translation>Avvia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="497"/>
+        <location filename="../screens/SettingsScreen.qml" line="490"/>
         <source>Upload</source>
         <translation>Carica</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <location filename="../screens/SettingsScreen.qml" line="491"/>
         <source>Open</source>
         <translation>Apri</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="579"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>English</source>
         <translation>Inglese</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="581"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Italian</source>
         <translation>Italiano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="583"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="585"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="587"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>German</source>
         <translation>Tedesco</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="589"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Greek</source>
         <translation>Greco</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="591"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Japanese</source>
         <translation>Giapponese</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="593"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Korean</source>
         <translation>Coreano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="595"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Dutch</source>
         <translation>Olandese</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="597"/>
+        <location filename="../screens/SettingsScreen.qml" line="590"/>
         <source>Romanian</source>
         <translation>Rumeno</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="599"/>
+        <location filename="../screens/SettingsScreen.qml" line="592"/>
         <source>Slovak</source>
         <translation>Slovacco</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="601"/>
+        <location filename="../screens/SettingsScreen.qml" line="594"/>
         <source>Ukrainian</source>
         <translation>Ucraino</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="603"/>
+        <location filename="../screens/SettingsScreen.qml" line="596"/>
         <source>Chinese (Simplified)</source>
         <translation>Cinese (semplificato)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="605"/>
+        <location filename="../screens/SettingsScreen.qml" line="598"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="607"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Hebrew</source>
         <translation>Ebraico</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="611"/>
+        <location filename="../screens/SettingsScreen.qml" line="604"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
-        <location filename="../screens/SettingsScreen.qml" line="620"/>
-        <location filename="../screens/SettingsScreen.qml" line="694"/>
+        <location filename="../screens/SettingsScreen.qml" line="605"/>
+        <location filename="../screens/SettingsScreen.qml" line="613"/>
+        <location filename="../screens/SettingsScreen.qml" line="687"/>
         <source>Auto</source>
         <translation>Automatico</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="610"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="619"/>
+        <location filename="../screens/SettingsScreen.qml" line="612"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="630"/>
+        <location filename="../screens/SettingsScreen.qml" line="623"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="632"/>
+        <location filename="../screens/SettingsScreen.qml" line="625"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="634"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="628"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="640"/>
+        <location filename="../screens/SettingsScreen.qml" line="633"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="642"/>
+        <location filename="../screens/SettingsScreen.qml" line="635"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="643"/>
+        <location filename="../screens/SettingsScreen.qml" line="636"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="648"/>
+        <location filename="../screens/SettingsScreen.qml" line="641"/>
         <source>Detailed list view</source>
         <translation>Vista elenco dettagliata</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="642"/>
         <source>Grid view</source>
         <translation>Vista griglia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="654"/>
+        <location filename="../screens/SettingsScreen.qml" line="647"/>
         <source>Style B</source>
         <translation>Stile B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="656"/>
+        <location filename="../screens/SettingsScreen.qml" line="649"/>
         <source>Style C</source>
         <translation>Stile C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="658"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
         <source>Style D</source>
         <translation>Stile D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="659"/>
+        <location filename="../screens/SettingsScreen.qml" line="652"/>
         <source>Style A</source>
         <translation>Stile A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1368"/>
+        <location filename="../screens/SettingsScreen.qml" line="1351"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="549"/>
+        <location filename="../screens/SettingsScreen.qml" line="542"/>
         <source>Default</source>
         <translation>Predefinito</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="674"/>
+        <location filename="../screens/SettingsScreen.qml" line="667"/>
         <source>Off</source>
         <translation>Disattivato</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="676"/>
+        <location filename="../screens/SettingsScreen.qml" line="669"/>
         <source>1 second (testing)</source>
         <translation>1 secondo (test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="678"/>
+        <location filename="../screens/SettingsScreen.qml" line="671"/>
         <source>1 minute</source>
         <translation>1 minuto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="680"/>
+        <location filename="../screens/SettingsScreen.qml" line="673"/>
         <source>2 minutes</source>
         <translation>2 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="682"/>
+        <location filename="../screens/SettingsScreen.qml" line="675"/>
         <source>5 minutes</source>
         <translation>5 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="684"/>
+        <location filename="../screens/SettingsScreen.qml" line="677"/>
         <source>10 minutes</source>
         <translation>10 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="686"/>
+        <location filename="../screens/SettingsScreen.qml" line="679"/>
         <source>15 minutes</source>
         <translation>15 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="688"/>
+        <location filename="../screens/SettingsScreen.qml" line="681"/>
         <source>30 minutes</source>
         <translation>30 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="682"/>
         <source>%1 seconds</source>
         <translation>%1 secondi</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
-        <location filename="../screens/SettingsScreen.qml" line="732"/>
+        <location filename="../screens/SettingsScreen.qml" line="105"/>
+        <location filename="../screens/SettingsScreen.qml" line="725"/>
         <source>Resolution</source>
         <translation>Risoluzione</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="225"/>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="219"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="89"/>
-        <location filename="../screens/SettingsScreen.qml" line="227"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="221"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="101"/>
-        <location filename="../screens/SettingsScreen.qml" line="231"/>
+        <location filename="../screens/SettingsScreen.qml" line="95"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="696"/>
+        <location filename="../screens/SettingsScreen.qml" line="689"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="698"/>
+        <location filename="../screens/SettingsScreen.qml" line="691"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="700"/>
+        <location filename="../screens/SettingsScreen.qml" line="693"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="702"/>
+        <location filename="../screens/SettingsScreen.qml" line="695"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="704"/>
+        <location filename="../screens/SettingsScreen.qml" line="697"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="706"/>
+        <location filename="../screens/SettingsScreen.qml" line="699"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="708"/>
+        <location filename="../screens/SettingsScreen.qml" line="701"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="710"/>
+        <location filename="../screens/SettingsScreen.qml" line="703"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="712"/>
+        <location filename="../screens/SettingsScreen.qml" line="705"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="714"/>
+        <location filename="../screens/SettingsScreen.qml" line="707"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="716"/>
+        <location filename="../screens/SettingsScreen.qml" line="709"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="718"/>
+        <location filename="../screens/SettingsScreen.qml" line="711"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="232"/>
+        <location filename="../screens/SettingsScreen.qml" line="226"/>
         <source>Settings</source>
         <translation>Impostazioni</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1356"/>
+        <location filename="../screens/SettingsScreen.qml" line="1339"/>
         <source>No settings available on this platform</source>
         <translation>Nessuna impostazione disponibile su questa piattaforma</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="236"/>
-        <location filename="../screens/SystemsScreen.qml" line="338"/>
+        <location filename="../screens/SystemsScreen.qml" line="242"/>
+        <location filename="../screens/SystemsScreen.qml" line="343"/>
         <source>%1 systems</source>
         <translation>%1 sistemi</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="237"/>
-        <location filename="../screens/SystemsScreen.qml" line="355"/>
+        <location filename="../screens/SystemsScreen.qml" line="243"/>
+        <location filename="../screens/SystemsScreen.qml" line="360"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="373"/>
+        <location filename="../screens/SystemsScreen.qml" line="378"/>
         <source>No systems in this category</source>
         <translation>Nessun sistema in questa categoria</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="374"/>
+        <location filename="../screens/SystemsScreen.qml" line="379"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>
@@ -1439,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="539"/>
+        <location filename="../components/Tile.qml" line="501"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -425,34 +425,34 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="116"/>
-        <location filename="../screens/GamesScreen.qml" line="151"/>
+        <location filename="../screens/GamesScreen.qml" line="127"/>
+        <location filename="../screens/GamesScreen.qml" line="162"/>
         <source>%1 files</source>
         <translation>%1 ファイル</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="53"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="125"/>
-        <location filename="../screens/GamesScreen.qml" line="152"/>
+        <location filename="../screens/GamesScreen.qml" line="136"/>
+        <location filename="../screens/GamesScreen.qml" line="163"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="48"/>
+        <location filename="../screens/GamesScreen.qml" line="49"/>
         <source>Loading games…</source>
         <translation>ゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="121"/>
+        <location filename="../screens/GamesScreen.qml" line="132"/>
         <source>Loading more…</source>
         <translation>さらに読み込み中…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="47"/>
+        <location filename="../screens/GamesScreen.qml" line="48"/>
         <source>No games in this system</source>
         <translation>このシステムにゲームはありません</translation>
     </message>
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="139"/>
+        <location filename="../screens/HubScreen.qml" line="149"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="145"/>
+        <location filename="../screens/HubScreen.qml" line="155"/>
         <source>Favorites</source>
         <translation>お気に入り</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="150"/>
+        <location filename="../screens/HubScreen.qml" line="160"/>
         <source>Recently Played</source>
         <translation>最近プレイしたゲーム</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="155"/>
+        <location filename="../screens/HubScreen.qml" line="165"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">設定</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="669"/>
+        <location filename="../screens/HubScreen.qml" line="701"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>利用可能なシステムがありません。設定からメディアデータベースの更新を実行してください。</translation>
     </message>
@@ -553,138 +553,138 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1361"/>
+        <location filename="../app/Main.qml" line="1367"/>
         <source>Launch core</source>
         <translation>コアを起動</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1367"/>
-        <location filename="../app/Main.qml" line="1606"/>
+        <location filename="../app/Main.qml" line="1373"/>
+        <location filename="../app/Main.qml" line="1612"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1425"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Remove from favorites</source>
         <translation>お気に入りから削除</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1425"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Add to favorites</source>
         <translation>お気に入りに追加</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1430"/>
+        <location filename="../app/Main.qml" line="1436"/>
         <source>Write to NFC token</source>
         <translation>NFC トークンに書き込む</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1434"/>
+        <location filename="../app/Main.qml" line="1440"/>
         <source>QR code</source>
         <translation>QR コード</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1409"/>
-        <location filename="../app/Main.qml" line="1444"/>
+        <location filename="../app/Main.qml" line="1415"/>
+        <location filename="../app/Main.qml" line="1450"/>
         <source>Launch game</source>
         <translation>ゲームを起動</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2604"/>
+        <location filename="../app/Main.qml" line="2610"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2616"/>
         <source>Loading favorites…</source>
         <translation>お気に入りを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2606"/>
+        <location filename="../app/Main.qml" line="2612"/>
         <source>Loading games…</source>
         <translation>ゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1374"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1380"/>
+        <location filename="../app/Main.qml" line="1403"/>
         <source>Update media database</source>
         <translation type="unfinished">メディアデータベースを更新</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1377"/>
-        <location filename="../app/Main.qml" line="1400"/>
+        <location filename="../app/Main.qml" line="1383"/>
+        <location filename="../app/Main.qml" line="1406"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">メタデータをスクレイピング</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1382"/>
-        <location filename="../app/Main.qml" line="1391"/>
+        <location filename="../app/Main.qml" line="1388"/>
+        <location filename="../app/Main.qml" line="1397"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1382"/>
-        <location filename="../app/Main.qml" line="1391"/>
+        <location filename="../app/Main.qml" line="1388"/>
+        <location filename="../app/Main.qml" line="1397"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1602"/>
+        <location filename="../app/Main.qml" line="1608"/>
         <source>Default</source>
         <translation type="unfinished">デフォルト</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1602"/>
+        <location filename="../app/Main.qml" line="1608"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1926"/>
+        <location filename="../app/Main.qml" line="1932"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1930"/>
+        <location filename="../app/Main.qml" line="1936"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1944"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1948"/>
+        <location filename="../app/Main.qml" line="1954"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1952"/>
+        <location filename="../app/Main.qml" line="1958"/>
         <source>Retry</source>
         <translation type="unfinished">再試行</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1956"/>
+        <location filename="../app/Main.qml" line="1962"/>
         <source>Cancel</source>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2608"/>
+        <location filename="../app/Main.qml" line="2614"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2612"/>
+        <location filename="../app/Main.qml" line="2618"/>
         <source>Loading recently played…</source>
         <translation>最近プレイしたゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2620"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2616"/>
+        <location filename="../app/Main.qml" line="2622"/>
         <source>Loading…</source>
         <translation>読み込み中…</translation>
     </message>
@@ -692,72 +692,72 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="683"/>
+        <location filename="../app/MainLayout.qml" line="685"/>
         <source>Writing failed</source>
         <translation>書き込み失敗</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="683"/>
+        <location filename="../app/MainLayout.qml" line="685"/>
         <source>Put a writable card near the reader</source>
         <translation>書き込み可能なカードをリーダーに近づけてください</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="811"/>
+        <location filename="../app/MainLayout.qml" line="813"/>
         <source>Are you sure you want to exit?</source>
         <translation>本当に終了しますか？</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="894"/>
-        <location filename="../app/MainLayout.qml" line="968"/>
+        <location filename="../app/MainLayout.qml" line="896"/>
+        <location filename="../app/MainLayout.qml" line="970"/>
         <source>Select</source>
         <translation>選択</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="902"/>
-        <location filename="../app/MainLayout.qml" line="916"/>
-        <location filename="../app/MainLayout.qml" line="931"/>
-        <location filename="../app/MainLayout.qml" line="942"/>
+        <location filename="../app/MainLayout.qml" line="900"/>
+        <location filename="../app/MainLayout.qml" line="904"/>
+        <location filename="../app/MainLayout.qml" line="918"/>
+        <location filename="../app/MainLayout.qml" line="933"/>
+        <location filename="../app/MainLayout.qml" line="944"/>
         <source>Close</source>
         <translation>閉じる</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="909"/>
-        <location filename="../app/MainLayout.qml" line="949"/>
-        <location filename="../app/MainLayout.qml" line="972"/>
-        <location filename="../app/MainLayout.qml" line="983"/>
+        <location filename="../app/MainLayout.qml" line="911"/>
+        <location filename="../app/MainLayout.qml" line="951"/>
+        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="985"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="927"/>
+        <location filename="../app/MainLayout.qml" line="929"/>
         <source>Done</source>
         <translation>完了</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="957"/>
+        <location filename="../app/MainLayout.qml" line="959"/>
         <source>I understand</source>
         <translation>了解しました</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="991"/>
+        <location filename="../app/MainLayout.qml" line="993"/>
         <source>Start</source>
         <translation>開始</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1203"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Scroll</source>
         <translation>スクロール</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="890"/>
-        <location filename="../app/MainLayout.qml" line="964"/>
-        <location filename="../app/MainLayout.qml" line="1010"/>
-        <location filename="../app/MainLayout.qml" line="1047"/>
-        <location filename="../app/MainLayout.qml" line="1097"/>
-        <location filename="../app/MainLayout.qml" line="1146"/>
-        <location filename="../app/MainLayout.qml" line="1165"/>
-        <location filename="../app/MainLayout.qml" line="1232"/>
+        <location filename="../app/MainLayout.qml" line="892"/>
+        <location filename="../app/MainLayout.qml" line="966"/>
+        <location filename="../app/MainLayout.qml" line="1012"/>
+        <location filename="../app/MainLayout.qml" line="1049"/>
+        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1148"/>
+        <location filename="../app/MainLayout.qml" line="1167"/>
+        <location filename="../app/MainLayout.qml" line="1234"/>
         <source>Move</source>
         <translation>移動</translation>
     </message>
@@ -777,81 +777,81 @@ Euskara - devilschile2</source>
         <translation type="unfinished">最近プレイしたゲーム</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="699"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="700"/>
+        <location filename="../app/MainLayout.qml" line="702"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="810"/>
+        <location filename="../app/MainLayout.qml" line="812"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1014"/>
-        <location filename="../app/MainLayout.qml" line="1057"/>
-        <location filename="../app/MainLayout.qml" line="1107"/>
-        <location filename="../app/MainLayout.qml" line="1151"/>
-        <location filename="../app/MainLayout.qml" line="1242"/>
+        <location filename="../app/MainLayout.qml" line="1016"/>
+        <location filename="../app/MainLayout.qml" line="1059"/>
+        <location filename="../app/MainLayout.qml" line="1109"/>
+        <location filename="../app/MainLayout.qml" line="1153"/>
+        <location filename="../app/MainLayout.qml" line="1244"/>
         <source>Open</source>
         <translation>開く</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1024"/>
+        <location filename="../app/MainLayout.qml" line="1026"/>
         <source>Quit</source>
         <translation>終了</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1033"/>
-        <location filename="../app/MainLayout.qml" line="1063"/>
-        <location filename="../app/MainLayout.qml" line="1074"/>
-        <location filename="../app/MainLayout.qml" line="1089"/>
-        <location filename="../app/MainLayout.qml" line="1116"/>
-        <location filename="../app/MainLayout.qml" line="1127"/>
-        <location filename="../app/MainLayout.qml" line="1139"/>
-        <location filename="../app/MainLayout.qml" line="1155"/>
-        <location filename="../app/MainLayout.qml" line="1189"/>
-        <location filename="../app/MainLayout.qml" line="1207"/>
-        <location filename="../app/MainLayout.qml" line="1216"/>
-        <location filename="../app/MainLayout.qml" line="1251"/>
-        <location filename="../app/MainLayout.qml" line="1262"/>
+        <location filename="../app/MainLayout.qml" line="1035"/>
+        <location filename="../app/MainLayout.qml" line="1065"/>
+        <location filename="../app/MainLayout.qml" line="1076"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
+        <location filename="../app/MainLayout.qml" line="1118"/>
+        <location filename="../app/MainLayout.qml" line="1129"/>
+        <location filename="../app/MainLayout.qml" line="1141"/>
+        <location filename="../app/MainLayout.qml" line="1157"/>
+        <location filename="../app/MainLayout.qml" line="1191"/>
+        <location filename="../app/MainLayout.qml" line="1209"/>
+        <location filename="../app/MainLayout.qml" line="1218"/>
+        <location filename="../app/MainLayout.qml" line="1253"/>
+        <location filename="../app/MainLayout.qml" line="1264"/>
         <source>Back</source>
         <translation>戻る</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1053"/>
-        <location filename="../app/MainLayout.qml" line="1103"/>
-        <location filename="../app/MainLayout.qml" line="1238"/>
+        <location filename="../app/MainLayout.qml" line="1055"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
+        <location filename="../app/MainLayout.qml" line="1240"/>
         <source>Page</source>
         <translation>ページ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1060"/>
-        <location filename="../app/MainLayout.qml" line="1112"/>
-        <location filename="../app/MainLayout.qml" line="1247"/>
+        <location filename="../app/MainLayout.qml" line="1022"/>
+        <location filename="../app/MainLayout.qml" line="1062"/>
+        <location filename="../app/MainLayout.qml" line="1114"/>
+        <location filename="../app/MainLayout.qml" line="1249"/>
         <source>Options</source>
         <translation>オプション</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1070"/>
-        <location filename="../app/MainLayout.qml" line="1123"/>
-        <location filename="../app/MainLayout.qml" line="1258"/>
+        <location filename="../app/MainLayout.qml" line="940"/>
+        <location filename="../app/MainLayout.qml" line="1072"/>
+        <location filename="../app/MainLayout.qml" line="1125"/>
+        <location filename="../app/MainLayout.qml" line="1260"/>
         <source>Retry</source>
         <translation>再試行</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1174"/>
+        <location filename="../app/MainLayout.qml" line="1176"/>
         <source>Change</source>
         <translation>変更</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1180"/>
+        <location filename="../app/MainLayout.qml" line="1182"/>
         <source>Toggle</source>
         <translation>切り替え</translation>
     </message>
@@ -864,12 +864,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">読み込み中…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="365"/>
+        <location filename="../screens/MediaListScreen.qml" line="395"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 件</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="366"/>
+        <location filename="../screens/MediaListScreen.qml" line="396"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>いいえ</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="198"/>
+        <location filename="../components/Modal.qml" line="246"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
@@ -936,24 +936,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="132"/>
-        <location filename="../screens/SettingsScreen.qml" line="718"/>
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
+        <location filename="../screens/SettingsScreen.qml" line="741"/>
         <source>Language</source>
         <translation>言語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="754"/>
+        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <location filename="../screens/SettingsScreen.qml" line="777"/>
         <source>Browsing layout</source>
         <translation>ブラウジングレイアウト</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="150"/>
+        <location filename="../screens/SettingsScreen.qml" line="165"/>
         <source>Mouse support</source>
         <translation>マウスサポート</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="157"/>
+        <location filename="../screens/SettingsScreen.qml" line="177"/>
         <source>Update media database</source>
         <translation>メディアデータベースを更新</translation>
     </message>
@@ -962,47 +962,47 @@ Euskara - devilschile2</source>
         <translation type="vanished">一般</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="745"/>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="768"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="145"/>
-        <location filename="../screens/SettingsScreen.qml" line="763"/>
+        <location filename="../screens/SettingsScreen.qml" line="160"/>
+        <location filename="../screens/SettingsScreen.qml" line="786"/>
         <source>Button style</source>
         <translation>ボタンスタイル</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="772"/>
+        <location filename="../screens/SettingsScreen.qml" line="132"/>
+        <location filename="../screens/SettingsScreen.qml" line="795"/>
         <source>Screensaver</source>
         <translation>スクリーンセーバー</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="80"/>
-        <location filename="../screens/SettingsScreen.qml" line="209"/>
+        <location filename="../screens/SettingsScreen.qml" line="95"/>
+        <location filename="../screens/SettingsScreen.qml" line="229"/>
         <source>Library</source>
         <translation>ライブラリ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="162"/>
+        <location filename="../screens/SettingsScreen.qml" line="182"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="112"/>
-        <location filename="../screens/SettingsScreen.qml" line="781"/>
+        <location filename="../screens/SettingsScreen.qml" line="127"/>
+        <location filename="../screens/SettingsScreen.qml" line="804"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="167"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
         <source>Scrape metadata</source>
         <translation>メタデータをスクレイピング</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="172"/>
+        <location filename="../screens/SettingsScreen.qml" line="192"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1011,397 +1011,402 @@ Euskara - devilschile2</source>
         <translation type="vanished">詳細設定</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="184"/>
+        <location filename="../screens/SettingsScreen.qml" line="204"/>
         <source>Debug logging</source>
         <translation>デバッグログ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="189"/>
+        <location filename="../screens/SettingsScreen.qml" line="209"/>
         <source>Upload log file</source>
         <translation>ログファイルをアップロード</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="179"/>
+        <location filename="../screens/SettingsScreen.qml" line="199"/>
         <source>About / License</source>
         <translation>情報 / ライセンス</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
-        <location filename="../screens/SettingsScreen.qml" line="727"/>
+        <location filename="../screens/SettingsScreen.qml" line="137"/>
+        <location filename="../screens/SettingsScreen.qml" line="750"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="127"/>
-        <location filename="../screens/SettingsScreen.qml" line="736"/>
+        <location filename="../screens/SettingsScreen.qml" line="142"/>
+        <location filename="../screens/SettingsScreen.qml" line="759"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="137"/>
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="226"/>
+        <location filename="../screens/SettingsScreen.qml" line="170"/>
+        <source>Reduce motion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
         <source>Optimizing</source>
         <translation>最適化中</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="228"/>
-        <location filename="../screens/SettingsScreen.qml" line="237"/>
+        <location filename="../screens/SettingsScreen.qml" line="248"/>
+        <location filename="../screens/SettingsScreen.qml" line="257"/>
         <source>Paused</source>
         <translation>一時停止中</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="228"/>
-        <location filename="../screens/SettingsScreen.qml" line="237"/>
+        <location filename="../screens/SettingsScreen.qml" line="248"/>
+        <location filename="../screens/SettingsScreen.qml" line="257"/>
         <source>In progress</source>
         <translation>実行中</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="231"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>%1 indexed</source>
         <translation>%1 件を索引化</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="240"/>
+        <location filename="../screens/SettingsScreen.qml" line="260"/>
         <source>%1 scraped</source>
         <translation>%1 件取得済み</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="472"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="472"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Start</source>
         <translation>開始</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="474"/>
+        <location filename="../screens/SettingsScreen.qml" line="497"/>
         <source>Upload</source>
         <translation>アップロード</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Open</source>
         <translation>開く</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="556"/>
+        <location filename="../screens/SettingsScreen.qml" line="579"/>
         <source>English</source>
         <translation>英語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="558"/>
+        <location filename="../screens/SettingsScreen.qml" line="581"/>
         <source>Italian</source>
         <translation>イタリア語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="560"/>
+        <location filename="../screens/SettingsScreen.qml" line="583"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="562"/>
+        <location filename="../screens/SettingsScreen.qml" line="585"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="564"/>
+        <location filename="../screens/SettingsScreen.qml" line="587"/>
         <source>German</source>
         <translation>ドイツ語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="566"/>
+        <location filename="../screens/SettingsScreen.qml" line="589"/>
         <source>Greek</source>
         <translation>ギリシャ語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="568"/>
+        <location filename="../screens/SettingsScreen.qml" line="591"/>
         <source>Japanese</source>
         <translation>日本語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="570"/>
+        <location filename="../screens/SettingsScreen.qml" line="593"/>
         <source>Korean</source>
         <translation>韓国語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="595"/>
         <source>Dutch</source>
         <translation>オランダ語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="597"/>
         <source>Romanian</source>
         <translation>ルーマニア語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="599"/>
         <source>Slovak</source>
         <translation>スロバキア語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="601"/>
         <source>Ukrainian</source>
         <translation>ウクライナ語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="603"/>
         <source>Chinese (Simplified)</source>
         <translation>中国語（簡体字）</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="605"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="607"/>
         <source>Hebrew</source>
         <translation>ヘブライ語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="588"/>
+        <location filename="../screens/SettingsScreen.qml" line="611"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="589"/>
-        <location filename="../screens/SettingsScreen.qml" line="597"/>
-        <location filename="../screens/SettingsScreen.qml" line="671"/>
+        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="620"/>
+        <location filename="../screens/SettingsScreen.qml" line="694"/>
         <source>Auto</source>
         <translation>自動</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="594"/>
+        <location filename="../screens/SettingsScreen.qml" line="617"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="596"/>
+        <location filename="../screens/SettingsScreen.qml" line="619"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="607"/>
+        <location filename="../screens/SettingsScreen.qml" line="630"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="632"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="611"/>
+        <location filename="../screens/SettingsScreen.qml" line="634"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="635"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="640"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="619"/>
+        <location filename="../screens/SettingsScreen.qml" line="642"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="620"/>
+        <location filename="../screens/SettingsScreen.qml" line="643"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="625"/>
+        <location filename="../screens/SettingsScreen.qml" line="648"/>
         <source>Detailed list view</source>
         <translation>詳細リスト表示</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="626"/>
+        <location filename="../screens/SettingsScreen.qml" line="649"/>
         <source>Grid view</source>
         <translation>グリッド表示</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="631"/>
+        <location filename="../screens/SettingsScreen.qml" line="654"/>
         <source>Style B</source>
         <translation>スタイル B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="633"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Style C</source>
         <translation>スタイル C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="658"/>
         <source>Style D</source>
         <translation>スタイル D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="659"/>
         <source>Style A</source>
         <translation>スタイル A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1292"/>
+        <location filename="../screens/SettingsScreen.qml" line="1358"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="526"/>
+        <location filename="../screens/SettingsScreen.qml" line="549"/>
         <source>Default</source>
         <translation>デフォルト</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="674"/>
         <source>Off</source>
         <translation>オフ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="653"/>
+        <location filename="../screens/SettingsScreen.qml" line="676"/>
         <source>1 second (testing)</source>
         <translation>1秒（テスト）</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="655"/>
+        <location filename="../screens/SettingsScreen.qml" line="678"/>
         <source>1 minute</source>
         <translation>1分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="657"/>
+        <location filename="../screens/SettingsScreen.qml" line="680"/>
         <source>2 minutes</source>
         <translation>2分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="659"/>
+        <location filename="../screens/SettingsScreen.qml" line="682"/>
         <source>5 minutes</source>
         <translation>5分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="661"/>
+        <location filename="../screens/SettingsScreen.qml" line="684"/>
         <source>10 minutes</source>
         <translation>10分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="663"/>
+        <location filename="../screens/SettingsScreen.qml" line="686"/>
         <source>15 minutes</source>
         <translation>15分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="665"/>
+        <location filename="../screens/SettingsScreen.qml" line="688"/>
         <source>30 minutes</source>
         <translation>30分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="666"/>
+        <location filename="../screens/SettingsScreen.qml" line="689"/>
         <source>%1 seconds</source>
         <translation>%1秒</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="96"/>
-        <location filename="../screens/SettingsScreen.qml" line="709"/>
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="732"/>
         <source>Resolution</source>
         <translation>解像度</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="68"/>
-        <location filename="../screens/SettingsScreen.qml" line="205"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="74"/>
-        <location filename="../screens/SettingsScreen.qml" line="207"/>
+        <location filename="../screens/SettingsScreen.qml" line="89"/>
+        <location filename="../screens/SettingsScreen.qml" line="227"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="86"/>
-        <location filename="../screens/SettingsScreen.qml" line="211"/>
+        <location filename="../screens/SettingsScreen.qml" line="101"/>
+        <location filename="../screens/SettingsScreen.qml" line="231"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="673"/>
+        <location filename="../screens/SettingsScreen.qml" line="696"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="675"/>
+        <location filename="../screens/SettingsScreen.qml" line="698"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="677"/>
+        <location filename="../screens/SettingsScreen.qml" line="700"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="679"/>
+        <location filename="../screens/SettingsScreen.qml" line="702"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="681"/>
+        <location filename="../screens/SettingsScreen.qml" line="704"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="683"/>
+        <location filename="../screens/SettingsScreen.qml" line="706"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="685"/>
+        <location filename="../screens/SettingsScreen.qml" line="708"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="687"/>
+        <location filename="../screens/SettingsScreen.qml" line="710"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="712"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="691"/>
+        <location filename="../screens/SettingsScreen.qml" line="714"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="693"/>
+        <location filename="../screens/SettingsScreen.qml" line="716"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="695"/>
+        <location filename="../screens/SettingsScreen.qml" line="718"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="212"/>
+        <location filename="../screens/SettingsScreen.qml" line="232"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1280"/>
+        <location filename="../screens/SettingsScreen.qml" line="1346"/>
         <source>No settings available on this platform</source>
         <translation>このプラットフォームでは設定項目がありません</translation>
     </message>
@@ -1409,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="206"/>
-        <location filename="../screens/SystemsScreen.qml" line="304"/>
+        <location filename="../screens/SystemsScreen.qml" line="229"/>
+        <location filename="../screens/SystemsScreen.qml" line="329"/>
         <source>%1 systems</source>
         <translation>%1 システム</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="207"/>
-        <location filename="../screens/SystemsScreen.qml" line="321"/>
+        <location filename="../screens/SystemsScreen.qml" line="230"/>
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="339"/>
+        <location filename="../screens/SystemsScreen.qml" line="364"/>
         <source>No systems in this category</source>
         <translation>このカテゴリにシステムはありません</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="340"/>
+        <location filename="../screens/SystemsScreen.qml" line="365"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>
@@ -1434,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="364"/>
+        <location filename="../components/Tile.qml" line="475"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="156"/>
+        <location filename="../screens/HubScreen.qml" line="154"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="162"/>
+        <location filename="../screens/HubScreen.qml" line="160"/>
         <source>Favorites</source>
         <translation>お気に入り</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="167"/>
+        <location filename="../screens/HubScreen.qml" line="165"/>
         <source>Recently Played</source>
         <translation>最近プレイしたゲーム</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="172"/>
+        <location filename="../screens/HubScreen.qml" line="170"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">設定</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="722"/>
+        <location filename="../screens/HubScreen.qml" line="718"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>利用可能なシステムがありません。設定からメディアデータベースの更新を実行してください。</translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>いいえ</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="256"/>
+        <location filename="../components/Modal.qml" line="246"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
@@ -936,24 +936,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147"/>
-        <location filename="../screens/SettingsScreen.qml" line="741"/>
+        <location filename="../screens/SettingsScreen.qml" line="141"/>
+        <location filename="../screens/SettingsScreen.qml" line="734"/>
         <source>Language</source>
         <translation>言語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
-        <location filename="../screens/SettingsScreen.qml" line="777"/>
+        <location filename="../screens/SettingsScreen.qml" line="116"/>
+        <location filename="../screens/SettingsScreen.qml" line="770"/>
         <source>Browsing layout</source>
         <translation>ブラウジングレイアウト</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="165"/>
+        <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>Mouse support</source>
         <translation>マウスサポート</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="177"/>
+        <location filename="../screens/SettingsScreen.qml" line="171"/>
         <source>Update media database</source>
         <translation>メディアデータベースを更新</translation>
     </message>
@@ -962,47 +962,47 @@ Euskara - devilschile2</source>
         <translation type="vanished">一般</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="768"/>
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="761"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="160"/>
-        <location filename="../screens/SettingsScreen.qml" line="786"/>
+        <location filename="../screens/SettingsScreen.qml" line="154"/>
+        <location filename="../screens/SettingsScreen.qml" line="779"/>
         <source>Button style</source>
         <translation>ボタンスタイル</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="132"/>
-        <location filename="../screens/SettingsScreen.qml" line="795"/>
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
+        <location filename="../screens/SettingsScreen.qml" line="788"/>
         <source>Screensaver</source>
         <translation>スクリーンセーバー</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="95"/>
-        <location filename="../screens/SettingsScreen.qml" line="229"/>
+        <location filename="../screens/SettingsScreen.qml" line="89"/>
+        <location filename="../screens/SettingsScreen.qml" line="223"/>
         <source>Library</source>
         <translation>ライブラリ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="182"/>
+        <location filename="../screens/SettingsScreen.qml" line="176"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="127"/>
-        <location filename="../screens/SettingsScreen.qml" line="804"/>
+        <location filename="../screens/SettingsScreen.qml" line="121"/>
+        <location filename="../screens/SettingsScreen.qml" line="797"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <location filename="../screens/SettingsScreen.qml" line="181"/>
         <source>Scrape metadata</source>
         <translation>メタデータをスクレイピング</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="192"/>
+        <location filename="../screens/SettingsScreen.qml" line="186"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1011,402 +1011,402 @@ Euskara - devilschile2</source>
         <translation type="vanished">詳細設定</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="204"/>
+        <location filename="../screens/SettingsScreen.qml" line="198"/>
         <source>Debug logging</source>
         <translation>デバッグログ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="209"/>
+        <location filename="../screens/SettingsScreen.qml" line="203"/>
         <source>Upload log file</source>
         <translation>ログファイルをアップロード</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="199"/>
+        <location filename="../screens/SettingsScreen.qml" line="193"/>
         <source>About / License</source>
         <translation>情報 / ライセンス</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="137"/>
-        <location filename="../screens/SettingsScreen.qml" line="750"/>
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="743"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="142"/>
-        <location filename="../screens/SettingsScreen.qml" line="759"/>
+        <location filename="../screens/SettingsScreen.qml" line="136"/>
+        <location filename="../screens/SettingsScreen.qml" line="752"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152"/>
+        <location filename="../screens/SettingsScreen.qml" line="146"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="170"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
         <source>Reduce motion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="240"/>
         <source>Optimizing</source>
         <translation>最適化中</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="248"/>
-        <location filename="../screens/SettingsScreen.qml" line="257"/>
+        <location filename="../screens/SettingsScreen.qml" line="242"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>Paused</source>
         <translation>一時停止中</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="248"/>
-        <location filename="../screens/SettingsScreen.qml" line="257"/>
+        <location filename="../screens/SettingsScreen.qml" line="242"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>In progress</source>
         <translation>実行中</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="245"/>
         <source>%1 indexed</source>
         <translation>%1 件を索引化</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="260"/>
+        <location filename="../screens/SettingsScreen.qml" line="254"/>
         <source>%1 scraped</source>
         <translation>%1 件取得済み</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="495"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="495"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Start</source>
         <translation>開始</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="497"/>
+        <location filename="../screens/SettingsScreen.qml" line="490"/>
         <source>Upload</source>
         <translation>アップロード</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <location filename="../screens/SettingsScreen.qml" line="491"/>
         <source>Open</source>
         <translation>開く</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="579"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>English</source>
         <translation>英語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="581"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Italian</source>
         <translation>イタリア語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="583"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="585"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="587"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>German</source>
         <translation>ドイツ語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="589"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Greek</source>
         <translation>ギリシャ語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="591"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Japanese</source>
         <translation>日本語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="593"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Korean</source>
         <translation>韓国語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="595"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Dutch</source>
         <translation>オランダ語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="597"/>
+        <location filename="../screens/SettingsScreen.qml" line="590"/>
         <source>Romanian</source>
         <translation>ルーマニア語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="599"/>
+        <location filename="../screens/SettingsScreen.qml" line="592"/>
         <source>Slovak</source>
         <translation>スロバキア語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="601"/>
+        <location filename="../screens/SettingsScreen.qml" line="594"/>
         <source>Ukrainian</source>
         <translation>ウクライナ語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="603"/>
+        <location filename="../screens/SettingsScreen.qml" line="596"/>
         <source>Chinese (Simplified)</source>
         <translation>中国語（簡体字）</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="605"/>
+        <location filename="../screens/SettingsScreen.qml" line="598"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="607"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Hebrew</source>
         <translation>ヘブライ語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="611"/>
+        <location filename="../screens/SettingsScreen.qml" line="604"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
-        <location filename="../screens/SettingsScreen.qml" line="620"/>
-        <location filename="../screens/SettingsScreen.qml" line="694"/>
+        <location filename="../screens/SettingsScreen.qml" line="605"/>
+        <location filename="../screens/SettingsScreen.qml" line="613"/>
+        <location filename="../screens/SettingsScreen.qml" line="687"/>
         <source>Auto</source>
         <translation>自動</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="610"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="619"/>
+        <location filename="../screens/SettingsScreen.qml" line="612"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="630"/>
+        <location filename="../screens/SettingsScreen.qml" line="623"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="632"/>
+        <location filename="../screens/SettingsScreen.qml" line="625"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="634"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="628"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="640"/>
+        <location filename="../screens/SettingsScreen.qml" line="633"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="642"/>
+        <location filename="../screens/SettingsScreen.qml" line="635"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="643"/>
+        <location filename="../screens/SettingsScreen.qml" line="636"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="648"/>
+        <location filename="../screens/SettingsScreen.qml" line="641"/>
         <source>Detailed list view</source>
         <translation>詳細リスト表示</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="642"/>
         <source>Grid view</source>
         <translation>グリッド表示</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="654"/>
+        <location filename="../screens/SettingsScreen.qml" line="647"/>
         <source>Style B</source>
         <translation>スタイル B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="656"/>
+        <location filename="../screens/SettingsScreen.qml" line="649"/>
         <source>Style C</source>
         <translation>スタイル C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="658"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
         <source>Style D</source>
         <translation>スタイル D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="659"/>
+        <location filename="../screens/SettingsScreen.qml" line="652"/>
         <source>Style A</source>
         <translation>スタイル A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1368"/>
+        <location filename="../screens/SettingsScreen.qml" line="1351"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="549"/>
+        <location filename="../screens/SettingsScreen.qml" line="542"/>
         <source>Default</source>
         <translation>デフォルト</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="674"/>
+        <location filename="../screens/SettingsScreen.qml" line="667"/>
         <source>Off</source>
         <translation>オフ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="676"/>
+        <location filename="../screens/SettingsScreen.qml" line="669"/>
         <source>1 second (testing)</source>
         <translation>1秒（テスト）</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="678"/>
+        <location filename="../screens/SettingsScreen.qml" line="671"/>
         <source>1 minute</source>
         <translation>1分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="680"/>
+        <location filename="../screens/SettingsScreen.qml" line="673"/>
         <source>2 minutes</source>
         <translation>2分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="682"/>
+        <location filename="../screens/SettingsScreen.qml" line="675"/>
         <source>5 minutes</source>
         <translation>5分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="684"/>
+        <location filename="../screens/SettingsScreen.qml" line="677"/>
         <source>10 minutes</source>
         <translation>10分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="686"/>
+        <location filename="../screens/SettingsScreen.qml" line="679"/>
         <source>15 minutes</source>
         <translation>15分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="688"/>
+        <location filename="../screens/SettingsScreen.qml" line="681"/>
         <source>30 minutes</source>
         <translation>30分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="682"/>
         <source>%1 seconds</source>
         <translation>%1秒</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
-        <location filename="../screens/SettingsScreen.qml" line="732"/>
+        <location filename="../screens/SettingsScreen.qml" line="105"/>
+        <location filename="../screens/SettingsScreen.qml" line="725"/>
         <source>Resolution</source>
         <translation>解像度</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="225"/>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="219"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="89"/>
-        <location filename="../screens/SettingsScreen.qml" line="227"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="221"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="101"/>
-        <location filename="../screens/SettingsScreen.qml" line="231"/>
+        <location filename="../screens/SettingsScreen.qml" line="95"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="696"/>
+        <location filename="../screens/SettingsScreen.qml" line="689"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="698"/>
+        <location filename="../screens/SettingsScreen.qml" line="691"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="700"/>
+        <location filename="../screens/SettingsScreen.qml" line="693"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="702"/>
+        <location filename="../screens/SettingsScreen.qml" line="695"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="704"/>
+        <location filename="../screens/SettingsScreen.qml" line="697"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="706"/>
+        <location filename="../screens/SettingsScreen.qml" line="699"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="708"/>
+        <location filename="../screens/SettingsScreen.qml" line="701"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="710"/>
+        <location filename="../screens/SettingsScreen.qml" line="703"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="712"/>
+        <location filename="../screens/SettingsScreen.qml" line="705"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="714"/>
+        <location filename="../screens/SettingsScreen.qml" line="707"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="716"/>
+        <location filename="../screens/SettingsScreen.qml" line="709"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="718"/>
+        <location filename="../screens/SettingsScreen.qml" line="711"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="232"/>
+        <location filename="../screens/SettingsScreen.qml" line="226"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1356"/>
+        <location filename="../screens/SettingsScreen.qml" line="1339"/>
         <source>No settings available on this platform</source>
         <translation>このプラットフォームでは設定項目がありません</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="236"/>
-        <location filename="../screens/SystemsScreen.qml" line="338"/>
+        <location filename="../screens/SystemsScreen.qml" line="242"/>
+        <location filename="../screens/SystemsScreen.qml" line="343"/>
         <source>%1 systems</source>
         <translation>%1 システム</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="237"/>
-        <location filename="../screens/SystemsScreen.qml" line="355"/>
+        <location filename="../screens/SystemsScreen.qml" line="243"/>
+        <location filename="../screens/SystemsScreen.qml" line="360"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="373"/>
+        <location filename="../screens/SystemsScreen.qml" line="378"/>
         <source>No systems in this category</source>
         <translation>このカテゴリにシステムはありません</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="374"/>
+        <location filename="../screens/SystemsScreen.qml" line="379"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>
@@ -1439,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="539"/>
+        <location filename="../components/Tile.qml" line="501"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -97,100 +97,100 @@ Euskara - devilschile2</source>
         <translation type="unfinished">読み込み中…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="196"/>
+        <location filename="../components/BrowseDetailPane.qml" line="167"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="196"/>
+        <location filename="../components/BrowseDetailPane.qml" line="167"/>
         <source>Yr</source>
         <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="198"/>
+        <location filename="../components/BrowseDetailPane.qml" line="169"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="198"/>
+        <location filename="../components/BrowseDetailPane.qml" line="169"/>
         <source>Gen</source>
         <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="200"/>
+        <location filename="../components/BrowseDetailPane.qml" line="171"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="200"/>
+        <location filename="../components/BrowseDetailPane.qml" line="171"/>
         <source>Plyr</source>
         <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="202"/>
+        <location filename="../components/BrowseDetailPane.qml" line="173"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="202"/>
+        <location filename="../components/BrowseDetailPane.qml" line="173"/>
         <source>Dev</source>
         <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="204"/>
+        <location filename="../components/BrowseDetailPane.qml" line="175"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="204"/>
+        <location filename="../components/BrowseDetailPane.qml" line="175"/>
         <source>Pub</source>
         <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="206"/>
+        <location filename="../components/BrowseDetailPane.qml" line="177"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="206"/>
+        <location filename="../components/BrowseDetailPane.qml" line="177"/>
         <source>Rtg</source>
         <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="208"/>
+        <location filename="../components/BrowseDetailPane.qml" line="179"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="208"/>
+        <location filename="../components/BrowseDetailPane.qml" line="179"/>
         <source>Cat</source>
         <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="210"/>
+        <location filename="../components/BrowseDetailPane.qml" line="181"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="210"/>
+        <location filename="../components/BrowseDetailPane.qml" line="181"/>
         <source>Date</source>
         <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="212"/>
+        <location filename="../components/BrowseDetailPane.qml" line="183"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="212"/>
+        <location filename="../components/BrowseDetailPane.qml" line="183"/>
         <source>Mfr</source>
         <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
@@ -425,8 +425,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="127"/>
-        <location filename="../screens/GamesScreen.qml" line="162"/>
+        <location filename="../screens/GamesScreen.qml" line="128"/>
+        <location filename="../screens/GamesScreen.qml" line="163"/>
         <source>%1 files</source>
         <translation>%1 ファイル</translation>
     </message>
@@ -436,8 +436,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="136"/>
-        <location filename="../screens/GamesScreen.qml" line="163"/>
+        <location filename="../screens/GamesScreen.qml" line="137"/>
+        <location filename="../screens/GamesScreen.qml" line="164"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -447,7 +447,7 @@ Euskara - devilschile2</source>
         <translation>ゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="132"/>
+        <location filename="../screens/GamesScreen.qml" line="133"/>
         <source>Loading more…</source>
         <translation>さらに読み込み中…</translation>
     </message>
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="149"/>
+        <location filename="../screens/HubScreen.qml" line="156"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="155"/>
+        <location filename="../screens/HubScreen.qml" line="162"/>
         <source>Favorites</source>
         <translation>お気に入り</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="160"/>
+        <location filename="../screens/HubScreen.qml" line="167"/>
         <source>Recently Played</source>
         <translation>最近プレイしたゲーム</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="165"/>
+        <location filename="../screens/HubScreen.qml" line="172"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">設定</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="701"/>
+        <location filename="../screens/HubScreen.qml" line="722"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>利用可能なシステムがありません。設定からメディアデータベースの更新を実行してください。</translation>
     </message>
@@ -553,138 +553,138 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1367"/>
+        <location filename="../app/Main.qml" line="1381"/>
         <source>Launch core</source>
         <translation>コアを起動</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1373"/>
-        <location filename="../app/Main.qml" line="1612"/>
+        <location filename="../app/Main.qml" line="1387"/>
+        <location filename="../app/Main.qml" line="1626"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1445"/>
         <source>Remove from favorites</source>
         <translation>お気に入りから削除</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1445"/>
         <source>Add to favorites</source>
         <translation>お気に入りに追加</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1436"/>
+        <location filename="../app/Main.qml" line="1450"/>
         <source>Write to NFC token</source>
         <translation>NFC トークンに書き込む</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1440"/>
+        <location filename="../app/Main.qml" line="1454"/>
         <source>QR code</source>
         <translation>QR コード</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1415"/>
-        <location filename="../app/Main.qml" line="1450"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1464"/>
         <source>Launch game</source>
         <translation>ゲームを起動</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2624"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2616"/>
+        <location filename="../app/Main.qml" line="2630"/>
         <source>Loading favorites…</source>
         <translation>お気に入りを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2612"/>
+        <location filename="../app/Main.qml" line="2626"/>
         <source>Loading games…</source>
         <translation>ゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1380"/>
-        <location filename="../app/Main.qml" line="1403"/>
+        <location filename="../app/Main.qml" line="1394"/>
+        <location filename="../app/Main.qml" line="1417"/>
         <source>Update media database</source>
         <translation type="unfinished">メディアデータベースを更新</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1383"/>
-        <location filename="../app/Main.qml" line="1406"/>
+        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1420"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">メタデータをスクレイピング</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1388"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1411"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1388"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1411"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1608"/>
+        <location filename="../app/Main.qml" line="1622"/>
         <source>Default</source>
         <translation type="unfinished">デフォルト</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1608"/>
+        <location filename="../app/Main.qml" line="1622"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1932"/>
+        <location filename="../app/Main.qml" line="1946"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1936"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1950"/>
+        <location filename="../app/Main.qml" line="1964"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1954"/>
+        <location filename="../app/Main.qml" line="1968"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1958"/>
+        <location filename="../app/Main.qml" line="1972"/>
         <source>Retry</source>
         <translation type="unfinished">再試行</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1962"/>
+        <location filename="../app/Main.qml" line="1976"/>
         <source>Cancel</source>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2628"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2618"/>
+        <location filename="../app/Main.qml" line="2632"/>
         <source>Loading recently played…</source>
         <translation>最近プレイしたゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2620"/>
+        <location filename="../app/Main.qml" line="2634"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2622"/>
+        <location filename="../app/Main.qml" line="2636"/>
         <source>Loading…</source>
         <translation>読み込み中…</translation>
     </message>
@@ -864,12 +864,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">読み込み中…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="395"/>
+        <location filename="../screens/MediaListScreen.qml" line="436"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 件</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="396"/>
+        <location filename="../screens/MediaListScreen.qml" line="437"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>いいえ</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="246"/>
+        <location filename="../components/Modal.qml" line="256"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
@@ -1262,7 +1262,7 @@ Euskara - devilschile2</source>
         <translation>スタイル A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1358"/>
+        <location filename="../screens/SettingsScreen.qml" line="1368"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1406,7 +1406,7 @@ Euskara - devilschile2</source>
         <translation>設定</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1346"/>
+        <location filename="../screens/SettingsScreen.qml" line="1356"/>
         <source>No settings available on this platform</source>
         <translation>このプラットフォームでは設定項目がありません</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="229"/>
-        <location filename="../screens/SystemsScreen.qml" line="329"/>
+        <location filename="../screens/SystemsScreen.qml" line="236"/>
+        <location filename="../screens/SystemsScreen.qml" line="338"/>
         <source>%1 systems</source>
         <translation>%1 システム</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="230"/>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="237"/>
+        <location filename="../screens/SystemsScreen.qml" line="355"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="364"/>
+        <location filename="../screens/SystemsScreen.qml" line="373"/>
         <source>No systems in this category</source>
         <translation>このカテゴリにシステムはありません</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="365"/>
+        <location filename="../screens/SystemsScreen.qml" line="374"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>
@@ -1439,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="475"/>
+        <location filename="../components/Tile.qml" line="539"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -425,8 +425,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="128"/>
-        <location filename="../screens/GamesScreen.qml" line="163"/>
+        <location filename="../screens/GamesScreen.qml" line="131"/>
+        <location filename="../screens/GamesScreen.qml" line="166"/>
         <source>%1 files</source>
         <translation>%1 ファイル</translation>
     </message>
@@ -436,8 +436,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="137"/>
-        <location filename="../screens/GamesScreen.qml" line="164"/>
+        <location filename="../screens/GamesScreen.qml" line="140"/>
+        <location filename="../screens/GamesScreen.qml" line="167"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -447,7 +447,7 @@ Euskara - devilschile2</source>
         <translation>ゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="133"/>
+        <location filename="../screens/GamesScreen.qml" line="136"/>
         <source>Loading more…</source>
         <translation>さらに読み込み中…</translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>いいえ</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="246"/>
+        <location filename="../components/Modal.qml" line="250"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
@@ -936,24 +936,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="141"/>
-        <location filename="../screens/SettingsScreen.qml" line="734"/>
+        <location filename="../screens/SettingsScreen.qml" line="145"/>
+        <location filename="../screens/SettingsScreen.qml" line="738"/>
         <source>Language</source>
         <translation>言語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116"/>
-        <location filename="../screens/SettingsScreen.qml" line="770"/>
+        <location filename="../screens/SettingsScreen.qml" line="120"/>
+        <location filename="../screens/SettingsScreen.qml" line="774"/>
         <source>Browsing layout</source>
         <translation>ブラウジングレイアウト</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="159"/>
+        <location filename="../screens/SettingsScreen.qml" line="163"/>
         <source>Mouse support</source>
         <translation>マウスサポート</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="171"/>
+        <location filename="../screens/SettingsScreen.qml" line="175"/>
         <source>Update media database</source>
         <translation>メディアデータベースを更新</translation>
     </message>
@@ -962,47 +962,47 @@ Euskara - devilschile2</source>
         <translation type="vanished">一般</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
-        <location filename="../screens/SettingsScreen.qml" line="761"/>
+        <location filename="../screens/SettingsScreen.qml" line="115"/>
+        <location filename="../screens/SettingsScreen.qml" line="765"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="154"/>
-        <location filename="../screens/SettingsScreen.qml" line="779"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="783"/>
         <source>Button style</source>
         <translation>ボタンスタイル</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
-        <location filename="../screens/SettingsScreen.qml" line="788"/>
+        <location filename="../screens/SettingsScreen.qml" line="130"/>
+        <location filename="../screens/SettingsScreen.qml" line="792"/>
         <source>Screensaver</source>
         <translation>スクリーンセーバー</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="89"/>
-        <location filename="../screens/SettingsScreen.qml" line="223"/>
+        <location filename="../screens/SettingsScreen.qml" line="93"/>
+        <location filename="../screens/SettingsScreen.qml" line="227"/>
         <source>Library</source>
         <translation>ライブラリ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="176"/>
+        <location filename="../screens/SettingsScreen.qml" line="180"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121"/>
-        <location filename="../screens/SettingsScreen.qml" line="797"/>
+        <location filename="../screens/SettingsScreen.qml" line="125"/>
+        <location filename="../screens/SettingsScreen.qml" line="801"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="181"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
         <source>Scrape metadata</source>
         <translation>メタデータをスクレイピング</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="186"/>
+        <location filename="../screens/SettingsScreen.qml" line="190"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1011,402 +1011,402 @@ Euskara - devilschile2</source>
         <translation type="vanished">詳細設定</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="198"/>
+        <location filename="../screens/SettingsScreen.qml" line="202"/>
         <source>Debug logging</source>
         <translation>デバッグログ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="203"/>
+        <location filename="../screens/SettingsScreen.qml" line="207"/>
         <source>Upload log file</source>
         <translation>ログファイルをアップロード</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="193"/>
+        <location filename="../screens/SettingsScreen.qml" line="197"/>
         <source>About / License</source>
         <translation>情報 / ライセンス</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
-        <location filename="../screens/SettingsScreen.qml" line="743"/>
+        <location filename="../screens/SettingsScreen.qml" line="135"/>
+        <location filename="../screens/SettingsScreen.qml" line="747"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="136"/>
-        <location filename="../screens/SettingsScreen.qml" line="752"/>
+        <location filename="../screens/SettingsScreen.qml" line="140"/>
+        <location filename="../screens/SettingsScreen.qml" line="756"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="146"/>
+        <location filename="../screens/SettingsScreen.qml" line="150"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="168"/>
         <source>Reduce motion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="240"/>
+        <location filename="../screens/SettingsScreen.qml" line="244"/>
         <source>Optimizing</source>
         <translation>最適化中</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="242"/>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="255"/>
         <source>Paused</source>
         <translation>一時停止中</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="242"/>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="255"/>
         <source>In progress</source>
         <translation>実行中</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="245"/>
+        <location filename="../screens/SettingsScreen.qml" line="249"/>
         <source>%1 indexed</source>
         <translation>%1 件を索引化</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="254"/>
+        <location filename="../screens/SettingsScreen.qml" line="258"/>
         <source>%1 scraped</source>
         <translation>%1 件取得済み</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="488"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="488"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Start</source>
         <translation>開始</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="490"/>
+        <location filename="../screens/SettingsScreen.qml" line="494"/>
         <source>Upload</source>
         <translation>アップロード</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="491"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Open</source>
         <translation>開く</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>English</source>
         <translation>英語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Italian</source>
         <translation>イタリア語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>German</source>
         <translation>ドイツ語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Greek</source>
         <translation>ギリシャ語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Japanese</source>
         <translation>日本語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="590"/>
         <source>Korean</source>
         <translation>韓国語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="588"/>
+        <location filename="../screens/SettingsScreen.qml" line="592"/>
         <source>Dutch</source>
         <translation>オランダ語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="590"/>
+        <location filename="../screens/SettingsScreen.qml" line="594"/>
         <source>Romanian</source>
         <translation>ルーマニア語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="592"/>
+        <location filename="../screens/SettingsScreen.qml" line="596"/>
         <source>Slovak</source>
         <translation>スロバキア語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="594"/>
+        <location filename="../screens/SettingsScreen.qml" line="598"/>
         <source>Ukrainian</source>
         <translation>ウクライナ語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="596"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Chinese (Simplified)</source>
         <translation>中国語（簡体字）</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="598"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="600"/>
+        <location filename="../screens/SettingsScreen.qml" line="604"/>
         <source>Hebrew</source>
         <translation>ヘブライ語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="602"/>
+        <location filename="../screens/SettingsScreen.qml" line="606"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="604"/>
+        <location filename="../screens/SettingsScreen.qml" line="608"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="605"/>
-        <location filename="../screens/SettingsScreen.qml" line="613"/>
-        <location filename="../screens/SettingsScreen.qml" line="687"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="691"/>
         <source>Auto</source>
         <translation>自動</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="610"/>
+        <location filename="../screens/SettingsScreen.qml" line="614"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="616"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="623"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="625"/>
+        <location filename="../screens/SettingsScreen.qml" line="629"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="627"/>
+        <location filename="../screens/SettingsScreen.qml" line="631"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="628"/>
+        <location filename="../screens/SettingsScreen.qml" line="632"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="633"/>
+        <location filename="../screens/SettingsScreen.qml" line="637"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="639"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="640"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="641"/>
+        <location filename="../screens/SettingsScreen.qml" line="645"/>
         <source>Detailed list view</source>
         <translation>詳細リスト表示</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="642"/>
+        <location filename="../screens/SettingsScreen.qml" line="646"/>
         <source>Grid view</source>
         <translation>グリッド表示</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
         <source>Style B</source>
         <translation>スタイル B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Style C</source>
         <translation>スタイル C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="655"/>
         <source>Style D</source>
         <translation>スタイル D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="652"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Style A</source>
         <translation>スタイル A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1351"/>
+        <location filename="../screens/SettingsScreen.qml" line="1382"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="542"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>Default</source>
         <translation>デフォルト</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="667"/>
+        <location filename="../screens/SettingsScreen.qml" line="671"/>
         <source>Off</source>
         <translation>オフ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="669"/>
+        <location filename="../screens/SettingsScreen.qml" line="673"/>
         <source>1 second (testing)</source>
         <translation>1秒（テスト）</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="671"/>
+        <location filename="../screens/SettingsScreen.qml" line="675"/>
         <source>1 minute</source>
         <translation>1分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="673"/>
+        <location filename="../screens/SettingsScreen.qml" line="677"/>
         <source>2 minutes</source>
         <translation>2分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="675"/>
+        <location filename="../screens/SettingsScreen.qml" line="679"/>
         <source>5 minutes</source>
         <translation>5分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="677"/>
+        <location filename="../screens/SettingsScreen.qml" line="681"/>
         <source>10 minutes</source>
         <translation>10分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="679"/>
+        <location filename="../screens/SettingsScreen.qml" line="683"/>
         <source>15 minutes</source>
         <translation>15分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="681"/>
+        <location filename="../screens/SettingsScreen.qml" line="685"/>
         <source>30 minutes</source>
         <translation>30分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="682"/>
+        <location filename="../screens/SettingsScreen.qml" line="686"/>
         <source>%1 seconds</source>
         <translation>%1秒</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="105"/>
-        <location filename="../screens/SettingsScreen.qml" line="725"/>
+        <location filename="../screens/SettingsScreen.qml" line="109"/>
+        <location filename="../screens/SettingsScreen.qml" line="729"/>
         <source>Resolution</source>
         <translation>解像度</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="77"/>
-        <location filename="../screens/SettingsScreen.qml" line="219"/>
+        <location filename="../screens/SettingsScreen.qml" line="81"/>
+        <location filename="../screens/SettingsScreen.qml" line="223"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="221"/>
+        <location filename="../screens/SettingsScreen.qml" line="87"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="95"/>
-        <location filename="../screens/SettingsScreen.qml" line="225"/>
+        <location filename="../screens/SettingsScreen.qml" line="99"/>
+        <location filename="../screens/SettingsScreen.qml" line="229"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="693"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="691"/>
+        <location filename="../screens/SettingsScreen.qml" line="695"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="693"/>
+        <location filename="../screens/SettingsScreen.qml" line="697"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="695"/>
+        <location filename="../screens/SettingsScreen.qml" line="699"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="697"/>
+        <location filename="../screens/SettingsScreen.qml" line="701"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="699"/>
+        <location filename="../screens/SettingsScreen.qml" line="703"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="701"/>
+        <location filename="../screens/SettingsScreen.qml" line="705"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="703"/>
+        <location filename="../screens/SettingsScreen.qml" line="707"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="705"/>
+        <location filename="../screens/SettingsScreen.qml" line="709"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="707"/>
+        <location filename="../screens/SettingsScreen.qml" line="711"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="709"/>
+        <location filename="../screens/SettingsScreen.qml" line="713"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="711"/>
+        <location filename="../screens/SettingsScreen.qml" line="715"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="226"/>
+        <location filename="../screens/SettingsScreen.qml" line="230"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1339"/>
+        <location filename="../screens/SettingsScreen.qml" line="1370"/>
         <source>No settings available on this platform</source>
         <translation>このプラットフォームでは設定項目がありません</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="242"/>
-        <location filename="../screens/SystemsScreen.qml" line="343"/>
+        <location filename="../screens/SystemsScreen.qml" line="245"/>
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>%1 systems</source>
         <translation>%1 システム</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="243"/>
-        <location filename="../screens/SystemsScreen.qml" line="360"/>
+        <location filename="../screens/SystemsScreen.qml" line="246"/>
+        <location filename="../screens/SystemsScreen.qml" line="363"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="378"/>
+        <location filename="../screens/SystemsScreen.qml" line="381"/>
         <source>No systems in this category</source>
         <translation>このカテゴリにシステムはありません</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="379"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -425,8 +425,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="128"/>
-        <location filename="../screens/GamesScreen.qml" line="163"/>
+        <location filename="../screens/GamesScreen.qml" line="131"/>
+        <location filename="../screens/GamesScreen.qml" line="166"/>
         <source>%1 files</source>
         <translation>파일 %1개</translation>
     </message>
@@ -436,8 +436,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="137"/>
-        <location filename="../screens/GamesScreen.qml" line="164"/>
+        <location filename="../screens/GamesScreen.qml" line="140"/>
+        <location filename="../screens/GamesScreen.qml" line="167"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -452,7 +452,7 @@ Euskara - devilschile2</source>
         <translation>게임 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="133"/>
+        <location filename="../screens/GamesScreen.qml" line="136"/>
         <source>Loading more…</source>
         <translation>더 불러오는 중…</translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>아니요</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="246"/>
+        <location filename="../components/Modal.qml" line="250"/>
         <source>Cancel</source>
         <translation>취소</translation>
     </message>
@@ -940,64 +940,64 @@ Euskara - devilschile2</source>
         <translation type="vanished">일반</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="141"/>
-        <location filename="../screens/SettingsScreen.qml" line="734"/>
+        <location filename="../screens/SettingsScreen.qml" line="145"/>
+        <location filename="../screens/SettingsScreen.qml" line="738"/>
         <source>Language</source>
         <translation>언어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
-        <location filename="../screens/SettingsScreen.qml" line="761"/>
+        <location filename="../screens/SettingsScreen.qml" line="115"/>
+        <location filename="../screens/SettingsScreen.qml" line="765"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116"/>
-        <location filename="../screens/SettingsScreen.qml" line="770"/>
+        <location filename="../screens/SettingsScreen.qml" line="120"/>
+        <location filename="../screens/SettingsScreen.qml" line="774"/>
         <source>Browsing layout</source>
         <translation>탐색 레이아웃</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="154"/>
-        <location filename="../screens/SettingsScreen.qml" line="779"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="783"/>
         <source>Button style</source>
         <translation>버튼 스타일</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
-        <location filename="../screens/SettingsScreen.qml" line="788"/>
+        <location filename="../screens/SettingsScreen.qml" line="130"/>
+        <location filename="../screens/SettingsScreen.qml" line="792"/>
         <source>Screensaver</source>
         <translation>화면 보호기</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="89"/>
-        <location filename="../screens/SettingsScreen.qml" line="223"/>
+        <location filename="../screens/SettingsScreen.qml" line="93"/>
+        <location filename="../screens/SettingsScreen.qml" line="227"/>
         <source>Library</source>
         <translation>라이브러리</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="176"/>
+        <location filename="../screens/SettingsScreen.qml" line="180"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121"/>
-        <location filename="../screens/SettingsScreen.qml" line="797"/>
+        <location filename="../screens/SettingsScreen.qml" line="125"/>
+        <location filename="../screens/SettingsScreen.qml" line="801"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="171"/>
+        <location filename="../screens/SettingsScreen.qml" line="175"/>
         <source>Update media database</source>
         <translation>미디어 데이터베이스 업데이트</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="181"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
         <source>Scrape metadata</source>
         <translation>메타데이터 수집</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="186"/>
+        <location filename="../screens/SettingsScreen.qml" line="190"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1006,407 +1006,407 @@ Euskara - devilschile2</source>
         <translation type="vanished">고급</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="159"/>
+        <location filename="../screens/SettingsScreen.qml" line="163"/>
         <source>Mouse support</source>
         <translation>마우스 지원</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="198"/>
+        <location filename="../screens/SettingsScreen.qml" line="202"/>
         <source>Debug logging</source>
         <translation>디버그 로깅</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="203"/>
+        <location filename="../screens/SettingsScreen.qml" line="207"/>
         <source>Upload log file</source>
         <translation>로그 파일 업로드</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="193"/>
+        <location filename="../screens/SettingsScreen.qml" line="197"/>
         <source>About / License</source>
         <translation>정보 / 라이선스</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
-        <location filename="../screens/SettingsScreen.qml" line="743"/>
+        <location filename="../screens/SettingsScreen.qml" line="135"/>
+        <location filename="../screens/SettingsScreen.qml" line="747"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="136"/>
-        <location filename="../screens/SettingsScreen.qml" line="752"/>
+        <location filename="../screens/SettingsScreen.qml" line="140"/>
+        <location filename="../screens/SettingsScreen.qml" line="756"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="146"/>
+        <location filename="../screens/SettingsScreen.qml" line="150"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="168"/>
         <source>Reduce motion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="240"/>
+        <location filename="../screens/SettingsScreen.qml" line="244"/>
         <source>Optimizing</source>
         <translation>최적화 중</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="242"/>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="255"/>
         <source>Paused</source>
         <translation>일시중지됨</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="242"/>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="255"/>
         <source>In progress</source>
         <translation>진행 중</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="245"/>
+        <location filename="../screens/SettingsScreen.qml" line="249"/>
         <source>%1 indexed</source>
         <translation>%1개 인덱싱됨</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="254"/>
+        <location filename="../screens/SettingsScreen.qml" line="258"/>
         <source>%1 scraped</source>
         <translation>%1개 수집됨</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="488"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Cancel</source>
         <translation>취소</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="488"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Start</source>
         <translation>시작</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="490"/>
+        <location filename="../screens/SettingsScreen.qml" line="494"/>
         <source>Upload</source>
         <translation>업로드</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="491"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Open</source>
         <translation>열기</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="542"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>Default</source>
         <translation>기본값</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>English</source>
         <translation>영어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Italian</source>
         <translation>이탈리아어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>German</source>
         <translation>독일어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Greek</source>
         <translation>그리스어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Japanese</source>
         <translation>일본어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="590"/>
         <source>Korean</source>
         <translation>한국어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="588"/>
+        <location filename="../screens/SettingsScreen.qml" line="592"/>
         <source>Dutch</source>
         <translation>네덜란드어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="590"/>
+        <location filename="../screens/SettingsScreen.qml" line="594"/>
         <source>Romanian</source>
         <translation>루마니아어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="592"/>
+        <location filename="../screens/SettingsScreen.qml" line="596"/>
         <source>Slovak</source>
         <translation>슬로바키아어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="594"/>
+        <location filename="../screens/SettingsScreen.qml" line="598"/>
         <source>Ukrainian</source>
         <translation>우크라이나어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="596"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Chinese (Simplified)</source>
         <translation>중국어(간체)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="598"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="600"/>
+        <location filename="../screens/SettingsScreen.qml" line="604"/>
         <source>Hebrew</source>
         <translation>히브리어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="602"/>
+        <location filename="../screens/SettingsScreen.qml" line="606"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="604"/>
+        <location filename="../screens/SettingsScreen.qml" line="608"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="605"/>
-        <location filename="../screens/SettingsScreen.qml" line="613"/>
-        <location filename="../screens/SettingsScreen.qml" line="687"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="691"/>
         <source>Auto</source>
         <translation>자동</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="610"/>
+        <location filename="../screens/SettingsScreen.qml" line="614"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="616"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="623"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="625"/>
+        <location filename="../screens/SettingsScreen.qml" line="629"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="627"/>
+        <location filename="../screens/SettingsScreen.qml" line="631"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="628"/>
+        <location filename="../screens/SettingsScreen.qml" line="632"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="633"/>
+        <location filename="../screens/SettingsScreen.qml" line="637"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="639"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="640"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="641"/>
+        <location filename="../screens/SettingsScreen.qml" line="645"/>
         <source>Detailed list view</source>
         <translation>자세한 목록 보기</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="642"/>
+        <location filename="../screens/SettingsScreen.qml" line="646"/>
         <source>Grid view</source>
         <translation>그리드 보기</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
         <source>Style B</source>
         <translation>스타일 B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Style C</source>
         <translation>스타일 C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="655"/>
         <source>Style D</source>
         <translation>스타일 D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="652"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Style A</source>
         <translation>스타일 A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="667"/>
+        <location filename="../screens/SettingsScreen.qml" line="671"/>
         <source>Off</source>
         <translation>끔</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="669"/>
+        <location filename="../screens/SettingsScreen.qml" line="673"/>
         <source>1 second (testing)</source>
         <translation>1초 (테스트용)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="671"/>
+        <location filename="../screens/SettingsScreen.qml" line="675"/>
         <source>1 minute</source>
         <translation>1분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="673"/>
+        <location filename="../screens/SettingsScreen.qml" line="677"/>
         <source>2 minutes</source>
         <translation>2분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="675"/>
+        <location filename="../screens/SettingsScreen.qml" line="679"/>
         <source>5 minutes</source>
         <translation>5분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="677"/>
+        <location filename="../screens/SettingsScreen.qml" line="681"/>
         <source>10 minutes</source>
         <translation>10분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="679"/>
+        <location filename="../screens/SettingsScreen.qml" line="683"/>
         <source>15 minutes</source>
         <translation>15분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="681"/>
+        <location filename="../screens/SettingsScreen.qml" line="685"/>
         <source>30 minutes</source>
         <translation>30분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="682"/>
+        <location filename="../screens/SettingsScreen.qml" line="686"/>
         <source>%1 seconds</source>
         <translation>%1초</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1351"/>
+        <location filename="../screens/SettingsScreen.qml" line="1382"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="105"/>
-        <location filename="../screens/SettingsScreen.qml" line="725"/>
+        <location filename="../screens/SettingsScreen.qml" line="109"/>
+        <location filename="../screens/SettingsScreen.qml" line="729"/>
         <source>Resolution</source>
         <translation>해상도</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="77"/>
-        <location filename="../screens/SettingsScreen.qml" line="219"/>
+        <location filename="../screens/SettingsScreen.qml" line="81"/>
+        <location filename="../screens/SettingsScreen.qml" line="223"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="221"/>
+        <location filename="../screens/SettingsScreen.qml" line="87"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="95"/>
-        <location filename="../screens/SettingsScreen.qml" line="225"/>
+        <location filename="../screens/SettingsScreen.qml" line="99"/>
+        <location filename="../screens/SettingsScreen.qml" line="229"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="693"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="691"/>
+        <location filename="../screens/SettingsScreen.qml" line="695"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="693"/>
+        <location filename="../screens/SettingsScreen.qml" line="697"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="695"/>
+        <location filename="../screens/SettingsScreen.qml" line="699"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="697"/>
+        <location filename="../screens/SettingsScreen.qml" line="701"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="699"/>
+        <location filename="../screens/SettingsScreen.qml" line="703"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="701"/>
+        <location filename="../screens/SettingsScreen.qml" line="705"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="703"/>
+        <location filename="../screens/SettingsScreen.qml" line="707"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="705"/>
+        <location filename="../screens/SettingsScreen.qml" line="709"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="707"/>
+        <location filename="../screens/SettingsScreen.qml" line="711"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="709"/>
+        <location filename="../screens/SettingsScreen.qml" line="713"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="711"/>
+        <location filename="../screens/SettingsScreen.qml" line="715"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="226"/>
+        <location filename="../screens/SettingsScreen.qml" line="230"/>
         <source>Settings</source>
         <translation>설정</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1339"/>
+        <location filename="../screens/SettingsScreen.qml" line="1370"/>
         <source>No settings available on this platform</source>
         <translation>이 플랫폼에서는 설정을 사용할 수 없습니다</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="242"/>
-        <location filename="../screens/SystemsScreen.qml" line="343"/>
+        <location filename="../screens/SystemsScreen.qml" line="245"/>
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>%1 systems</source>
         <translation>시스템 %1개</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="243"/>
-        <location filename="../screens/SystemsScreen.qml" line="360"/>
+        <location filename="../screens/SystemsScreen.qml" line="246"/>
+        <location filename="../screens/SystemsScreen.qml" line="363"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="378"/>
+        <location filename="../screens/SystemsScreen.qml" line="381"/>
         <source>No systems in this category</source>
         <translation>이 카테고리에는 시스템이 없습니다</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="379"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -425,34 +425,34 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="116"/>
-        <location filename="../screens/GamesScreen.qml" line="151"/>
+        <location filename="../screens/GamesScreen.qml" line="127"/>
+        <location filename="../screens/GamesScreen.qml" line="162"/>
         <source>%1 files</source>
         <translation>파일 %1개</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="53"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="125"/>
-        <location filename="../screens/GamesScreen.qml" line="152"/>
+        <location filename="../screens/GamesScreen.qml" line="136"/>
+        <location filename="../screens/GamesScreen.qml" line="163"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="47"/>
+        <location filename="../screens/GamesScreen.qml" line="48"/>
         <source>No games in this system</source>
         <translation>이 시스템에는 게임이 없습니다</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="48"/>
+        <location filename="../screens/GamesScreen.qml" line="49"/>
         <source>Loading games…</source>
         <translation>게임 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="121"/>
+        <location filename="../screens/GamesScreen.qml" line="132"/>
         <source>Loading more…</source>
         <translation>더 불러오는 중…</translation>
     </message>
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="139"/>
+        <location filename="../screens/HubScreen.qml" line="149"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="145"/>
+        <location filename="../screens/HubScreen.qml" line="155"/>
         <source>Favorites</source>
         <translation>즐겨찾기</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="150"/>
+        <location filename="../screens/HubScreen.qml" line="160"/>
         <source>Recently Played</source>
         <translation>최근 플레이</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="155"/>
+        <location filename="../screens/HubScreen.qml" line="165"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">설정</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="669"/>
+        <location filename="../screens/HubScreen.qml" line="701"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>사용 가능한 시스템이 없습니다. 설정에서 미디어 데이터베이스 업데이트를 실행하세요.</translation>
     </message>
@@ -553,138 +553,138 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1361"/>
+        <location filename="../app/Main.qml" line="1367"/>
         <source>Launch core</source>
         <translation>코어 실행</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1367"/>
-        <location filename="../app/Main.qml" line="1606"/>
+        <location filename="../app/Main.qml" line="1373"/>
+        <location filename="../app/Main.qml" line="1612"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1374"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1380"/>
+        <location filename="../app/Main.qml" line="1403"/>
         <source>Update media database</source>
         <translation type="unfinished">미디어 데이터베이스 업데이트</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1377"/>
-        <location filename="../app/Main.qml" line="1400"/>
+        <location filename="../app/Main.qml" line="1383"/>
+        <location filename="../app/Main.qml" line="1406"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">메타데이터 수집</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1382"/>
-        <location filename="../app/Main.qml" line="1391"/>
+        <location filename="../app/Main.qml" line="1388"/>
+        <location filename="../app/Main.qml" line="1397"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1382"/>
-        <location filename="../app/Main.qml" line="1391"/>
+        <location filename="../app/Main.qml" line="1388"/>
+        <location filename="../app/Main.qml" line="1397"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1409"/>
-        <location filename="../app/Main.qml" line="1444"/>
+        <location filename="../app/Main.qml" line="1415"/>
+        <location filename="../app/Main.qml" line="1450"/>
         <source>Launch game</source>
         <translation>게임 실행</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1425"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Remove from favorites</source>
         <translation>즐겨찾기에서 제거</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1425"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Add to favorites</source>
         <translation>즐겨찾기에 추가</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1430"/>
+        <location filename="../app/Main.qml" line="1436"/>
         <source>Write to NFC token</source>
         <translation>NFC 토큰에 쓰기</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1434"/>
+        <location filename="../app/Main.qml" line="1440"/>
         <source>QR code</source>
         <translation>QR 코드</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1602"/>
+        <location filename="../app/Main.qml" line="1608"/>
         <source>Default</source>
         <translation type="unfinished">기본값</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1602"/>
+        <location filename="../app/Main.qml" line="1608"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1926"/>
+        <location filename="../app/Main.qml" line="1932"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1930"/>
+        <location filename="../app/Main.qml" line="1936"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1944"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1948"/>
+        <location filename="../app/Main.qml" line="1954"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1952"/>
+        <location filename="../app/Main.qml" line="1958"/>
         <source>Retry</source>
         <translation type="unfinished">다시 시도</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1956"/>
+        <location filename="../app/Main.qml" line="1962"/>
         <source>Cancel</source>
         <translation type="unfinished">취소</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2604"/>
+        <location filename="../app/Main.qml" line="2610"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2606"/>
+        <location filename="../app/Main.qml" line="2612"/>
         <source>Loading games…</source>
         <translation>게임 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2608"/>
+        <location filename="../app/Main.qml" line="2614"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2616"/>
         <source>Loading favorites…</source>
         <translation>즐겨찾기 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2612"/>
+        <location filename="../app/Main.qml" line="2618"/>
         <source>Loading recently played…</source>
         <translation>최근 플레이 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2620"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2616"/>
+        <location filename="../app/Main.qml" line="2622"/>
         <source>Loading…</source>
         <translation>불러오는 중…</translation>
     </message>
@@ -692,12 +692,12 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="683"/>
+        <location filename="../app/MainLayout.qml" line="685"/>
         <source>Writing failed</source>
         <translation>쓰기 실패</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="683"/>
+        <location filename="../app/MainLayout.qml" line="685"/>
         <source>Put a writable card near the reader</source>
         <translation>기록 가능한 카드를 리더 근처에 놓으세요</translation>
     </message>
@@ -717,141 +717,141 @@ Euskara - devilschile2</source>
         <translation type="unfinished">최근 플레이</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="699"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="700"/>
+        <location filename="../app/MainLayout.qml" line="702"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="810"/>
+        <location filename="../app/MainLayout.qml" line="812"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="811"/>
+        <location filename="../app/MainLayout.qml" line="813"/>
         <source>Are you sure you want to exit?</source>
         <translation>정말 종료하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="890"/>
-        <location filename="../app/MainLayout.qml" line="964"/>
-        <location filename="../app/MainLayout.qml" line="1010"/>
-        <location filename="../app/MainLayout.qml" line="1047"/>
-        <location filename="../app/MainLayout.qml" line="1097"/>
-        <location filename="../app/MainLayout.qml" line="1146"/>
-        <location filename="../app/MainLayout.qml" line="1165"/>
-        <location filename="../app/MainLayout.qml" line="1232"/>
+        <location filename="../app/MainLayout.qml" line="892"/>
+        <location filename="../app/MainLayout.qml" line="966"/>
+        <location filename="../app/MainLayout.qml" line="1012"/>
+        <location filename="../app/MainLayout.qml" line="1049"/>
+        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1148"/>
+        <location filename="../app/MainLayout.qml" line="1167"/>
+        <location filename="../app/MainLayout.qml" line="1234"/>
         <source>Move</source>
         <translation>이동</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="894"/>
-        <location filename="../app/MainLayout.qml" line="968"/>
+        <location filename="../app/MainLayout.qml" line="896"/>
+        <location filename="../app/MainLayout.qml" line="970"/>
         <source>Select</source>
         <translation>선택</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="902"/>
-        <location filename="../app/MainLayout.qml" line="916"/>
-        <location filename="../app/MainLayout.qml" line="931"/>
-        <location filename="../app/MainLayout.qml" line="942"/>
+        <location filename="../app/MainLayout.qml" line="900"/>
+        <location filename="../app/MainLayout.qml" line="904"/>
+        <location filename="../app/MainLayout.qml" line="918"/>
+        <location filename="../app/MainLayout.qml" line="933"/>
+        <location filename="../app/MainLayout.qml" line="944"/>
         <source>Close</source>
         <translation>닫기</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="909"/>
-        <location filename="../app/MainLayout.qml" line="949"/>
-        <location filename="../app/MainLayout.qml" line="972"/>
-        <location filename="../app/MainLayout.qml" line="983"/>
+        <location filename="../app/MainLayout.qml" line="911"/>
+        <location filename="../app/MainLayout.qml" line="951"/>
+        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="985"/>
         <source>Cancel</source>
         <translation>취소</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="927"/>
+        <location filename="../app/MainLayout.qml" line="929"/>
         <source>Done</source>
         <translation>완료</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1070"/>
-        <location filename="../app/MainLayout.qml" line="1123"/>
-        <location filename="../app/MainLayout.qml" line="1258"/>
+        <location filename="../app/MainLayout.qml" line="940"/>
+        <location filename="../app/MainLayout.qml" line="1072"/>
+        <location filename="../app/MainLayout.qml" line="1125"/>
+        <location filename="../app/MainLayout.qml" line="1260"/>
         <source>Retry</source>
         <translation>다시 시도</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="957"/>
+        <location filename="../app/MainLayout.qml" line="959"/>
         <source>I understand</source>
         <translation>이해했습니다</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="991"/>
+        <location filename="../app/MainLayout.qml" line="993"/>
         <source>Start</source>
         <translation>시작</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1014"/>
-        <location filename="../app/MainLayout.qml" line="1057"/>
-        <location filename="../app/MainLayout.qml" line="1107"/>
-        <location filename="../app/MainLayout.qml" line="1151"/>
-        <location filename="../app/MainLayout.qml" line="1242"/>
+        <location filename="../app/MainLayout.qml" line="1016"/>
+        <location filename="../app/MainLayout.qml" line="1059"/>
+        <location filename="../app/MainLayout.qml" line="1109"/>
+        <location filename="../app/MainLayout.qml" line="1153"/>
+        <location filename="../app/MainLayout.qml" line="1244"/>
         <source>Open</source>
         <translation>열기</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1024"/>
+        <location filename="../app/MainLayout.qml" line="1026"/>
         <source>Quit</source>
         <translation>종료</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1033"/>
-        <location filename="../app/MainLayout.qml" line="1063"/>
-        <location filename="../app/MainLayout.qml" line="1074"/>
-        <location filename="../app/MainLayout.qml" line="1089"/>
-        <location filename="../app/MainLayout.qml" line="1116"/>
-        <location filename="../app/MainLayout.qml" line="1127"/>
-        <location filename="../app/MainLayout.qml" line="1139"/>
-        <location filename="../app/MainLayout.qml" line="1155"/>
-        <location filename="../app/MainLayout.qml" line="1189"/>
-        <location filename="../app/MainLayout.qml" line="1207"/>
-        <location filename="../app/MainLayout.qml" line="1216"/>
-        <location filename="../app/MainLayout.qml" line="1251"/>
-        <location filename="../app/MainLayout.qml" line="1262"/>
+        <location filename="../app/MainLayout.qml" line="1035"/>
+        <location filename="../app/MainLayout.qml" line="1065"/>
+        <location filename="../app/MainLayout.qml" line="1076"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
+        <location filename="../app/MainLayout.qml" line="1118"/>
+        <location filename="../app/MainLayout.qml" line="1129"/>
+        <location filename="../app/MainLayout.qml" line="1141"/>
+        <location filename="../app/MainLayout.qml" line="1157"/>
+        <location filename="../app/MainLayout.qml" line="1191"/>
+        <location filename="../app/MainLayout.qml" line="1209"/>
+        <location filename="../app/MainLayout.qml" line="1218"/>
+        <location filename="../app/MainLayout.qml" line="1253"/>
+        <location filename="../app/MainLayout.qml" line="1264"/>
         <source>Back</source>
         <translation>뒤로</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1053"/>
-        <location filename="../app/MainLayout.qml" line="1103"/>
-        <location filename="../app/MainLayout.qml" line="1238"/>
+        <location filename="../app/MainLayout.qml" line="1055"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
+        <location filename="../app/MainLayout.qml" line="1240"/>
         <source>Page</source>
         <translation>페이지</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1060"/>
-        <location filename="../app/MainLayout.qml" line="1112"/>
-        <location filename="../app/MainLayout.qml" line="1247"/>
+        <location filename="../app/MainLayout.qml" line="1022"/>
+        <location filename="../app/MainLayout.qml" line="1062"/>
+        <location filename="../app/MainLayout.qml" line="1114"/>
+        <location filename="../app/MainLayout.qml" line="1249"/>
         <source>Options</source>
         <translation>옵션</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1174"/>
+        <location filename="../app/MainLayout.qml" line="1176"/>
         <source>Change</source>
         <translation>변경</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1180"/>
+        <location filename="../app/MainLayout.qml" line="1182"/>
         <source>Toggle</source>
         <translation>전환</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1203"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Scroll</source>
         <translation>스크롤</translation>
     </message>
@@ -864,12 +864,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="365"/>
+        <location filename="../screens/MediaListScreen.qml" line="395"/>
         <source>%1 entries</source>
         <translation type="unfinished">항목 %1개</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="366"/>
+        <location filename="../screens/MediaListScreen.qml" line="396"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>아니요</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="198"/>
+        <location filename="../components/Modal.qml" line="246"/>
         <source>Cancel</source>
         <translation>취소</translation>
     </message>
@@ -940,64 +940,64 @@ Euskara - devilschile2</source>
         <translation type="vanished">일반</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="132"/>
-        <location filename="../screens/SettingsScreen.qml" line="718"/>
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
+        <location filename="../screens/SettingsScreen.qml" line="741"/>
         <source>Language</source>
         <translation>언어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="745"/>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="768"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="754"/>
+        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <location filename="../screens/SettingsScreen.qml" line="777"/>
         <source>Browsing layout</source>
         <translation>탐색 레이아웃</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="145"/>
-        <location filename="../screens/SettingsScreen.qml" line="763"/>
+        <location filename="../screens/SettingsScreen.qml" line="160"/>
+        <location filename="../screens/SettingsScreen.qml" line="786"/>
         <source>Button style</source>
         <translation>버튼 스타일</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="772"/>
+        <location filename="../screens/SettingsScreen.qml" line="132"/>
+        <location filename="../screens/SettingsScreen.qml" line="795"/>
         <source>Screensaver</source>
         <translation>화면 보호기</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="80"/>
-        <location filename="../screens/SettingsScreen.qml" line="209"/>
+        <location filename="../screens/SettingsScreen.qml" line="95"/>
+        <location filename="../screens/SettingsScreen.qml" line="229"/>
         <source>Library</source>
         <translation>라이브러리</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="162"/>
+        <location filename="../screens/SettingsScreen.qml" line="182"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="112"/>
-        <location filename="../screens/SettingsScreen.qml" line="781"/>
+        <location filename="../screens/SettingsScreen.qml" line="127"/>
+        <location filename="../screens/SettingsScreen.qml" line="804"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="157"/>
+        <location filename="../screens/SettingsScreen.qml" line="177"/>
         <source>Update media database</source>
         <translation>미디어 데이터베이스 업데이트</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="167"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
         <source>Scrape metadata</source>
         <translation>메타데이터 수집</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="172"/>
+        <location filename="../screens/SettingsScreen.qml" line="192"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1006,402 +1006,407 @@ Euskara - devilschile2</source>
         <translation type="vanished">고급</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="150"/>
+        <location filename="../screens/SettingsScreen.qml" line="165"/>
         <source>Mouse support</source>
         <translation>마우스 지원</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="184"/>
+        <location filename="../screens/SettingsScreen.qml" line="204"/>
         <source>Debug logging</source>
         <translation>디버그 로깅</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="189"/>
+        <location filename="../screens/SettingsScreen.qml" line="209"/>
         <source>Upload log file</source>
         <translation>로그 파일 업로드</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="179"/>
+        <location filename="../screens/SettingsScreen.qml" line="199"/>
         <source>About / License</source>
         <translation>정보 / 라이선스</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
-        <location filename="../screens/SettingsScreen.qml" line="727"/>
+        <location filename="../screens/SettingsScreen.qml" line="137"/>
+        <location filename="../screens/SettingsScreen.qml" line="750"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="127"/>
-        <location filename="../screens/SettingsScreen.qml" line="736"/>
+        <location filename="../screens/SettingsScreen.qml" line="142"/>
+        <location filename="../screens/SettingsScreen.qml" line="759"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="137"/>
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="226"/>
+        <location filename="../screens/SettingsScreen.qml" line="170"/>
+        <source>Reduce motion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
         <source>Optimizing</source>
         <translation>최적화 중</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="228"/>
-        <location filename="../screens/SettingsScreen.qml" line="237"/>
+        <location filename="../screens/SettingsScreen.qml" line="248"/>
+        <location filename="../screens/SettingsScreen.qml" line="257"/>
         <source>Paused</source>
         <translation>일시중지됨</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="228"/>
-        <location filename="../screens/SettingsScreen.qml" line="237"/>
+        <location filename="../screens/SettingsScreen.qml" line="248"/>
+        <location filename="../screens/SettingsScreen.qml" line="257"/>
         <source>In progress</source>
         <translation>진행 중</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="231"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>%1 indexed</source>
         <translation>%1개 인덱싱됨</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="240"/>
+        <location filename="../screens/SettingsScreen.qml" line="260"/>
         <source>%1 scraped</source>
         <translation>%1개 수집됨</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="472"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Cancel</source>
         <translation>취소</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="472"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Start</source>
         <translation>시작</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="474"/>
+        <location filename="../screens/SettingsScreen.qml" line="497"/>
         <source>Upload</source>
         <translation>업로드</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Open</source>
         <translation>열기</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="526"/>
+        <location filename="../screens/SettingsScreen.qml" line="549"/>
         <source>Default</source>
         <translation>기본값</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="556"/>
+        <location filename="../screens/SettingsScreen.qml" line="579"/>
         <source>English</source>
         <translation>영어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="558"/>
+        <location filename="../screens/SettingsScreen.qml" line="581"/>
         <source>Italian</source>
         <translation>이탈리아어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="560"/>
+        <location filename="../screens/SettingsScreen.qml" line="583"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="562"/>
+        <location filename="../screens/SettingsScreen.qml" line="585"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="564"/>
+        <location filename="../screens/SettingsScreen.qml" line="587"/>
         <source>German</source>
         <translation>독일어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="566"/>
+        <location filename="../screens/SettingsScreen.qml" line="589"/>
         <source>Greek</source>
         <translation>그리스어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="568"/>
+        <location filename="../screens/SettingsScreen.qml" line="591"/>
         <source>Japanese</source>
         <translation>일본어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="570"/>
+        <location filename="../screens/SettingsScreen.qml" line="593"/>
         <source>Korean</source>
         <translation>한국어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="595"/>
         <source>Dutch</source>
         <translation>네덜란드어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="597"/>
         <source>Romanian</source>
         <translation>루마니아어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="599"/>
         <source>Slovak</source>
         <translation>슬로바키아어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="601"/>
         <source>Ukrainian</source>
         <translation>우크라이나어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="603"/>
         <source>Chinese (Simplified)</source>
         <translation>중국어(간체)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="605"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="607"/>
         <source>Hebrew</source>
         <translation>히브리어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="588"/>
+        <location filename="../screens/SettingsScreen.qml" line="611"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="589"/>
-        <location filename="../screens/SettingsScreen.qml" line="597"/>
-        <location filename="../screens/SettingsScreen.qml" line="671"/>
+        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="620"/>
+        <location filename="../screens/SettingsScreen.qml" line="694"/>
         <source>Auto</source>
         <translation>자동</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="594"/>
+        <location filename="../screens/SettingsScreen.qml" line="617"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="596"/>
+        <location filename="../screens/SettingsScreen.qml" line="619"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="607"/>
+        <location filename="../screens/SettingsScreen.qml" line="630"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="632"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="611"/>
+        <location filename="../screens/SettingsScreen.qml" line="634"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="635"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="640"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="619"/>
+        <location filename="../screens/SettingsScreen.qml" line="642"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="620"/>
+        <location filename="../screens/SettingsScreen.qml" line="643"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="625"/>
+        <location filename="../screens/SettingsScreen.qml" line="648"/>
         <source>Detailed list view</source>
         <translation>자세한 목록 보기</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="626"/>
+        <location filename="../screens/SettingsScreen.qml" line="649"/>
         <source>Grid view</source>
         <translation>그리드 보기</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="631"/>
+        <location filename="../screens/SettingsScreen.qml" line="654"/>
         <source>Style B</source>
         <translation>스타일 B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="633"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Style C</source>
         <translation>스타일 C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="658"/>
         <source>Style D</source>
         <translation>스타일 D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="659"/>
         <source>Style A</source>
         <translation>스타일 A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="674"/>
         <source>Off</source>
         <translation>끔</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="653"/>
+        <location filename="../screens/SettingsScreen.qml" line="676"/>
         <source>1 second (testing)</source>
         <translation>1초 (테스트용)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="655"/>
+        <location filename="../screens/SettingsScreen.qml" line="678"/>
         <source>1 minute</source>
         <translation>1분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="657"/>
+        <location filename="../screens/SettingsScreen.qml" line="680"/>
         <source>2 minutes</source>
         <translation>2분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="659"/>
+        <location filename="../screens/SettingsScreen.qml" line="682"/>
         <source>5 minutes</source>
         <translation>5분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="661"/>
+        <location filename="../screens/SettingsScreen.qml" line="684"/>
         <source>10 minutes</source>
         <translation>10분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="663"/>
+        <location filename="../screens/SettingsScreen.qml" line="686"/>
         <source>15 minutes</source>
         <translation>15분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="665"/>
+        <location filename="../screens/SettingsScreen.qml" line="688"/>
         <source>30 minutes</source>
         <translation>30분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="666"/>
+        <location filename="../screens/SettingsScreen.qml" line="689"/>
         <source>%1 seconds</source>
         <translation>%1초</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1292"/>
+        <location filename="../screens/SettingsScreen.qml" line="1358"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="96"/>
-        <location filename="../screens/SettingsScreen.qml" line="709"/>
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="732"/>
         <source>Resolution</source>
         <translation>해상도</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="68"/>
-        <location filename="../screens/SettingsScreen.qml" line="205"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="74"/>
-        <location filename="../screens/SettingsScreen.qml" line="207"/>
+        <location filename="../screens/SettingsScreen.qml" line="89"/>
+        <location filename="../screens/SettingsScreen.qml" line="227"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="86"/>
-        <location filename="../screens/SettingsScreen.qml" line="211"/>
+        <location filename="../screens/SettingsScreen.qml" line="101"/>
+        <location filename="../screens/SettingsScreen.qml" line="231"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="673"/>
+        <location filename="../screens/SettingsScreen.qml" line="696"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="675"/>
+        <location filename="../screens/SettingsScreen.qml" line="698"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="677"/>
+        <location filename="../screens/SettingsScreen.qml" line="700"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="679"/>
+        <location filename="../screens/SettingsScreen.qml" line="702"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="681"/>
+        <location filename="../screens/SettingsScreen.qml" line="704"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="683"/>
+        <location filename="../screens/SettingsScreen.qml" line="706"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="685"/>
+        <location filename="../screens/SettingsScreen.qml" line="708"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="687"/>
+        <location filename="../screens/SettingsScreen.qml" line="710"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="712"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="691"/>
+        <location filename="../screens/SettingsScreen.qml" line="714"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="693"/>
+        <location filename="../screens/SettingsScreen.qml" line="716"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="695"/>
+        <location filename="../screens/SettingsScreen.qml" line="718"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="212"/>
+        <location filename="../screens/SettingsScreen.qml" line="232"/>
         <source>Settings</source>
         <translation>설정</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1280"/>
+        <location filename="../screens/SettingsScreen.qml" line="1346"/>
         <source>No settings available on this platform</source>
         <translation>이 플랫폼에서는 설정을 사용할 수 없습니다</translation>
     </message>
@@ -1409,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="206"/>
-        <location filename="../screens/SystemsScreen.qml" line="304"/>
+        <location filename="../screens/SystemsScreen.qml" line="229"/>
+        <location filename="../screens/SystemsScreen.qml" line="329"/>
         <source>%1 systems</source>
         <translation>시스템 %1개</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="207"/>
-        <location filename="../screens/SystemsScreen.qml" line="321"/>
+        <location filename="../screens/SystemsScreen.qml" line="230"/>
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="339"/>
+        <location filename="../screens/SystemsScreen.qml" line="364"/>
         <source>No systems in this category</source>
         <translation>이 카테고리에는 시스템이 없습니다</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="340"/>
+        <location filename="../screens/SystemsScreen.qml" line="365"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>
@@ -1434,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="364"/>
+        <location filename="../components/Tile.qml" line="475"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="156"/>
+        <location filename="../screens/HubScreen.qml" line="154"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="162"/>
+        <location filename="../screens/HubScreen.qml" line="160"/>
         <source>Favorites</source>
         <translation>즐겨찾기</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="167"/>
+        <location filename="../screens/HubScreen.qml" line="165"/>
         <source>Recently Played</source>
         <translation>최근 플레이</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="172"/>
+        <location filename="../screens/HubScreen.qml" line="170"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">설정</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="722"/>
+        <location filename="../screens/HubScreen.qml" line="718"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>사용 가능한 시스템이 없습니다. 설정에서 미디어 데이터베이스 업데이트를 실행하세요.</translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>아니요</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="256"/>
+        <location filename="../components/Modal.qml" line="246"/>
         <source>Cancel</source>
         <translation>취소</translation>
     </message>
@@ -940,64 +940,64 @@ Euskara - devilschile2</source>
         <translation type="vanished">일반</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147"/>
-        <location filename="../screens/SettingsScreen.qml" line="741"/>
+        <location filename="../screens/SettingsScreen.qml" line="141"/>
+        <location filename="../screens/SettingsScreen.qml" line="734"/>
         <source>Language</source>
         <translation>언어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="768"/>
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="761"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
-        <location filename="../screens/SettingsScreen.qml" line="777"/>
+        <location filename="../screens/SettingsScreen.qml" line="116"/>
+        <location filename="../screens/SettingsScreen.qml" line="770"/>
         <source>Browsing layout</source>
         <translation>탐색 레이아웃</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="160"/>
-        <location filename="../screens/SettingsScreen.qml" line="786"/>
+        <location filename="../screens/SettingsScreen.qml" line="154"/>
+        <location filename="../screens/SettingsScreen.qml" line="779"/>
         <source>Button style</source>
         <translation>버튼 스타일</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="132"/>
-        <location filename="../screens/SettingsScreen.qml" line="795"/>
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
+        <location filename="../screens/SettingsScreen.qml" line="788"/>
         <source>Screensaver</source>
         <translation>화면 보호기</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="95"/>
-        <location filename="../screens/SettingsScreen.qml" line="229"/>
+        <location filename="../screens/SettingsScreen.qml" line="89"/>
+        <location filename="../screens/SettingsScreen.qml" line="223"/>
         <source>Library</source>
         <translation>라이브러리</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="182"/>
+        <location filename="../screens/SettingsScreen.qml" line="176"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="127"/>
-        <location filename="../screens/SettingsScreen.qml" line="804"/>
+        <location filename="../screens/SettingsScreen.qml" line="121"/>
+        <location filename="../screens/SettingsScreen.qml" line="797"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="177"/>
+        <location filename="../screens/SettingsScreen.qml" line="171"/>
         <source>Update media database</source>
         <translation>미디어 데이터베이스 업데이트</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <location filename="../screens/SettingsScreen.qml" line="181"/>
         <source>Scrape metadata</source>
         <translation>메타데이터 수집</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="192"/>
+        <location filename="../screens/SettingsScreen.qml" line="186"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1006,407 +1006,407 @@ Euskara - devilschile2</source>
         <translation type="vanished">고급</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="165"/>
+        <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>Mouse support</source>
         <translation>마우스 지원</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="204"/>
+        <location filename="../screens/SettingsScreen.qml" line="198"/>
         <source>Debug logging</source>
         <translation>디버그 로깅</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="209"/>
+        <location filename="../screens/SettingsScreen.qml" line="203"/>
         <source>Upload log file</source>
         <translation>로그 파일 업로드</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="199"/>
+        <location filename="../screens/SettingsScreen.qml" line="193"/>
         <source>About / License</source>
         <translation>정보 / 라이선스</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="137"/>
-        <location filename="../screens/SettingsScreen.qml" line="750"/>
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="743"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="142"/>
-        <location filename="../screens/SettingsScreen.qml" line="759"/>
+        <location filename="../screens/SettingsScreen.qml" line="136"/>
+        <location filename="../screens/SettingsScreen.qml" line="752"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152"/>
+        <location filename="../screens/SettingsScreen.qml" line="146"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="170"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
         <source>Reduce motion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="240"/>
         <source>Optimizing</source>
         <translation>최적화 중</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="248"/>
-        <location filename="../screens/SettingsScreen.qml" line="257"/>
+        <location filename="../screens/SettingsScreen.qml" line="242"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>Paused</source>
         <translation>일시중지됨</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="248"/>
-        <location filename="../screens/SettingsScreen.qml" line="257"/>
+        <location filename="../screens/SettingsScreen.qml" line="242"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>In progress</source>
         <translation>진행 중</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="245"/>
         <source>%1 indexed</source>
         <translation>%1개 인덱싱됨</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="260"/>
+        <location filename="../screens/SettingsScreen.qml" line="254"/>
         <source>%1 scraped</source>
         <translation>%1개 수집됨</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="495"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Cancel</source>
         <translation>취소</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="495"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Start</source>
         <translation>시작</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="497"/>
+        <location filename="../screens/SettingsScreen.qml" line="490"/>
         <source>Upload</source>
         <translation>업로드</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <location filename="../screens/SettingsScreen.qml" line="491"/>
         <source>Open</source>
         <translation>열기</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="549"/>
+        <location filename="../screens/SettingsScreen.qml" line="542"/>
         <source>Default</source>
         <translation>기본값</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="579"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>English</source>
         <translation>영어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="581"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Italian</source>
         <translation>이탈리아어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="583"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="585"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="587"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>German</source>
         <translation>독일어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="589"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Greek</source>
         <translation>그리스어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="591"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Japanese</source>
         <translation>일본어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="593"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Korean</source>
         <translation>한국어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="595"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Dutch</source>
         <translation>네덜란드어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="597"/>
+        <location filename="../screens/SettingsScreen.qml" line="590"/>
         <source>Romanian</source>
         <translation>루마니아어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="599"/>
+        <location filename="../screens/SettingsScreen.qml" line="592"/>
         <source>Slovak</source>
         <translation>슬로바키아어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="601"/>
+        <location filename="../screens/SettingsScreen.qml" line="594"/>
         <source>Ukrainian</source>
         <translation>우크라이나어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="603"/>
+        <location filename="../screens/SettingsScreen.qml" line="596"/>
         <source>Chinese (Simplified)</source>
         <translation>중국어(간체)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="605"/>
+        <location filename="../screens/SettingsScreen.qml" line="598"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="607"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Hebrew</source>
         <translation>히브리어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="611"/>
+        <location filename="../screens/SettingsScreen.qml" line="604"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
-        <location filename="../screens/SettingsScreen.qml" line="620"/>
-        <location filename="../screens/SettingsScreen.qml" line="694"/>
+        <location filename="../screens/SettingsScreen.qml" line="605"/>
+        <location filename="../screens/SettingsScreen.qml" line="613"/>
+        <location filename="../screens/SettingsScreen.qml" line="687"/>
         <source>Auto</source>
         <translation>자동</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="610"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="619"/>
+        <location filename="../screens/SettingsScreen.qml" line="612"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="630"/>
+        <location filename="../screens/SettingsScreen.qml" line="623"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="632"/>
+        <location filename="../screens/SettingsScreen.qml" line="625"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="634"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="628"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="640"/>
+        <location filename="../screens/SettingsScreen.qml" line="633"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="642"/>
+        <location filename="../screens/SettingsScreen.qml" line="635"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="643"/>
+        <location filename="../screens/SettingsScreen.qml" line="636"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="648"/>
+        <location filename="../screens/SettingsScreen.qml" line="641"/>
         <source>Detailed list view</source>
         <translation>자세한 목록 보기</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="642"/>
         <source>Grid view</source>
         <translation>그리드 보기</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="654"/>
+        <location filename="../screens/SettingsScreen.qml" line="647"/>
         <source>Style B</source>
         <translation>스타일 B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="656"/>
+        <location filename="../screens/SettingsScreen.qml" line="649"/>
         <source>Style C</source>
         <translation>스타일 C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="658"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
         <source>Style D</source>
         <translation>스타일 D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="659"/>
+        <location filename="../screens/SettingsScreen.qml" line="652"/>
         <source>Style A</source>
         <translation>스타일 A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="674"/>
+        <location filename="../screens/SettingsScreen.qml" line="667"/>
         <source>Off</source>
         <translation>끔</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="676"/>
+        <location filename="../screens/SettingsScreen.qml" line="669"/>
         <source>1 second (testing)</source>
         <translation>1초 (테스트용)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="678"/>
+        <location filename="../screens/SettingsScreen.qml" line="671"/>
         <source>1 minute</source>
         <translation>1분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="680"/>
+        <location filename="../screens/SettingsScreen.qml" line="673"/>
         <source>2 minutes</source>
         <translation>2분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="682"/>
+        <location filename="../screens/SettingsScreen.qml" line="675"/>
         <source>5 minutes</source>
         <translation>5분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="684"/>
+        <location filename="../screens/SettingsScreen.qml" line="677"/>
         <source>10 minutes</source>
         <translation>10분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="686"/>
+        <location filename="../screens/SettingsScreen.qml" line="679"/>
         <source>15 minutes</source>
         <translation>15분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="688"/>
+        <location filename="../screens/SettingsScreen.qml" line="681"/>
         <source>30 minutes</source>
         <translation>30분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="682"/>
         <source>%1 seconds</source>
         <translation>%1초</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1368"/>
+        <location filename="../screens/SettingsScreen.qml" line="1351"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
-        <location filename="../screens/SettingsScreen.qml" line="732"/>
+        <location filename="../screens/SettingsScreen.qml" line="105"/>
+        <location filename="../screens/SettingsScreen.qml" line="725"/>
         <source>Resolution</source>
         <translation>해상도</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="225"/>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="219"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="89"/>
-        <location filename="../screens/SettingsScreen.qml" line="227"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="221"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="101"/>
-        <location filename="../screens/SettingsScreen.qml" line="231"/>
+        <location filename="../screens/SettingsScreen.qml" line="95"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="696"/>
+        <location filename="../screens/SettingsScreen.qml" line="689"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="698"/>
+        <location filename="../screens/SettingsScreen.qml" line="691"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="700"/>
+        <location filename="../screens/SettingsScreen.qml" line="693"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="702"/>
+        <location filename="../screens/SettingsScreen.qml" line="695"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="704"/>
+        <location filename="../screens/SettingsScreen.qml" line="697"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="706"/>
+        <location filename="../screens/SettingsScreen.qml" line="699"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="708"/>
+        <location filename="../screens/SettingsScreen.qml" line="701"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="710"/>
+        <location filename="../screens/SettingsScreen.qml" line="703"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="712"/>
+        <location filename="../screens/SettingsScreen.qml" line="705"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="714"/>
+        <location filename="../screens/SettingsScreen.qml" line="707"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="716"/>
+        <location filename="../screens/SettingsScreen.qml" line="709"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="718"/>
+        <location filename="../screens/SettingsScreen.qml" line="711"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="232"/>
+        <location filename="../screens/SettingsScreen.qml" line="226"/>
         <source>Settings</source>
         <translation>설정</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1356"/>
+        <location filename="../screens/SettingsScreen.qml" line="1339"/>
         <source>No settings available on this platform</source>
         <translation>이 플랫폼에서는 설정을 사용할 수 없습니다</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="236"/>
-        <location filename="../screens/SystemsScreen.qml" line="338"/>
+        <location filename="../screens/SystemsScreen.qml" line="242"/>
+        <location filename="../screens/SystemsScreen.qml" line="343"/>
         <source>%1 systems</source>
         <translation>시스템 %1개</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="237"/>
-        <location filename="../screens/SystemsScreen.qml" line="355"/>
+        <location filename="../screens/SystemsScreen.qml" line="243"/>
+        <location filename="../screens/SystemsScreen.qml" line="360"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="373"/>
+        <location filename="../screens/SystemsScreen.qml" line="378"/>
         <source>No systems in this category</source>
         <translation>이 카테고리에는 시스템이 없습니다</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="374"/>
+        <location filename="../screens/SystemsScreen.qml" line="379"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>
@@ -1439,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="539"/>
+        <location filename="../components/Tile.qml" line="501"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -97,100 +97,100 @@ Euskara - devilschile2</source>
         <translation type="unfinished">불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="196"/>
+        <location filename="../components/BrowseDetailPane.qml" line="167"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="196"/>
+        <location filename="../components/BrowseDetailPane.qml" line="167"/>
         <source>Yr</source>
         <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="198"/>
+        <location filename="../components/BrowseDetailPane.qml" line="169"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="198"/>
+        <location filename="../components/BrowseDetailPane.qml" line="169"/>
         <source>Gen</source>
         <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="200"/>
+        <location filename="../components/BrowseDetailPane.qml" line="171"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="200"/>
+        <location filename="../components/BrowseDetailPane.qml" line="171"/>
         <source>Plyr</source>
         <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="202"/>
+        <location filename="../components/BrowseDetailPane.qml" line="173"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="202"/>
+        <location filename="../components/BrowseDetailPane.qml" line="173"/>
         <source>Dev</source>
         <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="204"/>
+        <location filename="../components/BrowseDetailPane.qml" line="175"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="204"/>
+        <location filename="../components/BrowseDetailPane.qml" line="175"/>
         <source>Pub</source>
         <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="206"/>
+        <location filename="../components/BrowseDetailPane.qml" line="177"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="206"/>
+        <location filename="../components/BrowseDetailPane.qml" line="177"/>
         <source>Rtg</source>
         <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="208"/>
+        <location filename="../components/BrowseDetailPane.qml" line="179"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="208"/>
+        <location filename="../components/BrowseDetailPane.qml" line="179"/>
         <source>Cat</source>
         <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="210"/>
+        <location filename="../components/BrowseDetailPane.qml" line="181"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="210"/>
+        <location filename="../components/BrowseDetailPane.qml" line="181"/>
         <source>Date</source>
         <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="212"/>
+        <location filename="../components/BrowseDetailPane.qml" line="183"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="212"/>
+        <location filename="../components/BrowseDetailPane.qml" line="183"/>
         <source>Mfr</source>
         <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
@@ -425,8 +425,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="127"/>
-        <location filename="../screens/GamesScreen.qml" line="162"/>
+        <location filename="../screens/GamesScreen.qml" line="128"/>
+        <location filename="../screens/GamesScreen.qml" line="163"/>
         <source>%1 files</source>
         <translation>파일 %1개</translation>
     </message>
@@ -436,8 +436,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="136"/>
-        <location filename="../screens/GamesScreen.qml" line="163"/>
+        <location filename="../screens/GamesScreen.qml" line="137"/>
+        <location filename="../screens/GamesScreen.qml" line="164"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -452,7 +452,7 @@ Euskara - devilschile2</source>
         <translation>게임 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="132"/>
+        <location filename="../screens/GamesScreen.qml" line="133"/>
         <source>Loading more…</source>
         <translation>더 불러오는 중…</translation>
     </message>
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="149"/>
+        <location filename="../screens/HubScreen.qml" line="156"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="155"/>
+        <location filename="../screens/HubScreen.qml" line="162"/>
         <source>Favorites</source>
         <translation>즐겨찾기</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="160"/>
+        <location filename="../screens/HubScreen.qml" line="167"/>
         <source>Recently Played</source>
         <translation>최근 플레이</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="165"/>
+        <location filename="../screens/HubScreen.qml" line="172"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">설정</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="701"/>
+        <location filename="../screens/HubScreen.qml" line="722"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>사용 가능한 시스템이 없습니다. 설정에서 미디어 데이터베이스 업데이트를 실행하세요.</translation>
     </message>
@@ -553,138 +553,138 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1367"/>
+        <location filename="../app/Main.qml" line="1381"/>
         <source>Launch core</source>
         <translation>코어 실행</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1373"/>
-        <location filename="../app/Main.qml" line="1612"/>
+        <location filename="../app/Main.qml" line="1387"/>
+        <location filename="../app/Main.qml" line="1626"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1380"/>
-        <location filename="../app/Main.qml" line="1403"/>
+        <location filename="../app/Main.qml" line="1394"/>
+        <location filename="../app/Main.qml" line="1417"/>
         <source>Update media database</source>
         <translation type="unfinished">미디어 데이터베이스 업데이트</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1383"/>
-        <location filename="../app/Main.qml" line="1406"/>
+        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1420"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">메타데이터 수집</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1388"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1411"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1388"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1411"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1415"/>
-        <location filename="../app/Main.qml" line="1450"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1464"/>
         <source>Launch game</source>
         <translation>게임 실행</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1445"/>
         <source>Remove from favorites</source>
         <translation>즐겨찾기에서 제거</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1445"/>
         <source>Add to favorites</source>
         <translation>즐겨찾기에 추가</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1436"/>
+        <location filename="../app/Main.qml" line="1450"/>
         <source>Write to NFC token</source>
         <translation>NFC 토큰에 쓰기</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1440"/>
+        <location filename="../app/Main.qml" line="1454"/>
         <source>QR code</source>
         <translation>QR 코드</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1608"/>
+        <location filename="../app/Main.qml" line="1622"/>
         <source>Default</source>
         <translation type="unfinished">기본값</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1608"/>
+        <location filename="../app/Main.qml" line="1622"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1932"/>
+        <location filename="../app/Main.qml" line="1946"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1936"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1950"/>
+        <location filename="../app/Main.qml" line="1964"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1954"/>
+        <location filename="../app/Main.qml" line="1968"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1958"/>
+        <location filename="../app/Main.qml" line="1972"/>
         <source>Retry</source>
         <translation type="unfinished">다시 시도</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1962"/>
+        <location filename="../app/Main.qml" line="1976"/>
         <source>Cancel</source>
         <translation type="unfinished">취소</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2624"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2612"/>
+        <location filename="../app/Main.qml" line="2626"/>
         <source>Loading games…</source>
         <translation>게임 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2628"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2616"/>
+        <location filename="../app/Main.qml" line="2630"/>
         <source>Loading favorites…</source>
         <translation>즐겨찾기 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2618"/>
+        <location filename="../app/Main.qml" line="2632"/>
         <source>Loading recently played…</source>
         <translation>최근 플레이 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2620"/>
+        <location filename="../app/Main.qml" line="2634"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2622"/>
+        <location filename="../app/Main.qml" line="2636"/>
         <source>Loading…</source>
         <translation>불러오는 중…</translation>
     </message>
@@ -864,12 +864,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="395"/>
+        <location filename="../screens/MediaListScreen.qml" line="436"/>
         <source>%1 entries</source>
         <translation type="unfinished">항목 %1개</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="396"/>
+        <location filename="../screens/MediaListScreen.qml" line="437"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>아니요</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="246"/>
+        <location filename="../components/Modal.qml" line="256"/>
         <source>Cancel</source>
         <translation>취소</translation>
     </message>
@@ -1312,7 +1312,7 @@ Euskara - devilschile2</source>
         <translation>%1초</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1358"/>
+        <location filename="../screens/SettingsScreen.qml" line="1368"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1406,7 +1406,7 @@ Euskara - devilschile2</source>
         <translation>설정</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1346"/>
+        <location filename="../screens/SettingsScreen.qml" line="1356"/>
         <source>No settings available on this platform</source>
         <translation>이 플랫폼에서는 설정을 사용할 수 없습니다</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="229"/>
-        <location filename="../screens/SystemsScreen.qml" line="329"/>
+        <location filename="../screens/SystemsScreen.qml" line="236"/>
+        <location filename="../screens/SystemsScreen.qml" line="338"/>
         <source>%1 systems</source>
         <translation>시스템 %1개</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="230"/>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="237"/>
+        <location filename="../screens/SystemsScreen.qml" line="355"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="364"/>
+        <location filename="../screens/SystemsScreen.qml" line="373"/>
         <source>No systems in this category</source>
         <translation>이 카테고리에는 시스템이 없습니다</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="365"/>
+        <location filename="../screens/SystemsScreen.qml" line="374"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>
@@ -1439,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="475"/>
+        <location filename="../components/Tile.qml" line="539"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -425,34 +425,34 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="116"/>
-        <location filename="../screens/GamesScreen.qml" line="151"/>
+        <location filename="../screens/GamesScreen.qml" line="127"/>
+        <location filename="../screens/GamesScreen.qml" line="162"/>
         <source>%1 files</source>
         <translation>%1 bestanden</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="53"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="125"/>
-        <location filename="../screens/GamesScreen.qml" line="152"/>
+        <location filename="../screens/GamesScreen.qml" line="136"/>
+        <location filename="../screens/GamesScreen.qml" line="163"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="48"/>
+        <location filename="../screens/GamesScreen.qml" line="49"/>
         <source>Loading games…</source>
         <translation>Games laden…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="121"/>
+        <location filename="../screens/GamesScreen.qml" line="132"/>
         <source>Loading more…</source>
         <translation>Meer laden…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="47"/>
+        <location filename="../screens/GamesScreen.qml" line="48"/>
         <source>No games in this system</source>
         <translation>Geen games in dit systeem</translation>
     </message>
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="139"/>
+        <location filename="../screens/HubScreen.qml" line="149"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="145"/>
+        <location filename="../screens/HubScreen.qml" line="155"/>
         <source>Favorites</source>
         <translation>Favorieten</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="150"/>
+        <location filename="../screens/HubScreen.qml" line="160"/>
         <source>Recently Played</source>
         <translation>Recent gespeeld</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="155"/>
+        <location filename="../screens/HubScreen.qml" line="165"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Instellingen</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="669"/>
+        <location filename="../screens/HubScreen.qml" line="701"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Geen systemen beschikbaar. Voer Database bijwerken uit via Instellingen.</translation>
     </message>
@@ -553,138 +553,138 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1361"/>
+        <location filename="../app/Main.qml" line="1367"/>
         <source>Launch core</source>
         <translation>Core starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1367"/>
-        <location filename="../app/Main.qml" line="1606"/>
+        <location filename="../app/Main.qml" line="1373"/>
+        <location filename="../app/Main.qml" line="1612"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1425"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Remove from favorites</source>
         <translation>Uit favorieten verwijderen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1425"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Add to favorites</source>
         <translation>Aan favorieten toevoegen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1430"/>
+        <location filename="../app/Main.qml" line="1436"/>
         <source>Write to NFC token</source>
         <translation>Naar NFC-token schrijven</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1434"/>
+        <location filename="../app/Main.qml" line="1440"/>
         <source>QR code</source>
         <translation>QR-code</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1409"/>
-        <location filename="../app/Main.qml" line="1444"/>
+        <location filename="../app/Main.qml" line="1415"/>
+        <location filename="../app/Main.qml" line="1450"/>
         <source>Launch game</source>
         <translation>Game starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2604"/>
+        <location filename="../app/Main.qml" line="2610"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2616"/>
         <source>Loading favorites…</source>
         <translation>Favorieten laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2606"/>
+        <location filename="../app/Main.qml" line="2612"/>
         <source>Loading games…</source>
         <translation>Games laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1374"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1380"/>
+        <location filename="../app/Main.qml" line="1403"/>
         <source>Update media database</source>
         <translation type="unfinished">Mediadatabase bijwerken</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1377"/>
-        <location filename="../app/Main.qml" line="1400"/>
+        <location filename="../app/Main.qml" line="1383"/>
+        <location filename="../app/Main.qml" line="1406"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadata ophalen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1382"/>
-        <location filename="../app/Main.qml" line="1391"/>
+        <location filename="../app/Main.qml" line="1388"/>
+        <location filename="../app/Main.qml" line="1397"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1382"/>
-        <location filename="../app/Main.qml" line="1391"/>
+        <location filename="../app/Main.qml" line="1388"/>
+        <location filename="../app/Main.qml" line="1397"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1602"/>
+        <location filename="../app/Main.qml" line="1608"/>
         <source>Default</source>
         <translation type="unfinished">Standaard</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1602"/>
+        <location filename="../app/Main.qml" line="1608"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1926"/>
+        <location filename="../app/Main.qml" line="1932"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1930"/>
+        <location filename="../app/Main.qml" line="1936"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1944"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1948"/>
+        <location filename="../app/Main.qml" line="1954"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1952"/>
+        <location filename="../app/Main.qml" line="1958"/>
         <source>Retry</source>
         <translation type="unfinished">Opnieuw proberen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1956"/>
+        <location filename="../app/Main.qml" line="1962"/>
         <source>Cancel</source>
         <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2608"/>
+        <location filename="../app/Main.qml" line="2614"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2612"/>
+        <location filename="../app/Main.qml" line="2618"/>
         <source>Loading recently played…</source>
         <translation>Recent gespeeld laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2620"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2616"/>
+        <location filename="../app/Main.qml" line="2622"/>
         <source>Loading…</source>
         <translation>Laden…</translation>
     </message>
@@ -692,72 +692,72 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="683"/>
+        <location filename="../app/MainLayout.qml" line="685"/>
         <source>Writing failed</source>
         <translation>Schrijven mislukt</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="683"/>
+        <location filename="../app/MainLayout.qml" line="685"/>
         <source>Put a writable card near the reader</source>
         <translation>Houd een beschrijfbare kaart bij de lezer</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="811"/>
+        <location filename="../app/MainLayout.qml" line="813"/>
         <source>Are you sure you want to exit?</source>
         <translation>Weet u zeker dat u wilt afsluiten?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="894"/>
-        <location filename="../app/MainLayout.qml" line="968"/>
+        <location filename="../app/MainLayout.qml" line="896"/>
+        <location filename="../app/MainLayout.qml" line="970"/>
         <source>Select</source>
         <translation>Selecteren</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="902"/>
-        <location filename="../app/MainLayout.qml" line="916"/>
-        <location filename="../app/MainLayout.qml" line="931"/>
-        <location filename="../app/MainLayout.qml" line="942"/>
+        <location filename="../app/MainLayout.qml" line="900"/>
+        <location filename="../app/MainLayout.qml" line="904"/>
+        <location filename="../app/MainLayout.qml" line="918"/>
+        <location filename="../app/MainLayout.qml" line="933"/>
+        <location filename="../app/MainLayout.qml" line="944"/>
         <source>Close</source>
         <translation>Sluiten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="909"/>
-        <location filename="../app/MainLayout.qml" line="949"/>
-        <location filename="../app/MainLayout.qml" line="972"/>
-        <location filename="../app/MainLayout.qml" line="983"/>
+        <location filename="../app/MainLayout.qml" line="911"/>
+        <location filename="../app/MainLayout.qml" line="951"/>
+        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="985"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="927"/>
+        <location filename="../app/MainLayout.qml" line="929"/>
         <source>Done</source>
         <translation>Klaar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="957"/>
+        <location filename="../app/MainLayout.qml" line="959"/>
         <source>I understand</source>
         <translation>Ik begrijp het</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="991"/>
+        <location filename="../app/MainLayout.qml" line="993"/>
         <source>Start</source>
         <translation>Starten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1203"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Scroll</source>
         <translation>Scrollen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="890"/>
-        <location filename="../app/MainLayout.qml" line="964"/>
-        <location filename="../app/MainLayout.qml" line="1010"/>
-        <location filename="../app/MainLayout.qml" line="1047"/>
-        <location filename="../app/MainLayout.qml" line="1097"/>
-        <location filename="../app/MainLayout.qml" line="1146"/>
-        <location filename="../app/MainLayout.qml" line="1165"/>
-        <location filename="../app/MainLayout.qml" line="1232"/>
+        <location filename="../app/MainLayout.qml" line="892"/>
+        <location filename="../app/MainLayout.qml" line="966"/>
+        <location filename="../app/MainLayout.qml" line="1012"/>
+        <location filename="../app/MainLayout.qml" line="1049"/>
+        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1148"/>
+        <location filename="../app/MainLayout.qml" line="1167"/>
+        <location filename="../app/MainLayout.qml" line="1234"/>
         <source>Move</source>
         <translation>Bewegen</translation>
     </message>
@@ -777,81 +777,81 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Recent gespeeld</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="699"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="700"/>
+        <location filename="../app/MainLayout.qml" line="702"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="810"/>
+        <location filename="../app/MainLayout.qml" line="812"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1014"/>
-        <location filename="../app/MainLayout.qml" line="1057"/>
-        <location filename="../app/MainLayout.qml" line="1107"/>
-        <location filename="../app/MainLayout.qml" line="1151"/>
-        <location filename="../app/MainLayout.qml" line="1242"/>
+        <location filename="../app/MainLayout.qml" line="1016"/>
+        <location filename="../app/MainLayout.qml" line="1059"/>
+        <location filename="../app/MainLayout.qml" line="1109"/>
+        <location filename="../app/MainLayout.qml" line="1153"/>
+        <location filename="../app/MainLayout.qml" line="1244"/>
         <source>Open</source>
         <translation>Openen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1024"/>
+        <location filename="../app/MainLayout.qml" line="1026"/>
         <source>Quit</source>
         <translation>Afsluiten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1033"/>
-        <location filename="../app/MainLayout.qml" line="1063"/>
-        <location filename="../app/MainLayout.qml" line="1074"/>
-        <location filename="../app/MainLayout.qml" line="1089"/>
-        <location filename="../app/MainLayout.qml" line="1116"/>
-        <location filename="../app/MainLayout.qml" line="1127"/>
-        <location filename="../app/MainLayout.qml" line="1139"/>
-        <location filename="../app/MainLayout.qml" line="1155"/>
-        <location filename="../app/MainLayout.qml" line="1189"/>
-        <location filename="../app/MainLayout.qml" line="1207"/>
-        <location filename="../app/MainLayout.qml" line="1216"/>
-        <location filename="../app/MainLayout.qml" line="1251"/>
-        <location filename="../app/MainLayout.qml" line="1262"/>
+        <location filename="../app/MainLayout.qml" line="1035"/>
+        <location filename="../app/MainLayout.qml" line="1065"/>
+        <location filename="../app/MainLayout.qml" line="1076"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
+        <location filename="../app/MainLayout.qml" line="1118"/>
+        <location filename="../app/MainLayout.qml" line="1129"/>
+        <location filename="../app/MainLayout.qml" line="1141"/>
+        <location filename="../app/MainLayout.qml" line="1157"/>
+        <location filename="../app/MainLayout.qml" line="1191"/>
+        <location filename="../app/MainLayout.qml" line="1209"/>
+        <location filename="../app/MainLayout.qml" line="1218"/>
+        <location filename="../app/MainLayout.qml" line="1253"/>
+        <location filename="../app/MainLayout.qml" line="1264"/>
         <source>Back</source>
         <translation>Terug</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1053"/>
-        <location filename="../app/MainLayout.qml" line="1103"/>
-        <location filename="../app/MainLayout.qml" line="1238"/>
+        <location filename="../app/MainLayout.qml" line="1055"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
+        <location filename="../app/MainLayout.qml" line="1240"/>
         <source>Page</source>
         <translation>Pagina</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1060"/>
-        <location filename="../app/MainLayout.qml" line="1112"/>
-        <location filename="../app/MainLayout.qml" line="1247"/>
+        <location filename="../app/MainLayout.qml" line="1022"/>
+        <location filename="../app/MainLayout.qml" line="1062"/>
+        <location filename="../app/MainLayout.qml" line="1114"/>
+        <location filename="../app/MainLayout.qml" line="1249"/>
         <source>Options</source>
         <translation>Opties</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1070"/>
-        <location filename="../app/MainLayout.qml" line="1123"/>
-        <location filename="../app/MainLayout.qml" line="1258"/>
+        <location filename="../app/MainLayout.qml" line="940"/>
+        <location filename="../app/MainLayout.qml" line="1072"/>
+        <location filename="../app/MainLayout.qml" line="1125"/>
+        <location filename="../app/MainLayout.qml" line="1260"/>
         <source>Retry</source>
         <translation>Opnieuw proberen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1174"/>
+        <location filename="../app/MainLayout.qml" line="1176"/>
         <source>Change</source>
         <translation>Wijzigen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1180"/>
+        <location filename="../app/MainLayout.qml" line="1182"/>
         <source>Toggle</source>
         <translation>Schakelen</translation>
     </message>
@@ -864,12 +864,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Laden…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="365"/>
+        <location filename="../screens/MediaListScreen.qml" line="395"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 items</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="366"/>
+        <location filename="../screens/MediaListScreen.qml" line="396"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>Nee</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="198"/>
+        <location filename="../components/Modal.qml" line="246"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
@@ -936,24 +936,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="132"/>
-        <location filename="../screens/SettingsScreen.qml" line="718"/>
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
+        <location filename="../screens/SettingsScreen.qml" line="741"/>
         <source>Language</source>
         <translation>Taal</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="754"/>
+        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <location filename="../screens/SettingsScreen.qml" line="777"/>
         <source>Browsing layout</source>
         <translation>Bladerlayout</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="150"/>
+        <location filename="../screens/SettingsScreen.qml" line="165"/>
         <source>Mouse support</source>
         <translation>Muisondersteuning</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="157"/>
+        <location filename="../screens/SettingsScreen.qml" line="177"/>
         <source>Update media database</source>
         <translation>Mediadatabase bijwerken</translation>
     </message>
@@ -962,47 +962,47 @@ Euskara - devilschile2</source>
         <translation type="vanished">Algemeen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="745"/>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="768"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="145"/>
-        <location filename="../screens/SettingsScreen.qml" line="763"/>
+        <location filename="../screens/SettingsScreen.qml" line="160"/>
+        <location filename="../screens/SettingsScreen.qml" line="786"/>
         <source>Button style</source>
         <translation>Knopstijl</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="772"/>
+        <location filename="../screens/SettingsScreen.qml" line="132"/>
+        <location filename="../screens/SettingsScreen.qml" line="795"/>
         <source>Screensaver</source>
         <translation>Schermbeveiliging</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="80"/>
-        <location filename="../screens/SettingsScreen.qml" line="209"/>
+        <location filename="../screens/SettingsScreen.qml" line="95"/>
+        <location filename="../screens/SettingsScreen.qml" line="229"/>
         <source>Library</source>
         <translation>Bibliotheek</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="162"/>
+        <location filename="../screens/SettingsScreen.qml" line="182"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="112"/>
-        <location filename="../screens/SettingsScreen.qml" line="781"/>
+        <location filename="../screens/SettingsScreen.qml" line="127"/>
+        <location filename="../screens/SettingsScreen.qml" line="804"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="167"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
         <source>Scrape metadata</source>
         <translation>Metadata ophalen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="172"/>
+        <location filename="../screens/SettingsScreen.qml" line="192"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1011,397 +1011,402 @@ Euskara - devilschile2</source>
         <translation type="vanished">Geavanceerd</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="184"/>
+        <location filename="../screens/SettingsScreen.qml" line="204"/>
         <source>Debug logging</source>
         <translation>Debug-logging</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="189"/>
+        <location filename="../screens/SettingsScreen.qml" line="209"/>
         <source>Upload log file</source>
         <translation>Logbestand uploaden</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="179"/>
+        <location filename="../screens/SettingsScreen.qml" line="199"/>
         <source>About / License</source>
         <translation>Over / Licentie</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
-        <location filename="../screens/SettingsScreen.qml" line="727"/>
+        <location filename="../screens/SettingsScreen.qml" line="137"/>
+        <location filename="../screens/SettingsScreen.qml" line="750"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="127"/>
-        <location filename="../screens/SettingsScreen.qml" line="736"/>
+        <location filename="../screens/SettingsScreen.qml" line="142"/>
+        <location filename="../screens/SettingsScreen.qml" line="759"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="137"/>
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="226"/>
+        <location filename="../screens/SettingsScreen.qml" line="170"/>
+        <source>Reduce motion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
         <source>Optimizing</source>
         <translation>Optimaliseren</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="228"/>
-        <location filename="../screens/SettingsScreen.qml" line="237"/>
+        <location filename="../screens/SettingsScreen.qml" line="248"/>
+        <location filename="../screens/SettingsScreen.qml" line="257"/>
         <source>Paused</source>
         <translation>Gepauzeerd</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="228"/>
-        <location filename="../screens/SettingsScreen.qml" line="237"/>
+        <location filename="../screens/SettingsScreen.qml" line="248"/>
+        <location filename="../screens/SettingsScreen.qml" line="257"/>
         <source>In progress</source>
         <translation>Bezig</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="231"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>%1 indexed</source>
         <translation>%1 geïndexeerd</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="240"/>
+        <location filename="../screens/SettingsScreen.qml" line="260"/>
         <source>%1 scraped</source>
         <translation>%1 opgehaald</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="472"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="472"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Start</source>
         <translation>Starten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="474"/>
+        <location filename="../screens/SettingsScreen.qml" line="497"/>
         <source>Upload</source>
         <translation>Uploaden</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Open</source>
         <translation>Openen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="556"/>
+        <location filename="../screens/SettingsScreen.qml" line="579"/>
         <source>English</source>
         <translation>Engels</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="558"/>
+        <location filename="../screens/SettingsScreen.qml" line="581"/>
         <source>Italian</source>
         <translation>Italiaans</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="560"/>
+        <location filename="../screens/SettingsScreen.qml" line="583"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="562"/>
+        <location filename="../screens/SettingsScreen.qml" line="585"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="564"/>
+        <location filename="../screens/SettingsScreen.qml" line="587"/>
         <source>German</source>
         <translation>Duits</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="566"/>
+        <location filename="../screens/SettingsScreen.qml" line="589"/>
         <source>Greek</source>
         <translation>Grieks</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="568"/>
+        <location filename="../screens/SettingsScreen.qml" line="591"/>
         <source>Japanese</source>
         <translation>Japans</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="570"/>
+        <location filename="../screens/SettingsScreen.qml" line="593"/>
         <source>Korean</source>
         <translation>Koreaans</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="595"/>
         <source>Dutch</source>
         <translation>Nederlands</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="597"/>
         <source>Romanian</source>
         <translation>Roemeens</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="599"/>
         <source>Slovak</source>
         <translation>Slowaaks</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="601"/>
         <source>Ukrainian</source>
         <translation>Oekraïens</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="603"/>
         <source>Chinese (Simplified)</source>
         <translation>Chinees (vereenvoudigd)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="605"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="607"/>
         <source>Hebrew</source>
         <translation>Hebreeuws</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="588"/>
+        <location filename="../screens/SettingsScreen.qml" line="611"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="589"/>
-        <location filename="../screens/SettingsScreen.qml" line="597"/>
-        <location filename="../screens/SettingsScreen.qml" line="671"/>
+        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="620"/>
+        <location filename="../screens/SettingsScreen.qml" line="694"/>
         <source>Auto</source>
         <translation>Automatisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="594"/>
+        <location filename="../screens/SettingsScreen.qml" line="617"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="596"/>
+        <location filename="../screens/SettingsScreen.qml" line="619"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="607"/>
+        <location filename="../screens/SettingsScreen.qml" line="630"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="632"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="611"/>
+        <location filename="../screens/SettingsScreen.qml" line="634"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="635"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="640"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="619"/>
+        <location filename="../screens/SettingsScreen.qml" line="642"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="620"/>
+        <location filename="../screens/SettingsScreen.qml" line="643"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="625"/>
+        <location filename="../screens/SettingsScreen.qml" line="648"/>
         <source>Detailed list view</source>
         <translation>Gedetailleerde lijstweergave</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="626"/>
+        <location filename="../screens/SettingsScreen.qml" line="649"/>
         <source>Grid view</source>
         <translation>Rasterweergave</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="631"/>
+        <location filename="../screens/SettingsScreen.qml" line="654"/>
         <source>Style B</source>
         <translation>Stijl B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="633"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Style C</source>
         <translation>Stijl C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="658"/>
         <source>Style D</source>
         <translation>Stijl D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="659"/>
         <source>Style A</source>
         <translation>Stijl A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1292"/>
+        <location filename="../screens/SettingsScreen.qml" line="1358"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="526"/>
+        <location filename="../screens/SettingsScreen.qml" line="549"/>
         <source>Default</source>
         <translation>Standaard</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="674"/>
         <source>Off</source>
         <translation>Uit</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="653"/>
+        <location filename="../screens/SettingsScreen.qml" line="676"/>
         <source>1 second (testing)</source>
         <translation>1 seconde (test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="655"/>
+        <location filename="../screens/SettingsScreen.qml" line="678"/>
         <source>1 minute</source>
         <translation>1 minuut</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="657"/>
+        <location filename="../screens/SettingsScreen.qml" line="680"/>
         <source>2 minutes</source>
         <translation>2 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="659"/>
+        <location filename="../screens/SettingsScreen.qml" line="682"/>
         <source>5 minutes</source>
         <translation>5 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="661"/>
+        <location filename="../screens/SettingsScreen.qml" line="684"/>
         <source>10 minutes</source>
         <translation>10 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="663"/>
+        <location filename="../screens/SettingsScreen.qml" line="686"/>
         <source>15 minutes</source>
         <translation>15 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="665"/>
+        <location filename="../screens/SettingsScreen.qml" line="688"/>
         <source>30 minutes</source>
         <translation>30 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="666"/>
+        <location filename="../screens/SettingsScreen.qml" line="689"/>
         <source>%1 seconds</source>
         <translation>%1 seconden</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="96"/>
-        <location filename="../screens/SettingsScreen.qml" line="709"/>
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="732"/>
         <source>Resolution</source>
         <translation>Resolutie</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="68"/>
-        <location filename="../screens/SettingsScreen.qml" line="205"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="74"/>
-        <location filename="../screens/SettingsScreen.qml" line="207"/>
+        <location filename="../screens/SettingsScreen.qml" line="89"/>
+        <location filename="../screens/SettingsScreen.qml" line="227"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="86"/>
-        <location filename="../screens/SettingsScreen.qml" line="211"/>
+        <location filename="../screens/SettingsScreen.qml" line="101"/>
+        <location filename="../screens/SettingsScreen.qml" line="231"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="673"/>
+        <location filename="../screens/SettingsScreen.qml" line="696"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="675"/>
+        <location filename="../screens/SettingsScreen.qml" line="698"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="677"/>
+        <location filename="../screens/SettingsScreen.qml" line="700"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="679"/>
+        <location filename="../screens/SettingsScreen.qml" line="702"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="681"/>
+        <location filename="../screens/SettingsScreen.qml" line="704"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="683"/>
+        <location filename="../screens/SettingsScreen.qml" line="706"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="685"/>
+        <location filename="../screens/SettingsScreen.qml" line="708"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="687"/>
+        <location filename="../screens/SettingsScreen.qml" line="710"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="712"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="691"/>
+        <location filename="../screens/SettingsScreen.qml" line="714"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="693"/>
+        <location filename="../screens/SettingsScreen.qml" line="716"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="695"/>
+        <location filename="../screens/SettingsScreen.qml" line="718"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="212"/>
+        <location filename="../screens/SettingsScreen.qml" line="232"/>
         <source>Settings</source>
         <translation>Instellingen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1280"/>
+        <location filename="../screens/SettingsScreen.qml" line="1346"/>
         <source>No settings available on this platform</source>
         <translation>Geen instellingen beschikbaar op dit platform</translation>
     </message>
@@ -1409,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="206"/>
-        <location filename="../screens/SystemsScreen.qml" line="304"/>
+        <location filename="../screens/SystemsScreen.qml" line="229"/>
+        <location filename="../screens/SystemsScreen.qml" line="329"/>
         <source>%1 systems</source>
         <translation>%1 systemen</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="207"/>
-        <location filename="../screens/SystemsScreen.qml" line="321"/>
+        <location filename="../screens/SystemsScreen.qml" line="230"/>
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="339"/>
+        <location filename="../screens/SystemsScreen.qml" line="364"/>
         <source>No systems in this category</source>
         <translation>Geen systemen in deze categorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="340"/>
+        <location filename="../screens/SystemsScreen.qml" line="365"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>
@@ -1434,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="364"/>
+        <location filename="../components/Tile.qml" line="475"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="156"/>
+        <location filename="../screens/HubScreen.qml" line="154"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="162"/>
+        <location filename="../screens/HubScreen.qml" line="160"/>
         <source>Favorites</source>
         <translation>Favorieten</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="167"/>
+        <location filename="../screens/HubScreen.qml" line="165"/>
         <source>Recently Played</source>
         <translation>Recent gespeeld</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="172"/>
+        <location filename="../screens/HubScreen.qml" line="170"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Instellingen</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="722"/>
+        <location filename="../screens/HubScreen.qml" line="718"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Geen systemen beschikbaar. Voer Database bijwerken uit via Instellingen.</translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>Nee</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="256"/>
+        <location filename="../components/Modal.qml" line="246"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
@@ -936,24 +936,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147"/>
-        <location filename="../screens/SettingsScreen.qml" line="741"/>
+        <location filename="../screens/SettingsScreen.qml" line="141"/>
+        <location filename="../screens/SettingsScreen.qml" line="734"/>
         <source>Language</source>
         <translation>Taal</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
-        <location filename="../screens/SettingsScreen.qml" line="777"/>
+        <location filename="../screens/SettingsScreen.qml" line="116"/>
+        <location filename="../screens/SettingsScreen.qml" line="770"/>
         <source>Browsing layout</source>
         <translation>Bladerlayout</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="165"/>
+        <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>Mouse support</source>
         <translation>Muisondersteuning</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="177"/>
+        <location filename="../screens/SettingsScreen.qml" line="171"/>
         <source>Update media database</source>
         <translation>Mediadatabase bijwerken</translation>
     </message>
@@ -962,47 +962,47 @@ Euskara - devilschile2</source>
         <translation type="vanished">Algemeen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="768"/>
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="761"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="160"/>
-        <location filename="../screens/SettingsScreen.qml" line="786"/>
+        <location filename="../screens/SettingsScreen.qml" line="154"/>
+        <location filename="../screens/SettingsScreen.qml" line="779"/>
         <source>Button style</source>
         <translation>Knopstijl</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="132"/>
-        <location filename="../screens/SettingsScreen.qml" line="795"/>
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
+        <location filename="../screens/SettingsScreen.qml" line="788"/>
         <source>Screensaver</source>
         <translation>Schermbeveiliging</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="95"/>
-        <location filename="../screens/SettingsScreen.qml" line="229"/>
+        <location filename="../screens/SettingsScreen.qml" line="89"/>
+        <location filename="../screens/SettingsScreen.qml" line="223"/>
         <source>Library</source>
         <translation>Bibliotheek</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="182"/>
+        <location filename="../screens/SettingsScreen.qml" line="176"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="127"/>
-        <location filename="../screens/SettingsScreen.qml" line="804"/>
+        <location filename="../screens/SettingsScreen.qml" line="121"/>
+        <location filename="../screens/SettingsScreen.qml" line="797"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <location filename="../screens/SettingsScreen.qml" line="181"/>
         <source>Scrape metadata</source>
         <translation>Metadata ophalen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="192"/>
+        <location filename="../screens/SettingsScreen.qml" line="186"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1011,402 +1011,402 @@ Euskara - devilschile2</source>
         <translation type="vanished">Geavanceerd</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="204"/>
+        <location filename="../screens/SettingsScreen.qml" line="198"/>
         <source>Debug logging</source>
         <translation>Debug-logging</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="209"/>
+        <location filename="../screens/SettingsScreen.qml" line="203"/>
         <source>Upload log file</source>
         <translation>Logbestand uploaden</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="199"/>
+        <location filename="../screens/SettingsScreen.qml" line="193"/>
         <source>About / License</source>
         <translation>Over / Licentie</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="137"/>
-        <location filename="../screens/SettingsScreen.qml" line="750"/>
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="743"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="142"/>
-        <location filename="../screens/SettingsScreen.qml" line="759"/>
+        <location filename="../screens/SettingsScreen.qml" line="136"/>
+        <location filename="../screens/SettingsScreen.qml" line="752"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152"/>
+        <location filename="../screens/SettingsScreen.qml" line="146"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="170"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
         <source>Reduce motion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="240"/>
         <source>Optimizing</source>
         <translation>Optimaliseren</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="248"/>
-        <location filename="../screens/SettingsScreen.qml" line="257"/>
+        <location filename="../screens/SettingsScreen.qml" line="242"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>Paused</source>
         <translation>Gepauzeerd</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="248"/>
-        <location filename="../screens/SettingsScreen.qml" line="257"/>
+        <location filename="../screens/SettingsScreen.qml" line="242"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>In progress</source>
         <translation>Bezig</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="245"/>
         <source>%1 indexed</source>
         <translation>%1 geïndexeerd</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="260"/>
+        <location filename="../screens/SettingsScreen.qml" line="254"/>
         <source>%1 scraped</source>
         <translation>%1 opgehaald</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="495"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="495"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Start</source>
         <translation>Starten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="497"/>
+        <location filename="../screens/SettingsScreen.qml" line="490"/>
         <source>Upload</source>
         <translation>Uploaden</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <location filename="../screens/SettingsScreen.qml" line="491"/>
         <source>Open</source>
         <translation>Openen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="579"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>English</source>
         <translation>Engels</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="581"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Italian</source>
         <translation>Italiaans</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="583"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="585"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="587"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>German</source>
         <translation>Duits</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="589"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Greek</source>
         <translation>Grieks</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="591"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Japanese</source>
         <translation>Japans</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="593"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Korean</source>
         <translation>Koreaans</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="595"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Dutch</source>
         <translation>Nederlands</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="597"/>
+        <location filename="../screens/SettingsScreen.qml" line="590"/>
         <source>Romanian</source>
         <translation>Roemeens</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="599"/>
+        <location filename="../screens/SettingsScreen.qml" line="592"/>
         <source>Slovak</source>
         <translation>Slowaaks</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="601"/>
+        <location filename="../screens/SettingsScreen.qml" line="594"/>
         <source>Ukrainian</source>
         <translation>Oekraïens</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="603"/>
+        <location filename="../screens/SettingsScreen.qml" line="596"/>
         <source>Chinese (Simplified)</source>
         <translation>Chinees (vereenvoudigd)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="605"/>
+        <location filename="../screens/SettingsScreen.qml" line="598"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="607"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Hebrew</source>
         <translation>Hebreeuws</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="611"/>
+        <location filename="../screens/SettingsScreen.qml" line="604"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
-        <location filename="../screens/SettingsScreen.qml" line="620"/>
-        <location filename="../screens/SettingsScreen.qml" line="694"/>
+        <location filename="../screens/SettingsScreen.qml" line="605"/>
+        <location filename="../screens/SettingsScreen.qml" line="613"/>
+        <location filename="../screens/SettingsScreen.qml" line="687"/>
         <source>Auto</source>
         <translation>Automatisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="610"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="619"/>
+        <location filename="../screens/SettingsScreen.qml" line="612"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="630"/>
+        <location filename="../screens/SettingsScreen.qml" line="623"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="632"/>
+        <location filename="../screens/SettingsScreen.qml" line="625"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="634"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="628"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="640"/>
+        <location filename="../screens/SettingsScreen.qml" line="633"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="642"/>
+        <location filename="../screens/SettingsScreen.qml" line="635"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="643"/>
+        <location filename="../screens/SettingsScreen.qml" line="636"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="648"/>
+        <location filename="../screens/SettingsScreen.qml" line="641"/>
         <source>Detailed list view</source>
         <translation>Gedetailleerde lijstweergave</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="642"/>
         <source>Grid view</source>
         <translation>Rasterweergave</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="654"/>
+        <location filename="../screens/SettingsScreen.qml" line="647"/>
         <source>Style B</source>
         <translation>Stijl B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="656"/>
+        <location filename="../screens/SettingsScreen.qml" line="649"/>
         <source>Style C</source>
         <translation>Stijl C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="658"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
         <source>Style D</source>
         <translation>Stijl D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="659"/>
+        <location filename="../screens/SettingsScreen.qml" line="652"/>
         <source>Style A</source>
         <translation>Stijl A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1368"/>
+        <location filename="../screens/SettingsScreen.qml" line="1351"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="549"/>
+        <location filename="../screens/SettingsScreen.qml" line="542"/>
         <source>Default</source>
         <translation>Standaard</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="674"/>
+        <location filename="../screens/SettingsScreen.qml" line="667"/>
         <source>Off</source>
         <translation>Uit</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="676"/>
+        <location filename="../screens/SettingsScreen.qml" line="669"/>
         <source>1 second (testing)</source>
         <translation>1 seconde (test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="678"/>
+        <location filename="../screens/SettingsScreen.qml" line="671"/>
         <source>1 minute</source>
         <translation>1 minuut</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="680"/>
+        <location filename="../screens/SettingsScreen.qml" line="673"/>
         <source>2 minutes</source>
         <translation>2 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="682"/>
+        <location filename="../screens/SettingsScreen.qml" line="675"/>
         <source>5 minutes</source>
         <translation>5 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="684"/>
+        <location filename="../screens/SettingsScreen.qml" line="677"/>
         <source>10 minutes</source>
         <translation>10 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="686"/>
+        <location filename="../screens/SettingsScreen.qml" line="679"/>
         <source>15 minutes</source>
         <translation>15 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="688"/>
+        <location filename="../screens/SettingsScreen.qml" line="681"/>
         <source>30 minutes</source>
         <translation>30 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="682"/>
         <source>%1 seconds</source>
         <translation>%1 seconden</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
-        <location filename="../screens/SettingsScreen.qml" line="732"/>
+        <location filename="../screens/SettingsScreen.qml" line="105"/>
+        <location filename="../screens/SettingsScreen.qml" line="725"/>
         <source>Resolution</source>
         <translation>Resolutie</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="225"/>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="219"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="89"/>
-        <location filename="../screens/SettingsScreen.qml" line="227"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="221"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="101"/>
-        <location filename="../screens/SettingsScreen.qml" line="231"/>
+        <location filename="../screens/SettingsScreen.qml" line="95"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="696"/>
+        <location filename="../screens/SettingsScreen.qml" line="689"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="698"/>
+        <location filename="../screens/SettingsScreen.qml" line="691"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="700"/>
+        <location filename="../screens/SettingsScreen.qml" line="693"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="702"/>
+        <location filename="../screens/SettingsScreen.qml" line="695"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="704"/>
+        <location filename="../screens/SettingsScreen.qml" line="697"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="706"/>
+        <location filename="../screens/SettingsScreen.qml" line="699"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="708"/>
+        <location filename="../screens/SettingsScreen.qml" line="701"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="710"/>
+        <location filename="../screens/SettingsScreen.qml" line="703"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="712"/>
+        <location filename="../screens/SettingsScreen.qml" line="705"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="714"/>
+        <location filename="../screens/SettingsScreen.qml" line="707"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="716"/>
+        <location filename="../screens/SettingsScreen.qml" line="709"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="718"/>
+        <location filename="../screens/SettingsScreen.qml" line="711"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="232"/>
+        <location filename="../screens/SettingsScreen.qml" line="226"/>
         <source>Settings</source>
         <translation>Instellingen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1356"/>
+        <location filename="../screens/SettingsScreen.qml" line="1339"/>
         <source>No settings available on this platform</source>
         <translation>Geen instellingen beschikbaar op dit platform</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="236"/>
-        <location filename="../screens/SystemsScreen.qml" line="338"/>
+        <location filename="../screens/SystemsScreen.qml" line="242"/>
+        <location filename="../screens/SystemsScreen.qml" line="343"/>
         <source>%1 systems</source>
         <translation>%1 systemen</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="237"/>
-        <location filename="../screens/SystemsScreen.qml" line="355"/>
+        <location filename="../screens/SystemsScreen.qml" line="243"/>
+        <location filename="../screens/SystemsScreen.qml" line="360"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="373"/>
+        <location filename="../screens/SystemsScreen.qml" line="378"/>
         <source>No systems in this category</source>
         <translation>Geen systemen in deze categorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="374"/>
+        <location filename="../screens/SystemsScreen.qml" line="379"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>
@@ -1439,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="539"/>
+        <location filename="../components/Tile.qml" line="501"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -425,8 +425,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="128"/>
-        <location filename="../screens/GamesScreen.qml" line="163"/>
+        <location filename="../screens/GamesScreen.qml" line="131"/>
+        <location filename="../screens/GamesScreen.qml" line="166"/>
         <source>%1 files</source>
         <translation>%1 bestanden</translation>
     </message>
@@ -436,8 +436,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="137"/>
-        <location filename="../screens/GamesScreen.qml" line="164"/>
+        <location filename="../screens/GamesScreen.qml" line="140"/>
+        <location filename="../screens/GamesScreen.qml" line="167"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -447,7 +447,7 @@ Euskara - devilschile2</source>
         <translation>Games laden…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="133"/>
+        <location filename="../screens/GamesScreen.qml" line="136"/>
         <source>Loading more…</source>
         <translation>Meer laden…</translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>Nee</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="246"/>
+        <location filename="../components/Modal.qml" line="250"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
@@ -936,24 +936,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="141"/>
-        <location filename="../screens/SettingsScreen.qml" line="734"/>
+        <location filename="../screens/SettingsScreen.qml" line="145"/>
+        <location filename="../screens/SettingsScreen.qml" line="738"/>
         <source>Language</source>
         <translation>Taal</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116"/>
-        <location filename="../screens/SettingsScreen.qml" line="770"/>
+        <location filename="../screens/SettingsScreen.qml" line="120"/>
+        <location filename="../screens/SettingsScreen.qml" line="774"/>
         <source>Browsing layout</source>
         <translation>Bladerlayout</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="159"/>
+        <location filename="../screens/SettingsScreen.qml" line="163"/>
         <source>Mouse support</source>
         <translation>Muisondersteuning</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="171"/>
+        <location filename="../screens/SettingsScreen.qml" line="175"/>
         <source>Update media database</source>
         <translation>Mediadatabase bijwerken</translation>
     </message>
@@ -962,47 +962,47 @@ Euskara - devilschile2</source>
         <translation type="vanished">Algemeen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
-        <location filename="../screens/SettingsScreen.qml" line="761"/>
+        <location filename="../screens/SettingsScreen.qml" line="115"/>
+        <location filename="../screens/SettingsScreen.qml" line="765"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="154"/>
-        <location filename="../screens/SettingsScreen.qml" line="779"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="783"/>
         <source>Button style</source>
         <translation>Knopstijl</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
-        <location filename="../screens/SettingsScreen.qml" line="788"/>
+        <location filename="../screens/SettingsScreen.qml" line="130"/>
+        <location filename="../screens/SettingsScreen.qml" line="792"/>
         <source>Screensaver</source>
         <translation>Schermbeveiliging</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="89"/>
-        <location filename="../screens/SettingsScreen.qml" line="223"/>
+        <location filename="../screens/SettingsScreen.qml" line="93"/>
+        <location filename="../screens/SettingsScreen.qml" line="227"/>
         <source>Library</source>
         <translation>Bibliotheek</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="176"/>
+        <location filename="../screens/SettingsScreen.qml" line="180"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121"/>
-        <location filename="../screens/SettingsScreen.qml" line="797"/>
+        <location filename="../screens/SettingsScreen.qml" line="125"/>
+        <location filename="../screens/SettingsScreen.qml" line="801"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="181"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
         <source>Scrape metadata</source>
         <translation>Metadata ophalen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="186"/>
+        <location filename="../screens/SettingsScreen.qml" line="190"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1011,402 +1011,402 @@ Euskara - devilschile2</source>
         <translation type="vanished">Geavanceerd</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="198"/>
+        <location filename="../screens/SettingsScreen.qml" line="202"/>
         <source>Debug logging</source>
         <translation>Debug-logging</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="203"/>
+        <location filename="../screens/SettingsScreen.qml" line="207"/>
         <source>Upload log file</source>
         <translation>Logbestand uploaden</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="193"/>
+        <location filename="../screens/SettingsScreen.qml" line="197"/>
         <source>About / License</source>
         <translation>Over / Licentie</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
-        <location filename="../screens/SettingsScreen.qml" line="743"/>
+        <location filename="../screens/SettingsScreen.qml" line="135"/>
+        <location filename="../screens/SettingsScreen.qml" line="747"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="136"/>
-        <location filename="../screens/SettingsScreen.qml" line="752"/>
+        <location filename="../screens/SettingsScreen.qml" line="140"/>
+        <location filename="../screens/SettingsScreen.qml" line="756"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="146"/>
+        <location filename="../screens/SettingsScreen.qml" line="150"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="168"/>
         <source>Reduce motion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="240"/>
+        <location filename="../screens/SettingsScreen.qml" line="244"/>
         <source>Optimizing</source>
         <translation>Optimaliseren</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="242"/>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="255"/>
         <source>Paused</source>
         <translation>Gepauzeerd</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="242"/>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="255"/>
         <source>In progress</source>
         <translation>Bezig</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="245"/>
+        <location filename="../screens/SettingsScreen.qml" line="249"/>
         <source>%1 indexed</source>
         <translation>%1 geïndexeerd</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="254"/>
+        <location filename="../screens/SettingsScreen.qml" line="258"/>
         <source>%1 scraped</source>
         <translation>%1 opgehaald</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="488"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="488"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Start</source>
         <translation>Starten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="490"/>
+        <location filename="../screens/SettingsScreen.qml" line="494"/>
         <source>Upload</source>
         <translation>Uploaden</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="491"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Open</source>
         <translation>Openen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>English</source>
         <translation>Engels</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Italian</source>
         <translation>Italiaans</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>German</source>
         <translation>Duits</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Greek</source>
         <translation>Grieks</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Japanese</source>
         <translation>Japans</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="590"/>
         <source>Korean</source>
         <translation>Koreaans</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="588"/>
+        <location filename="../screens/SettingsScreen.qml" line="592"/>
         <source>Dutch</source>
         <translation>Nederlands</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="590"/>
+        <location filename="../screens/SettingsScreen.qml" line="594"/>
         <source>Romanian</source>
         <translation>Roemeens</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="592"/>
+        <location filename="../screens/SettingsScreen.qml" line="596"/>
         <source>Slovak</source>
         <translation>Slowaaks</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="594"/>
+        <location filename="../screens/SettingsScreen.qml" line="598"/>
         <source>Ukrainian</source>
         <translation>Oekraïens</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="596"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Chinese (Simplified)</source>
         <translation>Chinees (vereenvoudigd)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="598"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="600"/>
+        <location filename="../screens/SettingsScreen.qml" line="604"/>
         <source>Hebrew</source>
         <translation>Hebreeuws</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="602"/>
+        <location filename="../screens/SettingsScreen.qml" line="606"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="604"/>
+        <location filename="../screens/SettingsScreen.qml" line="608"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="605"/>
-        <location filename="../screens/SettingsScreen.qml" line="613"/>
-        <location filename="../screens/SettingsScreen.qml" line="687"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="691"/>
         <source>Auto</source>
         <translation>Automatisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="610"/>
+        <location filename="../screens/SettingsScreen.qml" line="614"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="616"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="623"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="625"/>
+        <location filename="../screens/SettingsScreen.qml" line="629"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="627"/>
+        <location filename="../screens/SettingsScreen.qml" line="631"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="628"/>
+        <location filename="../screens/SettingsScreen.qml" line="632"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="633"/>
+        <location filename="../screens/SettingsScreen.qml" line="637"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="639"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="640"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="641"/>
+        <location filename="../screens/SettingsScreen.qml" line="645"/>
         <source>Detailed list view</source>
         <translation>Gedetailleerde lijstweergave</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="642"/>
+        <location filename="../screens/SettingsScreen.qml" line="646"/>
         <source>Grid view</source>
         <translation>Rasterweergave</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
         <source>Style B</source>
         <translation>Stijl B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Style C</source>
         <translation>Stijl C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="655"/>
         <source>Style D</source>
         <translation>Stijl D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="652"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Style A</source>
         <translation>Stijl A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1351"/>
+        <location filename="../screens/SettingsScreen.qml" line="1382"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="542"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>Default</source>
         <translation>Standaard</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="667"/>
+        <location filename="../screens/SettingsScreen.qml" line="671"/>
         <source>Off</source>
         <translation>Uit</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="669"/>
+        <location filename="../screens/SettingsScreen.qml" line="673"/>
         <source>1 second (testing)</source>
         <translation>1 seconde (test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="671"/>
+        <location filename="../screens/SettingsScreen.qml" line="675"/>
         <source>1 minute</source>
         <translation>1 minuut</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="673"/>
+        <location filename="../screens/SettingsScreen.qml" line="677"/>
         <source>2 minutes</source>
         <translation>2 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="675"/>
+        <location filename="../screens/SettingsScreen.qml" line="679"/>
         <source>5 minutes</source>
         <translation>5 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="677"/>
+        <location filename="../screens/SettingsScreen.qml" line="681"/>
         <source>10 minutes</source>
         <translation>10 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="679"/>
+        <location filename="../screens/SettingsScreen.qml" line="683"/>
         <source>15 minutes</source>
         <translation>15 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="681"/>
+        <location filename="../screens/SettingsScreen.qml" line="685"/>
         <source>30 minutes</source>
         <translation>30 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="682"/>
+        <location filename="../screens/SettingsScreen.qml" line="686"/>
         <source>%1 seconds</source>
         <translation>%1 seconden</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="105"/>
-        <location filename="../screens/SettingsScreen.qml" line="725"/>
+        <location filename="../screens/SettingsScreen.qml" line="109"/>
+        <location filename="../screens/SettingsScreen.qml" line="729"/>
         <source>Resolution</source>
         <translation>Resolutie</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="77"/>
-        <location filename="../screens/SettingsScreen.qml" line="219"/>
+        <location filename="../screens/SettingsScreen.qml" line="81"/>
+        <location filename="../screens/SettingsScreen.qml" line="223"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="221"/>
+        <location filename="../screens/SettingsScreen.qml" line="87"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="95"/>
-        <location filename="../screens/SettingsScreen.qml" line="225"/>
+        <location filename="../screens/SettingsScreen.qml" line="99"/>
+        <location filename="../screens/SettingsScreen.qml" line="229"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="693"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="691"/>
+        <location filename="../screens/SettingsScreen.qml" line="695"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="693"/>
+        <location filename="../screens/SettingsScreen.qml" line="697"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="695"/>
+        <location filename="../screens/SettingsScreen.qml" line="699"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="697"/>
+        <location filename="../screens/SettingsScreen.qml" line="701"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="699"/>
+        <location filename="../screens/SettingsScreen.qml" line="703"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="701"/>
+        <location filename="../screens/SettingsScreen.qml" line="705"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="703"/>
+        <location filename="../screens/SettingsScreen.qml" line="707"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="705"/>
+        <location filename="../screens/SettingsScreen.qml" line="709"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="707"/>
+        <location filename="../screens/SettingsScreen.qml" line="711"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="709"/>
+        <location filename="../screens/SettingsScreen.qml" line="713"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="711"/>
+        <location filename="../screens/SettingsScreen.qml" line="715"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="226"/>
+        <location filename="../screens/SettingsScreen.qml" line="230"/>
         <source>Settings</source>
         <translation>Instellingen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1339"/>
+        <location filename="../screens/SettingsScreen.qml" line="1370"/>
         <source>No settings available on this platform</source>
         <translation>Geen instellingen beschikbaar op dit platform</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="242"/>
-        <location filename="../screens/SystemsScreen.qml" line="343"/>
+        <location filename="../screens/SystemsScreen.qml" line="245"/>
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>%1 systems</source>
         <translation>%1 systemen</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="243"/>
-        <location filename="../screens/SystemsScreen.qml" line="360"/>
+        <location filename="../screens/SystemsScreen.qml" line="246"/>
+        <location filename="../screens/SystemsScreen.qml" line="363"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="378"/>
+        <location filename="../screens/SystemsScreen.qml" line="381"/>
         <source>No systems in this category</source>
         <translation>Geen systemen in deze categorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="379"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -97,100 +97,100 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Laden…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="196"/>
+        <location filename="../components/BrowseDetailPane.qml" line="167"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="196"/>
+        <location filename="../components/BrowseDetailPane.qml" line="167"/>
         <source>Yr</source>
         <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="198"/>
+        <location filename="../components/BrowseDetailPane.qml" line="169"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="198"/>
+        <location filename="../components/BrowseDetailPane.qml" line="169"/>
         <source>Gen</source>
         <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="200"/>
+        <location filename="../components/BrowseDetailPane.qml" line="171"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="200"/>
+        <location filename="../components/BrowseDetailPane.qml" line="171"/>
         <source>Plyr</source>
         <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="202"/>
+        <location filename="../components/BrowseDetailPane.qml" line="173"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="202"/>
+        <location filename="../components/BrowseDetailPane.qml" line="173"/>
         <source>Dev</source>
         <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="204"/>
+        <location filename="../components/BrowseDetailPane.qml" line="175"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="204"/>
+        <location filename="../components/BrowseDetailPane.qml" line="175"/>
         <source>Pub</source>
         <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="206"/>
+        <location filename="../components/BrowseDetailPane.qml" line="177"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="206"/>
+        <location filename="../components/BrowseDetailPane.qml" line="177"/>
         <source>Rtg</source>
         <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="208"/>
+        <location filename="../components/BrowseDetailPane.qml" line="179"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="208"/>
+        <location filename="../components/BrowseDetailPane.qml" line="179"/>
         <source>Cat</source>
         <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="210"/>
+        <location filename="../components/BrowseDetailPane.qml" line="181"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="210"/>
+        <location filename="../components/BrowseDetailPane.qml" line="181"/>
         <source>Date</source>
         <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="212"/>
+        <location filename="../components/BrowseDetailPane.qml" line="183"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="212"/>
+        <location filename="../components/BrowseDetailPane.qml" line="183"/>
         <source>Mfr</source>
         <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
@@ -425,8 +425,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="127"/>
-        <location filename="../screens/GamesScreen.qml" line="162"/>
+        <location filename="../screens/GamesScreen.qml" line="128"/>
+        <location filename="../screens/GamesScreen.qml" line="163"/>
         <source>%1 files</source>
         <translation>%1 bestanden</translation>
     </message>
@@ -436,8 +436,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="136"/>
-        <location filename="../screens/GamesScreen.qml" line="163"/>
+        <location filename="../screens/GamesScreen.qml" line="137"/>
+        <location filename="../screens/GamesScreen.qml" line="164"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -447,7 +447,7 @@ Euskara - devilschile2</source>
         <translation>Games laden…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="132"/>
+        <location filename="../screens/GamesScreen.qml" line="133"/>
         <source>Loading more…</source>
         <translation>Meer laden…</translation>
     </message>
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="149"/>
+        <location filename="../screens/HubScreen.qml" line="156"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="155"/>
+        <location filename="../screens/HubScreen.qml" line="162"/>
         <source>Favorites</source>
         <translation>Favorieten</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="160"/>
+        <location filename="../screens/HubScreen.qml" line="167"/>
         <source>Recently Played</source>
         <translation>Recent gespeeld</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="165"/>
+        <location filename="../screens/HubScreen.qml" line="172"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Instellingen</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="701"/>
+        <location filename="../screens/HubScreen.qml" line="722"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Geen systemen beschikbaar. Voer Database bijwerken uit via Instellingen.</translation>
     </message>
@@ -553,138 +553,138 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1367"/>
+        <location filename="../app/Main.qml" line="1381"/>
         <source>Launch core</source>
         <translation>Core starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1373"/>
-        <location filename="../app/Main.qml" line="1612"/>
+        <location filename="../app/Main.qml" line="1387"/>
+        <location filename="../app/Main.qml" line="1626"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1445"/>
         <source>Remove from favorites</source>
         <translation>Uit favorieten verwijderen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1445"/>
         <source>Add to favorites</source>
         <translation>Aan favorieten toevoegen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1436"/>
+        <location filename="../app/Main.qml" line="1450"/>
         <source>Write to NFC token</source>
         <translation>Naar NFC-token schrijven</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1440"/>
+        <location filename="../app/Main.qml" line="1454"/>
         <source>QR code</source>
         <translation>QR-code</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1415"/>
-        <location filename="../app/Main.qml" line="1450"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1464"/>
         <source>Launch game</source>
         <translation>Game starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2624"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2616"/>
+        <location filename="../app/Main.qml" line="2630"/>
         <source>Loading favorites…</source>
         <translation>Favorieten laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2612"/>
+        <location filename="../app/Main.qml" line="2626"/>
         <source>Loading games…</source>
         <translation>Games laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1380"/>
-        <location filename="../app/Main.qml" line="1403"/>
+        <location filename="../app/Main.qml" line="1394"/>
+        <location filename="../app/Main.qml" line="1417"/>
         <source>Update media database</source>
         <translation type="unfinished">Mediadatabase bijwerken</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1383"/>
-        <location filename="../app/Main.qml" line="1406"/>
+        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1420"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadata ophalen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1388"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1411"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1388"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1411"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1608"/>
+        <location filename="../app/Main.qml" line="1622"/>
         <source>Default</source>
         <translation type="unfinished">Standaard</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1608"/>
+        <location filename="../app/Main.qml" line="1622"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1932"/>
+        <location filename="../app/Main.qml" line="1946"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1936"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1950"/>
+        <location filename="../app/Main.qml" line="1964"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1954"/>
+        <location filename="../app/Main.qml" line="1968"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1958"/>
+        <location filename="../app/Main.qml" line="1972"/>
         <source>Retry</source>
         <translation type="unfinished">Opnieuw proberen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1962"/>
+        <location filename="../app/Main.qml" line="1976"/>
         <source>Cancel</source>
         <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2628"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2618"/>
+        <location filename="../app/Main.qml" line="2632"/>
         <source>Loading recently played…</source>
         <translation>Recent gespeeld laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2620"/>
+        <location filename="../app/Main.qml" line="2634"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2622"/>
+        <location filename="../app/Main.qml" line="2636"/>
         <source>Loading…</source>
         <translation>Laden…</translation>
     </message>
@@ -864,12 +864,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Laden…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="395"/>
+        <location filename="../screens/MediaListScreen.qml" line="436"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 items</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="396"/>
+        <location filename="../screens/MediaListScreen.qml" line="437"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>Nee</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="246"/>
+        <location filename="../components/Modal.qml" line="256"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
@@ -1262,7 +1262,7 @@ Euskara - devilschile2</source>
         <translation>Stijl A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1358"/>
+        <location filename="../screens/SettingsScreen.qml" line="1368"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1406,7 +1406,7 @@ Euskara - devilschile2</source>
         <translation>Instellingen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1346"/>
+        <location filename="../screens/SettingsScreen.qml" line="1356"/>
         <source>No settings available on this platform</source>
         <translation>Geen instellingen beschikbaar op dit platform</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="229"/>
-        <location filename="../screens/SystemsScreen.qml" line="329"/>
+        <location filename="../screens/SystemsScreen.qml" line="236"/>
+        <location filename="../screens/SystemsScreen.qml" line="338"/>
         <source>%1 systems</source>
         <translation>%1 systemen</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="230"/>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="237"/>
+        <location filename="../screens/SystemsScreen.qml" line="355"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="364"/>
+        <location filename="../screens/SystemsScreen.qml" line="373"/>
         <source>No systems in this category</source>
         <translation>Geen systemen in deze categorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="365"/>
+        <location filename="../screens/SystemsScreen.qml" line="374"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>
@@ -1439,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="475"/>
+        <location filename="../components/Tile.qml" line="539"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -97,100 +97,100 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Se încarcă…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="196"/>
+        <location filename="../components/BrowseDetailPane.qml" line="167"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="196"/>
+        <location filename="../components/BrowseDetailPane.qml" line="167"/>
         <source>Yr</source>
         <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="198"/>
+        <location filename="../components/BrowseDetailPane.qml" line="169"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="198"/>
+        <location filename="../components/BrowseDetailPane.qml" line="169"/>
         <source>Gen</source>
         <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="200"/>
+        <location filename="../components/BrowseDetailPane.qml" line="171"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="200"/>
+        <location filename="../components/BrowseDetailPane.qml" line="171"/>
         <source>Plyr</source>
         <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="202"/>
+        <location filename="../components/BrowseDetailPane.qml" line="173"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="202"/>
+        <location filename="../components/BrowseDetailPane.qml" line="173"/>
         <source>Dev</source>
         <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="204"/>
+        <location filename="../components/BrowseDetailPane.qml" line="175"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="204"/>
+        <location filename="../components/BrowseDetailPane.qml" line="175"/>
         <source>Pub</source>
         <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="206"/>
+        <location filename="../components/BrowseDetailPane.qml" line="177"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="206"/>
+        <location filename="../components/BrowseDetailPane.qml" line="177"/>
         <source>Rtg</source>
         <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="208"/>
+        <location filename="../components/BrowseDetailPane.qml" line="179"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="208"/>
+        <location filename="../components/BrowseDetailPane.qml" line="179"/>
         <source>Cat</source>
         <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="210"/>
+        <location filename="../components/BrowseDetailPane.qml" line="181"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="210"/>
+        <location filename="../components/BrowseDetailPane.qml" line="181"/>
         <source>Date</source>
         <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="212"/>
+        <location filename="../components/BrowseDetailPane.qml" line="183"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="212"/>
+        <location filename="../components/BrowseDetailPane.qml" line="183"/>
         <source>Mfr</source>
         <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
@@ -425,8 +425,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="127"/>
-        <location filename="../screens/GamesScreen.qml" line="162"/>
+        <location filename="../screens/GamesScreen.qml" line="128"/>
+        <location filename="../screens/GamesScreen.qml" line="163"/>
         <source>%1 files</source>
         <translation>%1 fișiere</translation>
     </message>
@@ -436,8 +436,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="136"/>
-        <location filename="../screens/GamesScreen.qml" line="163"/>
+        <location filename="../screens/GamesScreen.qml" line="137"/>
+        <location filename="../screens/GamesScreen.qml" line="164"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -447,7 +447,7 @@ Euskara - devilschile2</source>
         <translation>Se încarcă jocurile…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="132"/>
+        <location filename="../screens/GamesScreen.qml" line="133"/>
         <source>Loading more…</source>
         <translation>Se încarcă mai multe…</translation>
     </message>
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="149"/>
+        <location filename="../screens/HubScreen.qml" line="156"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="155"/>
+        <location filename="../screens/HubScreen.qml" line="162"/>
         <source>Favorites</source>
         <translation>Favorite</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="160"/>
+        <location filename="../screens/HubScreen.qml" line="167"/>
         <source>Recently Played</source>
         <translation>Recent Jucate</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="165"/>
+        <location filename="../screens/HubScreen.qml" line="172"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Setări</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="701"/>
+        <location filename="../screens/HubScreen.qml" line="722"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Niciun sistem disponibil. Rulați Actualizare bază de date din Setări.</translation>
     </message>
@@ -553,138 +553,138 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1367"/>
+        <location filename="../app/Main.qml" line="1381"/>
         <source>Launch core</source>
         <translation>Lansare core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1373"/>
-        <location filename="../app/Main.qml" line="1612"/>
+        <location filename="../app/Main.qml" line="1387"/>
+        <location filename="../app/Main.qml" line="1626"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1445"/>
         <source>Remove from favorites</source>
         <translation>Elimină din favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1445"/>
         <source>Add to favorites</source>
         <translation>Adaugă la favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1436"/>
+        <location filename="../app/Main.qml" line="1450"/>
         <source>Write to NFC token</source>
         <translation>Scriere pe token NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1440"/>
+        <location filename="../app/Main.qml" line="1454"/>
         <source>QR code</source>
         <translation>Cod QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1415"/>
-        <location filename="../app/Main.qml" line="1450"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1464"/>
         <source>Launch game</source>
         <translation>Lansare joc</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2624"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2616"/>
+        <location filename="../app/Main.qml" line="2630"/>
         <source>Loading favorites…</source>
         <translation>Se încarcă favoritele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2612"/>
+        <location filename="../app/Main.qml" line="2626"/>
         <source>Loading games…</source>
         <translation>Se încarcă jocurile…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1380"/>
-        <location filename="../app/Main.qml" line="1403"/>
+        <location filename="../app/Main.qml" line="1394"/>
+        <location filename="../app/Main.qml" line="1417"/>
         <source>Update media database</source>
         <translation type="unfinished">Actualizare bază de date media</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1383"/>
-        <location filename="../app/Main.qml" line="1406"/>
+        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1420"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Extragere metadate</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1388"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1411"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1388"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1411"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1608"/>
+        <location filename="../app/Main.qml" line="1622"/>
         <source>Default</source>
         <translation type="unfinished">Implicit</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1608"/>
+        <location filename="../app/Main.qml" line="1622"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1932"/>
+        <location filename="../app/Main.qml" line="1946"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1936"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1950"/>
+        <location filename="../app/Main.qml" line="1964"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1954"/>
+        <location filename="../app/Main.qml" line="1968"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1958"/>
+        <location filename="../app/Main.qml" line="1972"/>
         <source>Retry</source>
         <translation type="unfinished">Reîncercare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1962"/>
+        <location filename="../app/Main.qml" line="1976"/>
         <source>Cancel</source>
         <translation type="unfinished">Anulare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2628"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2618"/>
+        <location filename="../app/Main.qml" line="2632"/>
         <source>Loading recently played…</source>
         <translation>Se încarcă recent jucatele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2620"/>
+        <location filename="../app/Main.qml" line="2634"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2622"/>
+        <location filename="../app/Main.qml" line="2636"/>
         <source>Loading…</source>
         <translation>Se încarcă…</translation>
     </message>
@@ -864,12 +864,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Se încarcă…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="395"/>
+        <location filename="../screens/MediaListScreen.qml" line="436"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 intrări</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="396"/>
+        <location filename="../screens/MediaListScreen.qml" line="437"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>Nu</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="246"/>
+        <location filename="../components/Modal.qml" line="256"/>
         <source>Cancel</source>
         <translation>Anulare</translation>
     </message>
@@ -1262,7 +1262,7 @@ Euskara - devilschile2</source>
         <translation>Stil A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1358"/>
+        <location filename="../screens/SettingsScreen.qml" line="1368"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1406,7 +1406,7 @@ Euskara - devilschile2</source>
         <translation>Setări</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1346"/>
+        <location filename="../screens/SettingsScreen.qml" line="1356"/>
         <source>No settings available on this platform</source>
         <translation>Nicio setare disponibilă pe această platformă</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="229"/>
-        <location filename="../screens/SystemsScreen.qml" line="329"/>
+        <location filename="../screens/SystemsScreen.qml" line="236"/>
+        <location filename="../screens/SystemsScreen.qml" line="338"/>
         <source>%1 systems</source>
         <translation>%1 sisteme</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="230"/>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="237"/>
+        <location filename="../screens/SystemsScreen.qml" line="355"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="364"/>
+        <location filename="../screens/SystemsScreen.qml" line="373"/>
         <source>No systems in this category</source>
         <translation>Niciun sistem în această categorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="365"/>
+        <location filename="../screens/SystemsScreen.qml" line="374"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>
@@ -1439,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="475"/>
+        <location filename="../components/Tile.qml" line="539"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -425,34 +425,34 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="116"/>
-        <location filename="../screens/GamesScreen.qml" line="151"/>
+        <location filename="../screens/GamesScreen.qml" line="127"/>
+        <location filename="../screens/GamesScreen.qml" line="162"/>
         <source>%1 files</source>
         <translation>%1 fișiere</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="53"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="125"/>
-        <location filename="../screens/GamesScreen.qml" line="152"/>
+        <location filename="../screens/GamesScreen.qml" line="136"/>
+        <location filename="../screens/GamesScreen.qml" line="163"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="48"/>
+        <location filename="../screens/GamesScreen.qml" line="49"/>
         <source>Loading games…</source>
         <translation>Se încarcă jocurile…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="121"/>
+        <location filename="../screens/GamesScreen.qml" line="132"/>
         <source>Loading more…</source>
         <translation>Se încarcă mai multe…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="47"/>
+        <location filename="../screens/GamesScreen.qml" line="48"/>
         <source>No games in this system</source>
         <translation>Niciun joc în acest sistem</translation>
     </message>
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="139"/>
+        <location filename="../screens/HubScreen.qml" line="149"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="145"/>
+        <location filename="../screens/HubScreen.qml" line="155"/>
         <source>Favorites</source>
         <translation>Favorite</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="150"/>
+        <location filename="../screens/HubScreen.qml" line="160"/>
         <source>Recently Played</source>
         <translation>Recent Jucate</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="155"/>
+        <location filename="../screens/HubScreen.qml" line="165"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Setări</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="669"/>
+        <location filename="../screens/HubScreen.qml" line="701"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Niciun sistem disponibil. Rulați Actualizare bază de date din Setări.</translation>
     </message>
@@ -553,138 +553,138 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1361"/>
+        <location filename="../app/Main.qml" line="1367"/>
         <source>Launch core</source>
         <translation>Lansare core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1367"/>
-        <location filename="../app/Main.qml" line="1606"/>
+        <location filename="../app/Main.qml" line="1373"/>
+        <location filename="../app/Main.qml" line="1612"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1425"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Remove from favorites</source>
         <translation>Elimină din favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1425"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Add to favorites</source>
         <translation>Adaugă la favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1430"/>
+        <location filename="../app/Main.qml" line="1436"/>
         <source>Write to NFC token</source>
         <translation>Scriere pe token NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1434"/>
+        <location filename="../app/Main.qml" line="1440"/>
         <source>QR code</source>
         <translation>Cod QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1409"/>
-        <location filename="../app/Main.qml" line="1444"/>
+        <location filename="../app/Main.qml" line="1415"/>
+        <location filename="../app/Main.qml" line="1450"/>
         <source>Launch game</source>
         <translation>Lansare joc</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2604"/>
+        <location filename="../app/Main.qml" line="2610"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2616"/>
         <source>Loading favorites…</source>
         <translation>Se încarcă favoritele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2606"/>
+        <location filename="../app/Main.qml" line="2612"/>
         <source>Loading games…</source>
         <translation>Se încarcă jocurile…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1374"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1380"/>
+        <location filename="../app/Main.qml" line="1403"/>
         <source>Update media database</source>
         <translation type="unfinished">Actualizare bază de date media</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1377"/>
-        <location filename="../app/Main.qml" line="1400"/>
+        <location filename="../app/Main.qml" line="1383"/>
+        <location filename="../app/Main.qml" line="1406"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Extragere metadate</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1382"/>
-        <location filename="../app/Main.qml" line="1391"/>
+        <location filename="../app/Main.qml" line="1388"/>
+        <location filename="../app/Main.qml" line="1397"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1382"/>
-        <location filename="../app/Main.qml" line="1391"/>
+        <location filename="../app/Main.qml" line="1388"/>
+        <location filename="../app/Main.qml" line="1397"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1602"/>
+        <location filename="../app/Main.qml" line="1608"/>
         <source>Default</source>
         <translation type="unfinished">Implicit</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1602"/>
+        <location filename="../app/Main.qml" line="1608"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1926"/>
+        <location filename="../app/Main.qml" line="1932"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1930"/>
+        <location filename="../app/Main.qml" line="1936"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1944"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1948"/>
+        <location filename="../app/Main.qml" line="1954"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1952"/>
+        <location filename="../app/Main.qml" line="1958"/>
         <source>Retry</source>
         <translation type="unfinished">Reîncercare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1956"/>
+        <location filename="../app/Main.qml" line="1962"/>
         <source>Cancel</source>
         <translation type="unfinished">Anulare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2608"/>
+        <location filename="../app/Main.qml" line="2614"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2612"/>
+        <location filename="../app/Main.qml" line="2618"/>
         <source>Loading recently played…</source>
         <translation>Se încarcă recent jucatele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2620"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2616"/>
+        <location filename="../app/Main.qml" line="2622"/>
         <source>Loading…</source>
         <translation>Se încarcă…</translation>
     </message>
@@ -692,72 +692,72 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="683"/>
+        <location filename="../app/MainLayout.qml" line="685"/>
         <source>Writing failed</source>
         <translation>Scriere eșuată</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="683"/>
+        <location filename="../app/MainLayout.qml" line="685"/>
         <source>Put a writable card near the reader</source>
         <translation>Apropiați un card inscriptibil de cititor</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="811"/>
+        <location filename="../app/MainLayout.qml" line="813"/>
         <source>Are you sure you want to exit?</source>
         <translation>Sigur doriți să ieșiți?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="894"/>
-        <location filename="../app/MainLayout.qml" line="968"/>
+        <location filename="../app/MainLayout.qml" line="896"/>
+        <location filename="../app/MainLayout.qml" line="970"/>
         <source>Select</source>
         <translation>Selectare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="902"/>
-        <location filename="../app/MainLayout.qml" line="916"/>
-        <location filename="../app/MainLayout.qml" line="931"/>
-        <location filename="../app/MainLayout.qml" line="942"/>
+        <location filename="../app/MainLayout.qml" line="900"/>
+        <location filename="../app/MainLayout.qml" line="904"/>
+        <location filename="../app/MainLayout.qml" line="918"/>
+        <location filename="../app/MainLayout.qml" line="933"/>
+        <location filename="../app/MainLayout.qml" line="944"/>
         <source>Close</source>
         <translation>Închidere</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="909"/>
-        <location filename="../app/MainLayout.qml" line="949"/>
-        <location filename="../app/MainLayout.qml" line="972"/>
-        <location filename="../app/MainLayout.qml" line="983"/>
+        <location filename="../app/MainLayout.qml" line="911"/>
+        <location filename="../app/MainLayout.qml" line="951"/>
+        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="985"/>
         <source>Cancel</source>
         <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="927"/>
+        <location filename="../app/MainLayout.qml" line="929"/>
         <source>Done</source>
         <translation>Gata</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="957"/>
+        <location filename="../app/MainLayout.qml" line="959"/>
         <source>I understand</source>
         <translation>Am înțeles</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="991"/>
+        <location filename="../app/MainLayout.qml" line="993"/>
         <source>Start</source>
         <translation>Pornire</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1203"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Scroll</source>
         <translation>Derulare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="890"/>
-        <location filename="../app/MainLayout.qml" line="964"/>
-        <location filename="../app/MainLayout.qml" line="1010"/>
-        <location filename="../app/MainLayout.qml" line="1047"/>
-        <location filename="../app/MainLayout.qml" line="1097"/>
-        <location filename="../app/MainLayout.qml" line="1146"/>
-        <location filename="../app/MainLayout.qml" line="1165"/>
-        <location filename="../app/MainLayout.qml" line="1232"/>
+        <location filename="../app/MainLayout.qml" line="892"/>
+        <location filename="../app/MainLayout.qml" line="966"/>
+        <location filename="../app/MainLayout.qml" line="1012"/>
+        <location filename="../app/MainLayout.qml" line="1049"/>
+        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1148"/>
+        <location filename="../app/MainLayout.qml" line="1167"/>
+        <location filename="../app/MainLayout.qml" line="1234"/>
         <source>Move</source>
         <translation>Mutare</translation>
     </message>
@@ -777,81 +777,81 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Recent Jucate</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="699"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="700"/>
+        <location filename="../app/MainLayout.qml" line="702"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="810"/>
+        <location filename="../app/MainLayout.qml" line="812"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1014"/>
-        <location filename="../app/MainLayout.qml" line="1057"/>
-        <location filename="../app/MainLayout.qml" line="1107"/>
-        <location filename="../app/MainLayout.qml" line="1151"/>
-        <location filename="../app/MainLayout.qml" line="1242"/>
+        <location filename="../app/MainLayout.qml" line="1016"/>
+        <location filename="../app/MainLayout.qml" line="1059"/>
+        <location filename="../app/MainLayout.qml" line="1109"/>
+        <location filename="../app/MainLayout.qml" line="1153"/>
+        <location filename="../app/MainLayout.qml" line="1244"/>
         <source>Open</source>
         <translation>Deschidere</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1024"/>
+        <location filename="../app/MainLayout.qml" line="1026"/>
         <source>Quit</source>
         <translation>Ieșire</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1033"/>
-        <location filename="../app/MainLayout.qml" line="1063"/>
-        <location filename="../app/MainLayout.qml" line="1074"/>
-        <location filename="../app/MainLayout.qml" line="1089"/>
-        <location filename="../app/MainLayout.qml" line="1116"/>
-        <location filename="../app/MainLayout.qml" line="1127"/>
-        <location filename="../app/MainLayout.qml" line="1139"/>
-        <location filename="../app/MainLayout.qml" line="1155"/>
-        <location filename="../app/MainLayout.qml" line="1189"/>
-        <location filename="../app/MainLayout.qml" line="1207"/>
-        <location filename="../app/MainLayout.qml" line="1216"/>
-        <location filename="../app/MainLayout.qml" line="1251"/>
-        <location filename="../app/MainLayout.qml" line="1262"/>
+        <location filename="../app/MainLayout.qml" line="1035"/>
+        <location filename="../app/MainLayout.qml" line="1065"/>
+        <location filename="../app/MainLayout.qml" line="1076"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
+        <location filename="../app/MainLayout.qml" line="1118"/>
+        <location filename="../app/MainLayout.qml" line="1129"/>
+        <location filename="../app/MainLayout.qml" line="1141"/>
+        <location filename="../app/MainLayout.qml" line="1157"/>
+        <location filename="../app/MainLayout.qml" line="1191"/>
+        <location filename="../app/MainLayout.qml" line="1209"/>
+        <location filename="../app/MainLayout.qml" line="1218"/>
+        <location filename="../app/MainLayout.qml" line="1253"/>
+        <location filename="../app/MainLayout.qml" line="1264"/>
         <source>Back</source>
         <translation>Înapoi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1053"/>
-        <location filename="../app/MainLayout.qml" line="1103"/>
-        <location filename="../app/MainLayout.qml" line="1238"/>
+        <location filename="../app/MainLayout.qml" line="1055"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
+        <location filename="../app/MainLayout.qml" line="1240"/>
         <source>Page</source>
         <translation>Pagină</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1060"/>
-        <location filename="../app/MainLayout.qml" line="1112"/>
-        <location filename="../app/MainLayout.qml" line="1247"/>
+        <location filename="../app/MainLayout.qml" line="1022"/>
+        <location filename="../app/MainLayout.qml" line="1062"/>
+        <location filename="../app/MainLayout.qml" line="1114"/>
+        <location filename="../app/MainLayout.qml" line="1249"/>
         <source>Options</source>
         <translation>Opțiuni</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1070"/>
-        <location filename="../app/MainLayout.qml" line="1123"/>
-        <location filename="../app/MainLayout.qml" line="1258"/>
+        <location filename="../app/MainLayout.qml" line="940"/>
+        <location filename="../app/MainLayout.qml" line="1072"/>
+        <location filename="../app/MainLayout.qml" line="1125"/>
+        <location filename="../app/MainLayout.qml" line="1260"/>
         <source>Retry</source>
         <translation>Reîncercare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1174"/>
+        <location filename="../app/MainLayout.qml" line="1176"/>
         <source>Change</source>
         <translation>Schimbare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1180"/>
+        <location filename="../app/MainLayout.qml" line="1182"/>
         <source>Toggle</source>
         <translation>Comutare</translation>
     </message>
@@ -864,12 +864,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Se încarcă…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="365"/>
+        <location filename="../screens/MediaListScreen.qml" line="395"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 intrări</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="366"/>
+        <location filename="../screens/MediaListScreen.qml" line="396"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>Nu</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="198"/>
+        <location filename="../components/Modal.qml" line="246"/>
         <source>Cancel</source>
         <translation>Anulare</translation>
     </message>
@@ -936,24 +936,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="132"/>
-        <location filename="../screens/SettingsScreen.qml" line="718"/>
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
+        <location filename="../screens/SettingsScreen.qml" line="741"/>
         <source>Language</source>
         <translation>Limbă</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="754"/>
+        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <location filename="../screens/SettingsScreen.qml" line="777"/>
         <source>Browsing layout</source>
         <translation>Aspect navigare</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="150"/>
+        <location filename="../screens/SettingsScreen.qml" line="165"/>
         <source>Mouse support</source>
         <translation>Suport mouse</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="157"/>
+        <location filename="../screens/SettingsScreen.qml" line="177"/>
         <source>Update media database</source>
         <translation>Actualizare bază de date media</translation>
     </message>
@@ -962,47 +962,47 @@ Euskara - devilschile2</source>
         <translation type="vanished">Generale</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="745"/>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="768"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="145"/>
-        <location filename="../screens/SettingsScreen.qml" line="763"/>
+        <location filename="../screens/SettingsScreen.qml" line="160"/>
+        <location filename="../screens/SettingsScreen.qml" line="786"/>
         <source>Button style</source>
         <translation>Stil butoane</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="772"/>
+        <location filename="../screens/SettingsScreen.qml" line="132"/>
+        <location filename="../screens/SettingsScreen.qml" line="795"/>
         <source>Screensaver</source>
         <translation>Economizor de ecran</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="80"/>
-        <location filename="../screens/SettingsScreen.qml" line="209"/>
+        <location filename="../screens/SettingsScreen.qml" line="95"/>
+        <location filename="../screens/SettingsScreen.qml" line="229"/>
         <source>Library</source>
         <translation>Bibliotecă</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="162"/>
+        <location filename="../screens/SettingsScreen.qml" line="182"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="112"/>
-        <location filename="../screens/SettingsScreen.qml" line="781"/>
+        <location filename="../screens/SettingsScreen.qml" line="127"/>
+        <location filename="../screens/SettingsScreen.qml" line="804"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="167"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
         <source>Scrape metadata</source>
         <translation>Extragere metadate</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="172"/>
+        <location filename="../screens/SettingsScreen.qml" line="192"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1011,397 +1011,402 @@ Euskara - devilschile2</source>
         <translation type="vanished">Avansat</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="184"/>
+        <location filename="../screens/SettingsScreen.qml" line="204"/>
         <source>Debug logging</source>
         <translation>Jurnal depanare</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="189"/>
+        <location filename="../screens/SettingsScreen.qml" line="209"/>
         <source>Upload log file</source>
         <translation>Încărcare fișier jurnal</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="179"/>
+        <location filename="../screens/SettingsScreen.qml" line="199"/>
         <source>About / License</source>
         <translation>Despre / Licență</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
-        <location filename="../screens/SettingsScreen.qml" line="727"/>
+        <location filename="../screens/SettingsScreen.qml" line="137"/>
+        <location filename="../screens/SettingsScreen.qml" line="750"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="127"/>
-        <location filename="../screens/SettingsScreen.qml" line="736"/>
+        <location filename="../screens/SettingsScreen.qml" line="142"/>
+        <location filename="../screens/SettingsScreen.qml" line="759"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="137"/>
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="226"/>
+        <location filename="../screens/SettingsScreen.qml" line="170"/>
+        <source>Reduce motion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
         <source>Optimizing</source>
         <translation>Optimizare</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="228"/>
-        <location filename="../screens/SettingsScreen.qml" line="237"/>
+        <location filename="../screens/SettingsScreen.qml" line="248"/>
+        <location filename="../screens/SettingsScreen.qml" line="257"/>
         <source>Paused</source>
         <translation>În pauză</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="228"/>
-        <location filename="../screens/SettingsScreen.qml" line="237"/>
+        <location filename="../screens/SettingsScreen.qml" line="248"/>
+        <location filename="../screens/SettingsScreen.qml" line="257"/>
         <source>In progress</source>
         <translation>În curs</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="231"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>%1 indexed</source>
         <translation>%1 indexate</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="240"/>
+        <location filename="../screens/SettingsScreen.qml" line="260"/>
         <source>%1 scraped</source>
         <translation>%1 extrase</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="472"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Cancel</source>
         <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="472"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Start</source>
         <translation>Pornire</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="474"/>
+        <location filename="../screens/SettingsScreen.qml" line="497"/>
         <source>Upload</source>
         <translation>Încărcare</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Open</source>
         <translation>Deschidere</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="556"/>
+        <location filename="../screens/SettingsScreen.qml" line="579"/>
         <source>English</source>
         <translation>Engleză</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="558"/>
+        <location filename="../screens/SettingsScreen.qml" line="581"/>
         <source>Italian</source>
         <translation>Italiană</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="560"/>
+        <location filename="../screens/SettingsScreen.qml" line="583"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="562"/>
+        <location filename="../screens/SettingsScreen.qml" line="585"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="564"/>
+        <location filename="../screens/SettingsScreen.qml" line="587"/>
         <source>German</source>
         <translation>Germană</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="566"/>
+        <location filename="../screens/SettingsScreen.qml" line="589"/>
         <source>Greek</source>
         <translation>Greacă</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="568"/>
+        <location filename="../screens/SettingsScreen.qml" line="591"/>
         <source>Japanese</source>
         <translation>Japoneză</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="570"/>
+        <location filename="../screens/SettingsScreen.qml" line="593"/>
         <source>Korean</source>
         <translation>Coreeană</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="595"/>
         <source>Dutch</source>
         <translation>Olandeză</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="597"/>
         <source>Romanian</source>
         <translation>Română</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="599"/>
         <source>Slovak</source>
         <translation>Slovacă</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="601"/>
         <source>Ukrainian</source>
         <translation>Ucraineană</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="603"/>
         <source>Chinese (Simplified)</source>
         <translation>Chineză (simplificată)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="605"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="607"/>
         <source>Hebrew</source>
         <translation>Ebraică</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="588"/>
+        <location filename="../screens/SettingsScreen.qml" line="611"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="589"/>
-        <location filename="../screens/SettingsScreen.qml" line="597"/>
-        <location filename="../screens/SettingsScreen.qml" line="671"/>
+        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="620"/>
+        <location filename="../screens/SettingsScreen.qml" line="694"/>
         <source>Auto</source>
         <translation>Automat</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="594"/>
+        <location filename="../screens/SettingsScreen.qml" line="617"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="596"/>
+        <location filename="../screens/SettingsScreen.qml" line="619"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="607"/>
+        <location filename="../screens/SettingsScreen.qml" line="630"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="632"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="611"/>
+        <location filename="../screens/SettingsScreen.qml" line="634"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="635"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="640"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="619"/>
+        <location filename="../screens/SettingsScreen.qml" line="642"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="620"/>
+        <location filename="../screens/SettingsScreen.qml" line="643"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="625"/>
+        <location filename="../screens/SettingsScreen.qml" line="648"/>
         <source>Detailed list view</source>
         <translation>Vizualizare listă detaliată</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="626"/>
+        <location filename="../screens/SettingsScreen.qml" line="649"/>
         <source>Grid view</source>
         <translation>Vizualizare grilă</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="631"/>
+        <location filename="../screens/SettingsScreen.qml" line="654"/>
         <source>Style B</source>
         <translation>Stil B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="633"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Style C</source>
         <translation>Stil C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="658"/>
         <source>Style D</source>
         <translation>Stil D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="659"/>
         <source>Style A</source>
         <translation>Stil A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1292"/>
+        <location filename="../screens/SettingsScreen.qml" line="1358"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="526"/>
+        <location filename="../screens/SettingsScreen.qml" line="549"/>
         <source>Default</source>
         <translation>Implicit</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="674"/>
         <source>Off</source>
         <translation>Dezactivat</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="653"/>
+        <location filename="../screens/SettingsScreen.qml" line="676"/>
         <source>1 second (testing)</source>
         <translation>1 secundă (test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="655"/>
+        <location filename="../screens/SettingsScreen.qml" line="678"/>
         <source>1 minute</source>
         <translation>1 minut</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="657"/>
+        <location filename="../screens/SettingsScreen.qml" line="680"/>
         <source>2 minutes</source>
         <translation>2 minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="659"/>
+        <location filename="../screens/SettingsScreen.qml" line="682"/>
         <source>5 minutes</source>
         <translation>5 minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="661"/>
+        <location filename="../screens/SettingsScreen.qml" line="684"/>
         <source>10 minutes</source>
         <translation>10 minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="663"/>
+        <location filename="../screens/SettingsScreen.qml" line="686"/>
         <source>15 minutes</source>
         <translation>15 minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="665"/>
+        <location filename="../screens/SettingsScreen.qml" line="688"/>
         <source>30 minutes</source>
         <translation>30 de minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="666"/>
+        <location filename="../screens/SettingsScreen.qml" line="689"/>
         <source>%1 seconds</source>
         <translation>%1 secunde</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="96"/>
-        <location filename="../screens/SettingsScreen.qml" line="709"/>
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="732"/>
         <source>Resolution</source>
         <translation>Rezoluție</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="68"/>
-        <location filename="../screens/SettingsScreen.qml" line="205"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="74"/>
-        <location filename="../screens/SettingsScreen.qml" line="207"/>
+        <location filename="../screens/SettingsScreen.qml" line="89"/>
+        <location filename="../screens/SettingsScreen.qml" line="227"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="86"/>
-        <location filename="../screens/SettingsScreen.qml" line="211"/>
+        <location filename="../screens/SettingsScreen.qml" line="101"/>
+        <location filename="../screens/SettingsScreen.qml" line="231"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="673"/>
+        <location filename="../screens/SettingsScreen.qml" line="696"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="675"/>
+        <location filename="../screens/SettingsScreen.qml" line="698"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="677"/>
+        <location filename="../screens/SettingsScreen.qml" line="700"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="679"/>
+        <location filename="../screens/SettingsScreen.qml" line="702"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="681"/>
+        <location filename="../screens/SettingsScreen.qml" line="704"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="683"/>
+        <location filename="../screens/SettingsScreen.qml" line="706"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="685"/>
+        <location filename="../screens/SettingsScreen.qml" line="708"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="687"/>
+        <location filename="../screens/SettingsScreen.qml" line="710"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="712"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="691"/>
+        <location filename="../screens/SettingsScreen.qml" line="714"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="693"/>
+        <location filename="../screens/SettingsScreen.qml" line="716"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="695"/>
+        <location filename="../screens/SettingsScreen.qml" line="718"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="212"/>
+        <location filename="../screens/SettingsScreen.qml" line="232"/>
         <source>Settings</source>
         <translation>Setări</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1280"/>
+        <location filename="../screens/SettingsScreen.qml" line="1346"/>
         <source>No settings available on this platform</source>
         <translation>Nicio setare disponibilă pe această platformă</translation>
     </message>
@@ -1409,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="206"/>
-        <location filename="../screens/SystemsScreen.qml" line="304"/>
+        <location filename="../screens/SystemsScreen.qml" line="229"/>
+        <location filename="../screens/SystemsScreen.qml" line="329"/>
         <source>%1 systems</source>
         <translation>%1 sisteme</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="207"/>
-        <location filename="../screens/SystemsScreen.qml" line="321"/>
+        <location filename="../screens/SystemsScreen.qml" line="230"/>
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="339"/>
+        <location filename="../screens/SystemsScreen.qml" line="364"/>
         <source>No systems in this category</source>
         <translation>Niciun sistem în această categorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="340"/>
+        <location filename="../screens/SystemsScreen.qml" line="365"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>
@@ -1434,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="364"/>
+        <location filename="../components/Tile.qml" line="475"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="156"/>
+        <location filename="../screens/HubScreen.qml" line="154"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="162"/>
+        <location filename="../screens/HubScreen.qml" line="160"/>
         <source>Favorites</source>
         <translation>Favorite</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="167"/>
+        <location filename="../screens/HubScreen.qml" line="165"/>
         <source>Recently Played</source>
         <translation>Recent Jucate</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="172"/>
+        <location filename="../screens/HubScreen.qml" line="170"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Setări</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="722"/>
+        <location filename="../screens/HubScreen.qml" line="718"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Niciun sistem disponibil. Rulați Actualizare bază de date din Setări.</translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>Nu</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="256"/>
+        <location filename="../components/Modal.qml" line="246"/>
         <source>Cancel</source>
         <translation>Anulare</translation>
     </message>
@@ -936,24 +936,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147"/>
-        <location filename="../screens/SettingsScreen.qml" line="741"/>
+        <location filename="../screens/SettingsScreen.qml" line="141"/>
+        <location filename="../screens/SettingsScreen.qml" line="734"/>
         <source>Language</source>
         <translation>Limbă</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
-        <location filename="../screens/SettingsScreen.qml" line="777"/>
+        <location filename="../screens/SettingsScreen.qml" line="116"/>
+        <location filename="../screens/SettingsScreen.qml" line="770"/>
         <source>Browsing layout</source>
         <translation>Aspect navigare</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="165"/>
+        <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>Mouse support</source>
         <translation>Suport mouse</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="177"/>
+        <location filename="../screens/SettingsScreen.qml" line="171"/>
         <source>Update media database</source>
         <translation>Actualizare bază de date media</translation>
     </message>
@@ -962,47 +962,47 @@ Euskara - devilschile2</source>
         <translation type="vanished">Generale</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="768"/>
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="761"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="160"/>
-        <location filename="../screens/SettingsScreen.qml" line="786"/>
+        <location filename="../screens/SettingsScreen.qml" line="154"/>
+        <location filename="../screens/SettingsScreen.qml" line="779"/>
         <source>Button style</source>
         <translation>Stil butoane</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="132"/>
-        <location filename="../screens/SettingsScreen.qml" line="795"/>
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
+        <location filename="../screens/SettingsScreen.qml" line="788"/>
         <source>Screensaver</source>
         <translation>Economizor de ecran</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="95"/>
-        <location filename="../screens/SettingsScreen.qml" line="229"/>
+        <location filename="../screens/SettingsScreen.qml" line="89"/>
+        <location filename="../screens/SettingsScreen.qml" line="223"/>
         <source>Library</source>
         <translation>Bibliotecă</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="182"/>
+        <location filename="../screens/SettingsScreen.qml" line="176"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="127"/>
-        <location filename="../screens/SettingsScreen.qml" line="804"/>
+        <location filename="../screens/SettingsScreen.qml" line="121"/>
+        <location filename="../screens/SettingsScreen.qml" line="797"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <location filename="../screens/SettingsScreen.qml" line="181"/>
         <source>Scrape metadata</source>
         <translation>Extragere metadate</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="192"/>
+        <location filename="../screens/SettingsScreen.qml" line="186"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1011,402 +1011,402 @@ Euskara - devilschile2</source>
         <translation type="vanished">Avansat</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="204"/>
+        <location filename="../screens/SettingsScreen.qml" line="198"/>
         <source>Debug logging</source>
         <translation>Jurnal depanare</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="209"/>
+        <location filename="../screens/SettingsScreen.qml" line="203"/>
         <source>Upload log file</source>
         <translation>Încărcare fișier jurnal</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="199"/>
+        <location filename="../screens/SettingsScreen.qml" line="193"/>
         <source>About / License</source>
         <translation>Despre / Licență</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="137"/>
-        <location filename="../screens/SettingsScreen.qml" line="750"/>
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="743"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="142"/>
-        <location filename="../screens/SettingsScreen.qml" line="759"/>
+        <location filename="../screens/SettingsScreen.qml" line="136"/>
+        <location filename="../screens/SettingsScreen.qml" line="752"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152"/>
+        <location filename="../screens/SettingsScreen.qml" line="146"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="170"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
         <source>Reduce motion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="240"/>
         <source>Optimizing</source>
         <translation>Optimizare</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="248"/>
-        <location filename="../screens/SettingsScreen.qml" line="257"/>
+        <location filename="../screens/SettingsScreen.qml" line="242"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>Paused</source>
         <translation>În pauză</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="248"/>
-        <location filename="../screens/SettingsScreen.qml" line="257"/>
+        <location filename="../screens/SettingsScreen.qml" line="242"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>In progress</source>
         <translation>În curs</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="245"/>
         <source>%1 indexed</source>
         <translation>%1 indexate</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="260"/>
+        <location filename="../screens/SettingsScreen.qml" line="254"/>
         <source>%1 scraped</source>
         <translation>%1 extrase</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="495"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Cancel</source>
         <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="495"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Start</source>
         <translation>Pornire</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="497"/>
+        <location filename="../screens/SettingsScreen.qml" line="490"/>
         <source>Upload</source>
         <translation>Încărcare</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <location filename="../screens/SettingsScreen.qml" line="491"/>
         <source>Open</source>
         <translation>Deschidere</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="579"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>English</source>
         <translation>Engleză</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="581"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Italian</source>
         <translation>Italiană</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="583"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="585"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="587"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>German</source>
         <translation>Germană</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="589"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Greek</source>
         <translation>Greacă</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="591"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Japanese</source>
         <translation>Japoneză</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="593"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Korean</source>
         <translation>Coreeană</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="595"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Dutch</source>
         <translation>Olandeză</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="597"/>
+        <location filename="../screens/SettingsScreen.qml" line="590"/>
         <source>Romanian</source>
         <translation>Română</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="599"/>
+        <location filename="../screens/SettingsScreen.qml" line="592"/>
         <source>Slovak</source>
         <translation>Slovacă</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="601"/>
+        <location filename="../screens/SettingsScreen.qml" line="594"/>
         <source>Ukrainian</source>
         <translation>Ucraineană</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="603"/>
+        <location filename="../screens/SettingsScreen.qml" line="596"/>
         <source>Chinese (Simplified)</source>
         <translation>Chineză (simplificată)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="605"/>
+        <location filename="../screens/SettingsScreen.qml" line="598"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="607"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Hebrew</source>
         <translation>Ebraică</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="611"/>
+        <location filename="../screens/SettingsScreen.qml" line="604"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
-        <location filename="../screens/SettingsScreen.qml" line="620"/>
-        <location filename="../screens/SettingsScreen.qml" line="694"/>
+        <location filename="../screens/SettingsScreen.qml" line="605"/>
+        <location filename="../screens/SettingsScreen.qml" line="613"/>
+        <location filename="../screens/SettingsScreen.qml" line="687"/>
         <source>Auto</source>
         <translation>Automat</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="610"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="619"/>
+        <location filename="../screens/SettingsScreen.qml" line="612"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="630"/>
+        <location filename="../screens/SettingsScreen.qml" line="623"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="632"/>
+        <location filename="../screens/SettingsScreen.qml" line="625"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="634"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="628"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="640"/>
+        <location filename="../screens/SettingsScreen.qml" line="633"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="642"/>
+        <location filename="../screens/SettingsScreen.qml" line="635"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="643"/>
+        <location filename="../screens/SettingsScreen.qml" line="636"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="648"/>
+        <location filename="../screens/SettingsScreen.qml" line="641"/>
         <source>Detailed list view</source>
         <translation>Vizualizare listă detaliată</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="642"/>
         <source>Grid view</source>
         <translation>Vizualizare grilă</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="654"/>
+        <location filename="../screens/SettingsScreen.qml" line="647"/>
         <source>Style B</source>
         <translation>Stil B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="656"/>
+        <location filename="../screens/SettingsScreen.qml" line="649"/>
         <source>Style C</source>
         <translation>Stil C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="658"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
         <source>Style D</source>
         <translation>Stil D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="659"/>
+        <location filename="../screens/SettingsScreen.qml" line="652"/>
         <source>Style A</source>
         <translation>Stil A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1368"/>
+        <location filename="../screens/SettingsScreen.qml" line="1351"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="549"/>
+        <location filename="../screens/SettingsScreen.qml" line="542"/>
         <source>Default</source>
         <translation>Implicit</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="674"/>
+        <location filename="../screens/SettingsScreen.qml" line="667"/>
         <source>Off</source>
         <translation>Dezactivat</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="676"/>
+        <location filename="../screens/SettingsScreen.qml" line="669"/>
         <source>1 second (testing)</source>
         <translation>1 secundă (test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="678"/>
+        <location filename="../screens/SettingsScreen.qml" line="671"/>
         <source>1 minute</source>
         <translation>1 minut</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="680"/>
+        <location filename="../screens/SettingsScreen.qml" line="673"/>
         <source>2 minutes</source>
         <translation>2 minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="682"/>
+        <location filename="../screens/SettingsScreen.qml" line="675"/>
         <source>5 minutes</source>
         <translation>5 minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="684"/>
+        <location filename="../screens/SettingsScreen.qml" line="677"/>
         <source>10 minutes</source>
         <translation>10 minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="686"/>
+        <location filename="../screens/SettingsScreen.qml" line="679"/>
         <source>15 minutes</source>
         <translation>15 minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="688"/>
+        <location filename="../screens/SettingsScreen.qml" line="681"/>
         <source>30 minutes</source>
         <translation>30 de minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="682"/>
         <source>%1 seconds</source>
         <translation>%1 secunde</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
-        <location filename="../screens/SettingsScreen.qml" line="732"/>
+        <location filename="../screens/SettingsScreen.qml" line="105"/>
+        <location filename="../screens/SettingsScreen.qml" line="725"/>
         <source>Resolution</source>
         <translation>Rezoluție</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="225"/>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="219"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="89"/>
-        <location filename="../screens/SettingsScreen.qml" line="227"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="221"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="101"/>
-        <location filename="../screens/SettingsScreen.qml" line="231"/>
+        <location filename="../screens/SettingsScreen.qml" line="95"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="696"/>
+        <location filename="../screens/SettingsScreen.qml" line="689"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="698"/>
+        <location filename="../screens/SettingsScreen.qml" line="691"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="700"/>
+        <location filename="../screens/SettingsScreen.qml" line="693"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="702"/>
+        <location filename="../screens/SettingsScreen.qml" line="695"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="704"/>
+        <location filename="../screens/SettingsScreen.qml" line="697"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="706"/>
+        <location filename="../screens/SettingsScreen.qml" line="699"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="708"/>
+        <location filename="../screens/SettingsScreen.qml" line="701"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="710"/>
+        <location filename="../screens/SettingsScreen.qml" line="703"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="712"/>
+        <location filename="../screens/SettingsScreen.qml" line="705"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="714"/>
+        <location filename="../screens/SettingsScreen.qml" line="707"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="716"/>
+        <location filename="../screens/SettingsScreen.qml" line="709"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="718"/>
+        <location filename="../screens/SettingsScreen.qml" line="711"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="232"/>
+        <location filename="../screens/SettingsScreen.qml" line="226"/>
         <source>Settings</source>
         <translation>Setări</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1356"/>
+        <location filename="../screens/SettingsScreen.qml" line="1339"/>
         <source>No settings available on this platform</source>
         <translation>Nicio setare disponibilă pe această platformă</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="236"/>
-        <location filename="../screens/SystemsScreen.qml" line="338"/>
+        <location filename="../screens/SystemsScreen.qml" line="242"/>
+        <location filename="../screens/SystemsScreen.qml" line="343"/>
         <source>%1 systems</source>
         <translation>%1 sisteme</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="237"/>
-        <location filename="../screens/SystemsScreen.qml" line="355"/>
+        <location filename="../screens/SystemsScreen.qml" line="243"/>
+        <location filename="../screens/SystemsScreen.qml" line="360"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="373"/>
+        <location filename="../screens/SystemsScreen.qml" line="378"/>
         <source>No systems in this category</source>
         <translation>Niciun sistem în această categorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="374"/>
+        <location filename="../screens/SystemsScreen.qml" line="379"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>
@@ -1439,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="539"/>
+        <location filename="../components/Tile.qml" line="501"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -425,8 +425,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="128"/>
-        <location filename="../screens/GamesScreen.qml" line="163"/>
+        <location filename="../screens/GamesScreen.qml" line="131"/>
+        <location filename="../screens/GamesScreen.qml" line="166"/>
         <source>%1 files</source>
         <translation>%1 fișiere</translation>
     </message>
@@ -436,8 +436,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="137"/>
-        <location filename="../screens/GamesScreen.qml" line="164"/>
+        <location filename="../screens/GamesScreen.qml" line="140"/>
+        <location filename="../screens/GamesScreen.qml" line="167"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -447,7 +447,7 @@ Euskara - devilschile2</source>
         <translation>Se încarcă jocurile…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="133"/>
+        <location filename="../screens/GamesScreen.qml" line="136"/>
         <source>Loading more…</source>
         <translation>Se încarcă mai multe…</translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>Nu</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="246"/>
+        <location filename="../components/Modal.qml" line="250"/>
         <source>Cancel</source>
         <translation>Anulare</translation>
     </message>
@@ -936,24 +936,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="141"/>
-        <location filename="../screens/SettingsScreen.qml" line="734"/>
+        <location filename="../screens/SettingsScreen.qml" line="145"/>
+        <location filename="../screens/SettingsScreen.qml" line="738"/>
         <source>Language</source>
         <translation>Limbă</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116"/>
-        <location filename="../screens/SettingsScreen.qml" line="770"/>
+        <location filename="../screens/SettingsScreen.qml" line="120"/>
+        <location filename="../screens/SettingsScreen.qml" line="774"/>
         <source>Browsing layout</source>
         <translation>Aspect navigare</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="159"/>
+        <location filename="../screens/SettingsScreen.qml" line="163"/>
         <source>Mouse support</source>
         <translation>Suport mouse</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="171"/>
+        <location filename="../screens/SettingsScreen.qml" line="175"/>
         <source>Update media database</source>
         <translation>Actualizare bază de date media</translation>
     </message>
@@ -962,47 +962,47 @@ Euskara - devilschile2</source>
         <translation type="vanished">Generale</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
-        <location filename="../screens/SettingsScreen.qml" line="761"/>
+        <location filename="../screens/SettingsScreen.qml" line="115"/>
+        <location filename="../screens/SettingsScreen.qml" line="765"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="154"/>
-        <location filename="../screens/SettingsScreen.qml" line="779"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="783"/>
         <source>Button style</source>
         <translation>Stil butoane</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
-        <location filename="../screens/SettingsScreen.qml" line="788"/>
+        <location filename="../screens/SettingsScreen.qml" line="130"/>
+        <location filename="../screens/SettingsScreen.qml" line="792"/>
         <source>Screensaver</source>
         <translation>Economizor de ecran</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="89"/>
-        <location filename="../screens/SettingsScreen.qml" line="223"/>
+        <location filename="../screens/SettingsScreen.qml" line="93"/>
+        <location filename="../screens/SettingsScreen.qml" line="227"/>
         <source>Library</source>
         <translation>Bibliotecă</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="176"/>
+        <location filename="../screens/SettingsScreen.qml" line="180"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121"/>
-        <location filename="../screens/SettingsScreen.qml" line="797"/>
+        <location filename="../screens/SettingsScreen.qml" line="125"/>
+        <location filename="../screens/SettingsScreen.qml" line="801"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="181"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
         <source>Scrape metadata</source>
         <translation>Extragere metadate</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="186"/>
+        <location filename="../screens/SettingsScreen.qml" line="190"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1011,402 +1011,402 @@ Euskara - devilschile2</source>
         <translation type="vanished">Avansat</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="198"/>
+        <location filename="../screens/SettingsScreen.qml" line="202"/>
         <source>Debug logging</source>
         <translation>Jurnal depanare</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="203"/>
+        <location filename="../screens/SettingsScreen.qml" line="207"/>
         <source>Upload log file</source>
         <translation>Încărcare fișier jurnal</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="193"/>
+        <location filename="../screens/SettingsScreen.qml" line="197"/>
         <source>About / License</source>
         <translation>Despre / Licență</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
-        <location filename="../screens/SettingsScreen.qml" line="743"/>
+        <location filename="../screens/SettingsScreen.qml" line="135"/>
+        <location filename="../screens/SettingsScreen.qml" line="747"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="136"/>
-        <location filename="../screens/SettingsScreen.qml" line="752"/>
+        <location filename="../screens/SettingsScreen.qml" line="140"/>
+        <location filename="../screens/SettingsScreen.qml" line="756"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="146"/>
+        <location filename="../screens/SettingsScreen.qml" line="150"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="168"/>
         <source>Reduce motion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="240"/>
+        <location filename="../screens/SettingsScreen.qml" line="244"/>
         <source>Optimizing</source>
         <translation>Optimizare</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="242"/>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="255"/>
         <source>Paused</source>
         <translation>În pauză</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="242"/>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="255"/>
         <source>In progress</source>
         <translation>În curs</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="245"/>
+        <location filename="../screens/SettingsScreen.qml" line="249"/>
         <source>%1 indexed</source>
         <translation>%1 indexate</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="254"/>
+        <location filename="../screens/SettingsScreen.qml" line="258"/>
         <source>%1 scraped</source>
         <translation>%1 extrase</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="488"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Cancel</source>
         <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="488"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Start</source>
         <translation>Pornire</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="490"/>
+        <location filename="../screens/SettingsScreen.qml" line="494"/>
         <source>Upload</source>
         <translation>Încărcare</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="491"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Open</source>
         <translation>Deschidere</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>English</source>
         <translation>Engleză</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Italian</source>
         <translation>Italiană</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>German</source>
         <translation>Germană</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Greek</source>
         <translation>Greacă</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Japanese</source>
         <translation>Japoneză</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="590"/>
         <source>Korean</source>
         <translation>Coreeană</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="588"/>
+        <location filename="../screens/SettingsScreen.qml" line="592"/>
         <source>Dutch</source>
         <translation>Olandeză</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="590"/>
+        <location filename="../screens/SettingsScreen.qml" line="594"/>
         <source>Romanian</source>
         <translation>Română</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="592"/>
+        <location filename="../screens/SettingsScreen.qml" line="596"/>
         <source>Slovak</source>
         <translation>Slovacă</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="594"/>
+        <location filename="../screens/SettingsScreen.qml" line="598"/>
         <source>Ukrainian</source>
         <translation>Ucraineană</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="596"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Chinese (Simplified)</source>
         <translation>Chineză (simplificată)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="598"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="600"/>
+        <location filename="../screens/SettingsScreen.qml" line="604"/>
         <source>Hebrew</source>
         <translation>Ebraică</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="602"/>
+        <location filename="../screens/SettingsScreen.qml" line="606"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="604"/>
+        <location filename="../screens/SettingsScreen.qml" line="608"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="605"/>
-        <location filename="../screens/SettingsScreen.qml" line="613"/>
-        <location filename="../screens/SettingsScreen.qml" line="687"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="691"/>
         <source>Auto</source>
         <translation>Automat</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="610"/>
+        <location filename="../screens/SettingsScreen.qml" line="614"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="616"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="623"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="625"/>
+        <location filename="../screens/SettingsScreen.qml" line="629"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="627"/>
+        <location filename="../screens/SettingsScreen.qml" line="631"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="628"/>
+        <location filename="../screens/SettingsScreen.qml" line="632"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="633"/>
+        <location filename="../screens/SettingsScreen.qml" line="637"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="639"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="640"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="641"/>
+        <location filename="../screens/SettingsScreen.qml" line="645"/>
         <source>Detailed list view</source>
         <translation>Vizualizare listă detaliată</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="642"/>
+        <location filename="../screens/SettingsScreen.qml" line="646"/>
         <source>Grid view</source>
         <translation>Vizualizare grilă</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
         <source>Style B</source>
         <translation>Stil B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Style C</source>
         <translation>Stil C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="655"/>
         <source>Style D</source>
         <translation>Stil D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="652"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Style A</source>
         <translation>Stil A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1351"/>
+        <location filename="../screens/SettingsScreen.qml" line="1382"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="542"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>Default</source>
         <translation>Implicit</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="667"/>
+        <location filename="../screens/SettingsScreen.qml" line="671"/>
         <source>Off</source>
         <translation>Dezactivat</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="669"/>
+        <location filename="../screens/SettingsScreen.qml" line="673"/>
         <source>1 second (testing)</source>
         <translation>1 secundă (test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="671"/>
+        <location filename="../screens/SettingsScreen.qml" line="675"/>
         <source>1 minute</source>
         <translation>1 minut</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="673"/>
+        <location filename="../screens/SettingsScreen.qml" line="677"/>
         <source>2 minutes</source>
         <translation>2 minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="675"/>
+        <location filename="../screens/SettingsScreen.qml" line="679"/>
         <source>5 minutes</source>
         <translation>5 minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="677"/>
+        <location filename="../screens/SettingsScreen.qml" line="681"/>
         <source>10 minutes</source>
         <translation>10 minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="679"/>
+        <location filename="../screens/SettingsScreen.qml" line="683"/>
         <source>15 minutes</source>
         <translation>15 minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="681"/>
+        <location filename="../screens/SettingsScreen.qml" line="685"/>
         <source>30 minutes</source>
         <translation>30 de minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="682"/>
+        <location filename="../screens/SettingsScreen.qml" line="686"/>
         <source>%1 seconds</source>
         <translation>%1 secunde</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="105"/>
-        <location filename="../screens/SettingsScreen.qml" line="725"/>
+        <location filename="../screens/SettingsScreen.qml" line="109"/>
+        <location filename="../screens/SettingsScreen.qml" line="729"/>
         <source>Resolution</source>
         <translation>Rezoluție</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="77"/>
-        <location filename="../screens/SettingsScreen.qml" line="219"/>
+        <location filename="../screens/SettingsScreen.qml" line="81"/>
+        <location filename="../screens/SettingsScreen.qml" line="223"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="221"/>
+        <location filename="../screens/SettingsScreen.qml" line="87"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="95"/>
-        <location filename="../screens/SettingsScreen.qml" line="225"/>
+        <location filename="../screens/SettingsScreen.qml" line="99"/>
+        <location filename="../screens/SettingsScreen.qml" line="229"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="693"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="691"/>
+        <location filename="../screens/SettingsScreen.qml" line="695"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="693"/>
+        <location filename="../screens/SettingsScreen.qml" line="697"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="695"/>
+        <location filename="../screens/SettingsScreen.qml" line="699"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="697"/>
+        <location filename="../screens/SettingsScreen.qml" line="701"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="699"/>
+        <location filename="../screens/SettingsScreen.qml" line="703"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="701"/>
+        <location filename="../screens/SettingsScreen.qml" line="705"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="703"/>
+        <location filename="../screens/SettingsScreen.qml" line="707"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="705"/>
+        <location filename="../screens/SettingsScreen.qml" line="709"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="707"/>
+        <location filename="../screens/SettingsScreen.qml" line="711"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="709"/>
+        <location filename="../screens/SettingsScreen.qml" line="713"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="711"/>
+        <location filename="../screens/SettingsScreen.qml" line="715"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="226"/>
+        <location filename="../screens/SettingsScreen.qml" line="230"/>
         <source>Settings</source>
         <translation>Setări</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1339"/>
+        <location filename="../screens/SettingsScreen.qml" line="1370"/>
         <source>No settings available on this platform</source>
         <translation>Nicio setare disponibilă pe această platformă</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="242"/>
-        <location filename="../screens/SystemsScreen.qml" line="343"/>
+        <location filename="../screens/SystemsScreen.qml" line="245"/>
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>%1 systems</source>
         <translation>%1 sisteme</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="243"/>
-        <location filename="../screens/SystemsScreen.qml" line="360"/>
+        <location filename="../screens/SystemsScreen.qml" line="246"/>
+        <location filename="../screens/SystemsScreen.qml" line="363"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="378"/>
+        <location filename="../screens/SystemsScreen.qml" line="381"/>
         <source>No systems in this category</source>
         <translation>Niciun sistem în această categorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="379"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="156"/>
+        <location filename="../screens/HubScreen.qml" line="154"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="162"/>
+        <location filename="../screens/HubScreen.qml" line="160"/>
         <source>Favorites</source>
         <translation>Obľúbené</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="167"/>
+        <location filename="../screens/HubScreen.qml" line="165"/>
         <source>Recently Played</source>
         <translation>Nedávno hrané</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="172"/>
+        <location filename="../screens/HubScreen.qml" line="170"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Nastavenia</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="722"/>
+        <location filename="../screens/HubScreen.qml" line="718"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Žiadne systémy nie sú dostupné. Spustite Aktualizovať databázu médií v Nastaveniach.</translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>Nie</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="256"/>
+        <location filename="../components/Modal.qml" line="246"/>
         <source>Cancel</source>
         <translation>Zrušiť</translation>
     </message>
@@ -936,24 +936,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147"/>
-        <location filename="../screens/SettingsScreen.qml" line="741"/>
+        <location filename="../screens/SettingsScreen.qml" line="141"/>
+        <location filename="../screens/SettingsScreen.qml" line="734"/>
         <source>Language</source>
         <translation>Jazyk</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
-        <location filename="../screens/SettingsScreen.qml" line="777"/>
+        <location filename="../screens/SettingsScreen.qml" line="116"/>
+        <location filename="../screens/SettingsScreen.qml" line="770"/>
         <source>Browsing layout</source>
         <translation>Rozloženie prehliadania</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="165"/>
+        <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>Mouse support</source>
         <translation>Podpora myši</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="177"/>
+        <location filename="../screens/SettingsScreen.qml" line="171"/>
         <source>Update media database</source>
         <translation>Aktualizovať databázu médií</translation>
     </message>
@@ -962,47 +962,47 @@ Euskara - devilschile2</source>
         <translation type="vanished">Všeobecné</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="768"/>
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="761"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="160"/>
-        <location filename="../screens/SettingsScreen.qml" line="786"/>
+        <location filename="../screens/SettingsScreen.qml" line="154"/>
+        <location filename="../screens/SettingsScreen.qml" line="779"/>
         <source>Button style</source>
         <translation>Štýl tlačidiel</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="132"/>
-        <location filename="../screens/SettingsScreen.qml" line="795"/>
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
+        <location filename="../screens/SettingsScreen.qml" line="788"/>
         <source>Screensaver</source>
         <translation>Šetrič obrazovky</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="95"/>
-        <location filename="../screens/SettingsScreen.qml" line="229"/>
+        <location filename="../screens/SettingsScreen.qml" line="89"/>
+        <location filename="../screens/SettingsScreen.qml" line="223"/>
         <source>Library</source>
         <translation>Knižnica</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="182"/>
+        <location filename="../screens/SettingsScreen.qml" line="176"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="127"/>
-        <location filename="../screens/SettingsScreen.qml" line="804"/>
+        <location filename="../screens/SettingsScreen.qml" line="121"/>
+        <location filename="../screens/SettingsScreen.qml" line="797"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <location filename="../screens/SettingsScreen.qml" line="181"/>
         <source>Scrape metadata</source>
         <translation>Získať metadáta</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="192"/>
+        <location filename="../screens/SettingsScreen.qml" line="186"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1011,402 +1011,402 @@ Euskara - devilschile2</source>
         <translation type="vanished">Rozšírené</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="204"/>
+        <location filename="../screens/SettingsScreen.qml" line="198"/>
         <source>Debug logging</source>
         <translation>Ladiace záznamy</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="209"/>
+        <location filename="../screens/SettingsScreen.qml" line="203"/>
         <source>Upload log file</source>
         <translation>Nahrať súbor protokolu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="199"/>
+        <location filename="../screens/SettingsScreen.qml" line="193"/>
         <source>About / License</source>
         <translation>O aplikácii / Licencia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="137"/>
-        <location filename="../screens/SettingsScreen.qml" line="750"/>
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="743"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="142"/>
-        <location filename="../screens/SettingsScreen.qml" line="759"/>
+        <location filename="../screens/SettingsScreen.qml" line="136"/>
+        <location filename="../screens/SettingsScreen.qml" line="752"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152"/>
+        <location filename="../screens/SettingsScreen.qml" line="146"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="170"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
         <source>Reduce motion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="240"/>
         <source>Optimizing</source>
         <translation>Optimalizácia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="248"/>
-        <location filename="../screens/SettingsScreen.qml" line="257"/>
+        <location filename="../screens/SettingsScreen.qml" line="242"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>Paused</source>
         <translation>Pozastavené</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="248"/>
-        <location filename="../screens/SettingsScreen.qml" line="257"/>
+        <location filename="../screens/SettingsScreen.qml" line="242"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>In progress</source>
         <translation>Prebieha</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="245"/>
         <source>%1 indexed</source>
         <translation>%1 indexovaných</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="260"/>
+        <location filename="../screens/SettingsScreen.qml" line="254"/>
         <source>%1 scraped</source>
         <translation>%1 zozbieraných</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="495"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Cancel</source>
         <translation>Zrušiť</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="495"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Start</source>
         <translation>Spustiť</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="497"/>
+        <location filename="../screens/SettingsScreen.qml" line="490"/>
         <source>Upload</source>
         <translation>Nahrať</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <location filename="../screens/SettingsScreen.qml" line="491"/>
         <source>Open</source>
         <translation>Otvoriť</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="579"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>English</source>
         <translation>Angličtina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="581"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Italian</source>
         <translation>Taliančina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="583"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="585"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="587"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>German</source>
         <translation>Nemčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="589"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Greek</source>
         <translation>Gréčtina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="591"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Japanese</source>
         <translation>Japončina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="593"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Korean</source>
         <translation>Kórejčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="595"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Dutch</source>
         <translation>Holandčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="597"/>
+        <location filename="../screens/SettingsScreen.qml" line="590"/>
         <source>Romanian</source>
         <translation>Rumunčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="599"/>
+        <location filename="../screens/SettingsScreen.qml" line="592"/>
         <source>Slovak</source>
         <translation>Slovenčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="601"/>
+        <location filename="../screens/SettingsScreen.qml" line="594"/>
         <source>Ukrainian</source>
         <translation>Ukrajinčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="603"/>
+        <location filename="../screens/SettingsScreen.qml" line="596"/>
         <source>Chinese (Simplified)</source>
         <translation>Čínština (zjednodušená)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="605"/>
+        <location filename="../screens/SettingsScreen.qml" line="598"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="607"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Hebrew</source>
         <translation>Hebrejčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="611"/>
+        <location filename="../screens/SettingsScreen.qml" line="604"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
-        <location filename="../screens/SettingsScreen.qml" line="620"/>
-        <location filename="../screens/SettingsScreen.qml" line="694"/>
+        <location filename="../screens/SettingsScreen.qml" line="605"/>
+        <location filename="../screens/SettingsScreen.qml" line="613"/>
+        <location filename="../screens/SettingsScreen.qml" line="687"/>
         <source>Auto</source>
         <translation>Automaticky</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="610"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="619"/>
+        <location filename="../screens/SettingsScreen.qml" line="612"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="630"/>
+        <location filename="../screens/SettingsScreen.qml" line="623"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="632"/>
+        <location filename="../screens/SettingsScreen.qml" line="625"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="634"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="628"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="640"/>
+        <location filename="../screens/SettingsScreen.qml" line="633"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="642"/>
+        <location filename="../screens/SettingsScreen.qml" line="635"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="643"/>
+        <location filename="../screens/SettingsScreen.qml" line="636"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="648"/>
+        <location filename="../screens/SettingsScreen.qml" line="641"/>
         <source>Detailed list view</source>
         <translation>Podrobné zobrazenie zoznamu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="642"/>
         <source>Grid view</source>
         <translation>Zobrazenie mriežky</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="654"/>
+        <location filename="../screens/SettingsScreen.qml" line="647"/>
         <source>Style B</source>
         <translation>Štýl B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="656"/>
+        <location filename="../screens/SettingsScreen.qml" line="649"/>
         <source>Style C</source>
         <translation>Štýl C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="658"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
         <source>Style D</source>
         <translation>Štýl D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="659"/>
+        <location filename="../screens/SettingsScreen.qml" line="652"/>
         <source>Style A</source>
         <translation>Štýl A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1368"/>
+        <location filename="../screens/SettingsScreen.qml" line="1351"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="549"/>
+        <location filename="../screens/SettingsScreen.qml" line="542"/>
         <source>Default</source>
         <translation>Predvolené</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="674"/>
+        <location filename="../screens/SettingsScreen.qml" line="667"/>
         <source>Off</source>
         <translation>Vypnuté</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="676"/>
+        <location filename="../screens/SettingsScreen.qml" line="669"/>
         <source>1 second (testing)</source>
         <translation>1 sekunda (test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="678"/>
+        <location filename="../screens/SettingsScreen.qml" line="671"/>
         <source>1 minute</source>
         <translation>1 minúta</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="680"/>
+        <location filename="../screens/SettingsScreen.qml" line="673"/>
         <source>2 minutes</source>
         <translation>2 minúty</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="682"/>
+        <location filename="../screens/SettingsScreen.qml" line="675"/>
         <source>5 minutes</source>
         <translation>5 minút</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="684"/>
+        <location filename="../screens/SettingsScreen.qml" line="677"/>
         <source>10 minutes</source>
         <translation>10 minút</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="686"/>
+        <location filename="../screens/SettingsScreen.qml" line="679"/>
         <source>15 minutes</source>
         <translation>15 minút</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="688"/>
+        <location filename="../screens/SettingsScreen.qml" line="681"/>
         <source>30 minutes</source>
         <translation>30 minút</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="682"/>
         <source>%1 seconds</source>
         <translation>%1 sekúnd</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
-        <location filename="../screens/SettingsScreen.qml" line="732"/>
+        <location filename="../screens/SettingsScreen.qml" line="105"/>
+        <location filename="../screens/SettingsScreen.qml" line="725"/>
         <source>Resolution</source>
         <translation>Rozlíšenie</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="225"/>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="219"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="89"/>
-        <location filename="../screens/SettingsScreen.qml" line="227"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="221"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="101"/>
-        <location filename="../screens/SettingsScreen.qml" line="231"/>
+        <location filename="../screens/SettingsScreen.qml" line="95"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="696"/>
+        <location filename="../screens/SettingsScreen.qml" line="689"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="698"/>
+        <location filename="../screens/SettingsScreen.qml" line="691"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="700"/>
+        <location filename="../screens/SettingsScreen.qml" line="693"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="702"/>
+        <location filename="../screens/SettingsScreen.qml" line="695"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="704"/>
+        <location filename="../screens/SettingsScreen.qml" line="697"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="706"/>
+        <location filename="../screens/SettingsScreen.qml" line="699"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="708"/>
+        <location filename="../screens/SettingsScreen.qml" line="701"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="710"/>
+        <location filename="../screens/SettingsScreen.qml" line="703"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="712"/>
+        <location filename="../screens/SettingsScreen.qml" line="705"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="714"/>
+        <location filename="../screens/SettingsScreen.qml" line="707"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="716"/>
+        <location filename="../screens/SettingsScreen.qml" line="709"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="718"/>
+        <location filename="../screens/SettingsScreen.qml" line="711"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="232"/>
+        <location filename="../screens/SettingsScreen.qml" line="226"/>
         <source>Settings</source>
         <translation>Nastavenia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1356"/>
+        <location filename="../screens/SettingsScreen.qml" line="1339"/>
         <source>No settings available on this platform</source>
         <translation>Na tejto platforme nie sú dostupné žiadne nastavenia</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="236"/>
-        <location filename="../screens/SystemsScreen.qml" line="338"/>
+        <location filename="../screens/SystemsScreen.qml" line="242"/>
+        <location filename="../screens/SystemsScreen.qml" line="343"/>
         <source>%1 systems</source>
         <translation>%1 systémov</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="237"/>
-        <location filename="../screens/SystemsScreen.qml" line="355"/>
+        <location filename="../screens/SystemsScreen.qml" line="243"/>
+        <location filename="../screens/SystemsScreen.qml" line="360"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="373"/>
+        <location filename="../screens/SystemsScreen.qml" line="378"/>
         <source>No systems in this category</source>
         <translation>V tejto kategórii nie sú žiadne systémy</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="374"/>
+        <location filename="../screens/SystemsScreen.qml" line="379"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>
@@ -1439,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="539"/>
+        <location filename="../components/Tile.qml" line="501"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -425,8 +425,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="128"/>
-        <location filename="../screens/GamesScreen.qml" line="163"/>
+        <location filename="../screens/GamesScreen.qml" line="131"/>
+        <location filename="../screens/GamesScreen.qml" line="166"/>
         <source>%1 files</source>
         <translation>%1 súborov</translation>
     </message>
@@ -436,8 +436,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="137"/>
-        <location filename="../screens/GamesScreen.qml" line="164"/>
+        <location filename="../screens/GamesScreen.qml" line="140"/>
+        <location filename="../screens/GamesScreen.qml" line="167"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -447,7 +447,7 @@ Euskara - devilschile2</source>
         <translation>Načítanie hier…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="133"/>
+        <location filename="../screens/GamesScreen.qml" line="136"/>
         <source>Loading more…</source>
         <translation>Načítava sa viac…</translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>Nie</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="246"/>
+        <location filename="../components/Modal.qml" line="250"/>
         <source>Cancel</source>
         <translation>Zrušiť</translation>
     </message>
@@ -936,24 +936,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="141"/>
-        <location filename="../screens/SettingsScreen.qml" line="734"/>
+        <location filename="../screens/SettingsScreen.qml" line="145"/>
+        <location filename="../screens/SettingsScreen.qml" line="738"/>
         <source>Language</source>
         <translation>Jazyk</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116"/>
-        <location filename="../screens/SettingsScreen.qml" line="770"/>
+        <location filename="../screens/SettingsScreen.qml" line="120"/>
+        <location filename="../screens/SettingsScreen.qml" line="774"/>
         <source>Browsing layout</source>
         <translation>Rozloženie prehliadania</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="159"/>
+        <location filename="../screens/SettingsScreen.qml" line="163"/>
         <source>Mouse support</source>
         <translation>Podpora myši</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="171"/>
+        <location filename="../screens/SettingsScreen.qml" line="175"/>
         <source>Update media database</source>
         <translation>Aktualizovať databázu médií</translation>
     </message>
@@ -962,47 +962,47 @@ Euskara - devilschile2</source>
         <translation type="vanished">Všeobecné</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
-        <location filename="../screens/SettingsScreen.qml" line="761"/>
+        <location filename="../screens/SettingsScreen.qml" line="115"/>
+        <location filename="../screens/SettingsScreen.qml" line="765"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="154"/>
-        <location filename="../screens/SettingsScreen.qml" line="779"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="783"/>
         <source>Button style</source>
         <translation>Štýl tlačidiel</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
-        <location filename="../screens/SettingsScreen.qml" line="788"/>
+        <location filename="../screens/SettingsScreen.qml" line="130"/>
+        <location filename="../screens/SettingsScreen.qml" line="792"/>
         <source>Screensaver</source>
         <translation>Šetrič obrazovky</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="89"/>
-        <location filename="../screens/SettingsScreen.qml" line="223"/>
+        <location filename="../screens/SettingsScreen.qml" line="93"/>
+        <location filename="../screens/SettingsScreen.qml" line="227"/>
         <source>Library</source>
         <translation>Knižnica</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="176"/>
+        <location filename="../screens/SettingsScreen.qml" line="180"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121"/>
-        <location filename="../screens/SettingsScreen.qml" line="797"/>
+        <location filename="../screens/SettingsScreen.qml" line="125"/>
+        <location filename="../screens/SettingsScreen.qml" line="801"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="181"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
         <source>Scrape metadata</source>
         <translation>Získať metadáta</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="186"/>
+        <location filename="../screens/SettingsScreen.qml" line="190"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1011,402 +1011,402 @@ Euskara - devilschile2</source>
         <translation type="vanished">Rozšírené</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="198"/>
+        <location filename="../screens/SettingsScreen.qml" line="202"/>
         <source>Debug logging</source>
         <translation>Ladiace záznamy</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="203"/>
+        <location filename="../screens/SettingsScreen.qml" line="207"/>
         <source>Upload log file</source>
         <translation>Nahrať súbor protokolu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="193"/>
+        <location filename="../screens/SettingsScreen.qml" line="197"/>
         <source>About / License</source>
         <translation>O aplikácii / Licencia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
-        <location filename="../screens/SettingsScreen.qml" line="743"/>
+        <location filename="../screens/SettingsScreen.qml" line="135"/>
+        <location filename="../screens/SettingsScreen.qml" line="747"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="136"/>
-        <location filename="../screens/SettingsScreen.qml" line="752"/>
+        <location filename="../screens/SettingsScreen.qml" line="140"/>
+        <location filename="../screens/SettingsScreen.qml" line="756"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="146"/>
+        <location filename="../screens/SettingsScreen.qml" line="150"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="168"/>
         <source>Reduce motion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="240"/>
+        <location filename="../screens/SettingsScreen.qml" line="244"/>
         <source>Optimizing</source>
         <translation>Optimalizácia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="242"/>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="255"/>
         <source>Paused</source>
         <translation>Pozastavené</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="242"/>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="255"/>
         <source>In progress</source>
         <translation>Prebieha</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="245"/>
+        <location filename="../screens/SettingsScreen.qml" line="249"/>
         <source>%1 indexed</source>
         <translation>%1 indexovaných</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="254"/>
+        <location filename="../screens/SettingsScreen.qml" line="258"/>
         <source>%1 scraped</source>
         <translation>%1 zozbieraných</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="488"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Cancel</source>
         <translation>Zrušiť</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="488"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Start</source>
         <translation>Spustiť</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="490"/>
+        <location filename="../screens/SettingsScreen.qml" line="494"/>
         <source>Upload</source>
         <translation>Nahrať</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="491"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Open</source>
         <translation>Otvoriť</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>English</source>
         <translation>Angličtina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Italian</source>
         <translation>Taliančina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>German</source>
         <translation>Nemčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Greek</source>
         <translation>Gréčtina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Japanese</source>
         <translation>Japončina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="590"/>
         <source>Korean</source>
         <translation>Kórejčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="588"/>
+        <location filename="../screens/SettingsScreen.qml" line="592"/>
         <source>Dutch</source>
         <translation>Holandčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="590"/>
+        <location filename="../screens/SettingsScreen.qml" line="594"/>
         <source>Romanian</source>
         <translation>Rumunčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="592"/>
+        <location filename="../screens/SettingsScreen.qml" line="596"/>
         <source>Slovak</source>
         <translation>Slovenčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="594"/>
+        <location filename="../screens/SettingsScreen.qml" line="598"/>
         <source>Ukrainian</source>
         <translation>Ukrajinčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="596"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Chinese (Simplified)</source>
         <translation>Čínština (zjednodušená)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="598"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="600"/>
+        <location filename="../screens/SettingsScreen.qml" line="604"/>
         <source>Hebrew</source>
         <translation>Hebrejčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="602"/>
+        <location filename="../screens/SettingsScreen.qml" line="606"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="604"/>
+        <location filename="../screens/SettingsScreen.qml" line="608"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="605"/>
-        <location filename="../screens/SettingsScreen.qml" line="613"/>
-        <location filename="../screens/SettingsScreen.qml" line="687"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="691"/>
         <source>Auto</source>
         <translation>Automaticky</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="610"/>
+        <location filename="../screens/SettingsScreen.qml" line="614"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="616"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="623"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="625"/>
+        <location filename="../screens/SettingsScreen.qml" line="629"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="627"/>
+        <location filename="../screens/SettingsScreen.qml" line="631"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="628"/>
+        <location filename="../screens/SettingsScreen.qml" line="632"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="633"/>
+        <location filename="../screens/SettingsScreen.qml" line="637"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="639"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="640"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="641"/>
+        <location filename="../screens/SettingsScreen.qml" line="645"/>
         <source>Detailed list view</source>
         <translation>Podrobné zobrazenie zoznamu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="642"/>
+        <location filename="../screens/SettingsScreen.qml" line="646"/>
         <source>Grid view</source>
         <translation>Zobrazenie mriežky</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
         <source>Style B</source>
         <translation>Štýl B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Style C</source>
         <translation>Štýl C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="655"/>
         <source>Style D</source>
         <translation>Štýl D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="652"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Style A</source>
         <translation>Štýl A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1351"/>
+        <location filename="../screens/SettingsScreen.qml" line="1382"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="542"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>Default</source>
         <translation>Predvolené</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="667"/>
+        <location filename="../screens/SettingsScreen.qml" line="671"/>
         <source>Off</source>
         <translation>Vypnuté</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="669"/>
+        <location filename="../screens/SettingsScreen.qml" line="673"/>
         <source>1 second (testing)</source>
         <translation>1 sekunda (test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="671"/>
+        <location filename="../screens/SettingsScreen.qml" line="675"/>
         <source>1 minute</source>
         <translation>1 minúta</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="673"/>
+        <location filename="../screens/SettingsScreen.qml" line="677"/>
         <source>2 minutes</source>
         <translation>2 minúty</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="675"/>
+        <location filename="../screens/SettingsScreen.qml" line="679"/>
         <source>5 minutes</source>
         <translation>5 minút</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="677"/>
+        <location filename="../screens/SettingsScreen.qml" line="681"/>
         <source>10 minutes</source>
         <translation>10 minút</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="679"/>
+        <location filename="../screens/SettingsScreen.qml" line="683"/>
         <source>15 minutes</source>
         <translation>15 minút</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="681"/>
+        <location filename="../screens/SettingsScreen.qml" line="685"/>
         <source>30 minutes</source>
         <translation>30 minút</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="682"/>
+        <location filename="../screens/SettingsScreen.qml" line="686"/>
         <source>%1 seconds</source>
         <translation>%1 sekúnd</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="105"/>
-        <location filename="../screens/SettingsScreen.qml" line="725"/>
+        <location filename="../screens/SettingsScreen.qml" line="109"/>
+        <location filename="../screens/SettingsScreen.qml" line="729"/>
         <source>Resolution</source>
         <translation>Rozlíšenie</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="77"/>
-        <location filename="../screens/SettingsScreen.qml" line="219"/>
+        <location filename="../screens/SettingsScreen.qml" line="81"/>
+        <location filename="../screens/SettingsScreen.qml" line="223"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="221"/>
+        <location filename="../screens/SettingsScreen.qml" line="87"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="95"/>
-        <location filename="../screens/SettingsScreen.qml" line="225"/>
+        <location filename="../screens/SettingsScreen.qml" line="99"/>
+        <location filename="../screens/SettingsScreen.qml" line="229"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="693"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="691"/>
+        <location filename="../screens/SettingsScreen.qml" line="695"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="693"/>
+        <location filename="../screens/SettingsScreen.qml" line="697"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="695"/>
+        <location filename="../screens/SettingsScreen.qml" line="699"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="697"/>
+        <location filename="../screens/SettingsScreen.qml" line="701"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="699"/>
+        <location filename="../screens/SettingsScreen.qml" line="703"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="701"/>
+        <location filename="../screens/SettingsScreen.qml" line="705"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="703"/>
+        <location filename="../screens/SettingsScreen.qml" line="707"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="705"/>
+        <location filename="../screens/SettingsScreen.qml" line="709"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="707"/>
+        <location filename="../screens/SettingsScreen.qml" line="711"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="709"/>
+        <location filename="../screens/SettingsScreen.qml" line="713"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="711"/>
+        <location filename="../screens/SettingsScreen.qml" line="715"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="226"/>
+        <location filename="../screens/SettingsScreen.qml" line="230"/>
         <source>Settings</source>
         <translation>Nastavenia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1339"/>
+        <location filename="../screens/SettingsScreen.qml" line="1370"/>
         <source>No settings available on this platform</source>
         <translation>Na tejto platforme nie sú dostupné žiadne nastavenia</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="242"/>
-        <location filename="../screens/SystemsScreen.qml" line="343"/>
+        <location filename="../screens/SystemsScreen.qml" line="245"/>
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>%1 systems</source>
         <translation>%1 systémov</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="243"/>
-        <location filename="../screens/SystemsScreen.qml" line="360"/>
+        <location filename="../screens/SystemsScreen.qml" line="246"/>
+        <location filename="../screens/SystemsScreen.qml" line="363"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="378"/>
+        <location filename="../screens/SystemsScreen.qml" line="381"/>
         <source>No systems in this category</source>
         <translation>V tejto kategórii nie sú žiadne systémy</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="379"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -425,34 +425,34 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="116"/>
-        <location filename="../screens/GamesScreen.qml" line="151"/>
+        <location filename="../screens/GamesScreen.qml" line="127"/>
+        <location filename="../screens/GamesScreen.qml" line="162"/>
         <source>%1 files</source>
         <translation>%1 súborov</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="53"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="125"/>
-        <location filename="../screens/GamesScreen.qml" line="152"/>
+        <location filename="../screens/GamesScreen.qml" line="136"/>
+        <location filename="../screens/GamesScreen.qml" line="163"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="48"/>
+        <location filename="../screens/GamesScreen.qml" line="49"/>
         <source>Loading games…</source>
         <translation>Načítanie hier…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="121"/>
+        <location filename="../screens/GamesScreen.qml" line="132"/>
         <source>Loading more…</source>
         <translation>Načítava sa viac…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="47"/>
+        <location filename="../screens/GamesScreen.qml" line="48"/>
         <source>No games in this system</source>
         <translation>V tomto systéme nie sú žiadne hry</translation>
     </message>
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="139"/>
+        <location filename="../screens/HubScreen.qml" line="149"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="145"/>
+        <location filename="../screens/HubScreen.qml" line="155"/>
         <source>Favorites</source>
         <translation>Obľúbené</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="150"/>
+        <location filename="../screens/HubScreen.qml" line="160"/>
         <source>Recently Played</source>
         <translation>Nedávno hrané</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="155"/>
+        <location filename="../screens/HubScreen.qml" line="165"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Nastavenia</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="669"/>
+        <location filename="../screens/HubScreen.qml" line="701"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Žiadne systémy nie sú dostupné. Spustite Aktualizovať databázu médií v Nastaveniach.</translation>
     </message>
@@ -553,138 +553,138 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1361"/>
+        <location filename="../app/Main.qml" line="1367"/>
         <source>Launch core</source>
         <translation>Spustiť core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1367"/>
-        <location filename="../app/Main.qml" line="1606"/>
+        <location filename="../app/Main.qml" line="1373"/>
+        <location filename="../app/Main.qml" line="1612"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1425"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Remove from favorites</source>
         <translation>Odstrániť z obľúbených</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1425"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Add to favorites</source>
         <translation>Pridať do obľúbených</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1430"/>
+        <location filename="../app/Main.qml" line="1436"/>
         <source>Write to NFC token</source>
         <translation>Zapísať na NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1434"/>
+        <location filename="../app/Main.qml" line="1440"/>
         <source>QR code</source>
         <translation>QR kód</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1409"/>
-        <location filename="../app/Main.qml" line="1444"/>
+        <location filename="../app/Main.qml" line="1415"/>
+        <location filename="../app/Main.qml" line="1450"/>
         <source>Launch game</source>
         <translation>Spustiť hru</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2604"/>
+        <location filename="../app/Main.qml" line="2610"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2616"/>
         <source>Loading favorites…</source>
         <translation>Načítanie obľúbených…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2606"/>
+        <location filename="../app/Main.qml" line="2612"/>
         <source>Loading games…</source>
         <translation>Načítanie hier…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1374"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1380"/>
+        <location filename="../app/Main.qml" line="1403"/>
         <source>Update media database</source>
         <translation type="unfinished">Aktualizovať databázu médií</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1377"/>
-        <location filename="../app/Main.qml" line="1400"/>
+        <location filename="../app/Main.qml" line="1383"/>
+        <location filename="../app/Main.qml" line="1406"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Získať metadáta</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1382"/>
-        <location filename="../app/Main.qml" line="1391"/>
+        <location filename="../app/Main.qml" line="1388"/>
+        <location filename="../app/Main.qml" line="1397"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1382"/>
-        <location filename="../app/Main.qml" line="1391"/>
+        <location filename="../app/Main.qml" line="1388"/>
+        <location filename="../app/Main.qml" line="1397"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1602"/>
+        <location filename="../app/Main.qml" line="1608"/>
         <source>Default</source>
         <translation type="unfinished">Predvolené</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1602"/>
+        <location filename="../app/Main.qml" line="1608"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1926"/>
+        <location filename="../app/Main.qml" line="1932"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1930"/>
+        <location filename="../app/Main.qml" line="1936"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1944"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1948"/>
+        <location filename="../app/Main.qml" line="1954"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1952"/>
+        <location filename="../app/Main.qml" line="1958"/>
         <source>Retry</source>
         <translation type="unfinished">Skúsiť znova</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1956"/>
+        <location filename="../app/Main.qml" line="1962"/>
         <source>Cancel</source>
         <translation type="unfinished">Zrušiť</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2608"/>
+        <location filename="../app/Main.qml" line="2614"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2612"/>
+        <location filename="../app/Main.qml" line="2618"/>
         <source>Loading recently played…</source>
         <translation>Načítanie nedávno hraných…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2620"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2616"/>
+        <location filename="../app/Main.qml" line="2622"/>
         <source>Loading…</source>
         <translation>Načítanie…</translation>
     </message>
@@ -692,72 +692,72 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="683"/>
+        <location filename="../app/MainLayout.qml" line="685"/>
         <source>Writing failed</source>
         <translation>Zápis zlyhal</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="683"/>
+        <location filename="../app/MainLayout.qml" line="685"/>
         <source>Put a writable card near the reader</source>
         <translation>Priložte zapisovateľnú kartu k čítačke</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="811"/>
+        <location filename="../app/MainLayout.qml" line="813"/>
         <source>Are you sure you want to exit?</source>
         <translation>Naozaj chcete ukončiť?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="894"/>
-        <location filename="../app/MainLayout.qml" line="968"/>
+        <location filename="../app/MainLayout.qml" line="896"/>
+        <location filename="../app/MainLayout.qml" line="970"/>
         <source>Select</source>
         <translation>Vybrať</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="902"/>
-        <location filename="../app/MainLayout.qml" line="916"/>
-        <location filename="../app/MainLayout.qml" line="931"/>
-        <location filename="../app/MainLayout.qml" line="942"/>
+        <location filename="../app/MainLayout.qml" line="900"/>
+        <location filename="../app/MainLayout.qml" line="904"/>
+        <location filename="../app/MainLayout.qml" line="918"/>
+        <location filename="../app/MainLayout.qml" line="933"/>
+        <location filename="../app/MainLayout.qml" line="944"/>
         <source>Close</source>
         <translation>Zavrieť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="909"/>
-        <location filename="../app/MainLayout.qml" line="949"/>
-        <location filename="../app/MainLayout.qml" line="972"/>
-        <location filename="../app/MainLayout.qml" line="983"/>
+        <location filename="../app/MainLayout.qml" line="911"/>
+        <location filename="../app/MainLayout.qml" line="951"/>
+        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="985"/>
         <source>Cancel</source>
         <translation>Zrušiť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="927"/>
+        <location filename="../app/MainLayout.qml" line="929"/>
         <source>Done</source>
         <translation>Hotovo</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="957"/>
+        <location filename="../app/MainLayout.qml" line="959"/>
         <source>I understand</source>
         <translation>Rozumiem</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="991"/>
+        <location filename="../app/MainLayout.qml" line="993"/>
         <source>Start</source>
         <translation>Spustiť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1203"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Scroll</source>
         <translation>Posúvať</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="890"/>
-        <location filename="../app/MainLayout.qml" line="964"/>
-        <location filename="../app/MainLayout.qml" line="1010"/>
-        <location filename="../app/MainLayout.qml" line="1047"/>
-        <location filename="../app/MainLayout.qml" line="1097"/>
-        <location filename="../app/MainLayout.qml" line="1146"/>
-        <location filename="../app/MainLayout.qml" line="1165"/>
-        <location filename="../app/MainLayout.qml" line="1232"/>
+        <location filename="../app/MainLayout.qml" line="892"/>
+        <location filename="../app/MainLayout.qml" line="966"/>
+        <location filename="../app/MainLayout.qml" line="1012"/>
+        <location filename="../app/MainLayout.qml" line="1049"/>
+        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1148"/>
+        <location filename="../app/MainLayout.qml" line="1167"/>
+        <location filename="../app/MainLayout.qml" line="1234"/>
         <source>Move</source>
         <translation>Presunúť</translation>
     </message>
@@ -777,81 +777,81 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Nedávno hrané</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="699"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="700"/>
+        <location filename="../app/MainLayout.qml" line="702"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="810"/>
+        <location filename="../app/MainLayout.qml" line="812"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1014"/>
-        <location filename="../app/MainLayout.qml" line="1057"/>
-        <location filename="../app/MainLayout.qml" line="1107"/>
-        <location filename="../app/MainLayout.qml" line="1151"/>
-        <location filename="../app/MainLayout.qml" line="1242"/>
+        <location filename="../app/MainLayout.qml" line="1016"/>
+        <location filename="../app/MainLayout.qml" line="1059"/>
+        <location filename="../app/MainLayout.qml" line="1109"/>
+        <location filename="../app/MainLayout.qml" line="1153"/>
+        <location filename="../app/MainLayout.qml" line="1244"/>
         <source>Open</source>
         <translation>Otvoriť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1024"/>
+        <location filename="../app/MainLayout.qml" line="1026"/>
         <source>Quit</source>
         <translation>Ukončiť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1033"/>
-        <location filename="../app/MainLayout.qml" line="1063"/>
-        <location filename="../app/MainLayout.qml" line="1074"/>
-        <location filename="../app/MainLayout.qml" line="1089"/>
-        <location filename="../app/MainLayout.qml" line="1116"/>
-        <location filename="../app/MainLayout.qml" line="1127"/>
-        <location filename="../app/MainLayout.qml" line="1139"/>
-        <location filename="../app/MainLayout.qml" line="1155"/>
-        <location filename="../app/MainLayout.qml" line="1189"/>
-        <location filename="../app/MainLayout.qml" line="1207"/>
-        <location filename="../app/MainLayout.qml" line="1216"/>
-        <location filename="../app/MainLayout.qml" line="1251"/>
-        <location filename="../app/MainLayout.qml" line="1262"/>
+        <location filename="../app/MainLayout.qml" line="1035"/>
+        <location filename="../app/MainLayout.qml" line="1065"/>
+        <location filename="../app/MainLayout.qml" line="1076"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
+        <location filename="../app/MainLayout.qml" line="1118"/>
+        <location filename="../app/MainLayout.qml" line="1129"/>
+        <location filename="../app/MainLayout.qml" line="1141"/>
+        <location filename="../app/MainLayout.qml" line="1157"/>
+        <location filename="../app/MainLayout.qml" line="1191"/>
+        <location filename="../app/MainLayout.qml" line="1209"/>
+        <location filename="../app/MainLayout.qml" line="1218"/>
+        <location filename="../app/MainLayout.qml" line="1253"/>
+        <location filename="../app/MainLayout.qml" line="1264"/>
         <source>Back</source>
         <translation>Späť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1053"/>
-        <location filename="../app/MainLayout.qml" line="1103"/>
-        <location filename="../app/MainLayout.qml" line="1238"/>
+        <location filename="../app/MainLayout.qml" line="1055"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
+        <location filename="../app/MainLayout.qml" line="1240"/>
         <source>Page</source>
         <translation>Stránka</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1060"/>
-        <location filename="../app/MainLayout.qml" line="1112"/>
-        <location filename="../app/MainLayout.qml" line="1247"/>
+        <location filename="../app/MainLayout.qml" line="1022"/>
+        <location filename="../app/MainLayout.qml" line="1062"/>
+        <location filename="../app/MainLayout.qml" line="1114"/>
+        <location filename="../app/MainLayout.qml" line="1249"/>
         <source>Options</source>
         <translation>Možnosti</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1070"/>
-        <location filename="../app/MainLayout.qml" line="1123"/>
-        <location filename="../app/MainLayout.qml" line="1258"/>
+        <location filename="../app/MainLayout.qml" line="940"/>
+        <location filename="../app/MainLayout.qml" line="1072"/>
+        <location filename="../app/MainLayout.qml" line="1125"/>
+        <location filename="../app/MainLayout.qml" line="1260"/>
         <source>Retry</source>
         <translation>Skúsiť znova</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1174"/>
+        <location filename="../app/MainLayout.qml" line="1176"/>
         <source>Change</source>
         <translation>Zmeniť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1180"/>
+        <location filename="../app/MainLayout.qml" line="1182"/>
         <source>Toggle</source>
         <translation>Prepínať</translation>
     </message>
@@ -864,12 +864,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Načítanie…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="365"/>
+        <location filename="../screens/MediaListScreen.qml" line="395"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 položiek</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="366"/>
+        <location filename="../screens/MediaListScreen.qml" line="396"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>Nie</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="198"/>
+        <location filename="../components/Modal.qml" line="246"/>
         <source>Cancel</source>
         <translation>Zrušiť</translation>
     </message>
@@ -936,24 +936,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="132"/>
-        <location filename="../screens/SettingsScreen.qml" line="718"/>
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
+        <location filename="../screens/SettingsScreen.qml" line="741"/>
         <source>Language</source>
         <translation>Jazyk</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="754"/>
+        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <location filename="../screens/SettingsScreen.qml" line="777"/>
         <source>Browsing layout</source>
         <translation>Rozloženie prehliadania</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="150"/>
+        <location filename="../screens/SettingsScreen.qml" line="165"/>
         <source>Mouse support</source>
         <translation>Podpora myši</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="157"/>
+        <location filename="../screens/SettingsScreen.qml" line="177"/>
         <source>Update media database</source>
         <translation>Aktualizovať databázu médií</translation>
     </message>
@@ -962,47 +962,47 @@ Euskara - devilschile2</source>
         <translation type="vanished">Všeobecné</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="745"/>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="768"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="145"/>
-        <location filename="../screens/SettingsScreen.qml" line="763"/>
+        <location filename="../screens/SettingsScreen.qml" line="160"/>
+        <location filename="../screens/SettingsScreen.qml" line="786"/>
         <source>Button style</source>
         <translation>Štýl tlačidiel</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="772"/>
+        <location filename="../screens/SettingsScreen.qml" line="132"/>
+        <location filename="../screens/SettingsScreen.qml" line="795"/>
         <source>Screensaver</source>
         <translation>Šetrič obrazovky</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="80"/>
-        <location filename="../screens/SettingsScreen.qml" line="209"/>
+        <location filename="../screens/SettingsScreen.qml" line="95"/>
+        <location filename="../screens/SettingsScreen.qml" line="229"/>
         <source>Library</source>
         <translation>Knižnica</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="162"/>
+        <location filename="../screens/SettingsScreen.qml" line="182"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="112"/>
-        <location filename="../screens/SettingsScreen.qml" line="781"/>
+        <location filename="../screens/SettingsScreen.qml" line="127"/>
+        <location filename="../screens/SettingsScreen.qml" line="804"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="167"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
         <source>Scrape metadata</source>
         <translation>Získať metadáta</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="172"/>
+        <location filename="../screens/SettingsScreen.qml" line="192"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1011,397 +1011,402 @@ Euskara - devilschile2</source>
         <translation type="vanished">Rozšírené</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="184"/>
+        <location filename="../screens/SettingsScreen.qml" line="204"/>
         <source>Debug logging</source>
         <translation>Ladiace záznamy</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="189"/>
+        <location filename="../screens/SettingsScreen.qml" line="209"/>
         <source>Upload log file</source>
         <translation>Nahrať súbor protokolu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="179"/>
+        <location filename="../screens/SettingsScreen.qml" line="199"/>
         <source>About / License</source>
         <translation>O aplikácii / Licencia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
-        <location filename="../screens/SettingsScreen.qml" line="727"/>
+        <location filename="../screens/SettingsScreen.qml" line="137"/>
+        <location filename="../screens/SettingsScreen.qml" line="750"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="127"/>
-        <location filename="../screens/SettingsScreen.qml" line="736"/>
+        <location filename="../screens/SettingsScreen.qml" line="142"/>
+        <location filename="../screens/SettingsScreen.qml" line="759"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="137"/>
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="226"/>
+        <location filename="../screens/SettingsScreen.qml" line="170"/>
+        <source>Reduce motion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
         <source>Optimizing</source>
         <translation>Optimalizácia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="228"/>
-        <location filename="../screens/SettingsScreen.qml" line="237"/>
+        <location filename="../screens/SettingsScreen.qml" line="248"/>
+        <location filename="../screens/SettingsScreen.qml" line="257"/>
         <source>Paused</source>
         <translation>Pozastavené</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="228"/>
-        <location filename="../screens/SettingsScreen.qml" line="237"/>
+        <location filename="../screens/SettingsScreen.qml" line="248"/>
+        <location filename="../screens/SettingsScreen.qml" line="257"/>
         <source>In progress</source>
         <translation>Prebieha</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="231"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>%1 indexed</source>
         <translation>%1 indexovaných</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="240"/>
+        <location filename="../screens/SettingsScreen.qml" line="260"/>
         <source>%1 scraped</source>
         <translation>%1 zozbieraných</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="472"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Cancel</source>
         <translation>Zrušiť</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="472"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Start</source>
         <translation>Spustiť</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="474"/>
+        <location filename="../screens/SettingsScreen.qml" line="497"/>
         <source>Upload</source>
         <translation>Nahrať</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Open</source>
         <translation>Otvoriť</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="556"/>
+        <location filename="../screens/SettingsScreen.qml" line="579"/>
         <source>English</source>
         <translation>Angličtina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="558"/>
+        <location filename="../screens/SettingsScreen.qml" line="581"/>
         <source>Italian</source>
         <translation>Taliančina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="560"/>
+        <location filename="../screens/SettingsScreen.qml" line="583"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="562"/>
+        <location filename="../screens/SettingsScreen.qml" line="585"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="564"/>
+        <location filename="../screens/SettingsScreen.qml" line="587"/>
         <source>German</source>
         <translation>Nemčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="566"/>
+        <location filename="../screens/SettingsScreen.qml" line="589"/>
         <source>Greek</source>
         <translation>Gréčtina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="568"/>
+        <location filename="../screens/SettingsScreen.qml" line="591"/>
         <source>Japanese</source>
         <translation>Japončina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="570"/>
+        <location filename="../screens/SettingsScreen.qml" line="593"/>
         <source>Korean</source>
         <translation>Kórejčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="595"/>
         <source>Dutch</source>
         <translation>Holandčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="597"/>
         <source>Romanian</source>
         <translation>Rumunčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="599"/>
         <source>Slovak</source>
         <translation>Slovenčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="601"/>
         <source>Ukrainian</source>
         <translation>Ukrajinčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="603"/>
         <source>Chinese (Simplified)</source>
         <translation>Čínština (zjednodušená)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="605"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="607"/>
         <source>Hebrew</source>
         <translation>Hebrejčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="588"/>
+        <location filename="../screens/SettingsScreen.qml" line="611"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="589"/>
-        <location filename="../screens/SettingsScreen.qml" line="597"/>
-        <location filename="../screens/SettingsScreen.qml" line="671"/>
+        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="620"/>
+        <location filename="../screens/SettingsScreen.qml" line="694"/>
         <source>Auto</source>
         <translation>Automaticky</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="594"/>
+        <location filename="../screens/SettingsScreen.qml" line="617"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="596"/>
+        <location filename="../screens/SettingsScreen.qml" line="619"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="607"/>
+        <location filename="../screens/SettingsScreen.qml" line="630"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="632"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="611"/>
+        <location filename="../screens/SettingsScreen.qml" line="634"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="635"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="640"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="619"/>
+        <location filename="../screens/SettingsScreen.qml" line="642"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="620"/>
+        <location filename="../screens/SettingsScreen.qml" line="643"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="625"/>
+        <location filename="../screens/SettingsScreen.qml" line="648"/>
         <source>Detailed list view</source>
         <translation>Podrobné zobrazenie zoznamu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="626"/>
+        <location filename="../screens/SettingsScreen.qml" line="649"/>
         <source>Grid view</source>
         <translation>Zobrazenie mriežky</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="631"/>
+        <location filename="../screens/SettingsScreen.qml" line="654"/>
         <source>Style B</source>
         <translation>Štýl B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="633"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Style C</source>
         <translation>Štýl C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="658"/>
         <source>Style D</source>
         <translation>Štýl D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="659"/>
         <source>Style A</source>
         <translation>Štýl A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1292"/>
+        <location filename="../screens/SettingsScreen.qml" line="1358"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="526"/>
+        <location filename="../screens/SettingsScreen.qml" line="549"/>
         <source>Default</source>
         <translation>Predvolené</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="674"/>
         <source>Off</source>
         <translation>Vypnuté</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="653"/>
+        <location filename="../screens/SettingsScreen.qml" line="676"/>
         <source>1 second (testing)</source>
         <translation>1 sekunda (test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="655"/>
+        <location filename="../screens/SettingsScreen.qml" line="678"/>
         <source>1 minute</source>
         <translation>1 minúta</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="657"/>
+        <location filename="../screens/SettingsScreen.qml" line="680"/>
         <source>2 minutes</source>
         <translation>2 minúty</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="659"/>
+        <location filename="../screens/SettingsScreen.qml" line="682"/>
         <source>5 minutes</source>
         <translation>5 minút</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="661"/>
+        <location filename="../screens/SettingsScreen.qml" line="684"/>
         <source>10 minutes</source>
         <translation>10 minút</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="663"/>
+        <location filename="../screens/SettingsScreen.qml" line="686"/>
         <source>15 minutes</source>
         <translation>15 minút</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="665"/>
+        <location filename="../screens/SettingsScreen.qml" line="688"/>
         <source>30 minutes</source>
         <translation>30 minút</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="666"/>
+        <location filename="../screens/SettingsScreen.qml" line="689"/>
         <source>%1 seconds</source>
         <translation>%1 sekúnd</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="96"/>
-        <location filename="../screens/SettingsScreen.qml" line="709"/>
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="732"/>
         <source>Resolution</source>
         <translation>Rozlíšenie</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="68"/>
-        <location filename="../screens/SettingsScreen.qml" line="205"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="74"/>
-        <location filename="../screens/SettingsScreen.qml" line="207"/>
+        <location filename="../screens/SettingsScreen.qml" line="89"/>
+        <location filename="../screens/SettingsScreen.qml" line="227"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="86"/>
-        <location filename="../screens/SettingsScreen.qml" line="211"/>
+        <location filename="../screens/SettingsScreen.qml" line="101"/>
+        <location filename="../screens/SettingsScreen.qml" line="231"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="673"/>
+        <location filename="../screens/SettingsScreen.qml" line="696"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="675"/>
+        <location filename="../screens/SettingsScreen.qml" line="698"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="677"/>
+        <location filename="../screens/SettingsScreen.qml" line="700"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="679"/>
+        <location filename="../screens/SettingsScreen.qml" line="702"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="681"/>
+        <location filename="../screens/SettingsScreen.qml" line="704"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="683"/>
+        <location filename="../screens/SettingsScreen.qml" line="706"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="685"/>
+        <location filename="../screens/SettingsScreen.qml" line="708"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="687"/>
+        <location filename="../screens/SettingsScreen.qml" line="710"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="712"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="691"/>
+        <location filename="../screens/SettingsScreen.qml" line="714"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="693"/>
+        <location filename="../screens/SettingsScreen.qml" line="716"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="695"/>
+        <location filename="../screens/SettingsScreen.qml" line="718"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="212"/>
+        <location filename="../screens/SettingsScreen.qml" line="232"/>
         <source>Settings</source>
         <translation>Nastavenia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1280"/>
+        <location filename="../screens/SettingsScreen.qml" line="1346"/>
         <source>No settings available on this platform</source>
         <translation>Na tejto platforme nie sú dostupné žiadne nastavenia</translation>
     </message>
@@ -1409,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="206"/>
-        <location filename="../screens/SystemsScreen.qml" line="304"/>
+        <location filename="../screens/SystemsScreen.qml" line="229"/>
+        <location filename="../screens/SystemsScreen.qml" line="329"/>
         <source>%1 systems</source>
         <translation>%1 systémov</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="207"/>
-        <location filename="../screens/SystemsScreen.qml" line="321"/>
+        <location filename="../screens/SystemsScreen.qml" line="230"/>
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="339"/>
+        <location filename="../screens/SystemsScreen.qml" line="364"/>
         <source>No systems in this category</source>
         <translation>V tejto kategórii nie sú žiadne systémy</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="340"/>
+        <location filename="../screens/SystemsScreen.qml" line="365"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>
@@ -1434,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="364"/>
+        <location filename="../components/Tile.qml" line="475"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -97,100 +97,100 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Načítanie…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="196"/>
+        <location filename="../components/BrowseDetailPane.qml" line="167"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="196"/>
+        <location filename="../components/BrowseDetailPane.qml" line="167"/>
         <source>Yr</source>
         <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="198"/>
+        <location filename="../components/BrowseDetailPane.qml" line="169"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="198"/>
+        <location filename="../components/BrowseDetailPane.qml" line="169"/>
         <source>Gen</source>
         <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="200"/>
+        <location filename="../components/BrowseDetailPane.qml" line="171"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="200"/>
+        <location filename="../components/BrowseDetailPane.qml" line="171"/>
         <source>Plyr</source>
         <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="202"/>
+        <location filename="../components/BrowseDetailPane.qml" line="173"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="202"/>
+        <location filename="../components/BrowseDetailPane.qml" line="173"/>
         <source>Dev</source>
         <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="204"/>
+        <location filename="../components/BrowseDetailPane.qml" line="175"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="204"/>
+        <location filename="../components/BrowseDetailPane.qml" line="175"/>
         <source>Pub</source>
         <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="206"/>
+        <location filename="../components/BrowseDetailPane.qml" line="177"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="206"/>
+        <location filename="../components/BrowseDetailPane.qml" line="177"/>
         <source>Rtg</source>
         <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="208"/>
+        <location filename="../components/BrowseDetailPane.qml" line="179"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="208"/>
+        <location filename="../components/BrowseDetailPane.qml" line="179"/>
         <source>Cat</source>
         <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="210"/>
+        <location filename="../components/BrowseDetailPane.qml" line="181"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="210"/>
+        <location filename="../components/BrowseDetailPane.qml" line="181"/>
         <source>Date</source>
         <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="212"/>
+        <location filename="../components/BrowseDetailPane.qml" line="183"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="212"/>
+        <location filename="../components/BrowseDetailPane.qml" line="183"/>
         <source>Mfr</source>
         <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
@@ -425,8 +425,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="127"/>
-        <location filename="../screens/GamesScreen.qml" line="162"/>
+        <location filename="../screens/GamesScreen.qml" line="128"/>
+        <location filename="../screens/GamesScreen.qml" line="163"/>
         <source>%1 files</source>
         <translation>%1 súborov</translation>
     </message>
@@ -436,8 +436,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="136"/>
-        <location filename="../screens/GamesScreen.qml" line="163"/>
+        <location filename="../screens/GamesScreen.qml" line="137"/>
+        <location filename="../screens/GamesScreen.qml" line="164"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -447,7 +447,7 @@ Euskara - devilschile2</source>
         <translation>Načítanie hier…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="132"/>
+        <location filename="../screens/GamesScreen.qml" line="133"/>
         <source>Loading more…</source>
         <translation>Načítava sa viac…</translation>
     </message>
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="149"/>
+        <location filename="../screens/HubScreen.qml" line="156"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="155"/>
+        <location filename="../screens/HubScreen.qml" line="162"/>
         <source>Favorites</source>
         <translation>Obľúbené</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="160"/>
+        <location filename="../screens/HubScreen.qml" line="167"/>
         <source>Recently Played</source>
         <translation>Nedávno hrané</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="165"/>
+        <location filename="../screens/HubScreen.qml" line="172"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Nastavenia</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="701"/>
+        <location filename="../screens/HubScreen.qml" line="722"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Žiadne systémy nie sú dostupné. Spustite Aktualizovať databázu médií v Nastaveniach.</translation>
     </message>
@@ -553,138 +553,138 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1367"/>
+        <location filename="../app/Main.qml" line="1381"/>
         <source>Launch core</source>
         <translation>Spustiť core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1373"/>
-        <location filename="../app/Main.qml" line="1612"/>
+        <location filename="../app/Main.qml" line="1387"/>
+        <location filename="../app/Main.qml" line="1626"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1445"/>
         <source>Remove from favorites</source>
         <translation>Odstrániť z obľúbených</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1445"/>
         <source>Add to favorites</source>
         <translation>Pridať do obľúbených</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1436"/>
+        <location filename="../app/Main.qml" line="1450"/>
         <source>Write to NFC token</source>
         <translation>Zapísať na NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1440"/>
+        <location filename="../app/Main.qml" line="1454"/>
         <source>QR code</source>
         <translation>QR kód</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1415"/>
-        <location filename="../app/Main.qml" line="1450"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1464"/>
         <source>Launch game</source>
         <translation>Spustiť hru</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2624"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2616"/>
+        <location filename="../app/Main.qml" line="2630"/>
         <source>Loading favorites…</source>
         <translation>Načítanie obľúbených…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2612"/>
+        <location filename="../app/Main.qml" line="2626"/>
         <source>Loading games…</source>
         <translation>Načítanie hier…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1380"/>
-        <location filename="../app/Main.qml" line="1403"/>
+        <location filename="../app/Main.qml" line="1394"/>
+        <location filename="../app/Main.qml" line="1417"/>
         <source>Update media database</source>
         <translation type="unfinished">Aktualizovať databázu médií</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1383"/>
-        <location filename="../app/Main.qml" line="1406"/>
+        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1420"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Získať metadáta</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1388"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1411"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1388"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1411"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1608"/>
+        <location filename="../app/Main.qml" line="1622"/>
         <source>Default</source>
         <translation type="unfinished">Predvolené</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1608"/>
+        <location filename="../app/Main.qml" line="1622"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1932"/>
+        <location filename="../app/Main.qml" line="1946"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1936"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1950"/>
+        <location filename="../app/Main.qml" line="1964"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1954"/>
+        <location filename="../app/Main.qml" line="1968"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1958"/>
+        <location filename="../app/Main.qml" line="1972"/>
         <source>Retry</source>
         <translation type="unfinished">Skúsiť znova</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1962"/>
+        <location filename="../app/Main.qml" line="1976"/>
         <source>Cancel</source>
         <translation type="unfinished">Zrušiť</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2628"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2618"/>
+        <location filename="../app/Main.qml" line="2632"/>
         <source>Loading recently played…</source>
         <translation>Načítanie nedávno hraných…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2620"/>
+        <location filename="../app/Main.qml" line="2634"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2622"/>
+        <location filename="../app/Main.qml" line="2636"/>
         <source>Loading…</source>
         <translation>Načítanie…</translation>
     </message>
@@ -864,12 +864,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Načítanie…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="395"/>
+        <location filename="../screens/MediaListScreen.qml" line="436"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 položiek</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="396"/>
+        <location filename="../screens/MediaListScreen.qml" line="437"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>Nie</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="246"/>
+        <location filename="../components/Modal.qml" line="256"/>
         <source>Cancel</source>
         <translation>Zrušiť</translation>
     </message>
@@ -1262,7 +1262,7 @@ Euskara - devilschile2</source>
         <translation>Štýl A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1358"/>
+        <location filename="../screens/SettingsScreen.qml" line="1368"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1406,7 +1406,7 @@ Euskara - devilschile2</source>
         <translation>Nastavenia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1346"/>
+        <location filename="../screens/SettingsScreen.qml" line="1356"/>
         <source>No settings available on this platform</source>
         <translation>Na tejto platforme nie sú dostupné žiadne nastavenia</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="229"/>
-        <location filename="../screens/SystemsScreen.qml" line="329"/>
+        <location filename="../screens/SystemsScreen.qml" line="236"/>
+        <location filename="../screens/SystemsScreen.qml" line="338"/>
         <source>%1 systems</source>
         <translation>%1 systémov</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="230"/>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="237"/>
+        <location filename="../screens/SystemsScreen.qml" line="355"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="364"/>
+        <location filename="../screens/SystemsScreen.qml" line="373"/>
         <source>No systems in this category</source>
         <translation>V tejto kategórii nie sú žiadne systémy</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="365"/>
+        <location filename="../screens/SystemsScreen.qml" line="374"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>
@@ -1439,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="475"/>
+        <location filename="../components/Tile.qml" line="539"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -425,8 +425,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="128"/>
-        <location filename="../screens/GamesScreen.qml" line="163"/>
+        <location filename="../screens/GamesScreen.qml" line="131"/>
+        <location filename="../screens/GamesScreen.qml" line="166"/>
         <source>%1 files</source>
         <translation>%1 файлів</translation>
     </message>
@@ -436,8 +436,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="137"/>
-        <location filename="../screens/GamesScreen.qml" line="164"/>
+        <location filename="../screens/GamesScreen.qml" line="140"/>
+        <location filename="../screens/GamesScreen.qml" line="167"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -447,7 +447,7 @@ Euskara - devilschile2</source>
         <translation>Завантаження ігор…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="133"/>
+        <location filename="../screens/GamesScreen.qml" line="136"/>
         <source>Loading more…</source>
         <translation>Завантаження ще…</translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>Ні</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="246"/>
+        <location filename="../components/Modal.qml" line="250"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
@@ -936,24 +936,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="141"/>
-        <location filename="../screens/SettingsScreen.qml" line="734"/>
+        <location filename="../screens/SettingsScreen.qml" line="145"/>
+        <location filename="../screens/SettingsScreen.qml" line="738"/>
         <source>Language</source>
         <translation>Мова</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116"/>
-        <location filename="../screens/SettingsScreen.qml" line="770"/>
+        <location filename="../screens/SettingsScreen.qml" line="120"/>
+        <location filename="../screens/SettingsScreen.qml" line="774"/>
         <source>Browsing layout</source>
         <translation>Режим перегляду</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="159"/>
+        <location filename="../screens/SettingsScreen.qml" line="163"/>
         <source>Mouse support</source>
         <translation>Підтримка миші</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="171"/>
+        <location filename="../screens/SettingsScreen.qml" line="175"/>
         <source>Update media database</source>
         <translation>Оновити базу медіа</translation>
     </message>
@@ -962,47 +962,47 @@ Euskara - devilschile2</source>
         <translation type="vanished">Загальні</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
-        <location filename="../screens/SettingsScreen.qml" line="761"/>
+        <location filename="../screens/SettingsScreen.qml" line="115"/>
+        <location filename="../screens/SettingsScreen.qml" line="765"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="154"/>
-        <location filename="../screens/SettingsScreen.qml" line="779"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="783"/>
         <source>Button style</source>
         <translation>Стиль кнопок</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
-        <location filename="../screens/SettingsScreen.qml" line="788"/>
+        <location filename="../screens/SettingsScreen.qml" line="130"/>
+        <location filename="../screens/SettingsScreen.qml" line="792"/>
         <source>Screensaver</source>
         <translation>Заставка</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="89"/>
-        <location filename="../screens/SettingsScreen.qml" line="223"/>
+        <location filename="../screens/SettingsScreen.qml" line="93"/>
+        <location filename="../screens/SettingsScreen.qml" line="227"/>
         <source>Library</source>
         <translation>Бібліотека</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="176"/>
+        <location filename="../screens/SettingsScreen.qml" line="180"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121"/>
-        <location filename="../screens/SettingsScreen.qml" line="797"/>
+        <location filename="../screens/SettingsScreen.qml" line="125"/>
+        <location filename="../screens/SettingsScreen.qml" line="801"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="181"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
         <source>Scrape metadata</source>
         <translation>Отримати метадані</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="186"/>
+        <location filename="../screens/SettingsScreen.qml" line="190"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1011,402 +1011,402 @@ Euskara - devilschile2</source>
         <translation type="vanished">Розширені</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="198"/>
+        <location filename="../screens/SettingsScreen.qml" line="202"/>
         <source>Debug logging</source>
         <translation>Журнал відлагодження</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="203"/>
+        <location filename="../screens/SettingsScreen.qml" line="207"/>
         <source>Upload log file</source>
         <translation>Завантажити файл журналу</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="193"/>
+        <location filename="../screens/SettingsScreen.qml" line="197"/>
         <source>About / License</source>
         <translation>Про програму / Ліцензія</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
-        <location filename="../screens/SettingsScreen.qml" line="743"/>
+        <location filename="../screens/SettingsScreen.qml" line="135"/>
+        <location filename="../screens/SettingsScreen.qml" line="747"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="136"/>
-        <location filename="../screens/SettingsScreen.qml" line="752"/>
+        <location filename="../screens/SettingsScreen.qml" line="140"/>
+        <location filename="../screens/SettingsScreen.qml" line="756"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="146"/>
+        <location filename="../screens/SettingsScreen.qml" line="150"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="168"/>
         <source>Reduce motion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="240"/>
+        <location filename="../screens/SettingsScreen.qml" line="244"/>
         <source>Optimizing</source>
         <translation>Оптимізація</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="242"/>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="255"/>
         <source>Paused</source>
         <translation>Призупинено</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="242"/>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="255"/>
         <source>In progress</source>
         <translation>Виконується</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="245"/>
+        <location filename="../screens/SettingsScreen.qml" line="249"/>
         <source>%1 indexed</source>
         <translation>%1 проіндексовано</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="254"/>
+        <location filename="../screens/SettingsScreen.qml" line="258"/>
         <source>%1 scraped</source>
         <translation>%1 зібрано</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="488"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="488"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Start</source>
         <translation>Почати</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="490"/>
+        <location filename="../screens/SettingsScreen.qml" line="494"/>
         <source>Upload</source>
         <translation>Вивантажити</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="491"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Open</source>
         <translation>Відкрити</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>English</source>
         <translation>Англійська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Italian</source>
         <translation>Італійська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>German</source>
         <translation>Німецька</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Greek</source>
         <translation>Грецька</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Japanese</source>
         <translation>Японська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="590"/>
         <source>Korean</source>
         <translation>Корейська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="588"/>
+        <location filename="../screens/SettingsScreen.qml" line="592"/>
         <source>Dutch</source>
         <translation>Нідерландська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="590"/>
+        <location filename="../screens/SettingsScreen.qml" line="594"/>
         <source>Romanian</source>
         <translation>Румунська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="592"/>
+        <location filename="../screens/SettingsScreen.qml" line="596"/>
         <source>Slovak</source>
         <translation>Словацька</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="594"/>
+        <location filename="../screens/SettingsScreen.qml" line="598"/>
         <source>Ukrainian</source>
         <translation>Українська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="596"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Chinese (Simplified)</source>
         <translation>Китайська (спрощена)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="598"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="600"/>
+        <location filename="../screens/SettingsScreen.qml" line="604"/>
         <source>Hebrew</source>
         <translation>Іврит</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="602"/>
+        <location filename="../screens/SettingsScreen.qml" line="606"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="604"/>
+        <location filename="../screens/SettingsScreen.qml" line="608"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="605"/>
-        <location filename="../screens/SettingsScreen.qml" line="613"/>
-        <location filename="../screens/SettingsScreen.qml" line="687"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="691"/>
         <source>Auto</source>
         <translation>Автоматично</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="610"/>
+        <location filename="../screens/SettingsScreen.qml" line="614"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="616"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="623"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="625"/>
+        <location filename="../screens/SettingsScreen.qml" line="629"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="627"/>
+        <location filename="../screens/SettingsScreen.qml" line="631"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="628"/>
+        <location filename="../screens/SettingsScreen.qml" line="632"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="633"/>
+        <location filename="../screens/SettingsScreen.qml" line="637"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="639"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="640"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="641"/>
+        <location filename="../screens/SettingsScreen.qml" line="645"/>
         <source>Detailed list view</source>
         <translation>Детальний перегляд списку</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="642"/>
+        <location filename="../screens/SettingsScreen.qml" line="646"/>
         <source>Grid view</source>
         <translation>Перегляд сіткою</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
         <source>Style B</source>
         <translation>Стиль B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Style C</source>
         <translation>Стиль C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="655"/>
         <source>Style D</source>
         <translation>Стиль D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="652"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Style A</source>
         <translation>Стиль A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1351"/>
+        <location filename="../screens/SettingsScreen.qml" line="1382"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="542"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>Default</source>
         <translation>Типовий</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="667"/>
+        <location filename="../screens/SettingsScreen.qml" line="671"/>
         <source>Off</source>
         <translation>Вимкнено</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="669"/>
+        <location filename="../screens/SettingsScreen.qml" line="673"/>
         <source>1 second (testing)</source>
         <translation>1 секунда (тест)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="671"/>
+        <location filename="../screens/SettingsScreen.qml" line="675"/>
         <source>1 minute</source>
         <translation>1 хвилина</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="673"/>
+        <location filename="../screens/SettingsScreen.qml" line="677"/>
         <source>2 minutes</source>
         <translation>2 хвилини</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="675"/>
+        <location filename="../screens/SettingsScreen.qml" line="679"/>
         <source>5 minutes</source>
         <translation>5 хвилин</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="677"/>
+        <location filename="../screens/SettingsScreen.qml" line="681"/>
         <source>10 minutes</source>
         <translation>10 хвилин</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="679"/>
+        <location filename="../screens/SettingsScreen.qml" line="683"/>
         <source>15 minutes</source>
         <translation>15 хвилин</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="681"/>
+        <location filename="../screens/SettingsScreen.qml" line="685"/>
         <source>30 minutes</source>
         <translation>30 хвилин</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="682"/>
+        <location filename="../screens/SettingsScreen.qml" line="686"/>
         <source>%1 seconds</source>
         <translation>%1 секунд</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="105"/>
-        <location filename="../screens/SettingsScreen.qml" line="725"/>
+        <location filename="../screens/SettingsScreen.qml" line="109"/>
+        <location filename="../screens/SettingsScreen.qml" line="729"/>
         <source>Resolution</source>
         <translation>Роздільна здатність</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="77"/>
-        <location filename="../screens/SettingsScreen.qml" line="219"/>
+        <location filename="../screens/SettingsScreen.qml" line="81"/>
+        <location filename="../screens/SettingsScreen.qml" line="223"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="221"/>
+        <location filename="../screens/SettingsScreen.qml" line="87"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="95"/>
-        <location filename="../screens/SettingsScreen.qml" line="225"/>
+        <location filename="../screens/SettingsScreen.qml" line="99"/>
+        <location filename="../screens/SettingsScreen.qml" line="229"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="693"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="691"/>
+        <location filename="../screens/SettingsScreen.qml" line="695"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="693"/>
+        <location filename="../screens/SettingsScreen.qml" line="697"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="695"/>
+        <location filename="../screens/SettingsScreen.qml" line="699"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="697"/>
+        <location filename="../screens/SettingsScreen.qml" line="701"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="699"/>
+        <location filename="../screens/SettingsScreen.qml" line="703"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="701"/>
+        <location filename="../screens/SettingsScreen.qml" line="705"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="703"/>
+        <location filename="../screens/SettingsScreen.qml" line="707"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="705"/>
+        <location filename="../screens/SettingsScreen.qml" line="709"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="707"/>
+        <location filename="../screens/SettingsScreen.qml" line="711"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="709"/>
+        <location filename="../screens/SettingsScreen.qml" line="713"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="711"/>
+        <location filename="../screens/SettingsScreen.qml" line="715"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="226"/>
+        <location filename="../screens/SettingsScreen.qml" line="230"/>
         <source>Settings</source>
         <translation>Налаштування</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1339"/>
+        <location filename="../screens/SettingsScreen.qml" line="1370"/>
         <source>No settings available on this platform</source>
         <translation>На цій платформі налаштування недоступні</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="242"/>
-        <location filename="../screens/SystemsScreen.qml" line="343"/>
+        <location filename="../screens/SystemsScreen.qml" line="245"/>
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>%1 systems</source>
         <translation>%1 систем</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="243"/>
-        <location filename="../screens/SystemsScreen.qml" line="360"/>
+        <location filename="../screens/SystemsScreen.qml" line="246"/>
+        <location filename="../screens/SystemsScreen.qml" line="363"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="378"/>
+        <location filename="../screens/SystemsScreen.qml" line="381"/>
         <source>No systems in this category</source>
         <translation>У цій категорії немає систем</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="379"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -425,34 +425,34 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="116"/>
-        <location filename="../screens/GamesScreen.qml" line="151"/>
+        <location filename="../screens/GamesScreen.qml" line="127"/>
+        <location filename="../screens/GamesScreen.qml" line="162"/>
         <source>%1 files</source>
         <translation>%1 файлів</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="53"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="125"/>
-        <location filename="../screens/GamesScreen.qml" line="152"/>
+        <location filename="../screens/GamesScreen.qml" line="136"/>
+        <location filename="../screens/GamesScreen.qml" line="163"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="48"/>
+        <location filename="../screens/GamesScreen.qml" line="49"/>
         <source>Loading games…</source>
         <translation>Завантаження ігор…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="121"/>
+        <location filename="../screens/GamesScreen.qml" line="132"/>
         <source>Loading more…</source>
         <translation>Завантаження ще…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="47"/>
+        <location filename="../screens/GamesScreen.qml" line="48"/>
         <source>No games in this system</source>
         <translation>У цій системі немає ігор</translation>
     </message>
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="139"/>
+        <location filename="../screens/HubScreen.qml" line="149"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="145"/>
+        <location filename="../screens/HubScreen.qml" line="155"/>
         <source>Favorites</source>
         <translation>Вибране</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="150"/>
+        <location filename="../screens/HubScreen.qml" line="160"/>
         <source>Recently Played</source>
         <translation>Нещодавно зіграні</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="155"/>
+        <location filename="../screens/HubScreen.qml" line="165"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Налаштування</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="669"/>
+        <location filename="../screens/HubScreen.qml" line="701"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Немає доступних систем. Запустіть Оновлення бази даних з Налаштувань.</translation>
     </message>
@@ -553,138 +553,138 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1361"/>
+        <location filename="../app/Main.qml" line="1367"/>
         <source>Launch core</source>
         <translation>Запустити core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1367"/>
-        <location filename="../app/Main.qml" line="1606"/>
+        <location filename="../app/Main.qml" line="1373"/>
+        <location filename="../app/Main.qml" line="1612"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1425"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Remove from favorites</source>
         <translation>Видалити з вибраного</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1425"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Add to favorites</source>
         <translation>Додати до вибраного</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1430"/>
+        <location filename="../app/Main.qml" line="1436"/>
         <source>Write to NFC token</source>
         <translation>Записати на NFC-токен</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1434"/>
+        <location filename="../app/Main.qml" line="1440"/>
         <source>QR code</source>
         <translation>QR-код</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1409"/>
-        <location filename="../app/Main.qml" line="1444"/>
+        <location filename="../app/Main.qml" line="1415"/>
+        <location filename="../app/Main.qml" line="1450"/>
         <source>Launch game</source>
         <translation>Запустити гру</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2604"/>
+        <location filename="../app/Main.qml" line="2610"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2616"/>
         <source>Loading favorites…</source>
         <translation>Завантаження вибраного…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2606"/>
+        <location filename="../app/Main.qml" line="2612"/>
         <source>Loading games…</source>
         <translation>Завантаження ігор…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1374"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1380"/>
+        <location filename="../app/Main.qml" line="1403"/>
         <source>Update media database</source>
         <translation type="unfinished">Оновити базу медіа</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1377"/>
-        <location filename="../app/Main.qml" line="1400"/>
+        <location filename="../app/Main.qml" line="1383"/>
+        <location filename="../app/Main.qml" line="1406"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Отримати метадані</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1382"/>
-        <location filename="../app/Main.qml" line="1391"/>
+        <location filename="../app/Main.qml" line="1388"/>
+        <location filename="../app/Main.qml" line="1397"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1382"/>
-        <location filename="../app/Main.qml" line="1391"/>
+        <location filename="../app/Main.qml" line="1388"/>
+        <location filename="../app/Main.qml" line="1397"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1602"/>
+        <location filename="../app/Main.qml" line="1608"/>
         <source>Default</source>
         <translation type="unfinished">Типовий</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1602"/>
+        <location filename="../app/Main.qml" line="1608"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1926"/>
+        <location filename="../app/Main.qml" line="1932"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1930"/>
+        <location filename="../app/Main.qml" line="1936"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1944"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1948"/>
+        <location filename="../app/Main.qml" line="1954"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1952"/>
+        <location filename="../app/Main.qml" line="1958"/>
         <source>Retry</source>
         <translation type="unfinished">Повторити</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1956"/>
+        <location filename="../app/Main.qml" line="1962"/>
         <source>Cancel</source>
         <translation type="unfinished">Скасувати</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2608"/>
+        <location filename="../app/Main.qml" line="2614"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2612"/>
+        <location filename="../app/Main.qml" line="2618"/>
         <source>Loading recently played…</source>
         <translation>Завантаження нещодавніх…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2620"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2616"/>
+        <location filename="../app/Main.qml" line="2622"/>
         <source>Loading…</source>
         <translation>Завантаження…</translation>
     </message>
@@ -692,72 +692,72 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="683"/>
+        <location filename="../app/MainLayout.qml" line="685"/>
         <source>Writing failed</source>
         <translation>Помилка запису</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="683"/>
+        <location filename="../app/MainLayout.qml" line="685"/>
         <source>Put a writable card near the reader</source>
         <translation>Прикладіть картку для запису до зчитувача</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="811"/>
+        <location filename="../app/MainLayout.qml" line="813"/>
         <source>Are you sure you want to exit?</source>
         <translation>Ви впевнені, що хочете вийти?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="894"/>
-        <location filename="../app/MainLayout.qml" line="968"/>
+        <location filename="../app/MainLayout.qml" line="896"/>
+        <location filename="../app/MainLayout.qml" line="970"/>
         <source>Select</source>
         <translation>Вибрати</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="902"/>
-        <location filename="../app/MainLayout.qml" line="916"/>
-        <location filename="../app/MainLayout.qml" line="931"/>
-        <location filename="../app/MainLayout.qml" line="942"/>
+        <location filename="../app/MainLayout.qml" line="900"/>
+        <location filename="../app/MainLayout.qml" line="904"/>
+        <location filename="../app/MainLayout.qml" line="918"/>
+        <location filename="../app/MainLayout.qml" line="933"/>
+        <location filename="../app/MainLayout.qml" line="944"/>
         <source>Close</source>
         <translation>Закрити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="909"/>
-        <location filename="../app/MainLayout.qml" line="949"/>
-        <location filename="../app/MainLayout.qml" line="972"/>
-        <location filename="../app/MainLayout.qml" line="983"/>
+        <location filename="../app/MainLayout.qml" line="911"/>
+        <location filename="../app/MainLayout.qml" line="951"/>
+        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="985"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="927"/>
+        <location filename="../app/MainLayout.qml" line="929"/>
         <source>Done</source>
         <translation>Готово</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="957"/>
+        <location filename="../app/MainLayout.qml" line="959"/>
         <source>I understand</source>
         <translation>Я розумію</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="991"/>
+        <location filename="../app/MainLayout.qml" line="993"/>
         <source>Start</source>
         <translation>Почати</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1203"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Scroll</source>
         <translation>Прокрутка</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="890"/>
-        <location filename="../app/MainLayout.qml" line="964"/>
-        <location filename="../app/MainLayout.qml" line="1010"/>
-        <location filename="../app/MainLayout.qml" line="1047"/>
-        <location filename="../app/MainLayout.qml" line="1097"/>
-        <location filename="../app/MainLayout.qml" line="1146"/>
-        <location filename="../app/MainLayout.qml" line="1165"/>
-        <location filename="../app/MainLayout.qml" line="1232"/>
+        <location filename="../app/MainLayout.qml" line="892"/>
+        <location filename="../app/MainLayout.qml" line="966"/>
+        <location filename="../app/MainLayout.qml" line="1012"/>
+        <location filename="../app/MainLayout.qml" line="1049"/>
+        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1148"/>
+        <location filename="../app/MainLayout.qml" line="1167"/>
+        <location filename="../app/MainLayout.qml" line="1234"/>
         <source>Move</source>
         <translation>Переміщення</translation>
     </message>
@@ -777,81 +777,81 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Нещодавно зіграні</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="699"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="700"/>
+        <location filename="../app/MainLayout.qml" line="702"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="810"/>
+        <location filename="../app/MainLayout.qml" line="812"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1014"/>
-        <location filename="../app/MainLayout.qml" line="1057"/>
-        <location filename="../app/MainLayout.qml" line="1107"/>
-        <location filename="../app/MainLayout.qml" line="1151"/>
-        <location filename="../app/MainLayout.qml" line="1242"/>
+        <location filename="../app/MainLayout.qml" line="1016"/>
+        <location filename="../app/MainLayout.qml" line="1059"/>
+        <location filename="../app/MainLayout.qml" line="1109"/>
+        <location filename="../app/MainLayout.qml" line="1153"/>
+        <location filename="../app/MainLayout.qml" line="1244"/>
         <source>Open</source>
         <translation>Відкрити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1024"/>
+        <location filename="../app/MainLayout.qml" line="1026"/>
         <source>Quit</source>
         <translation>Вийти</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1033"/>
-        <location filename="../app/MainLayout.qml" line="1063"/>
-        <location filename="../app/MainLayout.qml" line="1074"/>
-        <location filename="../app/MainLayout.qml" line="1089"/>
-        <location filename="../app/MainLayout.qml" line="1116"/>
-        <location filename="../app/MainLayout.qml" line="1127"/>
-        <location filename="../app/MainLayout.qml" line="1139"/>
-        <location filename="../app/MainLayout.qml" line="1155"/>
-        <location filename="../app/MainLayout.qml" line="1189"/>
-        <location filename="../app/MainLayout.qml" line="1207"/>
-        <location filename="../app/MainLayout.qml" line="1216"/>
-        <location filename="../app/MainLayout.qml" line="1251"/>
-        <location filename="../app/MainLayout.qml" line="1262"/>
+        <location filename="../app/MainLayout.qml" line="1035"/>
+        <location filename="../app/MainLayout.qml" line="1065"/>
+        <location filename="../app/MainLayout.qml" line="1076"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
+        <location filename="../app/MainLayout.qml" line="1118"/>
+        <location filename="../app/MainLayout.qml" line="1129"/>
+        <location filename="../app/MainLayout.qml" line="1141"/>
+        <location filename="../app/MainLayout.qml" line="1157"/>
+        <location filename="../app/MainLayout.qml" line="1191"/>
+        <location filename="../app/MainLayout.qml" line="1209"/>
+        <location filename="../app/MainLayout.qml" line="1218"/>
+        <location filename="../app/MainLayout.qml" line="1253"/>
+        <location filename="../app/MainLayout.qml" line="1264"/>
         <source>Back</source>
         <translation>Назад</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1053"/>
-        <location filename="../app/MainLayout.qml" line="1103"/>
-        <location filename="../app/MainLayout.qml" line="1238"/>
+        <location filename="../app/MainLayout.qml" line="1055"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
+        <location filename="../app/MainLayout.qml" line="1240"/>
         <source>Page</source>
         <translation>Сторінка</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1060"/>
-        <location filename="../app/MainLayout.qml" line="1112"/>
-        <location filename="../app/MainLayout.qml" line="1247"/>
+        <location filename="../app/MainLayout.qml" line="1022"/>
+        <location filename="../app/MainLayout.qml" line="1062"/>
+        <location filename="../app/MainLayout.qml" line="1114"/>
+        <location filename="../app/MainLayout.qml" line="1249"/>
         <source>Options</source>
         <translation>Параметри</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1070"/>
-        <location filename="../app/MainLayout.qml" line="1123"/>
-        <location filename="../app/MainLayout.qml" line="1258"/>
+        <location filename="../app/MainLayout.qml" line="940"/>
+        <location filename="../app/MainLayout.qml" line="1072"/>
+        <location filename="../app/MainLayout.qml" line="1125"/>
+        <location filename="../app/MainLayout.qml" line="1260"/>
         <source>Retry</source>
         <translation>Повторити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1174"/>
+        <location filename="../app/MainLayout.qml" line="1176"/>
         <source>Change</source>
         <translation>Змінити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1180"/>
+        <location filename="../app/MainLayout.qml" line="1182"/>
         <source>Toggle</source>
         <translation>Перемкнути</translation>
     </message>
@@ -864,12 +864,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Завантаження…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="365"/>
+        <location filename="../screens/MediaListScreen.qml" line="395"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 записів</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="366"/>
+        <location filename="../screens/MediaListScreen.qml" line="396"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>Ні</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="198"/>
+        <location filename="../components/Modal.qml" line="246"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
@@ -936,24 +936,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="132"/>
-        <location filename="../screens/SettingsScreen.qml" line="718"/>
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
+        <location filename="../screens/SettingsScreen.qml" line="741"/>
         <source>Language</source>
         <translation>Мова</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="754"/>
+        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <location filename="../screens/SettingsScreen.qml" line="777"/>
         <source>Browsing layout</source>
         <translation>Режим перегляду</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="150"/>
+        <location filename="../screens/SettingsScreen.qml" line="165"/>
         <source>Mouse support</source>
         <translation>Підтримка миші</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="157"/>
+        <location filename="../screens/SettingsScreen.qml" line="177"/>
         <source>Update media database</source>
         <translation>Оновити базу медіа</translation>
     </message>
@@ -962,47 +962,47 @@ Euskara - devilschile2</source>
         <translation type="vanished">Загальні</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="745"/>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="768"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="145"/>
-        <location filename="../screens/SettingsScreen.qml" line="763"/>
+        <location filename="../screens/SettingsScreen.qml" line="160"/>
+        <location filename="../screens/SettingsScreen.qml" line="786"/>
         <source>Button style</source>
         <translation>Стиль кнопок</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="772"/>
+        <location filename="../screens/SettingsScreen.qml" line="132"/>
+        <location filename="../screens/SettingsScreen.qml" line="795"/>
         <source>Screensaver</source>
         <translation>Заставка</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="80"/>
-        <location filename="../screens/SettingsScreen.qml" line="209"/>
+        <location filename="../screens/SettingsScreen.qml" line="95"/>
+        <location filename="../screens/SettingsScreen.qml" line="229"/>
         <source>Library</source>
         <translation>Бібліотека</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="162"/>
+        <location filename="../screens/SettingsScreen.qml" line="182"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="112"/>
-        <location filename="../screens/SettingsScreen.qml" line="781"/>
+        <location filename="../screens/SettingsScreen.qml" line="127"/>
+        <location filename="../screens/SettingsScreen.qml" line="804"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="167"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
         <source>Scrape metadata</source>
         <translation>Отримати метадані</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="172"/>
+        <location filename="../screens/SettingsScreen.qml" line="192"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1011,397 +1011,402 @@ Euskara - devilschile2</source>
         <translation type="vanished">Розширені</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="184"/>
+        <location filename="../screens/SettingsScreen.qml" line="204"/>
         <source>Debug logging</source>
         <translation>Журнал відлагодження</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="189"/>
+        <location filename="../screens/SettingsScreen.qml" line="209"/>
         <source>Upload log file</source>
         <translation>Завантажити файл журналу</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="179"/>
+        <location filename="../screens/SettingsScreen.qml" line="199"/>
         <source>About / License</source>
         <translation>Про програму / Ліцензія</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
-        <location filename="../screens/SettingsScreen.qml" line="727"/>
+        <location filename="../screens/SettingsScreen.qml" line="137"/>
+        <location filename="../screens/SettingsScreen.qml" line="750"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="127"/>
-        <location filename="../screens/SettingsScreen.qml" line="736"/>
+        <location filename="../screens/SettingsScreen.qml" line="142"/>
+        <location filename="../screens/SettingsScreen.qml" line="759"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="137"/>
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="226"/>
+        <location filename="../screens/SettingsScreen.qml" line="170"/>
+        <source>Reduce motion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
         <source>Optimizing</source>
         <translation>Оптимізація</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="228"/>
-        <location filename="../screens/SettingsScreen.qml" line="237"/>
+        <location filename="../screens/SettingsScreen.qml" line="248"/>
+        <location filename="../screens/SettingsScreen.qml" line="257"/>
         <source>Paused</source>
         <translation>Призупинено</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="228"/>
-        <location filename="../screens/SettingsScreen.qml" line="237"/>
+        <location filename="../screens/SettingsScreen.qml" line="248"/>
+        <location filename="../screens/SettingsScreen.qml" line="257"/>
         <source>In progress</source>
         <translation>Виконується</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="231"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>%1 indexed</source>
         <translation>%1 проіндексовано</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="240"/>
+        <location filename="../screens/SettingsScreen.qml" line="260"/>
         <source>%1 scraped</source>
         <translation>%1 зібрано</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="472"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="472"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Start</source>
         <translation>Почати</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="474"/>
+        <location filename="../screens/SettingsScreen.qml" line="497"/>
         <source>Upload</source>
         <translation>Вивантажити</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Open</source>
         <translation>Відкрити</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="556"/>
+        <location filename="../screens/SettingsScreen.qml" line="579"/>
         <source>English</source>
         <translation>Англійська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="558"/>
+        <location filename="../screens/SettingsScreen.qml" line="581"/>
         <source>Italian</source>
         <translation>Італійська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="560"/>
+        <location filename="../screens/SettingsScreen.qml" line="583"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="562"/>
+        <location filename="../screens/SettingsScreen.qml" line="585"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="564"/>
+        <location filename="../screens/SettingsScreen.qml" line="587"/>
         <source>German</source>
         <translation>Німецька</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="566"/>
+        <location filename="../screens/SettingsScreen.qml" line="589"/>
         <source>Greek</source>
         <translation>Грецька</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="568"/>
+        <location filename="../screens/SettingsScreen.qml" line="591"/>
         <source>Japanese</source>
         <translation>Японська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="570"/>
+        <location filename="../screens/SettingsScreen.qml" line="593"/>
         <source>Korean</source>
         <translation>Корейська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="595"/>
         <source>Dutch</source>
         <translation>Нідерландська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="597"/>
         <source>Romanian</source>
         <translation>Румунська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="599"/>
         <source>Slovak</source>
         <translation>Словацька</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="601"/>
         <source>Ukrainian</source>
         <translation>Українська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="603"/>
         <source>Chinese (Simplified)</source>
         <translation>Китайська (спрощена)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="605"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="607"/>
         <source>Hebrew</source>
         <translation>Іврит</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="588"/>
+        <location filename="../screens/SettingsScreen.qml" line="611"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="589"/>
-        <location filename="../screens/SettingsScreen.qml" line="597"/>
-        <location filename="../screens/SettingsScreen.qml" line="671"/>
+        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="620"/>
+        <location filename="../screens/SettingsScreen.qml" line="694"/>
         <source>Auto</source>
         <translation>Автоматично</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="594"/>
+        <location filename="../screens/SettingsScreen.qml" line="617"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="596"/>
+        <location filename="../screens/SettingsScreen.qml" line="619"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="607"/>
+        <location filename="../screens/SettingsScreen.qml" line="630"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="632"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="611"/>
+        <location filename="../screens/SettingsScreen.qml" line="634"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="635"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="640"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="619"/>
+        <location filename="../screens/SettingsScreen.qml" line="642"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="620"/>
+        <location filename="../screens/SettingsScreen.qml" line="643"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="625"/>
+        <location filename="../screens/SettingsScreen.qml" line="648"/>
         <source>Detailed list view</source>
         <translation>Детальний перегляд списку</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="626"/>
+        <location filename="../screens/SettingsScreen.qml" line="649"/>
         <source>Grid view</source>
         <translation>Перегляд сіткою</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="631"/>
+        <location filename="../screens/SettingsScreen.qml" line="654"/>
         <source>Style B</source>
         <translation>Стиль B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="633"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Style C</source>
         <translation>Стиль C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="658"/>
         <source>Style D</source>
         <translation>Стиль D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="659"/>
         <source>Style A</source>
         <translation>Стиль A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1292"/>
+        <location filename="../screens/SettingsScreen.qml" line="1358"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="526"/>
+        <location filename="../screens/SettingsScreen.qml" line="549"/>
         <source>Default</source>
         <translation>Типовий</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="674"/>
         <source>Off</source>
         <translation>Вимкнено</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="653"/>
+        <location filename="../screens/SettingsScreen.qml" line="676"/>
         <source>1 second (testing)</source>
         <translation>1 секунда (тест)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="655"/>
+        <location filename="../screens/SettingsScreen.qml" line="678"/>
         <source>1 minute</source>
         <translation>1 хвилина</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="657"/>
+        <location filename="../screens/SettingsScreen.qml" line="680"/>
         <source>2 minutes</source>
         <translation>2 хвилини</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="659"/>
+        <location filename="../screens/SettingsScreen.qml" line="682"/>
         <source>5 minutes</source>
         <translation>5 хвилин</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="661"/>
+        <location filename="../screens/SettingsScreen.qml" line="684"/>
         <source>10 minutes</source>
         <translation>10 хвилин</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="663"/>
+        <location filename="../screens/SettingsScreen.qml" line="686"/>
         <source>15 minutes</source>
         <translation>15 хвилин</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="665"/>
+        <location filename="../screens/SettingsScreen.qml" line="688"/>
         <source>30 minutes</source>
         <translation>30 хвилин</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="666"/>
+        <location filename="../screens/SettingsScreen.qml" line="689"/>
         <source>%1 seconds</source>
         <translation>%1 секунд</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="96"/>
-        <location filename="../screens/SettingsScreen.qml" line="709"/>
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="732"/>
         <source>Resolution</source>
         <translation>Роздільна здатність</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="68"/>
-        <location filename="../screens/SettingsScreen.qml" line="205"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="74"/>
-        <location filename="../screens/SettingsScreen.qml" line="207"/>
+        <location filename="../screens/SettingsScreen.qml" line="89"/>
+        <location filename="../screens/SettingsScreen.qml" line="227"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="86"/>
-        <location filename="../screens/SettingsScreen.qml" line="211"/>
+        <location filename="../screens/SettingsScreen.qml" line="101"/>
+        <location filename="../screens/SettingsScreen.qml" line="231"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="673"/>
+        <location filename="../screens/SettingsScreen.qml" line="696"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="675"/>
+        <location filename="../screens/SettingsScreen.qml" line="698"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="677"/>
+        <location filename="../screens/SettingsScreen.qml" line="700"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="679"/>
+        <location filename="../screens/SettingsScreen.qml" line="702"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="681"/>
+        <location filename="../screens/SettingsScreen.qml" line="704"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="683"/>
+        <location filename="../screens/SettingsScreen.qml" line="706"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="685"/>
+        <location filename="../screens/SettingsScreen.qml" line="708"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="687"/>
+        <location filename="../screens/SettingsScreen.qml" line="710"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="712"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="691"/>
+        <location filename="../screens/SettingsScreen.qml" line="714"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="693"/>
+        <location filename="../screens/SettingsScreen.qml" line="716"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="695"/>
+        <location filename="../screens/SettingsScreen.qml" line="718"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="212"/>
+        <location filename="../screens/SettingsScreen.qml" line="232"/>
         <source>Settings</source>
         <translation>Налаштування</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1280"/>
+        <location filename="../screens/SettingsScreen.qml" line="1346"/>
         <source>No settings available on this platform</source>
         <translation>На цій платформі налаштування недоступні</translation>
     </message>
@@ -1409,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="206"/>
-        <location filename="../screens/SystemsScreen.qml" line="304"/>
+        <location filename="../screens/SystemsScreen.qml" line="229"/>
+        <location filename="../screens/SystemsScreen.qml" line="329"/>
         <source>%1 systems</source>
         <translation>%1 систем</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="207"/>
-        <location filename="../screens/SystemsScreen.qml" line="321"/>
+        <location filename="../screens/SystemsScreen.qml" line="230"/>
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="339"/>
+        <location filename="../screens/SystemsScreen.qml" line="364"/>
         <source>No systems in this category</source>
         <translation>У цій категорії немає систем</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="340"/>
+        <location filename="../screens/SystemsScreen.qml" line="365"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>
@@ -1434,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="364"/>
+        <location filename="../components/Tile.qml" line="475"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -97,100 +97,100 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Завантаження…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="196"/>
+        <location filename="../components/BrowseDetailPane.qml" line="167"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="196"/>
+        <location filename="../components/BrowseDetailPane.qml" line="167"/>
         <source>Yr</source>
         <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="198"/>
+        <location filename="../components/BrowseDetailPane.qml" line="169"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="198"/>
+        <location filename="../components/BrowseDetailPane.qml" line="169"/>
         <source>Gen</source>
         <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="200"/>
+        <location filename="../components/BrowseDetailPane.qml" line="171"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="200"/>
+        <location filename="../components/BrowseDetailPane.qml" line="171"/>
         <source>Plyr</source>
         <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="202"/>
+        <location filename="../components/BrowseDetailPane.qml" line="173"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="202"/>
+        <location filename="../components/BrowseDetailPane.qml" line="173"/>
         <source>Dev</source>
         <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="204"/>
+        <location filename="../components/BrowseDetailPane.qml" line="175"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="204"/>
+        <location filename="../components/BrowseDetailPane.qml" line="175"/>
         <source>Pub</source>
         <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="206"/>
+        <location filename="../components/BrowseDetailPane.qml" line="177"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="206"/>
+        <location filename="../components/BrowseDetailPane.qml" line="177"/>
         <source>Rtg</source>
         <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="208"/>
+        <location filename="../components/BrowseDetailPane.qml" line="179"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="208"/>
+        <location filename="../components/BrowseDetailPane.qml" line="179"/>
         <source>Cat</source>
         <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="210"/>
+        <location filename="../components/BrowseDetailPane.qml" line="181"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="210"/>
+        <location filename="../components/BrowseDetailPane.qml" line="181"/>
         <source>Date</source>
         <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="212"/>
+        <location filename="../components/BrowseDetailPane.qml" line="183"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="212"/>
+        <location filename="../components/BrowseDetailPane.qml" line="183"/>
         <source>Mfr</source>
         <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
@@ -425,8 +425,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="127"/>
-        <location filename="../screens/GamesScreen.qml" line="162"/>
+        <location filename="../screens/GamesScreen.qml" line="128"/>
+        <location filename="../screens/GamesScreen.qml" line="163"/>
         <source>%1 files</source>
         <translation>%1 файлів</translation>
     </message>
@@ -436,8 +436,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="136"/>
-        <location filename="../screens/GamesScreen.qml" line="163"/>
+        <location filename="../screens/GamesScreen.qml" line="137"/>
+        <location filename="../screens/GamesScreen.qml" line="164"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -447,7 +447,7 @@ Euskara - devilschile2</source>
         <translation>Завантаження ігор…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="132"/>
+        <location filename="../screens/GamesScreen.qml" line="133"/>
         <source>Loading more…</source>
         <translation>Завантаження ще…</translation>
     </message>
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="149"/>
+        <location filename="../screens/HubScreen.qml" line="156"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="155"/>
+        <location filename="../screens/HubScreen.qml" line="162"/>
         <source>Favorites</source>
         <translation>Вибране</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="160"/>
+        <location filename="../screens/HubScreen.qml" line="167"/>
         <source>Recently Played</source>
         <translation>Нещодавно зіграні</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="165"/>
+        <location filename="../screens/HubScreen.qml" line="172"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Налаштування</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="701"/>
+        <location filename="../screens/HubScreen.qml" line="722"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Немає доступних систем. Запустіть Оновлення бази даних з Налаштувань.</translation>
     </message>
@@ -553,138 +553,138 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1367"/>
+        <location filename="../app/Main.qml" line="1381"/>
         <source>Launch core</source>
         <translation>Запустити core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1373"/>
-        <location filename="../app/Main.qml" line="1612"/>
+        <location filename="../app/Main.qml" line="1387"/>
+        <location filename="../app/Main.qml" line="1626"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1445"/>
         <source>Remove from favorites</source>
         <translation>Видалити з вибраного</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1445"/>
         <source>Add to favorites</source>
         <translation>Додати до вибраного</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1436"/>
+        <location filename="../app/Main.qml" line="1450"/>
         <source>Write to NFC token</source>
         <translation>Записати на NFC-токен</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1440"/>
+        <location filename="../app/Main.qml" line="1454"/>
         <source>QR code</source>
         <translation>QR-код</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1415"/>
-        <location filename="../app/Main.qml" line="1450"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1464"/>
         <source>Launch game</source>
         <translation>Запустити гру</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2624"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2616"/>
+        <location filename="../app/Main.qml" line="2630"/>
         <source>Loading favorites…</source>
         <translation>Завантаження вибраного…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2612"/>
+        <location filename="../app/Main.qml" line="2626"/>
         <source>Loading games…</source>
         <translation>Завантаження ігор…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1380"/>
-        <location filename="../app/Main.qml" line="1403"/>
+        <location filename="../app/Main.qml" line="1394"/>
+        <location filename="../app/Main.qml" line="1417"/>
         <source>Update media database</source>
         <translation type="unfinished">Оновити базу медіа</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1383"/>
-        <location filename="../app/Main.qml" line="1406"/>
+        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1420"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Отримати метадані</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1388"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1411"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1388"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1411"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1608"/>
+        <location filename="../app/Main.qml" line="1622"/>
         <source>Default</source>
         <translation type="unfinished">Типовий</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1608"/>
+        <location filename="../app/Main.qml" line="1622"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1932"/>
+        <location filename="../app/Main.qml" line="1946"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1936"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1950"/>
+        <location filename="../app/Main.qml" line="1964"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1954"/>
+        <location filename="../app/Main.qml" line="1968"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1958"/>
+        <location filename="../app/Main.qml" line="1972"/>
         <source>Retry</source>
         <translation type="unfinished">Повторити</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1962"/>
+        <location filename="../app/Main.qml" line="1976"/>
         <source>Cancel</source>
         <translation type="unfinished">Скасувати</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2628"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2618"/>
+        <location filename="../app/Main.qml" line="2632"/>
         <source>Loading recently played…</source>
         <translation>Завантаження нещодавніх…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2620"/>
+        <location filename="../app/Main.qml" line="2634"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2622"/>
+        <location filename="../app/Main.qml" line="2636"/>
         <source>Loading…</source>
         <translation>Завантаження…</translation>
     </message>
@@ -864,12 +864,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Завантаження…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="395"/>
+        <location filename="../screens/MediaListScreen.qml" line="436"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 записів</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="396"/>
+        <location filename="../screens/MediaListScreen.qml" line="437"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>Ні</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="246"/>
+        <location filename="../components/Modal.qml" line="256"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
@@ -1262,7 +1262,7 @@ Euskara - devilschile2</source>
         <translation>Стиль A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1358"/>
+        <location filename="../screens/SettingsScreen.qml" line="1368"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1406,7 +1406,7 @@ Euskara - devilschile2</source>
         <translation>Налаштування</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1346"/>
+        <location filename="../screens/SettingsScreen.qml" line="1356"/>
         <source>No settings available on this platform</source>
         <translation>На цій платформі налаштування недоступні</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="229"/>
-        <location filename="../screens/SystemsScreen.qml" line="329"/>
+        <location filename="../screens/SystemsScreen.qml" line="236"/>
+        <location filename="../screens/SystemsScreen.qml" line="338"/>
         <source>%1 systems</source>
         <translation>%1 систем</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="230"/>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="237"/>
+        <location filename="../screens/SystemsScreen.qml" line="355"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="364"/>
+        <location filename="../screens/SystemsScreen.qml" line="373"/>
         <source>No systems in this category</source>
         <translation>У цій категорії немає систем</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="365"/>
+        <location filename="../screens/SystemsScreen.qml" line="374"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>
@@ -1439,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="475"/>
+        <location filename="../components/Tile.qml" line="539"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="156"/>
+        <location filename="../screens/HubScreen.qml" line="154"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="162"/>
+        <location filename="../screens/HubScreen.qml" line="160"/>
         <source>Favorites</source>
         <translation>Вибране</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="167"/>
+        <location filename="../screens/HubScreen.qml" line="165"/>
         <source>Recently Played</source>
         <translation>Нещодавно зіграні</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="172"/>
+        <location filename="../screens/HubScreen.qml" line="170"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Налаштування</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="722"/>
+        <location filename="../screens/HubScreen.qml" line="718"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Немає доступних систем. Запустіть Оновлення бази даних з Налаштувань.</translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>Ні</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="256"/>
+        <location filename="../components/Modal.qml" line="246"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
@@ -936,24 +936,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SettingsScreen</name>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147"/>
-        <location filename="../screens/SettingsScreen.qml" line="741"/>
+        <location filename="../screens/SettingsScreen.qml" line="141"/>
+        <location filename="../screens/SettingsScreen.qml" line="734"/>
         <source>Language</source>
         <translation>Мова</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
-        <location filename="../screens/SettingsScreen.qml" line="777"/>
+        <location filename="../screens/SettingsScreen.qml" line="116"/>
+        <location filename="../screens/SettingsScreen.qml" line="770"/>
         <source>Browsing layout</source>
         <translation>Режим перегляду</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="165"/>
+        <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>Mouse support</source>
         <translation>Підтримка миші</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="177"/>
+        <location filename="../screens/SettingsScreen.qml" line="171"/>
         <source>Update media database</source>
         <translation>Оновити базу медіа</translation>
     </message>
@@ -962,47 +962,47 @@ Euskara - devilschile2</source>
         <translation type="vanished">Загальні</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="768"/>
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="761"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="160"/>
-        <location filename="../screens/SettingsScreen.qml" line="786"/>
+        <location filename="../screens/SettingsScreen.qml" line="154"/>
+        <location filename="../screens/SettingsScreen.qml" line="779"/>
         <source>Button style</source>
         <translation>Стиль кнопок</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="132"/>
-        <location filename="../screens/SettingsScreen.qml" line="795"/>
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
+        <location filename="../screens/SettingsScreen.qml" line="788"/>
         <source>Screensaver</source>
         <translation>Заставка</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="95"/>
-        <location filename="../screens/SettingsScreen.qml" line="229"/>
+        <location filename="../screens/SettingsScreen.qml" line="89"/>
+        <location filename="../screens/SettingsScreen.qml" line="223"/>
         <source>Library</source>
         <translation>Бібліотека</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="182"/>
+        <location filename="../screens/SettingsScreen.qml" line="176"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="127"/>
-        <location filename="../screens/SettingsScreen.qml" line="804"/>
+        <location filename="../screens/SettingsScreen.qml" line="121"/>
+        <location filename="../screens/SettingsScreen.qml" line="797"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <location filename="../screens/SettingsScreen.qml" line="181"/>
         <source>Scrape metadata</source>
         <translation>Отримати метадані</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="192"/>
+        <location filename="../screens/SettingsScreen.qml" line="186"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1011,402 +1011,402 @@ Euskara - devilschile2</source>
         <translation type="vanished">Розширені</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="204"/>
+        <location filename="../screens/SettingsScreen.qml" line="198"/>
         <source>Debug logging</source>
         <translation>Журнал відлагодження</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="209"/>
+        <location filename="../screens/SettingsScreen.qml" line="203"/>
         <source>Upload log file</source>
         <translation>Завантажити файл журналу</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="199"/>
+        <location filename="../screens/SettingsScreen.qml" line="193"/>
         <source>About / License</source>
         <translation>Про програму / Ліцензія</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="137"/>
-        <location filename="../screens/SettingsScreen.qml" line="750"/>
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="743"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="142"/>
-        <location filename="../screens/SettingsScreen.qml" line="759"/>
+        <location filename="../screens/SettingsScreen.qml" line="136"/>
+        <location filename="../screens/SettingsScreen.qml" line="752"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152"/>
+        <location filename="../screens/SettingsScreen.qml" line="146"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="170"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
         <source>Reduce motion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="240"/>
         <source>Optimizing</source>
         <translation>Оптимізація</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="248"/>
-        <location filename="../screens/SettingsScreen.qml" line="257"/>
+        <location filename="../screens/SettingsScreen.qml" line="242"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>Paused</source>
         <translation>Призупинено</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="248"/>
-        <location filename="../screens/SettingsScreen.qml" line="257"/>
+        <location filename="../screens/SettingsScreen.qml" line="242"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>In progress</source>
         <translation>Виконується</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="245"/>
         <source>%1 indexed</source>
         <translation>%1 проіндексовано</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="260"/>
+        <location filename="../screens/SettingsScreen.qml" line="254"/>
         <source>%1 scraped</source>
         <translation>%1 зібрано</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="495"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="495"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Start</source>
         <translation>Почати</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="497"/>
+        <location filename="../screens/SettingsScreen.qml" line="490"/>
         <source>Upload</source>
         <translation>Вивантажити</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <location filename="../screens/SettingsScreen.qml" line="491"/>
         <source>Open</source>
         <translation>Відкрити</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="579"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>English</source>
         <translation>Англійська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="581"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Italian</source>
         <translation>Італійська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="583"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="585"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="587"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>German</source>
         <translation>Німецька</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="589"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Greek</source>
         <translation>Грецька</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="591"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Japanese</source>
         <translation>Японська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="593"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Korean</source>
         <translation>Корейська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="595"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Dutch</source>
         <translation>Нідерландська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="597"/>
+        <location filename="../screens/SettingsScreen.qml" line="590"/>
         <source>Romanian</source>
         <translation>Румунська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="599"/>
+        <location filename="../screens/SettingsScreen.qml" line="592"/>
         <source>Slovak</source>
         <translation>Словацька</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="601"/>
+        <location filename="../screens/SettingsScreen.qml" line="594"/>
         <source>Ukrainian</source>
         <translation>Українська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="603"/>
+        <location filename="../screens/SettingsScreen.qml" line="596"/>
         <source>Chinese (Simplified)</source>
         <translation>Китайська (спрощена)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="605"/>
+        <location filename="../screens/SettingsScreen.qml" line="598"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="607"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Hebrew</source>
         <translation>Іврит</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="611"/>
+        <location filename="../screens/SettingsScreen.qml" line="604"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
-        <location filename="../screens/SettingsScreen.qml" line="620"/>
-        <location filename="../screens/SettingsScreen.qml" line="694"/>
+        <location filename="../screens/SettingsScreen.qml" line="605"/>
+        <location filename="../screens/SettingsScreen.qml" line="613"/>
+        <location filename="../screens/SettingsScreen.qml" line="687"/>
         <source>Auto</source>
         <translation>Автоматично</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="610"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="619"/>
+        <location filename="../screens/SettingsScreen.qml" line="612"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="630"/>
+        <location filename="../screens/SettingsScreen.qml" line="623"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="632"/>
+        <location filename="../screens/SettingsScreen.qml" line="625"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="634"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="628"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="640"/>
+        <location filename="../screens/SettingsScreen.qml" line="633"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="642"/>
+        <location filename="../screens/SettingsScreen.qml" line="635"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="643"/>
+        <location filename="../screens/SettingsScreen.qml" line="636"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="648"/>
+        <location filename="../screens/SettingsScreen.qml" line="641"/>
         <source>Detailed list view</source>
         <translation>Детальний перегляд списку</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="642"/>
         <source>Grid view</source>
         <translation>Перегляд сіткою</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="654"/>
+        <location filename="../screens/SettingsScreen.qml" line="647"/>
         <source>Style B</source>
         <translation>Стиль B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="656"/>
+        <location filename="../screens/SettingsScreen.qml" line="649"/>
         <source>Style C</source>
         <translation>Стиль C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="658"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
         <source>Style D</source>
         <translation>Стиль D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="659"/>
+        <location filename="../screens/SettingsScreen.qml" line="652"/>
         <source>Style A</source>
         <translation>Стиль A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1368"/>
+        <location filename="../screens/SettingsScreen.qml" line="1351"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="549"/>
+        <location filename="../screens/SettingsScreen.qml" line="542"/>
         <source>Default</source>
         <translation>Типовий</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="674"/>
+        <location filename="../screens/SettingsScreen.qml" line="667"/>
         <source>Off</source>
         <translation>Вимкнено</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="676"/>
+        <location filename="../screens/SettingsScreen.qml" line="669"/>
         <source>1 second (testing)</source>
         <translation>1 секунда (тест)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="678"/>
+        <location filename="../screens/SettingsScreen.qml" line="671"/>
         <source>1 minute</source>
         <translation>1 хвилина</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="680"/>
+        <location filename="../screens/SettingsScreen.qml" line="673"/>
         <source>2 minutes</source>
         <translation>2 хвилини</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="682"/>
+        <location filename="../screens/SettingsScreen.qml" line="675"/>
         <source>5 minutes</source>
         <translation>5 хвилин</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="684"/>
+        <location filename="../screens/SettingsScreen.qml" line="677"/>
         <source>10 minutes</source>
         <translation>10 хвилин</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="686"/>
+        <location filename="../screens/SettingsScreen.qml" line="679"/>
         <source>15 minutes</source>
         <translation>15 хвилин</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="688"/>
+        <location filename="../screens/SettingsScreen.qml" line="681"/>
         <source>30 minutes</source>
         <translation>30 хвилин</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="682"/>
         <source>%1 seconds</source>
         <translation>%1 секунд</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
-        <location filename="../screens/SettingsScreen.qml" line="732"/>
+        <location filename="../screens/SettingsScreen.qml" line="105"/>
+        <location filename="../screens/SettingsScreen.qml" line="725"/>
         <source>Resolution</source>
         <translation>Роздільна здатність</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="225"/>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="219"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="89"/>
-        <location filename="../screens/SettingsScreen.qml" line="227"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="221"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="101"/>
-        <location filename="../screens/SettingsScreen.qml" line="231"/>
+        <location filename="../screens/SettingsScreen.qml" line="95"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="696"/>
+        <location filename="../screens/SettingsScreen.qml" line="689"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="698"/>
+        <location filename="../screens/SettingsScreen.qml" line="691"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="700"/>
+        <location filename="../screens/SettingsScreen.qml" line="693"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="702"/>
+        <location filename="../screens/SettingsScreen.qml" line="695"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="704"/>
+        <location filename="../screens/SettingsScreen.qml" line="697"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="706"/>
+        <location filename="../screens/SettingsScreen.qml" line="699"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="708"/>
+        <location filename="../screens/SettingsScreen.qml" line="701"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="710"/>
+        <location filename="../screens/SettingsScreen.qml" line="703"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="712"/>
+        <location filename="../screens/SettingsScreen.qml" line="705"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="714"/>
+        <location filename="../screens/SettingsScreen.qml" line="707"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="716"/>
+        <location filename="../screens/SettingsScreen.qml" line="709"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="718"/>
+        <location filename="../screens/SettingsScreen.qml" line="711"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="232"/>
+        <location filename="../screens/SettingsScreen.qml" line="226"/>
         <source>Settings</source>
         <translation>Налаштування</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1356"/>
+        <location filename="../screens/SettingsScreen.qml" line="1339"/>
         <source>No settings available on this platform</source>
         <translation>На цій платформі налаштування недоступні</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="236"/>
-        <location filename="../screens/SystemsScreen.qml" line="338"/>
+        <location filename="../screens/SystemsScreen.qml" line="242"/>
+        <location filename="../screens/SystemsScreen.qml" line="343"/>
         <source>%1 systems</source>
         <translation>%1 систем</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="237"/>
-        <location filename="../screens/SystemsScreen.qml" line="355"/>
+        <location filename="../screens/SystemsScreen.qml" line="243"/>
+        <location filename="../screens/SystemsScreen.qml" line="360"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="373"/>
+        <location filename="../screens/SystemsScreen.qml" line="378"/>
         <source>No systems in this category</source>
         <translation>У цій категорії немає систем</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="374"/>
+        <location filename="../screens/SystemsScreen.qml" line="379"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>
@@ -1439,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="539"/>
+        <location filename="../components/Tile.qml" line="501"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="156"/>
+        <location filename="../screens/HubScreen.qml" line="154"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="162"/>
+        <location filename="../screens/HubScreen.qml" line="160"/>
         <source>Favorites</source>
         <translation>收藏</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="167"/>
+        <location filename="../screens/HubScreen.qml" line="165"/>
         <source>Recently Played</source>
         <translation>最近游玩</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="172"/>
+        <location filename="../screens/HubScreen.qml" line="170"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">设置</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="722"/>
+        <location filename="../screens/HubScreen.qml" line="718"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>没有可用系统。请在“设置”中运行“更新媒体数据库”。</translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>否</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="256"/>
+        <location filename="../components/Modal.qml" line="246"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
@@ -940,64 +940,64 @@ Euskara - devilschile2</source>
         <translation type="vanished">常规</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="147"/>
-        <location filename="../screens/SettingsScreen.qml" line="741"/>
+        <location filename="../screens/SettingsScreen.qml" line="141"/>
+        <location filename="../screens/SettingsScreen.qml" line="734"/>
         <source>Language</source>
         <translation>语言</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="768"/>
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="761"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
-        <location filename="../screens/SettingsScreen.qml" line="777"/>
+        <location filename="../screens/SettingsScreen.qml" line="116"/>
+        <location filename="../screens/SettingsScreen.qml" line="770"/>
         <source>Browsing layout</source>
         <translation>浏览布局</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="160"/>
-        <location filename="../screens/SettingsScreen.qml" line="786"/>
+        <location filename="../screens/SettingsScreen.qml" line="154"/>
+        <location filename="../screens/SettingsScreen.qml" line="779"/>
         <source>Button style</source>
         <translation>按钮样式</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="132"/>
-        <location filename="../screens/SettingsScreen.qml" line="795"/>
+        <location filename="../screens/SettingsScreen.qml" line="126"/>
+        <location filename="../screens/SettingsScreen.qml" line="788"/>
         <source>Screensaver</source>
         <translation>屏幕保护程序</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="95"/>
-        <location filename="../screens/SettingsScreen.qml" line="229"/>
+        <location filename="../screens/SettingsScreen.qml" line="89"/>
+        <location filename="../screens/SettingsScreen.qml" line="223"/>
         <source>Library</source>
         <translation>资料库</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="182"/>
+        <location filename="../screens/SettingsScreen.qml" line="176"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="127"/>
-        <location filename="../screens/SettingsScreen.qml" line="804"/>
+        <location filename="../screens/SettingsScreen.qml" line="121"/>
+        <location filename="../screens/SettingsScreen.qml" line="797"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="177"/>
+        <location filename="../screens/SettingsScreen.qml" line="171"/>
         <source>Update media database</source>
         <translation>更新媒体数据库</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="187"/>
+        <location filename="../screens/SettingsScreen.qml" line="181"/>
         <source>Scrape metadata</source>
         <translation>抓取元数据</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="192"/>
+        <location filename="../screens/SettingsScreen.qml" line="186"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1006,407 +1006,407 @@ Euskara - devilschile2</source>
         <translation type="vanished">高级</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="165"/>
+        <location filename="../screens/SettingsScreen.qml" line="159"/>
         <source>Mouse support</source>
         <translation>鼠标支持</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="204"/>
+        <location filename="../screens/SettingsScreen.qml" line="198"/>
         <source>Debug logging</source>
         <translation>调试日志</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="209"/>
+        <location filename="../screens/SettingsScreen.qml" line="203"/>
         <source>Upload log file</source>
         <translation>上传日志文件</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="199"/>
+        <location filename="../screens/SettingsScreen.qml" line="193"/>
         <source>About / License</source>
         <translation>关于 / 许可</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="137"/>
-        <location filename="../screens/SettingsScreen.qml" line="750"/>
+        <location filename="../screens/SettingsScreen.qml" line="131"/>
+        <location filename="../screens/SettingsScreen.qml" line="743"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="142"/>
-        <location filename="../screens/SettingsScreen.qml" line="759"/>
+        <location filename="../screens/SettingsScreen.qml" line="136"/>
+        <location filename="../screens/SettingsScreen.qml" line="752"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="152"/>
+        <location filename="../screens/SettingsScreen.qml" line="146"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="170"/>
+        <location filename="../screens/SettingsScreen.qml" line="164"/>
         <source>Reduce motion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="240"/>
         <source>Optimizing</source>
         <translation>正在优化</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="248"/>
-        <location filename="../screens/SettingsScreen.qml" line="257"/>
+        <location filename="../screens/SettingsScreen.qml" line="242"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>Paused</source>
         <translation>已暂停</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="248"/>
-        <location filename="../screens/SettingsScreen.qml" line="257"/>
+        <location filename="../screens/SettingsScreen.qml" line="242"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>In progress</source>
         <translation>进行中</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="245"/>
         <source>%1 indexed</source>
         <translation>已索引 %1 个</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="260"/>
+        <location filename="../screens/SettingsScreen.qml" line="254"/>
         <source>%1 scraped</source>
         <translation>已抓取 %1 个</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="495"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="495"/>
+        <location filename="../screens/SettingsScreen.qml" line="488"/>
         <source>Start</source>
         <translation>开始</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="497"/>
+        <location filename="../screens/SettingsScreen.qml" line="490"/>
         <source>Upload</source>
         <translation>上传</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="498"/>
+        <location filename="../screens/SettingsScreen.qml" line="491"/>
         <source>Open</source>
         <translation>打开</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="549"/>
+        <location filename="../screens/SettingsScreen.qml" line="542"/>
         <source>Default</source>
         <translation>默认</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="579"/>
+        <location filename="../screens/SettingsScreen.qml" line="572"/>
         <source>English</source>
         <translation>英语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="581"/>
+        <location filename="../screens/SettingsScreen.qml" line="574"/>
         <source>Italian</source>
         <translation>意大利语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="583"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="585"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="587"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>German</source>
         <translation>德语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="589"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Greek</source>
         <translation>希腊语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="591"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>Japanese</source>
         <translation>日语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="593"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Korean</source>
         <translation>韩语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="595"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Dutch</source>
         <translation>荷兰语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="597"/>
+        <location filename="../screens/SettingsScreen.qml" line="590"/>
         <source>Romanian</source>
         <translation>罗马尼亚语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="599"/>
+        <location filename="../screens/SettingsScreen.qml" line="592"/>
         <source>Slovak</source>
         <translation>斯洛伐克语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="601"/>
+        <location filename="../screens/SettingsScreen.qml" line="594"/>
         <source>Ukrainian</source>
         <translation>乌克兰语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="603"/>
+        <location filename="../screens/SettingsScreen.qml" line="596"/>
         <source>Chinese (Simplified)</source>
         <translation>简体中文</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="605"/>
+        <location filename="../screens/SettingsScreen.qml" line="598"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="607"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Hebrew</source>
         <translation>希伯来语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="611"/>
+        <location filename="../screens/SettingsScreen.qml" line="604"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
-        <location filename="../screens/SettingsScreen.qml" line="620"/>
-        <location filename="../screens/SettingsScreen.qml" line="694"/>
+        <location filename="../screens/SettingsScreen.qml" line="605"/>
+        <location filename="../screens/SettingsScreen.qml" line="613"/>
+        <location filename="../screens/SettingsScreen.qml" line="687"/>
         <source>Auto</source>
         <translation>自动</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="610"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="619"/>
+        <location filename="../screens/SettingsScreen.qml" line="612"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="630"/>
+        <location filename="../screens/SettingsScreen.qml" line="623"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="632"/>
+        <location filename="../screens/SettingsScreen.qml" line="625"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="634"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="628"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="640"/>
+        <location filename="../screens/SettingsScreen.qml" line="633"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="642"/>
+        <location filename="../screens/SettingsScreen.qml" line="635"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="643"/>
+        <location filename="../screens/SettingsScreen.qml" line="636"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="648"/>
+        <location filename="../screens/SettingsScreen.qml" line="641"/>
         <source>Detailed list view</source>
         <translation>详细列表视图</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="642"/>
         <source>Grid view</source>
         <translation>网格视图</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="654"/>
+        <location filename="../screens/SettingsScreen.qml" line="647"/>
         <source>Style B</source>
         <translation>样式 B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="656"/>
+        <location filename="../screens/SettingsScreen.qml" line="649"/>
         <source>Style C</source>
         <translation>样式 C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="658"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
         <source>Style D</source>
         <translation>样式 D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="659"/>
+        <location filename="../screens/SettingsScreen.qml" line="652"/>
         <source>Style A</source>
         <translation>样式 A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="674"/>
+        <location filename="../screens/SettingsScreen.qml" line="667"/>
         <source>Off</source>
         <translation>关闭</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="676"/>
+        <location filename="../screens/SettingsScreen.qml" line="669"/>
         <source>1 second (testing)</source>
         <translation>1 秒（测试）</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="678"/>
+        <location filename="../screens/SettingsScreen.qml" line="671"/>
         <source>1 minute</source>
         <translation>1 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="680"/>
+        <location filename="../screens/SettingsScreen.qml" line="673"/>
         <source>2 minutes</source>
         <translation>2 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="682"/>
+        <location filename="../screens/SettingsScreen.qml" line="675"/>
         <source>5 minutes</source>
         <translation>5 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="684"/>
+        <location filename="../screens/SettingsScreen.qml" line="677"/>
         <source>10 minutes</source>
         <translation>10 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="686"/>
+        <location filename="../screens/SettingsScreen.qml" line="679"/>
         <source>15 minutes</source>
         <translation>15 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="688"/>
+        <location filename="../screens/SettingsScreen.qml" line="681"/>
         <source>30 minutes</source>
         <translation>30 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="682"/>
         <source>%1 seconds</source>
         <translation>%1 秒</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1368"/>
+        <location filename="../screens/SettingsScreen.qml" line="1351"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
-        <location filename="../screens/SettingsScreen.qml" line="732"/>
+        <location filename="../screens/SettingsScreen.qml" line="105"/>
+        <location filename="../screens/SettingsScreen.qml" line="725"/>
         <source>Resolution</source>
         <translation>分辨率</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="225"/>
+        <location filename="../screens/SettingsScreen.qml" line="77"/>
+        <location filename="../screens/SettingsScreen.qml" line="219"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="89"/>
-        <location filename="../screens/SettingsScreen.qml" line="227"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="221"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="101"/>
-        <location filename="../screens/SettingsScreen.qml" line="231"/>
+        <location filename="../screens/SettingsScreen.qml" line="95"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="696"/>
+        <location filename="../screens/SettingsScreen.qml" line="689"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="698"/>
+        <location filename="../screens/SettingsScreen.qml" line="691"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="700"/>
+        <location filename="../screens/SettingsScreen.qml" line="693"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="702"/>
+        <location filename="../screens/SettingsScreen.qml" line="695"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="704"/>
+        <location filename="../screens/SettingsScreen.qml" line="697"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="706"/>
+        <location filename="../screens/SettingsScreen.qml" line="699"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="708"/>
+        <location filename="../screens/SettingsScreen.qml" line="701"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="710"/>
+        <location filename="../screens/SettingsScreen.qml" line="703"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="712"/>
+        <location filename="../screens/SettingsScreen.qml" line="705"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="714"/>
+        <location filename="../screens/SettingsScreen.qml" line="707"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="716"/>
+        <location filename="../screens/SettingsScreen.qml" line="709"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="718"/>
+        <location filename="../screens/SettingsScreen.qml" line="711"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="232"/>
+        <location filename="../screens/SettingsScreen.qml" line="226"/>
         <source>Settings</source>
         <translation>设置</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1356"/>
+        <location filename="../screens/SettingsScreen.qml" line="1339"/>
         <source>No settings available on this platform</source>
         <translation>此平台上没有可用设置</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="236"/>
-        <location filename="../screens/SystemsScreen.qml" line="338"/>
+        <location filename="../screens/SystemsScreen.qml" line="242"/>
+        <location filename="../screens/SystemsScreen.qml" line="343"/>
         <source>%1 systems</source>
         <translation>%1 个系统</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="237"/>
-        <location filename="../screens/SystemsScreen.qml" line="355"/>
+        <location filename="../screens/SystemsScreen.qml" line="243"/>
+        <location filename="../screens/SystemsScreen.qml" line="360"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="373"/>
+        <location filename="../screens/SystemsScreen.qml" line="378"/>
         <source>No systems in this category</source>
         <translation>此类别中没有系统</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="374"/>
+        <location filename="../screens/SystemsScreen.qml" line="379"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>
@@ -1439,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="539"/>
+        <location filename="../components/Tile.qml" line="501"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -97,100 +97,100 @@ Euskara - devilschile2</source>
         <translation type="unfinished">正在加载…</translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="196"/>
+        <location filename="../components/BrowseDetailPane.qml" line="167"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="196"/>
+        <location filename="../components/BrowseDetailPane.qml" line="167"/>
         <source>Yr</source>
         <comment>Short metadata label for Year; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="198"/>
+        <location filename="../components/BrowseDetailPane.qml" line="169"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="198"/>
+        <location filename="../components/BrowseDetailPane.qml" line="169"/>
         <source>Gen</source>
         <comment>Short metadata label for Genre; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="200"/>
+        <location filename="../components/BrowseDetailPane.qml" line="171"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="200"/>
+        <location filename="../components/BrowseDetailPane.qml" line="171"/>
         <source>Plyr</source>
         <comment>Short metadata label for Players; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="202"/>
+        <location filename="../components/BrowseDetailPane.qml" line="173"/>
         <source>Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="202"/>
+        <location filename="../components/BrowseDetailPane.qml" line="173"/>
         <source>Dev</source>
         <comment>Short metadata label for Developer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="204"/>
+        <location filename="../components/BrowseDetailPane.qml" line="175"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="204"/>
+        <location filename="../components/BrowseDetailPane.qml" line="175"/>
         <source>Pub</source>
         <comment>Short metadata label for Publisher; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="206"/>
+        <location filename="../components/BrowseDetailPane.qml" line="177"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="206"/>
+        <location filename="../components/BrowseDetailPane.qml" line="177"/>
         <source>Rtg</source>
         <comment>Short metadata label for Rating; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="208"/>
+        <location filename="../components/BrowseDetailPane.qml" line="179"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="208"/>
+        <location filename="../components/BrowseDetailPane.qml" line="179"/>
         <source>Cat</source>
         <comment>Short metadata label for Category; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="210"/>
+        <location filename="../components/BrowseDetailPane.qml" line="181"/>
         <source>Release date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="210"/>
+        <location filename="../components/BrowseDetailPane.qml" line="181"/>
         <source>Date</source>
         <comment>Short metadata label for Release date; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="212"/>
+        <location filename="../components/BrowseDetailPane.qml" line="183"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/BrowseDetailPane.qml" line="212"/>
+        <location filename="../components/BrowseDetailPane.qml" line="183"/>
         <source>Mfr</source>
         <comment>Short metadata label for Manufacturer; keep 2-4 characters if possible</comment>
         <translation type="unfinished"></translation>
@@ -425,8 +425,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="127"/>
-        <location filename="../screens/GamesScreen.qml" line="162"/>
+        <location filename="../screens/GamesScreen.qml" line="128"/>
+        <location filename="../screens/GamesScreen.qml" line="163"/>
         <source>%1 files</source>
         <translation>%1 个文件</translation>
     </message>
@@ -436,8 +436,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="136"/>
-        <location filename="../screens/GamesScreen.qml" line="163"/>
+        <location filename="../screens/GamesScreen.qml" line="137"/>
+        <location filename="../screens/GamesScreen.qml" line="164"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -452,7 +452,7 @@ Euskara - devilschile2</source>
         <translation>正在加载游戏…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="132"/>
+        <location filename="../screens/GamesScreen.qml" line="133"/>
         <source>Loading more…</source>
         <translation>正在加载更多…</translation>
     </message>
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="149"/>
+        <location filename="../screens/HubScreen.qml" line="156"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="155"/>
+        <location filename="../screens/HubScreen.qml" line="162"/>
         <source>Favorites</source>
         <translation>收藏</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="160"/>
+        <location filename="../screens/HubScreen.qml" line="167"/>
         <source>Recently Played</source>
         <translation>最近游玩</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="165"/>
+        <location filename="../screens/HubScreen.qml" line="172"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">设置</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="701"/>
+        <location filename="../screens/HubScreen.qml" line="722"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>没有可用系统。请在“设置”中运行“更新媒体数据库”。</translation>
     </message>
@@ -553,138 +553,138 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1367"/>
+        <location filename="../app/Main.qml" line="1381"/>
         <source>Launch core</source>
         <translation>启动核心</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1373"/>
-        <location filename="../app/Main.qml" line="1612"/>
+        <location filename="../app/Main.qml" line="1387"/>
+        <location filename="../app/Main.qml" line="1626"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1380"/>
-        <location filename="../app/Main.qml" line="1403"/>
+        <location filename="../app/Main.qml" line="1394"/>
+        <location filename="../app/Main.qml" line="1417"/>
         <source>Update media database</source>
         <translation type="unfinished">更新媒体数据库</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1383"/>
-        <location filename="../app/Main.qml" line="1406"/>
+        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1420"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">抓取元数据</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1388"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1411"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1388"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1411"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1415"/>
-        <location filename="../app/Main.qml" line="1450"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1464"/>
         <source>Launch game</source>
         <translation>启动游戏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1445"/>
         <source>Remove from favorites</source>
         <translation>从收藏中移除</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1445"/>
         <source>Add to favorites</source>
         <translation>添加到收藏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1436"/>
+        <location filename="../app/Main.qml" line="1450"/>
         <source>Write to NFC token</source>
         <translation>写入 NFC 令牌</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1440"/>
+        <location filename="../app/Main.qml" line="1454"/>
         <source>QR code</source>
         <translation>二维码</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1608"/>
+        <location filename="../app/Main.qml" line="1622"/>
         <source>Default</source>
         <translation type="unfinished">默认</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1608"/>
+        <location filename="../app/Main.qml" line="1622"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1932"/>
+        <location filename="../app/Main.qml" line="1946"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1936"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1950"/>
+        <location filename="../app/Main.qml" line="1964"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1954"/>
+        <location filename="../app/Main.qml" line="1968"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1958"/>
+        <location filename="../app/Main.qml" line="1972"/>
         <source>Retry</source>
         <translation type="unfinished">重试</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1962"/>
+        <location filename="../app/Main.qml" line="1976"/>
         <source>Cancel</source>
         <translation type="unfinished">取消</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2624"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2612"/>
+        <location filename="../app/Main.qml" line="2626"/>
         <source>Loading games…</source>
         <translation>正在加载游戏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2628"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2616"/>
+        <location filename="../app/Main.qml" line="2630"/>
         <source>Loading favorites…</source>
         <translation>正在加载收藏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2618"/>
+        <location filename="../app/Main.qml" line="2632"/>
         <source>Loading recently played…</source>
         <translation>正在加载最近游玩…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2620"/>
+        <location filename="../app/Main.qml" line="2634"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2622"/>
+        <location filename="../app/Main.qml" line="2636"/>
         <source>Loading…</source>
         <translation>正在加载…</translation>
     </message>
@@ -864,12 +864,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">正在加载…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="395"/>
+        <location filename="../screens/MediaListScreen.qml" line="436"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 个条目</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="396"/>
+        <location filename="../screens/MediaListScreen.qml" line="437"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>否</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="246"/>
+        <location filename="../components/Modal.qml" line="256"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
@@ -1312,7 +1312,7 @@ Euskara - devilschile2</source>
         <translation>%1 秒</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1358"/>
+        <location filename="../screens/SettingsScreen.qml" line="1368"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1406,7 +1406,7 @@ Euskara - devilschile2</source>
         <translation>设置</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1346"/>
+        <location filename="../screens/SettingsScreen.qml" line="1356"/>
         <source>No settings available on this platform</source>
         <translation>此平台上没有可用设置</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="229"/>
-        <location filename="../screens/SystemsScreen.qml" line="329"/>
+        <location filename="../screens/SystemsScreen.qml" line="236"/>
+        <location filename="../screens/SystemsScreen.qml" line="338"/>
         <source>%1 systems</source>
         <translation>%1 个系统</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="230"/>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="237"/>
+        <location filename="../screens/SystemsScreen.qml" line="355"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="364"/>
+        <location filename="../screens/SystemsScreen.qml" line="373"/>
         <source>No systems in this category</source>
         <translation>此类别中没有系统</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="365"/>
+        <location filename="../screens/SystemsScreen.qml" line="374"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>
@@ -1439,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="475"/>
+        <location filename="../components/Tile.qml" line="539"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -425,8 +425,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="128"/>
-        <location filename="../screens/GamesScreen.qml" line="163"/>
+        <location filename="../screens/GamesScreen.qml" line="131"/>
+        <location filename="../screens/GamesScreen.qml" line="166"/>
         <source>%1 files</source>
         <translation>%1 个文件</translation>
     </message>
@@ -436,8 +436,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="137"/>
-        <location filename="../screens/GamesScreen.qml" line="164"/>
+        <location filename="../screens/GamesScreen.qml" line="140"/>
+        <location filename="../screens/GamesScreen.qml" line="167"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -452,7 +452,7 @@ Euskara - devilschile2</source>
         <translation>正在加载游戏…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="133"/>
+        <location filename="../screens/GamesScreen.qml" line="136"/>
         <source>Loading more…</source>
         <translation>正在加载更多…</translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>否</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="246"/>
+        <location filename="../components/Modal.qml" line="250"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
@@ -940,64 +940,64 @@ Euskara - devilschile2</source>
         <translation type="vanished">常规</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="141"/>
-        <location filename="../screens/SettingsScreen.qml" line="734"/>
+        <location filename="../screens/SettingsScreen.qml" line="145"/>
+        <location filename="../screens/SettingsScreen.qml" line="738"/>
         <source>Language</source>
         <translation>语言</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="111"/>
-        <location filename="../screens/SettingsScreen.qml" line="761"/>
+        <location filename="../screens/SettingsScreen.qml" line="115"/>
+        <location filename="../screens/SettingsScreen.qml" line="765"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="116"/>
-        <location filename="../screens/SettingsScreen.qml" line="770"/>
+        <location filename="../screens/SettingsScreen.qml" line="120"/>
+        <location filename="../screens/SettingsScreen.qml" line="774"/>
         <source>Browsing layout</source>
         <translation>浏览布局</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="154"/>
-        <location filename="../screens/SettingsScreen.qml" line="779"/>
+        <location filename="../screens/SettingsScreen.qml" line="158"/>
+        <location filename="../screens/SettingsScreen.qml" line="783"/>
         <source>Button style</source>
         <translation>按钮样式</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="126"/>
-        <location filename="../screens/SettingsScreen.qml" line="788"/>
+        <location filename="../screens/SettingsScreen.qml" line="130"/>
+        <location filename="../screens/SettingsScreen.qml" line="792"/>
         <source>Screensaver</source>
         <translation>屏幕保护程序</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="89"/>
-        <location filename="../screens/SettingsScreen.qml" line="223"/>
+        <location filename="../screens/SettingsScreen.qml" line="93"/>
+        <location filename="../screens/SettingsScreen.qml" line="227"/>
         <source>Library</source>
         <translation>资料库</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="176"/>
+        <location filename="../screens/SettingsScreen.qml" line="180"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="121"/>
-        <location filename="../screens/SettingsScreen.qml" line="797"/>
+        <location filename="../screens/SettingsScreen.qml" line="125"/>
+        <location filename="../screens/SettingsScreen.qml" line="801"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="171"/>
+        <location filename="../screens/SettingsScreen.qml" line="175"/>
         <source>Update media database</source>
         <translation>更新媒体数据库</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="181"/>
+        <location filename="../screens/SettingsScreen.qml" line="185"/>
         <source>Scrape metadata</source>
         <translation>抓取元数据</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="186"/>
+        <location filename="../screens/SettingsScreen.qml" line="190"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1006,407 +1006,407 @@ Euskara - devilschile2</source>
         <translation type="vanished">高级</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="159"/>
+        <location filename="../screens/SettingsScreen.qml" line="163"/>
         <source>Mouse support</source>
         <translation>鼠标支持</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="198"/>
+        <location filename="../screens/SettingsScreen.qml" line="202"/>
         <source>Debug logging</source>
         <translation>调试日志</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="203"/>
+        <location filename="../screens/SettingsScreen.qml" line="207"/>
         <source>Upload log file</source>
         <translation>上传日志文件</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="193"/>
+        <location filename="../screens/SettingsScreen.qml" line="197"/>
         <source>About / License</source>
         <translation>关于 / 许可</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="131"/>
-        <location filename="../screens/SettingsScreen.qml" line="743"/>
+        <location filename="../screens/SettingsScreen.qml" line="135"/>
+        <location filename="../screens/SettingsScreen.qml" line="747"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="136"/>
-        <location filename="../screens/SettingsScreen.qml" line="752"/>
+        <location filename="../screens/SettingsScreen.qml" line="140"/>
+        <location filename="../screens/SettingsScreen.qml" line="756"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="146"/>
+        <location filename="../screens/SettingsScreen.qml" line="150"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="164"/>
+        <location filename="../screens/SettingsScreen.qml" line="168"/>
         <source>Reduce motion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="240"/>
+        <location filename="../screens/SettingsScreen.qml" line="244"/>
         <source>Optimizing</source>
         <translation>正在优化</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="242"/>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="255"/>
         <source>Paused</source>
         <translation>已暂停</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="242"/>
-        <location filename="../screens/SettingsScreen.qml" line="251"/>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
+        <location filename="../screens/SettingsScreen.qml" line="255"/>
         <source>In progress</source>
         <translation>进行中</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="245"/>
+        <location filename="../screens/SettingsScreen.qml" line="249"/>
         <source>%1 indexed</source>
         <translation>已索引 %1 个</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="254"/>
+        <location filename="../screens/SettingsScreen.qml" line="258"/>
         <source>%1 scraped</source>
         <translation>已抓取 %1 个</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="488"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="488"/>
+        <location filename="../screens/SettingsScreen.qml" line="492"/>
         <source>Start</source>
         <translation>开始</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="490"/>
+        <location filename="../screens/SettingsScreen.qml" line="494"/>
         <source>Upload</source>
         <translation>上传</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="491"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Open</source>
         <translation>打开</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="542"/>
+        <location filename="../screens/SettingsScreen.qml" line="546"/>
         <source>Default</source>
         <translation>默认</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="576"/>
         <source>English</source>
         <translation>英语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="578"/>
         <source>Italian</source>
         <translation>意大利语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="580"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="582"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="584"/>
         <source>German</source>
         <translation>德语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="586"/>
         <source>Greek</source>
         <translation>希腊语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="588"/>
         <source>Japanese</source>
         <translation>日语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="590"/>
         <source>Korean</source>
         <translation>韩语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="588"/>
+        <location filename="../screens/SettingsScreen.qml" line="592"/>
         <source>Dutch</source>
         <translation>荷兰语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="590"/>
+        <location filename="../screens/SettingsScreen.qml" line="594"/>
         <source>Romanian</source>
         <translation>罗马尼亚语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="592"/>
+        <location filename="../screens/SettingsScreen.qml" line="596"/>
         <source>Slovak</source>
         <translation>斯洛伐克语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="594"/>
+        <location filename="../screens/SettingsScreen.qml" line="598"/>
         <source>Ukrainian</source>
         <translation>乌克兰语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="596"/>
+        <location filename="../screens/SettingsScreen.qml" line="600"/>
         <source>Chinese (Simplified)</source>
         <translation>简体中文</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="598"/>
+        <location filename="../screens/SettingsScreen.qml" line="602"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="600"/>
+        <location filename="../screens/SettingsScreen.qml" line="604"/>
         <source>Hebrew</source>
         <translation>希伯来语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="602"/>
+        <location filename="../screens/SettingsScreen.qml" line="606"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="604"/>
+        <location filename="../screens/SettingsScreen.qml" line="608"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="605"/>
-        <location filename="../screens/SettingsScreen.qml" line="613"/>
-        <location filename="../screens/SettingsScreen.qml" line="687"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="691"/>
         <source>Auto</source>
         <translation>自动</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="610"/>
+        <location filename="../screens/SettingsScreen.qml" line="614"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="616"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="623"/>
+        <location filename="../screens/SettingsScreen.qml" line="627"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="625"/>
+        <location filename="../screens/SettingsScreen.qml" line="629"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="627"/>
+        <location filename="../screens/SettingsScreen.qml" line="631"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="628"/>
+        <location filename="../screens/SettingsScreen.qml" line="632"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="633"/>
+        <location filename="../screens/SettingsScreen.qml" line="637"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="639"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="640"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="641"/>
+        <location filename="../screens/SettingsScreen.qml" line="645"/>
         <source>Detailed list view</source>
         <translation>详细列表视图</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="642"/>
+        <location filename="../screens/SettingsScreen.qml" line="646"/>
         <source>Grid view</source>
         <translation>网格视图</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
         <source>Style B</source>
         <translation>样式 B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Style C</source>
         <translation>样式 C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="655"/>
         <source>Style D</source>
         <translation>样式 D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="652"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Style A</source>
         <translation>样式 A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="667"/>
+        <location filename="../screens/SettingsScreen.qml" line="671"/>
         <source>Off</source>
         <translation>关闭</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="669"/>
+        <location filename="../screens/SettingsScreen.qml" line="673"/>
         <source>1 second (testing)</source>
         <translation>1 秒（测试）</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="671"/>
+        <location filename="../screens/SettingsScreen.qml" line="675"/>
         <source>1 minute</source>
         <translation>1 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="673"/>
+        <location filename="../screens/SettingsScreen.qml" line="677"/>
         <source>2 minutes</source>
         <translation>2 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="675"/>
+        <location filename="../screens/SettingsScreen.qml" line="679"/>
         <source>5 minutes</source>
         <translation>5 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="677"/>
+        <location filename="../screens/SettingsScreen.qml" line="681"/>
         <source>10 minutes</source>
         <translation>10 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="679"/>
+        <location filename="../screens/SettingsScreen.qml" line="683"/>
         <source>15 minutes</source>
         <translation>15 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="681"/>
+        <location filename="../screens/SettingsScreen.qml" line="685"/>
         <source>30 minutes</source>
         <translation>30 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="682"/>
+        <location filename="../screens/SettingsScreen.qml" line="686"/>
         <source>%1 seconds</source>
         <translation>%1 秒</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1351"/>
+        <location filename="../screens/SettingsScreen.qml" line="1382"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="105"/>
-        <location filename="../screens/SettingsScreen.qml" line="725"/>
+        <location filename="../screens/SettingsScreen.qml" line="109"/>
+        <location filename="../screens/SettingsScreen.qml" line="729"/>
         <source>Resolution</source>
         <translation>分辨率</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="77"/>
-        <location filename="../screens/SettingsScreen.qml" line="219"/>
+        <location filename="../screens/SettingsScreen.qml" line="81"/>
+        <location filename="../screens/SettingsScreen.qml" line="223"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="83"/>
-        <location filename="../screens/SettingsScreen.qml" line="221"/>
+        <location filename="../screens/SettingsScreen.qml" line="87"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="95"/>
-        <location filename="../screens/SettingsScreen.qml" line="225"/>
+        <location filename="../screens/SettingsScreen.qml" line="99"/>
+        <location filename="../screens/SettingsScreen.qml" line="229"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="693"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="691"/>
+        <location filename="../screens/SettingsScreen.qml" line="695"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="693"/>
+        <location filename="../screens/SettingsScreen.qml" line="697"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="695"/>
+        <location filename="../screens/SettingsScreen.qml" line="699"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="697"/>
+        <location filename="../screens/SettingsScreen.qml" line="701"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="699"/>
+        <location filename="../screens/SettingsScreen.qml" line="703"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="701"/>
+        <location filename="../screens/SettingsScreen.qml" line="705"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="703"/>
+        <location filename="../screens/SettingsScreen.qml" line="707"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="705"/>
+        <location filename="../screens/SettingsScreen.qml" line="709"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="707"/>
+        <location filename="../screens/SettingsScreen.qml" line="711"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="709"/>
+        <location filename="../screens/SettingsScreen.qml" line="713"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="711"/>
+        <location filename="../screens/SettingsScreen.qml" line="715"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="226"/>
+        <location filename="../screens/SettingsScreen.qml" line="230"/>
         <source>Settings</source>
         <translation>设置</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1339"/>
+        <location filename="../screens/SettingsScreen.qml" line="1370"/>
         <source>No settings available on this platform</source>
         <translation>此平台上没有可用设置</translation>
     </message>
@@ -1414,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="242"/>
-        <location filename="../screens/SystemsScreen.qml" line="343"/>
+        <location filename="../screens/SystemsScreen.qml" line="245"/>
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>%1 systems</source>
         <translation>%1 个系统</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="243"/>
-        <location filename="../screens/SystemsScreen.qml" line="360"/>
+        <location filename="../screens/SystemsScreen.qml" line="246"/>
+        <location filename="../screens/SystemsScreen.qml" line="363"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="378"/>
+        <location filename="../screens/SystemsScreen.qml" line="381"/>
         <source>No systems in this category</source>
         <translation>此类别中没有系统</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="379"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -425,34 +425,34 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="116"/>
-        <location filename="../screens/GamesScreen.qml" line="151"/>
+        <location filename="../screens/GamesScreen.qml" line="127"/>
+        <location filename="../screens/GamesScreen.qml" line="162"/>
         <source>%1 files</source>
         <translation>%1 个文件</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="53"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="125"/>
-        <location filename="../screens/GamesScreen.qml" line="152"/>
+        <location filename="../screens/GamesScreen.qml" line="136"/>
+        <location filename="../screens/GamesScreen.qml" line="163"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="47"/>
+        <location filename="../screens/GamesScreen.qml" line="48"/>
         <source>No games in this system</source>
         <translation>此系统中没有游戏</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="48"/>
+        <location filename="../screens/GamesScreen.qml" line="49"/>
         <source>Loading games…</source>
         <translation>正在加载游戏…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="121"/>
+        <location filename="../screens/GamesScreen.qml" line="132"/>
         <source>Loading more…</source>
         <translation>正在加载更多…</translation>
     </message>
@@ -480,22 +480,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="139"/>
+        <location filename="../screens/HubScreen.qml" line="149"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="145"/>
+        <location filename="../screens/HubScreen.qml" line="155"/>
         <source>Favorites</source>
         <translation>收藏</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="150"/>
+        <location filename="../screens/HubScreen.qml" line="160"/>
         <source>Recently Played</source>
         <translation>最近游玩</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="155"/>
+        <location filename="../screens/HubScreen.qml" line="165"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +504,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">设置</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="669"/>
+        <location filename="../screens/HubScreen.qml" line="701"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>没有可用系统。请在“设置”中运行“更新媒体数据库”。</translation>
     </message>
@@ -553,138 +553,138 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1361"/>
+        <location filename="../app/Main.qml" line="1367"/>
         <source>Launch core</source>
         <translation>启动核心</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1367"/>
-        <location filename="../app/Main.qml" line="1606"/>
+        <location filename="../app/Main.qml" line="1373"/>
+        <location filename="../app/Main.qml" line="1612"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1374"/>
-        <location filename="../app/Main.qml" line="1397"/>
+        <location filename="../app/Main.qml" line="1380"/>
+        <location filename="../app/Main.qml" line="1403"/>
         <source>Update media database</source>
         <translation type="unfinished">更新媒体数据库</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1377"/>
-        <location filename="../app/Main.qml" line="1400"/>
+        <location filename="../app/Main.qml" line="1383"/>
+        <location filename="../app/Main.qml" line="1406"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">抓取元数据</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1382"/>
-        <location filename="../app/Main.qml" line="1391"/>
+        <location filename="../app/Main.qml" line="1388"/>
+        <location filename="../app/Main.qml" line="1397"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1382"/>
-        <location filename="../app/Main.qml" line="1391"/>
+        <location filename="../app/Main.qml" line="1388"/>
+        <location filename="../app/Main.qml" line="1397"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1409"/>
-        <location filename="../app/Main.qml" line="1444"/>
+        <location filename="../app/Main.qml" line="1415"/>
+        <location filename="../app/Main.qml" line="1450"/>
         <source>Launch game</source>
         <translation>启动游戏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1425"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Remove from favorites</source>
         <translation>从收藏中移除</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1425"/>
+        <location filename="../app/Main.qml" line="1431"/>
         <source>Add to favorites</source>
         <translation>添加到收藏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1430"/>
+        <location filename="../app/Main.qml" line="1436"/>
         <source>Write to NFC token</source>
         <translation>写入 NFC 令牌</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1434"/>
+        <location filename="../app/Main.qml" line="1440"/>
         <source>QR code</source>
         <translation>二维码</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1602"/>
+        <location filename="../app/Main.qml" line="1608"/>
         <source>Default</source>
         <translation type="unfinished">默认</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1602"/>
+        <location filename="../app/Main.qml" line="1608"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1926"/>
+        <location filename="../app/Main.qml" line="1932"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1930"/>
+        <location filename="../app/Main.qml" line="1936"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1944"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1948"/>
+        <location filename="../app/Main.qml" line="1954"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1952"/>
+        <location filename="../app/Main.qml" line="1958"/>
         <source>Retry</source>
         <translation type="unfinished">重试</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1956"/>
+        <location filename="../app/Main.qml" line="1962"/>
         <source>Cancel</source>
         <translation type="unfinished">取消</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2604"/>
+        <location filename="../app/Main.qml" line="2610"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2606"/>
+        <location filename="../app/Main.qml" line="2612"/>
         <source>Loading games…</source>
         <translation>正在加载游戏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2608"/>
+        <location filename="../app/Main.qml" line="2614"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2616"/>
         <source>Loading favorites…</source>
         <translation>正在加载收藏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2612"/>
+        <location filename="../app/Main.qml" line="2618"/>
         <source>Loading recently played…</source>
         <translation>正在加载最近游玩…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2620"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2616"/>
+        <location filename="../app/Main.qml" line="2622"/>
         <source>Loading…</source>
         <translation>正在加载…</translation>
     </message>
@@ -692,12 +692,12 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="683"/>
+        <location filename="../app/MainLayout.qml" line="685"/>
         <source>Writing failed</source>
         <translation>写入失败</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="683"/>
+        <location filename="../app/MainLayout.qml" line="685"/>
         <source>Put a writable card near the reader</source>
         <translation>将可写卡片放在读卡器附近</translation>
     </message>
@@ -717,141 +717,141 @@ Euskara - devilschile2</source>
         <translation type="unfinished">最近游玩</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="699"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="700"/>
+        <location filename="../app/MainLayout.qml" line="702"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="810"/>
+        <location filename="../app/MainLayout.qml" line="812"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="811"/>
+        <location filename="../app/MainLayout.qml" line="813"/>
         <source>Are you sure you want to exit?</source>
         <translation>确定要退出吗？</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="890"/>
-        <location filename="../app/MainLayout.qml" line="964"/>
-        <location filename="../app/MainLayout.qml" line="1010"/>
-        <location filename="../app/MainLayout.qml" line="1047"/>
-        <location filename="../app/MainLayout.qml" line="1097"/>
-        <location filename="../app/MainLayout.qml" line="1146"/>
-        <location filename="../app/MainLayout.qml" line="1165"/>
-        <location filename="../app/MainLayout.qml" line="1232"/>
+        <location filename="../app/MainLayout.qml" line="892"/>
+        <location filename="../app/MainLayout.qml" line="966"/>
+        <location filename="../app/MainLayout.qml" line="1012"/>
+        <location filename="../app/MainLayout.qml" line="1049"/>
+        <location filename="../app/MainLayout.qml" line="1099"/>
+        <location filename="../app/MainLayout.qml" line="1148"/>
+        <location filename="../app/MainLayout.qml" line="1167"/>
+        <location filename="../app/MainLayout.qml" line="1234"/>
         <source>Move</source>
         <translation>移动</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="894"/>
-        <location filename="../app/MainLayout.qml" line="968"/>
+        <location filename="../app/MainLayout.qml" line="896"/>
+        <location filename="../app/MainLayout.qml" line="970"/>
         <source>Select</source>
         <translation>选择</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="898"/>
-        <location filename="../app/MainLayout.qml" line="902"/>
-        <location filename="../app/MainLayout.qml" line="916"/>
-        <location filename="../app/MainLayout.qml" line="931"/>
-        <location filename="../app/MainLayout.qml" line="942"/>
+        <location filename="../app/MainLayout.qml" line="900"/>
+        <location filename="../app/MainLayout.qml" line="904"/>
+        <location filename="../app/MainLayout.qml" line="918"/>
+        <location filename="../app/MainLayout.qml" line="933"/>
+        <location filename="../app/MainLayout.qml" line="944"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="909"/>
-        <location filename="../app/MainLayout.qml" line="949"/>
-        <location filename="../app/MainLayout.qml" line="972"/>
-        <location filename="../app/MainLayout.qml" line="983"/>
+        <location filename="../app/MainLayout.qml" line="911"/>
+        <location filename="../app/MainLayout.qml" line="951"/>
+        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="985"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="927"/>
+        <location filename="../app/MainLayout.qml" line="929"/>
         <source>Done</source>
         <translation>完成</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1070"/>
-        <location filename="../app/MainLayout.qml" line="1123"/>
-        <location filename="../app/MainLayout.qml" line="1258"/>
+        <location filename="../app/MainLayout.qml" line="940"/>
+        <location filename="../app/MainLayout.qml" line="1072"/>
+        <location filename="../app/MainLayout.qml" line="1125"/>
+        <location filename="../app/MainLayout.qml" line="1260"/>
         <source>Retry</source>
         <translation>重试</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="957"/>
+        <location filename="../app/MainLayout.qml" line="959"/>
         <source>I understand</source>
         <translation>我明白了</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="991"/>
+        <location filename="../app/MainLayout.qml" line="993"/>
         <source>Start</source>
         <translation>开始</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1014"/>
-        <location filename="../app/MainLayout.qml" line="1057"/>
-        <location filename="../app/MainLayout.qml" line="1107"/>
-        <location filename="../app/MainLayout.qml" line="1151"/>
-        <location filename="../app/MainLayout.qml" line="1242"/>
+        <location filename="../app/MainLayout.qml" line="1016"/>
+        <location filename="../app/MainLayout.qml" line="1059"/>
+        <location filename="../app/MainLayout.qml" line="1109"/>
+        <location filename="../app/MainLayout.qml" line="1153"/>
+        <location filename="../app/MainLayout.qml" line="1244"/>
         <source>Open</source>
         <translation>打开</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1024"/>
+        <location filename="../app/MainLayout.qml" line="1026"/>
         <source>Quit</source>
         <translation>退出</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1033"/>
-        <location filename="../app/MainLayout.qml" line="1063"/>
-        <location filename="../app/MainLayout.qml" line="1074"/>
-        <location filename="../app/MainLayout.qml" line="1089"/>
-        <location filename="../app/MainLayout.qml" line="1116"/>
-        <location filename="../app/MainLayout.qml" line="1127"/>
-        <location filename="../app/MainLayout.qml" line="1139"/>
-        <location filename="../app/MainLayout.qml" line="1155"/>
-        <location filename="../app/MainLayout.qml" line="1189"/>
-        <location filename="../app/MainLayout.qml" line="1207"/>
-        <location filename="../app/MainLayout.qml" line="1216"/>
-        <location filename="../app/MainLayout.qml" line="1251"/>
-        <location filename="../app/MainLayout.qml" line="1262"/>
+        <location filename="../app/MainLayout.qml" line="1035"/>
+        <location filename="../app/MainLayout.qml" line="1065"/>
+        <location filename="../app/MainLayout.qml" line="1076"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
+        <location filename="../app/MainLayout.qml" line="1118"/>
+        <location filename="../app/MainLayout.qml" line="1129"/>
+        <location filename="../app/MainLayout.qml" line="1141"/>
+        <location filename="../app/MainLayout.qml" line="1157"/>
+        <location filename="../app/MainLayout.qml" line="1191"/>
+        <location filename="../app/MainLayout.qml" line="1209"/>
+        <location filename="../app/MainLayout.qml" line="1218"/>
+        <location filename="../app/MainLayout.qml" line="1253"/>
+        <location filename="../app/MainLayout.qml" line="1264"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1053"/>
-        <location filename="../app/MainLayout.qml" line="1103"/>
-        <location filename="../app/MainLayout.qml" line="1238"/>
+        <location filename="../app/MainLayout.qml" line="1055"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
+        <location filename="../app/MainLayout.qml" line="1240"/>
         <source>Page</source>
         <translation>页面</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1020"/>
-        <location filename="../app/MainLayout.qml" line="1060"/>
-        <location filename="../app/MainLayout.qml" line="1112"/>
-        <location filename="../app/MainLayout.qml" line="1247"/>
+        <location filename="../app/MainLayout.qml" line="1022"/>
+        <location filename="../app/MainLayout.qml" line="1062"/>
+        <location filename="../app/MainLayout.qml" line="1114"/>
+        <location filename="../app/MainLayout.qml" line="1249"/>
         <source>Options</source>
         <translation>选项</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1174"/>
+        <location filename="../app/MainLayout.qml" line="1176"/>
         <source>Change</source>
         <translation>更改</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1180"/>
+        <location filename="../app/MainLayout.qml" line="1182"/>
         <source>Toggle</source>
         <translation>切换</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1203"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>Scroll</source>
         <translation>滚动</translation>
     </message>
@@ -864,12 +864,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">正在加载…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="365"/>
+        <location filename="../screens/MediaListScreen.qml" line="395"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 个条目</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="366"/>
+        <location filename="../screens/MediaListScreen.qml" line="396"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -892,7 +892,7 @@ Euskara - devilschile2</source>
         <translation>否</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="198"/>
+        <location filename="../components/Modal.qml" line="246"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
@@ -940,64 +940,64 @@ Euskara - devilschile2</source>
         <translation type="vanished">常规</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="132"/>
-        <location filename="../screens/SettingsScreen.qml" line="718"/>
+        <location filename="../screens/SettingsScreen.qml" line="147"/>
+        <location filename="../screens/SettingsScreen.qml" line="741"/>
         <source>Language</source>
         <translation>语言</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="745"/>
+        <location filename="../screens/SettingsScreen.qml" line="117"/>
+        <location filename="../screens/SettingsScreen.qml" line="768"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="107"/>
-        <location filename="../screens/SettingsScreen.qml" line="754"/>
+        <location filename="../screens/SettingsScreen.qml" line="122"/>
+        <location filename="../screens/SettingsScreen.qml" line="777"/>
         <source>Browsing layout</source>
         <translation>浏览布局</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="145"/>
-        <location filename="../screens/SettingsScreen.qml" line="763"/>
+        <location filename="../screens/SettingsScreen.qml" line="160"/>
+        <location filename="../screens/SettingsScreen.qml" line="786"/>
         <source>Button style</source>
         <translation>按钮样式</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="117"/>
-        <location filename="../screens/SettingsScreen.qml" line="772"/>
+        <location filename="../screens/SettingsScreen.qml" line="132"/>
+        <location filename="../screens/SettingsScreen.qml" line="795"/>
         <source>Screensaver</source>
         <translation>屏幕保护程序</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="80"/>
-        <location filename="../screens/SettingsScreen.qml" line="209"/>
+        <location filename="../screens/SettingsScreen.qml" line="95"/>
+        <location filename="../screens/SettingsScreen.qml" line="229"/>
         <source>Library</source>
         <translation>资料库</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="162"/>
+        <location filename="../screens/SettingsScreen.qml" line="182"/>
         <source>Discover arcade alternate versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="112"/>
-        <location filename="../screens/SettingsScreen.qml" line="781"/>
+        <location filename="../screens/SettingsScreen.qml" line="127"/>
+        <location filename="../screens/SettingsScreen.qml" line="804"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="157"/>
+        <location filename="../screens/SettingsScreen.qml" line="177"/>
         <source>Update media database</source>
         <translation>更新媒体数据库</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="167"/>
+        <location filename="../screens/SettingsScreen.qml" line="187"/>
         <source>Scrape metadata</source>
         <translation>抓取元数据</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="172"/>
+        <location filename="../screens/SettingsScreen.qml" line="192"/>
         <source>Re-scrape existing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1006,402 +1006,407 @@ Euskara - devilschile2</source>
         <translation type="vanished">高级</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="150"/>
+        <location filename="../screens/SettingsScreen.qml" line="165"/>
         <source>Mouse support</source>
         <translation>鼠标支持</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="184"/>
+        <location filename="../screens/SettingsScreen.qml" line="204"/>
         <source>Debug logging</source>
         <translation>调试日志</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="189"/>
+        <location filename="../screens/SettingsScreen.qml" line="209"/>
         <source>Upload log file</source>
         <translation>上传日志文件</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="179"/>
+        <location filename="../screens/SettingsScreen.qml" line="199"/>
         <source>About / License</source>
         <translation>关于 / 许可</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="122"/>
-        <location filename="../screens/SettingsScreen.qml" line="727"/>
+        <location filename="../screens/SettingsScreen.qml" line="137"/>
+        <location filename="../screens/SettingsScreen.qml" line="750"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="127"/>
-        <location filename="../screens/SettingsScreen.qml" line="736"/>
+        <location filename="../screens/SettingsScreen.qml" line="142"/>
+        <location filename="../screens/SettingsScreen.qml" line="759"/>
         <source>System names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="137"/>
+        <location filename="../screens/SettingsScreen.qml" line="152"/>
         <source>Show hidden items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="226"/>
+        <location filename="../screens/SettingsScreen.qml" line="170"/>
+        <source>Reduce motion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="246"/>
         <source>Optimizing</source>
         <translation>正在优化</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="228"/>
-        <location filename="../screens/SettingsScreen.qml" line="237"/>
+        <location filename="../screens/SettingsScreen.qml" line="248"/>
+        <location filename="../screens/SettingsScreen.qml" line="257"/>
         <source>Paused</source>
         <translation>已暂停</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="228"/>
-        <location filename="../screens/SettingsScreen.qml" line="237"/>
+        <location filename="../screens/SettingsScreen.qml" line="248"/>
+        <location filename="../screens/SettingsScreen.qml" line="257"/>
         <source>In progress</source>
         <translation>进行中</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="231"/>
+        <location filename="../screens/SettingsScreen.qml" line="251"/>
         <source>%1 indexed</source>
         <translation>已索引 %1 个</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="240"/>
+        <location filename="../screens/SettingsScreen.qml" line="260"/>
         <source>%1 scraped</source>
         <translation>已抓取 %1 个</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="472"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="472"/>
+        <location filename="../screens/SettingsScreen.qml" line="495"/>
         <source>Start</source>
         <translation>开始</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="474"/>
+        <location filename="../screens/SettingsScreen.qml" line="497"/>
         <source>Upload</source>
         <translation>上传</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="475"/>
+        <location filename="../screens/SettingsScreen.qml" line="498"/>
         <source>Open</source>
         <translation>打开</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="526"/>
+        <location filename="../screens/SettingsScreen.qml" line="549"/>
         <source>Default</source>
         <translation>默认</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="556"/>
+        <location filename="../screens/SettingsScreen.qml" line="579"/>
         <source>English</source>
         <translation>英语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="558"/>
+        <location filename="../screens/SettingsScreen.qml" line="581"/>
         <source>Italian</source>
         <translation>意大利语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="560"/>
+        <location filename="../screens/SettingsScreen.qml" line="583"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="562"/>
+        <location filename="../screens/SettingsScreen.qml" line="585"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="564"/>
+        <location filename="../screens/SettingsScreen.qml" line="587"/>
         <source>German</source>
         <translation>德语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="566"/>
+        <location filename="../screens/SettingsScreen.qml" line="589"/>
         <source>Greek</source>
         <translation>希腊语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="568"/>
+        <location filename="../screens/SettingsScreen.qml" line="591"/>
         <source>Japanese</source>
         <translation>日语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="570"/>
+        <location filename="../screens/SettingsScreen.qml" line="593"/>
         <source>Korean</source>
         <translation>韩语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="572"/>
+        <location filename="../screens/SettingsScreen.qml" line="595"/>
         <source>Dutch</source>
         <translation>荷兰语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="574"/>
+        <location filename="../screens/SettingsScreen.qml" line="597"/>
         <source>Romanian</source>
         <translation>罗马尼亚语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="576"/>
+        <location filename="../screens/SettingsScreen.qml" line="599"/>
         <source>Slovak</source>
         <translation>斯洛伐克语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="578"/>
+        <location filename="../screens/SettingsScreen.qml" line="601"/>
         <source>Ukrainian</source>
         <translation>乌克兰语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="580"/>
+        <location filename="../screens/SettingsScreen.qml" line="603"/>
         <source>Chinese (Simplified)</source>
         <translation>简体中文</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="582"/>
+        <location filename="../screens/SettingsScreen.qml" line="605"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="584"/>
+        <location filename="../screens/SettingsScreen.qml" line="607"/>
         <source>Hebrew</source>
         <translation>希伯来语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="586"/>
+        <location filename="../screens/SettingsScreen.qml" line="609"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="588"/>
+        <location filename="../screens/SettingsScreen.qml" line="611"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="589"/>
-        <location filename="../screens/SettingsScreen.qml" line="597"/>
-        <location filename="../screens/SettingsScreen.qml" line="671"/>
+        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="620"/>
+        <location filename="../screens/SettingsScreen.qml" line="694"/>
         <source>Auto</source>
         <translation>自动</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="594"/>
+        <location filename="../screens/SettingsScreen.qml" line="617"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="596"/>
+        <location filename="../screens/SettingsScreen.qml" line="619"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="607"/>
+        <location filename="../screens/SettingsScreen.qml" line="630"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="609"/>
+        <location filename="../screens/SettingsScreen.qml" line="632"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="611"/>
+        <location filename="../screens/SettingsScreen.qml" line="634"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="612"/>
+        <location filename="../screens/SettingsScreen.qml" line="635"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="617"/>
+        <location filename="../screens/SettingsScreen.qml" line="640"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="619"/>
+        <location filename="../screens/SettingsScreen.qml" line="642"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="620"/>
+        <location filename="../screens/SettingsScreen.qml" line="643"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="625"/>
+        <location filename="../screens/SettingsScreen.qml" line="648"/>
         <source>Detailed list view</source>
         <translation>详细列表视图</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="626"/>
+        <location filename="../screens/SettingsScreen.qml" line="649"/>
         <source>Grid view</source>
         <translation>网格视图</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="631"/>
+        <location filename="../screens/SettingsScreen.qml" line="654"/>
         <source>Style B</source>
         <translation>样式 B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="633"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Style C</source>
         <translation>样式 C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="635"/>
+        <location filename="../screens/SettingsScreen.qml" line="658"/>
         <source>Style D</source>
         <translation>样式 D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="636"/>
+        <location filename="../screens/SettingsScreen.qml" line="659"/>
         <source>Style A</source>
         <translation>样式 A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="674"/>
         <source>Off</source>
         <translation>关闭</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="653"/>
+        <location filename="../screens/SettingsScreen.qml" line="676"/>
         <source>1 second (testing)</source>
         <translation>1 秒（测试）</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="655"/>
+        <location filename="../screens/SettingsScreen.qml" line="678"/>
         <source>1 minute</source>
         <translation>1 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="657"/>
+        <location filename="../screens/SettingsScreen.qml" line="680"/>
         <source>2 minutes</source>
         <translation>2 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="659"/>
+        <location filename="../screens/SettingsScreen.qml" line="682"/>
         <source>5 minutes</source>
         <translation>5 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="661"/>
+        <location filename="../screens/SettingsScreen.qml" line="684"/>
         <source>10 minutes</source>
         <translation>10 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="663"/>
+        <location filename="../screens/SettingsScreen.qml" line="686"/>
         <source>15 minutes</source>
         <translation>15 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="665"/>
+        <location filename="../screens/SettingsScreen.qml" line="688"/>
         <source>30 minutes</source>
         <translation>30 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="666"/>
+        <location filename="../screens/SettingsScreen.qml" line="689"/>
         <source>%1 seconds</source>
         <translation>%1 秒</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1292"/>
+        <location filename="../screens/SettingsScreen.qml" line="1358"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="96"/>
-        <location filename="../screens/SettingsScreen.qml" line="709"/>
+        <location filename="../screens/SettingsScreen.qml" line="111"/>
+        <location filename="../screens/SettingsScreen.qml" line="732"/>
         <source>Resolution</source>
         <translation>分辨率</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="68"/>
-        <location filename="../screens/SettingsScreen.qml" line="205"/>
+        <location filename="../screens/SettingsScreen.qml" line="83"/>
+        <location filename="../screens/SettingsScreen.qml" line="225"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="74"/>
-        <location filename="../screens/SettingsScreen.qml" line="207"/>
+        <location filename="../screens/SettingsScreen.qml" line="89"/>
+        <location filename="../screens/SettingsScreen.qml" line="227"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="86"/>
-        <location filename="../screens/SettingsScreen.qml" line="211"/>
+        <location filename="../screens/SettingsScreen.qml" line="101"/>
+        <location filename="../screens/SettingsScreen.qml" line="231"/>
         <source>Support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="673"/>
+        <location filename="../screens/SettingsScreen.qml" line="696"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="675"/>
+        <location filename="../screens/SettingsScreen.qml" line="698"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="677"/>
+        <location filename="../screens/SettingsScreen.qml" line="700"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="679"/>
+        <location filename="../screens/SettingsScreen.qml" line="702"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="681"/>
+        <location filename="../screens/SettingsScreen.qml" line="704"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="683"/>
+        <location filename="../screens/SettingsScreen.qml" line="706"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="685"/>
+        <location filename="../screens/SettingsScreen.qml" line="708"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="687"/>
+        <location filename="../screens/SettingsScreen.qml" line="710"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="689"/>
+        <location filename="../screens/SettingsScreen.qml" line="712"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="691"/>
+        <location filename="../screens/SettingsScreen.qml" line="714"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="693"/>
+        <location filename="../screens/SettingsScreen.qml" line="716"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="695"/>
+        <location filename="../screens/SettingsScreen.qml" line="718"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="212"/>
+        <location filename="../screens/SettingsScreen.qml" line="232"/>
         <source>Settings</source>
         <translation>设置</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1280"/>
+        <location filename="../screens/SettingsScreen.qml" line="1346"/>
         <source>No settings available on this platform</source>
         <translation>此平台上没有可用设置</translation>
     </message>
@@ -1409,24 +1414,24 @@ Euskara - devilschile2</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="206"/>
-        <location filename="../screens/SystemsScreen.qml" line="304"/>
+        <location filename="../screens/SystemsScreen.qml" line="229"/>
+        <location filename="../screens/SystemsScreen.qml" line="329"/>
         <source>%1 systems</source>
         <translation>%1 个系统</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="207"/>
-        <location filename="../screens/SystemsScreen.qml" line="321"/>
+        <location filename="../screens/SystemsScreen.qml" line="230"/>
+        <location filename="../screens/SystemsScreen.qml" line="346"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="339"/>
+        <location filename="../screens/SystemsScreen.qml" line="364"/>
         <source>No systems in this category</source>
         <translation>此类别中没有系统</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="340"/>
+        <location filename="../screens/SystemsScreen.qml" line="365"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>
@@ -1434,7 +1439,7 @@ Euskara - devilschile2</source>
 <context>
     <name>Tile</name>
     <message>
-        <location filename="../components/Tile.qml" line="364"/>
+        <location filename="../components/Tile.qml" line="475"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>

--- a/tests/ui/CMakeLists.txt
+++ b/tests/ui/CMakeLists.txt
@@ -19,6 +19,8 @@ qt_add_qml_module(
         tst_browse_detail_pane.qml
         tst_media_list_titles.qml
         tst_list_picker_modal.qml
+        tst_motion.qml
+        tst_deferred_action.qml
     IMPORTS
         Zaparoo.App
         Zaparoo.Browse

--- a/tests/ui/tst_browse_detail_pane.qml
+++ b/tests/ui/tst_browse_detail_pane.qml
@@ -40,12 +40,21 @@ TestCase {
 
     Component {
         id: noTitlePaneComp
-        BrowseDetailPane { width: 320; height: 240; showTitle: false }
+        BrowseDetailPane {
+            width: 320
+            height: 240
+            showTitle: false
+        }
     }
 
     Component {
         id: reserveNavPaneComp
-        BrowseDetailPane { width: 320; height: 240; showTitle: false; reserveImageNav: true }
+        BrowseDetailPane {
+            width: 320
+            height: 240
+            showTitle: false
+            reserveImageNav: true
+        }
     }
 
     function resetPane(): void {
@@ -56,7 +65,6 @@ TestCase {
         pane.detailTags = "";
         pane.coverKey = "";
         pane._lastGoodCoverSource = "";
-        pane._heldDetailRows = [];
         wait(1);
     }
 
@@ -150,30 +158,32 @@ TestCase {
         paneNav.destroy();
     }
 
-    // Regression: when meta is still loading (loading: true) and the live tags
-    // are value-less, the table must display the last-good (held) rows, not the
-    // blank ones. Once loading settles (loading: false), the live rows win even
-    // if they are empty, so a genuinely metadata-less item shows blank.
-    function test_metadata_hold_while_loading(): void {
-        // Prime the hold with real values.
+    // Regression (stale-metadata flash): the detail table tracks the focused
+    // row's live tags directly, never the previous row's values. The model
+    // keeps current_detail_tags identity-correct on every move (an immediate
+    // peek shows cached/local rows or a clean blank), so the moment the live
+    // tags go value-less the table must reflect that — not hold the prior
+    // item's metadata.
+    function test_metadata_tracks_live_tags(): void {
+        // One item with real values.
         pane.loading = false;
         pane.detailTags = "Year\t1990\nGenre\tAction";
         wait(1);
-        // Move to a new item: live tags are the blank synchronous set; loading is true.
+        verify(pane._displayRows.length > 0, "real rows must be shown");
+        verify((pane._displayRows[0].value ?? "") !== "", "real row value must be present");
+
+        // Move to a value-less item while a fetch is pending: the table must
+        // show the blank live rows immediately, never the previous 1990/Action.
         pane.loading = true;
         pane.detailTags = "Year\t\nGenre\t\nPlayers\t\nDeveloper\t\nPublisher\t\nRating\t";
         wait(1);
-        const table = findChild(pane, "detailTagTable");
-        verify(table.visible, "tag table must remain visible while held rows exist and loading");
-        // The held rows carry Year=1990; confirm the held data is being used.
-        // We access _displayRows via the model that drives the Repeater.
-        verify(pane._displayRows.length > 0, "displayRows must be the held rows, not empty");
-        verify((pane._displayRows[0].value ?? "") !== "", "held row value must be non-empty while loading with blank live tags");
+        verify(pane._displayRows[0].value === "" || pane._displayRows[0].value === undefined, "blank live rows must be shown at once, never the previous item's values");
 
-        // Once loading settles, the live (blank) rows replace the held ones.
+        // A genuinely metadata-less item (empty tags) shows no table at all.
+        pane.detailTags = "";
         pane.loading = false;
         wait(1);
-        verify(pane._displayRows[0].value === "" || pane._displayRows[0].value === undefined, "after loading, live (blank) rows must be shown");
+        verify(!findChild(pane, "detailTagTable").visible, "tag table must be hidden when the item has no metadata");
     }
 
     function test_cover_hold_hidden_with_no_prior_cover(): void {

--- a/tests/ui/tst_deferred_action.qml
+++ b/tests/ui/tst_deferred_action.qml
@@ -1,0 +1,54 @@
+// Zaparoo Frontend
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+import QtQuick
+import QtTest
+import Zaparoo.Theme
+import Zaparoo.Ui
+
+// DeferredAction contract:
+// - With motion disabled, arm() emits deferred synchronously (no event-loop hop).
+// - With motion enabled, arm() emits deferred after Motion.pressMs.
+// - Re-arming while the timer is running is a no-op (deferred fires exactly once).
+TestCase {
+    name: "DeferredAction"
+    when: windowShown
+
+    DeferredAction {
+        id: subject
+        property int deferredCount: 0
+        onDeferred: deferredCount++
+    }
+
+    function init(): void {
+        subject.deferredCount = 0;
+        Motion.enabled = true;
+    }
+
+    function cleanup(): void {
+        Motion.enabled = true;
+    }
+
+    function test_instant_when_motion_disabled(): void {
+        Motion.enabled = false;
+        subject.arm();
+        compare(subject.deferredCount, 1, "arm() must emit deferred synchronously when motion is disabled");
+    }
+
+    function test_deferred_when_motion_enabled(): void {
+        Motion.enabled = true;
+        subject.arm();
+        compare(subject.deferredCount, 0, "arm() must not emit deferred synchronously when motion is enabled");
+        wait(Motion.pressMs + 50);
+        compare(subject.deferredCount, 1, "arm() must have emitted deferred after pressMs elapsed");
+    }
+
+    function test_rearm_while_running_is_dropped(): void {
+        Motion.enabled = true;
+        subject.arm();
+        subject.arm();
+        wait(Motion.pressMs + 50);
+        compare(subject.deferredCount, 1, "deferred must fire exactly once when re-armed while running");
+    }
+}

--- a/tests/ui/tst_list_picker_modal.qml
+++ b/tests/ui/tst_list_picker_modal.qml
@@ -135,7 +135,9 @@ TestCase {
         picker.open = true;
         picker.currentIndex = 2;
         picker.handleAction("accept");
-        compare(acceptedSpy.count, 1);
+        // accepted() is deferred via DeferredAction so the push-in
+        // animation completes first. tryCompare polls until it fires.
+        tryCompare(acceptedSpy, "count", 1);
         compare(acceptedSpy.signalArguments[0][0], "id-2");
     }
 

--- a/tests/ui/tst_motion.qml
+++ b/tests/ui/tst_motion.qml
@@ -1,0 +1,52 @@
+// Zaparoo Frontend
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+import QtQuick
+import QtTest
+import Zaparoo.Theme
+
+// Motion singleton contract: dur() returns the raw ms when enabled and 0
+// when disabled. Token values must match the design-spec constants.
+TestCase {
+    name: "Motion"
+    when: windowShown
+
+    function init(): void {
+        Motion.enabled = true;
+    }
+
+    function cleanup(): void {
+        Motion.enabled = true;
+    }
+
+    function test_dur_returns_ms_when_enabled(): void {
+        Motion.enabled = true;
+        compare(Motion.dur(Motion.pressMs), Motion.pressMs, "dur(pressMs) must equal pressMs when enabled");
+        compare(Motion.dur(Motion.settleMs), Motion.settleMs, "dur(settleMs) must equal settleMs when enabled");
+        compare(Motion.dur(140), 140, "dur(140) must equal 140 when enabled");
+    }
+
+    function test_dur_returns_zero_when_disabled(): void {
+        Motion.enabled = false;
+        compare(Motion.dur(Motion.pressMs), 0, "dur(pressMs) must be 0 when disabled");
+        compare(Motion.dur(Motion.settleMs), 0, "dur(settleMs) must be 0 when disabled");
+        compare(Motion.dur(140), 0, "dur(140) must be 0 when disabled");
+    }
+
+    function test_token_sanity(): void {
+        // Tokens must be in the expected design ranges.
+        verify(Motion.pressMs >= 80 && Motion.pressMs <= 120, "pressMs should be 80-120ms");
+        verify(Motion.settleMs >= 100 && Motion.settleMs <= 200, "settleMs should be 100-200ms");
+        verify(Motion.pressScale > 0.9 && Motion.pressScale < 1.0, "pressScale should be 0.9-1.0");
+    }
+
+    function test_enabled_toggle_round_trip(): void {
+        Motion.enabled = true;
+        verify(Motion.enabled, "enabled should be true after setting true");
+        Motion.enabled = false;
+        verify(!Motion.enabled, "enabled should be false after setting false");
+        Motion.enabled = true;
+        verify(Motion.enabled, "enabled should be true after toggling back");
+    }
+}

--- a/tests/ui/tst_navigation.qml
+++ b/tests/ui/tst_navigation.qml
@@ -10,6 +10,7 @@ import QtQuick
 import QtTest
 import Zaparoo.App
 import Zaparoo.Browse as Browse
+import Zaparoo.Theme
 
 // Exercises the hub ↔ systems ↔ games navigation state machine defined
 // in Main.qml. State is driven either by writing to the activeScreen
@@ -29,6 +30,10 @@ TestCase {
     }
 
     function init(): void {
+        // Disable motion so DeferredAction.arm() runs dispatch synchronously.
+        // Navigation tests assert state immediately after handleKey/handleAction;
+        // a 90 ms async lead would cause every accept test to fail.
+        Motion.enabled = false;
         // The cold-launch BootOverlay normally hides every screen until
         // Core's catalog reaches READY. Tests don't run a real Core, so
         // we mark the boot complete up-front; otherwise every visibility
@@ -51,6 +56,10 @@ TestCase {
         // next test if we didn't reset it here.
         main._stopRepeat();
         main._resetRapidNavigation();
+    }
+
+    function cleanup(): void {
+        Motion.enabled = true;
     }
 
     function test_initial_state_is_hub(): void {

--- a/tests/ui/tst_persistence.qml
+++ b/tests/ui/tst_persistence.qml
@@ -35,6 +35,10 @@ TestCase {
     }
 
     function init(): void {
+        // Disable motion so DeferredAction.arm() runs dispatch synchronously.
+        // Persistence tests assert state immediately after handleKey/handleAction;
+        // a 90 ms async lead would cause every accept test to fail.
+        Motion.enabled = false;
         // The cold-launch BootOverlay normally hides every screen until
         // Core's catalog reaches READY. Tests don't run a real Core, so
         // mark the boot complete up-front; otherwise visibility-driven
@@ -51,6 +55,7 @@ TestCase {
     // later suites — in particular tst_smoke's test_initial_state — see
     // a clean Component.onCompleted path.
     function cleanup(): void {
+        Motion.enabled = true;
         Browse.AppState.active_screen = "";
         Browse.HubState.category = "";
         Browse.HubState.selected_row = 0;


### PR DESCRIPTION
Draft. A consistent, hardware-appropriate interaction-animation system for the Qt/QML frontend, plus the reduce-motion setting.

Commits:
1. `7cae3d7` Reduce-motion setting and the `Motion` token system.
2. `8eca86b` Focus-ready gating (cold-boot ring fix), immediate detail peek, push-in/release cue.
3. `700e2a3` Consolidate to **snap-focus + push-in**; fix the MiSTer cover/animation regressions.
4. `f6c82e8` Settings-row push-in, gentler wide-row press, cancel-disarm, and review fixes.

## The vocabulary

Two cues, everywhere, driven entirely by central `Motion` tokens:

- **Focus = snap.** No cross-fades anywhere (tiles, list rows, menus, modals, settings). Cross-fades were decorative, the worst case for software rendering under load, and fought the list center-scroll.
- **Activation = push-in.** Every activatable surface scales down on accept/launch:
  - Tiles, list-detail rows, context-menu / list-picker rows, modal buttons, and **settings field rows** (picker / action / About-License).
  - **Toggles are exempt** — the knob slide is their cue.
  - Squarish surfaces (tiles, dialog buttons) use `pressScale` (0.96); **wide rows** use a gentler `rowPressScale` (0.985) so the same press reads equally subtle despite their width.

All durations route through `Motion.dur()` with two tokens (`pressMs 80`, `settleMs 110`) and one easing (`OutQuad`); reduce-motion collapses everything to 0 in one place. Timings sit just above MiSTer's frame-budget floor (documented in `Motion.qml`).

**Deferred-flip:** any activation that opens a modal or navigates away runs the push-in first, then acts after `pressMs`, so the cue is never covered or cut off. **Cancel-disarm:** backing out within that window disarms the pending action, so it can't fire after you've cancelled.

## Notable fixes

- **Cold-boot focus ring** shows on the saved item before Core connects (no wrong-tile flash), across all browse screens.
- **SystemsScreen push-in** now routes to the visible layout (it was pulsing the hidden grid in list mode).
- **Detail-cover hourglass on MiSTer:** `peek` no longer re-points the cover every keypress (that held `_coverBusy` true and starved the prefetch). Cover settles via the debounced load with its hold.
- Removed dead `ringFadeReady` / `_navArmed` / `rapidScrollActive`.
- `deploy-mister.sh` portable `wc -c`; `reduce_motion` test coverage; `docs/qml-gotchas.md` animation section refreshed.

## Before un-drafting (TODO)

- [ ] Strip the temporary `recents-diag:` `info!` logging (8 sites in `rust/frontend/src/models/recents.rs`).
- [x] `just test` (506/506) + `just lint` green.

## Test plan

Best judged on the MiSTer (the animation floor is its frame rate). Run with reduce-motion OFF and ON.

- **Cold-boot focus:** relaunch cold; saved tile/row shows focus immediately, no row-0 flash. Hub / Systems / Games / Favorites / Recents, grid and list.
- **Push-in everywhere:** accept a tile, a list-detail row (esp. Systems consoles in list mode), a context-menu row, a list-picker row, a confirm button, and **settings rows** (picker, action, About/License) — all press; toggles slide; wide rows are as subtle as tiles.
- **Deferred-flip / cancel:** press-then-back fast on a tile / settings row — no launch/navigate after backing out.
- **Detail cover:** fast-scroll a list; no per-move hourglass, next cover warm.
- **Reduce-motion:** all motion collapses to instant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Reduce motion” accessibility setting to disable animations when enabled.
  * Introduced centralized motion tokens and pulse-based push-in cues for selections/confirmations, with focus gating during startup/restore.
  * Added instant “peek” detail previews across favorites, games, and recents.
* **Performance**
  * Added an LRU-bounded media metadata cache with prefetching for faster detail-pane updates.
* **Bug Fixes**
  * Improved MiSTer frontend deployment using verified, atomic updates.
* **Chores**
  * Updated ignore rules and refreshed UI translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->