### PR TITLE
Add jump-to-letter navigation and the View page menu

### DIFF
--- a/rust/frontend/src/models/games.rs
+++ b/rust/frontend/src/models/games.rs
@@ -54,8 +54,8 @@ use zaparoo_core::endpoints::media_tags_update::MediaTagsUpdateMutation;
 use zaparoo_core::endpoints::readers_write::ReadersWriteMutation;
 use zaparoo_core::endpoints::run::RunMutation;
 use zaparoo_core::media_types::{
-    BrowseEntry, MediaBrowseParams, MediaBrowseResult, MediaMeta, MediaMetaParams,
-    MediaTagsUpdateParams, ReadersWriteParams, RunParams, TagInfo,
+    BrowseEntry, MediaBrowseIndexParams, MediaBrowseParams, MediaBrowseResult, MediaMeta,
+    MediaMetaParams, MediaTagsUpdateParams, ReadersWriteParams, RunParams, TagInfo,
 };
 use zaparoo_core::platform::{self, Platform};
 use zaparoo_core::remote_resource::ResourceStatus;
@@ -121,6 +121,23 @@ const DEFAULT_PAGE_SIZE: i32 = 15;
 // longer floods the cover queue.
 const FETCH_MORE_CHUNK_SIZE: i32 = 100;
 const FETCH_MORE_RAPID_CHUNK_SIZE: i32 = 300;
+// Ceiling for a jump-to-letter fetch (Core's `max_results` cap). A position
+// jump must load every row up to the target before
+// `PagedGrid._commitPendingTarget` can land on it; doing that as the 12-row
+// frame-gapped trickle (`apply_append_page`) takes seconds on a far jump. The
+// jump path instead inserts the whole chunk in one shot (`bulk` append) — the
+// loading overlay is up and the appended rows sit far from `currentPage`, so
+// their Tile delegates stay unmaterialised (the per-cell Loader is
+// retention-gated), making the bulk insert cheap. `fetch_more_jump` sizes each
+// request to the gap remaining to the target (rounded up to whole `page_size`
+// pages, plus one page of margin) rather than always pulling the full
+// remainder, so a near/mid-folder jump transfers far less; a gap larger than
+// this ceiling chains another bulk call.
+const JUMP_FETCH_CHUNK_SIZE: i32 = 1000;
+// Stay within Core's `max_results` ceiling, and never smaller than the rapid
+// scroll chunk (a jump must not load slower than ordinary scrolling).
+const _: () = assert!(JUMP_FETCH_CHUNK_SIZE <= 1000);
+const _: () = assert!(JUMP_FETCH_CHUNK_SIZE >= FETCH_MORE_RAPID_CHUNK_SIZE);
 const COLLAPSED_DIRECTORY_BROWSE_PAGE_SIZE: u32 = 1000;
 const COVER_PREFETCH_NEXT_PAGES: i32 = 2;
 const COVER_PREFETCH_PREVIOUS_PAGES: i32 = 1;
@@ -297,6 +314,17 @@ pub struct GamesModelRust {
     // carousel once the cover lands and the type can be looked up, then clears
     // this field.
     pending_carousel_keys: Option<Vec<MediaKey>>,
+    // Latest `media.browse.index` facet for the current scope, surfaced to QML
+    // for the jump-to-letter rail. `letter_index_json` is a JSON array of
+    // `{key,label,count,cursor}` objects (the QML pickers consume `var` arrays,
+    // so a parsed-in-QML JSON string fits that convention without a second
+    // QAbstractListModel for transient modal data). `letter_index_scheme` is
+    // the facet scheme (`latin`/`none`); QML omits the menu entry when no rail
+    // applies. Bumped each `load_letter_index` so a stale in-flight facet from a
+    // prior scope can't overwrite the current one.
+    letter_index_json: QString,
+    letter_index_scheme: QString,
+    letter_index_seq: Arc<AtomicU64>,
 }
 
 impl Default for GamesModelRust {
@@ -348,6 +376,9 @@ impl Default for GamesModelRust {
             cover_max_size: 0,
             nav_timing: None,
             pending_carousel_keys: None,
+            letter_index_json: QString::default(),
+            letter_index_scheme: QString::default(),
+            letter_index_seq: Arc::new(AtomicU64::new(0)),
         }
     }
 }
@@ -400,6 +431,8 @@ pub mod ffi {
         #[qproperty(bool, show_original_filenames, READ, WRITE = set_show_original_filenames, NOTIFY)]
         #[qproperty(i32, visible_first_row)]
         #[qproperty(i32, cover_max_size, READ, WRITE = set_cover_max_size, NOTIFY)]
+        #[qproperty(QString, letter_index_json)]
+        #[qproperty(QString, letter_index_scheme)]
         type GamesModel = super::GamesModelRust;
 
         #[qinvokable]
@@ -419,6 +452,12 @@ pub mod ffi {
 
         #[qinvokable]
         fn fetch_more_rapid(self: Pin<&mut GamesModel>);
+
+        #[qinvokable]
+        fn fetch_more_jump(self: Pin<&mut GamesModel>, target_index: i32);
+
+        #[qinvokable]
+        fn load_letter_index(self: Pin<&mut GamesModel>);
 
         #[qinvokable]
         fn prefetch_around(self: Pin<&mut GamesModel>, first_visible_row: i32);
@@ -657,14 +696,26 @@ impl ffi::GamesModel {
     }
 
     fn fetch_more(self: Pin<&mut Self>) {
-        self.fetch_more_with_limit(FETCH_MORE_CHUNK_SIZE);
+        self.fetch_more_with_limit(FETCH_MORE_CHUNK_SIZE, false);
     }
 
     fn fetch_more_rapid(self: Pin<&mut Self>) {
-        self.fetch_more_with_limit(FETCH_MORE_RAPID_CHUNK_SIZE);
+        self.fetch_more_with_limit(FETCH_MORE_RAPID_CHUNK_SIZE, false);
     }
 
-    fn fetch_more_with_limit(mut self: Pin<&mut Self>, limit: i32) {
+    fn fetch_more_jump(self: Pin<&mut Self>, target_index: i32) {
+        // Size the fetch to the gap remaining to the jump target instead of
+        // always pulling the server max. `target_index` is the absolute grid
+        // row the cursor will land on (it shares the model's row space, so it
+        // includes leading directories); `count` is the rows already loaded.
+        // A near/mid-folder jump transfers far less than the full remainder; an
+        // under-shoot (huge folder, or the target moved) just re-enters here via
+        // the pending-target loop and converges.
+        let limit = jump_fetch_limit(target_index, self.count, self.page_size);
+        self.fetch_more_with_limit(limit, true);
+    }
+
+    fn fetch_more_with_limit(mut self: Pin<&mut Self>, limit: i32, bulk: bool) {
         // Debounce: PagedGrid fires `loadMoreRequested` once per page
         // turn, but a fast spinner on the last loaded page can fire
         // twice before the first follow-up returns. All three guards
@@ -695,6 +746,19 @@ impl ffi::GamesModel {
         let seq = self.seq.clone();
         let ticket = seq.load(Ordering::SeqCst);
         let max_results = u32::try_from(limit.max(1)).unwrap_or(u32::from(u16::MAX));
+        // Jump path: pause cover fetching for the duration of this request and
+        // drop anything queued. Covers travel over the same WebSocket as
+        // `media.browse`, so the cold-entry cover storm (the leaving page's
+        // covers) head-of-line-blocks the jump's browse request at Core — this
+        // is why the *first* jump after entering a folder is the slow one.
+        // Pausing dedicates the socket to the browse call; `apply_append_page`
+        // resumes covers and warms the landing page once the rows land, and
+        // `start_initial_browse` resets the flag if the user leaves mid-jump
+        // (the in-flight response is then ticket-rejected before it can resume).
+        if bulk {
+            self.as_mut().set_cover_requests_paused(true);
+            global_media_image_cache().clear_pending_requests();
+        }
         self.as_mut().set_loading_more(true);
         let qt_thread = self.qt_thread();
         let store = global_store();
@@ -720,7 +784,72 @@ impl ffi::GamesModel {
                 if seq.load(Ordering::SeqCst) != ticket {
                     return;
                 }
-                apply_append_page(model, result, expected_prev_cursor.as_deref());
+                apply_append_page(model, result, expected_prev_cursor.as_deref(), bulk);
+            });
+        });
+    }
+
+    /// Fetch the `media.browse.index` facet for the current scope and surface
+    /// it to QML as `letter_index_json` / `letter_index_scheme` for the
+    /// jump-to-letter rail. Fire-and-forget: the router calls this when the
+    /// page-ops menu opens so the buckets are likely ready by the time the
+    /// user picks "Jump to letter".
+    fn load_letter_index(mut self: Pin<&mut Self>) {
+        let path = self.current_path.to_string();
+        // A root listing has no meaningful first-character rail.
+        if path.is_empty() {
+            self.as_mut().set_letter_index_json(QString::from("[]"));
+            self.as_mut().set_letter_index_scheme(QString::from("none"));
+            return;
+        }
+        let sid = self.current_system_id.to_string();
+        let systems = if sid.is_empty() {
+            Vec::new()
+        } else {
+            vec![sid]
+        };
+        // Clear any facet from a prior scope to the loading state (empty groups,
+        // empty scheme) so the rail shows "loading" rather than the previous
+        // folder's buckets until the fresh fetch lands.
+        self.as_mut().set_letter_index_json(QString::from("[]"));
+        self.as_mut().set_letter_index_scheme(QString::default());
+        // Ticket so a stale facet from a prior scope can't overwrite a newer
+        // one if the user moves on before this resolves.
+        let seq = self.letter_index_seq.clone();
+        let ticket = seq.fetch_add(1, Ordering::SeqCst) + 1;
+        let qt_thread = self.qt_thread();
+        let store = global_store();
+        global_handle().spawn(async move {
+            let result = store
+                .client()
+                .media_browse_index(MediaBrowseIndexParams {
+                    path,
+                    systems,
+                    sort: None,
+                })
+                .await;
+            let _ = qt_thread.queue(move |mut model| {
+                if seq.load(Ordering::SeqCst) != ticket {
+                    return;
+                }
+                match result {
+                    Ok(index) => {
+                        let json = index.groups_json();
+                        model
+                            .as_mut()
+                            .set_letter_index_json(QString::from(json.as_str()));
+                        model
+                            .as_mut()
+                            .set_letter_index_scheme(QString::from(index.scheme.as_str()));
+                    }
+                    Err(e) => {
+                        warn!("media.browse.index failed: {}", e.message);
+                        model.as_mut().set_letter_index_json(QString::from("[]"));
+                        model
+                            .as_mut()
+                            .set_letter_index_scheme(QString::from("none"));
+                    }
+                }
             });
         });
     }
@@ -1277,6 +1406,12 @@ impl ffi::GamesModel {
             .fetch_add(1, Ordering::SeqCst);
         self.as_mut().set_has_next_page(false);
         self.as_mut().set_loading_more(false);
+        // Clear any cover pause held by a jump fetch that's being abandoned by
+        // this scope swap. The in-flight jump response is ticket-rejected below
+        // (the `seq` bump), so it never reaches `apply_append_page` to resume
+        // covers itself; without this the new folder would render with covers
+        // stuck paused.
+        self.as_mut().set_cover_requests_paused(false);
         self.as_mut().rust_mut().auto_nav_eligible = eligible_for_auto_nav;
         // Cleared on every browse target swap: a new path needs the
         // full `apply_initial_page` reset to install fresh entries.
@@ -2575,6 +2710,21 @@ fn decide_initial(
 /// the `MiSTer` menu, which is a layout artifact not user-facing intent.
 /// Path stays untouched — launching/navigation still depend on the
 /// original.
+/// Rows a jump fetch should request to reach `target_index` from a model
+/// holding `count` rows. Pulls the gap plus one page of margin (so the landing
+/// page is full and there is a little look-ahead past it), rounded up to whole
+/// `page_size` pages — batch sizes always derive from the user-configurable
+/// page size — and clamped to `[page_size, JUMP_FETCH_CHUNK_SIZE]` (Core's
+/// `max_results` ceiling). Pure so it is unit-testable.
+fn jump_fetch_limit(target_index: i32, count: i32, page_size: i32) -> i32 {
+    let page = page_size.max(1);
+    let gap = (target_index - count).max(0) + page;
+    // Manual ceil-div: signed `i32::div_ceil` is still unstable. `gap` and
+    // `page` are both >= 1, so this can't overflow for realistic folder sizes.
+    let pages = (gap + page - 1) / page;
+    (pages * page).clamp(page, JUMP_FETCH_CHUNK_SIZE)
+}
+
 fn transform_entries(
     mut entries: Vec<BrowseEntry>,
     platform: Option<&Platform>,
@@ -2988,6 +3138,7 @@ fn apply_append_page(
     mut model: Pin<&mut ffi::GamesModel>,
     result: Result<MediaBrowseResult, ClientError>,
     expected_prev_cursor: Option<&str>,
+    bulk: bool,
 ) {
     // Cursor-chain check: if the model's `next_cursor` no longer
     // matches the cursor this append was advancing from, an
@@ -3038,6 +3189,37 @@ fn apply_append_page(
             // `start_initial_browse` lands during the trickle window.
             model.as_mut().rust_mut().next_cursor = next_cursor;
             model.as_mut().set_loading_more(false);
+            // Jump path: insert the whole chunk in one shot, no frame-gapped
+            // trickle. The appended rows sit far from `currentPage`, so their
+            // Tile delegates stay unmaterialised (per-cell Loader is
+            // retention-gated) and the bulk insert is cheap; the loading
+            // overlay is up so a single brief stall is invisible, and it lets
+            // `_commitPendingTarget` see the target as loaded in one step
+            // instead of creeping toward it over dozens of frames.
+            if bulk {
+                let had_entries = !entries.is_empty();
+                if had_entries {
+                    insert_sub_batch(model.as_mut(), entries);
+                }
+                // Resume covers (paused by `fetch_more_with_limit` for the jump
+                // request) BEFORE prefetching: the insert above drives
+                // `_commitPendingTarget` synchronously, which moves
+                // `visible_first_row` to the landing page, so prefetching now —
+                // with covers re-enabled — warms exactly that page. Resuming
+                // unconditionally (even on an empty page) guarantees the pause
+                // never sticks past the request that set it.
+                model.as_mut().set_cover_requests_paused(false);
+                if had_entries {
+                    let visible = model.visible_first_row;
+                    model.as_mut().prefetch_around(visible);
+                }
+                model.as_mut().set_has_next_page(has_next_page);
+                if model.total_files != total {
+                    model.as_mut().set_total_files(total);
+                }
+                release_initial_lookahead_gate(model.as_mut());
+                return;
+            }
             let mut batches = chunk_for_subbatching(entries, APPEND_SUB_BATCH_SIZE);
             if batches.is_empty() {
                 // No new rows landed (empty page). Finalise immediately
@@ -3149,12 +3331,13 @@ mod tests {
         child_launch_text_from_browse_result, chunk_for_subbatching, compute_unresolved_keys,
         cover_key_for_with, cover_placeholder_for, decide_initial, dedup_roots_drop_ancestors,
         detail_image_keys_from_meta, detail_tags_from_tags, display_name, display_title_for_entry,
-        entry_system_id, is_media_capable_entry, is_strict_ancestor_path, leading_dir_count,
-        media_capable_directory_browse_params, media_key_for, meta_params_for_entry,
-        ordered_detail_image_keys, position_of_game_path, prefetch_around_plan,
-        prefetch_cursor_window_plan, project_status, run_text_for_entry,
+        entry_system_id, is_media_capable_entry, is_strict_ancestor_path, jump_fetch_limit,
+        leading_dir_count, media_capable_directory_browse_params, media_key_for,
+        meta_params_for_entry, ordered_detail_image_keys, position_of_game_path,
+        prefetch_around_plan, prefetch_cursor_window_plan, project_status, run_text_for_entry,
         singleton_directory_needs_launch_resolution, transform_entries, InitialAction, Projection,
     };
+    use super::{FETCH_MORE_RAPID_CHUNK_SIZE, JUMP_FETCH_CHUNK_SIZE};
     use crate::media_image_cache::{MediaImageCache, MediaKey};
     use std::collections::HashSet;
     use zaparoo_core::media_types::{BrowseEntry, MediaBrowseResult, Pagination, TagInfo};
@@ -3990,6 +4173,58 @@ mod tests {
         let entries = vec![media("a", "/a", "NES")];
         let out = chunk_for_subbatching(entries, 0);
         assert!(out.is_empty());
+    }
+
+    #[test]
+    fn jump_fetch_limit_sizes_to_gap_plus_one_page_rounded_up() {
+        // Target 570, 113 loaded, page 100: gap = 457 + 100 margin = 557 ->
+        // 6 pages -> 600. Far less than the 1000 ceiling for a mid-folder jump.
+        assert_eq!(jump_fetch_limit(570, 113, 100), 600);
+    }
+
+    #[test]
+    fn jump_fetch_limit_clamps_to_ceiling_for_far_targets() {
+        // A target past what one ceiling-sized fetch covers clamps to the cap;
+        // the pending-target loop fetches the next slice afterward.
+        assert_eq!(jump_fetch_limit(5000, 113, 100), JUMP_FETCH_CHUNK_SIZE);
+    }
+
+    #[test]
+    fn jump_fetch_limit_floors_at_one_page_when_target_already_loaded() {
+        // Target at or behind the loaded count has no gap, but the one-page
+        // margin still pulls a single page (look-ahead past the landing page).
+        assert_eq!(jump_fetch_limit(113, 113, 100), 100);
+        assert_eq!(jump_fetch_limit(50, 113, 100), 100);
+    }
+
+    #[test]
+    fn jump_fetch_limit_margin_rounds_a_small_gap_up_to_two_pages() {
+        // A target just past the loaded slice: gap (7) + one-page margin (100)
+        // = 107 -> rounds up to 2 pages so the landing page is fully covered.
+        assert_eq!(jump_fetch_limit(120, 113, 100), 200);
+    }
+
+    #[test]
+    fn jump_fetch_limit_is_a_whole_number_of_pages() {
+        for target in [0, 37, 113, 251, 499, 800] {
+            let limit = jump_fetch_limit(target, 113, 100);
+            assert_eq!(limit % 100, 0, "limit {limit} not a page multiple");
+        }
+    }
+
+    #[test]
+    fn jump_fetch_limit_never_below_rapid_scroll_chunk_at_default_page() {
+        // A jump must not pull a smaller batch than ordinary rapid scrolling
+        // when the configured page is at least the rapid chunk.
+        let limit = jump_fetch_limit(2000, 0, FETCH_MORE_RAPID_CHUNK_SIZE);
+        assert!(limit >= FETCH_MORE_RAPID_CHUNK_SIZE);
+    }
+
+    #[test]
+    fn jump_fetch_limit_tolerates_nonpositive_page_size() {
+        // Defensive: a zero/negative page_size must not divide-by-zero; it
+        // floors to a single one-row page (gap = 0 + 1 margin = 1 page).
+        assert_eq!(jump_fetch_limit(0, 0, 0), 1);
     }
 
     #[test]

--- a/rust/frontend/src/models/games.rs
+++ b/rust/frontend/src/models/games.rs
@@ -3149,6 +3149,15 @@ fn apply_append_page(
         if model.loading_more {
             model.as_mut().set_loading_more(false);
         }
+        // A bulk jump paused covers for this request (`fetch_more_with_limit`).
+        // The intervening reset that tripped this mismatch was an `is_seeded`
+        // refetch on the same scope, which doesn't resume covers, so resume
+        // here or the page stays frozen with covers paused. `loading_more`
+        // forbids a second concurrent bulk fetch, so no other request is
+        // relying on the pause.
+        if bulk {
+            model.as_mut().set_cover_requests_paused(false);
+        }
         return;
     }
     match result {
@@ -3308,6 +3317,12 @@ fn apply_append_page(
                 .as_mut()
                 .set_error_message(QString::from(e.message.as_str()));
             model.as_mut().set_loading_more(false);
+            // A bulk jump paused covers for this request; resume on the error
+            // path too, mirroring the Ok path's unconditional resume, so a
+            // failed jump fetch never leaves the pause stuck.
+            if bulk {
+                model.as_mut().set_cover_requests_paused(false);
+            }
             // Even on a failed first prefetch, we have to release the
             // cover gate's hold or the user is stuck on Loading…
             // forever. The visible page is already in place from

--- a/rust/zaparoo-core/src/client.rs
+++ b/rust/zaparoo-core/src/client.rs
@@ -14,11 +14,12 @@
 // instead of disappearing into a queue.
 
 use crate::media_types::{
-    HealthResult, LaunchersResult, LogDownloadResult, MediaBrowseParams, MediaBrowseResult,
-    MediaHistoryLatestResult, MediaHistoryParams, MediaHistoryResult, MediaHistoryTopParams,
-    MediaHistoryTopResult, MediaImageParams, MediaImageResult, MediaIndexParams, MediaLookupParams,
-    MediaLookupResult, MediaMetaParams, MediaMetaResult, MediaResult, MediaScrapeParams,
-    MediaSearchParams, MediaSearchResult, MediaTagsParams, MediaTagsResult, MediaTagsUpdateParams,
+    HealthResult, LaunchersResult, LogDownloadResult, MediaBrowseIndexParams,
+    MediaBrowseIndexResult, MediaBrowseParams, MediaBrowseResult, MediaHistoryLatestResult,
+    MediaHistoryParams, MediaHistoryResult, MediaHistoryTopParams, MediaHistoryTopResult,
+    MediaImageParams, MediaImageResult, MediaIndexParams, MediaLookupParams, MediaLookupResult,
+    MediaMetaParams, MediaMetaResult, MediaResult, MediaScrapeParams, MediaSearchParams,
+    MediaSearchResult, MediaTagsParams, MediaTagsResult, MediaTagsUpdateParams,
     MediaTagsUpdateResult, ReadersResult, ReadersWriteParams, RunParams, ScrapersResult,
     ScrapingStatusResponse, SettingsResult, SystemsParams, SystemsResult, TokensHistoryResult,
     TokensResult, UpdateSettingsParams, VersionResult,
@@ -623,6 +624,20 @@ impl Client {
         let total_files = val.get("totalFiles").and_then(Value::as_u64).unwrap_or(0);
         debug!(entries_len, total_files, "media.browse response");
         deserialize_timed("media.browse", val)
+    }
+
+    pub async fn media_browse_index(
+        &self,
+        params: MediaBrowseIndexParams,
+    ) -> Result<MediaBrowseIndexResult, ClientError> {
+        debug!(
+            path = %params.path,
+            systems = ?params.systems,
+            sort = ?params.sort,
+            "media.browse.index request",
+        );
+        let val = self.call("media.browse.index", &params).await?;
+        deserialize_timed("media.browse.index", val)
     }
 
     /// Fetches a single best-match cover image for the given media row.

--- a/rust/zaparoo-core/src/config.rs
+++ b/rust/zaparoo-core/src/config.rs
@@ -582,9 +582,14 @@ mod tests {
     fn keyboard_override_replaces_default_for_that_action() {
         use crate::input_actions::{actions, qt_key_code};
 
+        // `page_menu` defaults to Space, so unbind it here (empty list =
+        // unbind) before reusing Space to demonstrate that an `accept`
+        // override replaces accept's own defaults. Without freeing Space the
+        // deterministic collision policy would hand it to `page_menu`.
         let toml = r#"
             [input.keyboard]
             accept = ["Space"]
+            page_menu = []
         "#;
         let f = write_tmp(toml);
         let cfg = load_config(f.path());

--- a/rust/zaparoo-core/src/input_actions.rs
+++ b/rust/zaparoo-core/src/input_actions.rs
@@ -20,6 +20,7 @@ pub mod actions {
     pub const DETAILS: &str = "details";
     pub const PAGE_PREV: &str = "page_prev";
     pub const PAGE_NEXT: &str = "page_next";
+    pub const PAGE_MENU: &str = "page_menu";
     pub const QUIT: &str = "quit";
 }
 
@@ -68,6 +69,7 @@ pub fn default_bindings() -> HashMap<String, Vec<String>> {
     map.insert(actions::CONTEXT_MENU.into(), vec!["Tab".into()]);
     map.insert(actions::PAGE_PREV.into(), vec!["PageUp".into()]);
     map.insert(actions::PAGE_NEXT.into(), vec!["PageDown".into()]);
+    map.insert(actions::PAGE_MENU.into(), vec!["Space".into()]);
     map
 }
 
@@ -140,6 +142,10 @@ mod tests {
         assert_eq!(
             map.get(&qt_key_code("Tab").unwrap()).map(String::as_str),
             Some(actions::CONTEXT_MENU),
+        );
+        assert_eq!(
+            map.get(&qt_key_code("Space").unwrap()).map(String::as_str),
+            Some(actions::PAGE_MENU),
         );
     }
 

--- a/rust/zaparoo-core/src/media_types.rs
+++ b/rust/zaparoo-core/src/media_types.rs
@@ -311,6 +311,71 @@ impl MediaBrowseResult {
     }
 }
 
+// Parameters for `media.browse.index`. The scope fields mirror
+// `MediaBrowseParams` so the returned index describes the exact list
+// `media.browse` would page through for the same scope. As with browse, the
+// `fuzzySystem` flag is deliberately not surfaced: the frontend composes
+// canonical system ids, so a mismatch is a bug rather than something to fuzz
+// over.
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MediaBrowseIndexParams {
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub path: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub systems: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sort: Option<String>,
+}
+
+/// One first-character section of a browse list. `key`/`label` are opaque so a
+/// future locale-aware scheme (pinyin/kana/hangul) needs no client change.
+/// `cursor` is an ordinary `media.browse` cursor positioned just before the
+/// bucket's first row; an empty string means the bucket begins the list (browse
+/// with no cursor).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BrowseIndexGroup {
+    pub key: String,
+    pub label: String,
+    #[serde(default)]
+    pub count: u32,
+    #[serde(default)]
+    pub cursor: String,
+    /// 0-based position of the bucket's first item among the scope's files
+    /// (excludes leading directories, which the client adds). Authoritative
+    /// browse-order position from Core, used to jump to the bucket.
+    #[serde(default)]
+    pub offset: u32,
+}
+
+/// Response for `media.browse.index`. `scheme` is the collation used to derive
+/// the buckets (`latin`, or `none` when no rail applies, in which case `groups`
+/// is empty).
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MediaBrowseIndexResult {
+    #[serde(default)]
+    pub scheme: String,
+    #[serde(default)]
+    pub total_files: u32,
+    #[serde(default)]
+    pub groups: Vec<BrowseIndexGroup>,
+}
+
+impl MediaBrowseIndexResult {
+    /// Serialize the buckets as a JSON array of `{key,label,count,cursor}`
+    /// objects. The frontend surfaces this string to QML, where the
+    /// jump-to-letter picker parses it (the pickers already consume `var`
+    /// arrays, so a JSON string fits that convention). Returns `[]` on the
+    /// (practically impossible) serialize failure so QML always gets valid
+    /// JSON to parse.
+    #[must_use]
+    pub fn groups_json(&self) -> String {
+        serde_json::to_string(&self.groups).unwrap_or_else(|_| "[]".to_string())
+    }
+}
+
 /// Parameters for `media.history`. Cursor-driven pagination shares the
 /// same shape as `media.browse`/`media.search`; fields are optional and
 /// `skip_serializing_if` keeps the on-the-wire object minimal.
@@ -1091,14 +1156,15 @@ mod tests {
     )]
 
     use super::{
-        BrowseEntry, HealthResult, IndexingStatusResponse, LaunchersResult, LogDownloadResult,
-        MediaBrowseParams, MediaBrowseResult, MediaHistoryLatestResult, MediaHistoryParams,
-        MediaHistoryResult, MediaHistoryTopParams, MediaHistoryTopResult, MediaImageParams,
-        MediaImageResult, MediaIndexParams, MediaLookupParams, MediaLookupResult, MediaMetaParams,
-        MediaMetaResult, MediaResult, MediaScrapeParams, MediaSearchParams, MediaSearchResult,
-        MediaTagsParams, MediaTagsResult, ReaderInfo, ReadersResult, ScrapersResult,
-        ScrapingStatusResponse, SettingsResult, SystemDefault, SystemsResult, TagInfo,
-        TokensHistoryResult, TokensResult, UpdateSettingsParams, VersionResult,
+        BrowseEntry, BrowseIndexGroup, HealthResult, IndexingStatusResponse, LaunchersResult,
+        LogDownloadResult, MediaBrowseIndexParams, MediaBrowseIndexResult, MediaBrowseParams,
+        MediaBrowseResult, MediaHistoryLatestResult, MediaHistoryParams, MediaHistoryResult,
+        MediaHistoryTopParams, MediaHistoryTopResult, MediaImageParams, MediaImageResult,
+        MediaIndexParams, MediaLookupParams, MediaLookupResult, MediaMetaParams, MediaMetaResult,
+        MediaResult, MediaScrapeParams, MediaSearchParams, MediaSearchResult, MediaTagsParams,
+        MediaTagsResult, ReaderInfo, ReadersResult, ScrapersResult, ScrapingStatusResponse,
+        SettingsResult, SystemDefault, SystemsResult, TagInfo, TokensHistoryResult, TokensResult,
+        UpdateSettingsParams, VersionResult,
     };
 
     #[test]
@@ -1332,6 +1398,83 @@ mod tests {
         let pagination = result.pagination.expect("pagination present");
         assert!(pagination.has_next_page);
         assert_eq!(pagination.next_cursor.as_deref(), Some("x"));
+    }
+
+    #[test]
+    fn media_browse_index_result_parses_scheme_and_groups() {
+        let json = r##"{
+            "scheme": "latin",
+            "totalFiles": 150,
+            "groups": [
+                {"key":"#","label":"#","count":3,"cursor":"","offset":0},
+                {"key":"A","label":"A","count":12,"cursor":"opaqueA","offset":10}
+            ]
+        }"##;
+        let result: MediaBrowseIndexResult = serde_json::from_str(json).expect("parse");
+        assert_eq!(result.scheme, "latin");
+        assert_eq!(result.total_files, 150);
+        assert_eq!(result.groups.len(), 2);
+        // The list-leading bucket has an empty cursor (browse from the top).
+        assert_eq!(result.groups[0].key, "#");
+        assert_eq!(result.groups[0].cursor, "");
+        assert_eq!(result.groups[0].offset, 0);
+        assert_eq!(result.groups[1].key, "A");
+        assert_eq!(result.groups[1].count, 12);
+        assert_eq!(result.groups[1].cursor, "opaqueA");
+        assert_eq!(result.groups[1].offset, 10);
+    }
+
+    #[test]
+    fn media_browse_index_groups_json_emits_camel_case_objects() {
+        let result = MediaBrowseIndexResult {
+            scheme: "latin".into(),
+            total_files: 4,
+            groups: vec![BrowseIndexGroup {
+                key: "A".into(),
+                label: "A".into(),
+                count: 4,
+                cursor: "opaqueA".into(),
+                offset: 10,
+            }],
+        };
+        // QML JSON.parse consumes this string; keys must match what the grid
+        // reads (key/label/count/cursor/offset).
+        let parsed: serde_json::Value =
+            serde_json::from_str(&result.groups_json()).expect("parse json");
+        let first = &parsed.as_array().expect("array")[0];
+        assert_eq!(first.get("key").and_then(|v| v.as_str()), Some("A"));
+        assert_eq!(first.get("label").and_then(|v| v.as_str()), Some("A"));
+        assert_eq!(
+            first.get("count").and_then(serde_json::Value::as_u64),
+            Some(4)
+        );
+        assert_eq!(
+            first.get("cursor").and_then(|v| v.as_str()),
+            Some("opaqueA")
+        );
+        assert_eq!(
+            first.get("offset").and_then(serde_json::Value::as_u64),
+            Some(10)
+        );
+    }
+
+    #[test]
+    fn media_browse_index_params_systems_only_omits_path_and_sort() {
+        let params = MediaBrowseIndexParams {
+            systems: vec!["SNES".into()],
+            ..MediaBrowseIndexParams::default()
+        };
+        let json = serde_json::to_value(&params).expect("serialise");
+        let object = json.as_object().expect("object");
+        assert!(!object.contains_key("path"));
+        assert!(!object.contains_key("sort"));
+        assert_eq!(
+            object
+                .get("systems")
+                .and_then(|v| v.as_array())
+                .map(Vec::len),
+            Some(1)
+        );
     }
 
     #[test]

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -41,6 +41,7 @@ MainLayout {
     readonly property string modalLogUpload: "log_upload"
     readonly property string modalQuitConfirm: "quit_confirm"
     readonly property string modalListPicker: "list_picker"
+    readonly property string modalLetterJump: "letter_jump"
     readonly property string modalSettingNeedsRestart: "restart_confirm"
 
     // One-shot session flag: the first-run modal is shown at most
@@ -225,6 +226,8 @@ MainLayout {
             root.quitConfirmModalRequested = true;
         else if (modal === root.modalListPicker)
             root.listPickerModalRequested = true;
+        else if (modal === root.modalLetterJump)
+            root.letterJumpModalRequested = true;
         else if (modal === root.modalSettingNeedsRestart)
             root.settingNeedsRestartModalRequested = true;
     }
@@ -1348,6 +1351,9 @@ MainLayout {
         function onRequestContextMenu(index: int, anchorRect): void {
             root.openContextMenu("games", index, anchorRect);
         }
+        function onRequestPageMenu(): void {
+            root.openPageMenu();
+        }
     }
 
     onActiveCardWritePendingChanged: root.handleCardWriteStatus()
@@ -1917,6 +1923,54 @@ MainLayout {
             ScreenManager.popModal();
     }
 
+    // Open the page/list-scoped operations menu (West button), the "View"
+    // counterpart to North's item-scoped "Options". For now it holds a single
+    // entry, Go to..., kept pre-focused so the common path is a fixed
+    // West-then-Accept chord; future list ops (sort/filter/layout) append here.
+    // The facet fetch is kicked off here so the buckets are likely ready by the
+    // time the user advances into the grid.
+    function openPageMenu(): void {
+        Browse.GamesModel.load_letter_index();
+        const entries = [
+            {
+                "id": "jump_letter",
+                "label": qsTr("Go to...")
+            }
+        ];
+        root.openListPickerModal(qsTr("View"), entries, "jump_letter", "page_menu");
+    }
+
+    // Re-parse the model's facet JSON into the live grid entries. Bound through
+    // a Connections below so the grid populates the instant the fetch lands.
+    function _refreshLetterJumpEntries(): void {
+        const scheme = Browse.GamesModel.letter_index_scheme;
+        let parsed = [];
+        try {
+            parsed = JSON.parse(Browse.GamesModel.letter_index_json);
+        } catch (e) {
+            parsed = [];
+        }
+        root.letterJumpEntries = Array.isArray(parsed) ? parsed : [];
+        // Empty scheme = facet still resolving; anything else is final.
+        root.letterJumpLoading = scheme === "";
+    }
+
+    function openLetterJumpModal(): void {
+        root._refreshLetterJumpEntries();
+        root._requestModal(root.modalLetterJump);
+        root.letterJumpModalVisible = true;
+        if (ScreenManager.topModal !== root.modalLetterJump)
+            ScreenManager.pushModal(root.modalLetterJump);
+    }
+
+    function closeLetterJumpModal(): void {
+        root.letterJumpModalVisible = false;
+        root.letterJumpEntries = [];
+        root.letterJumpLoading = false;
+        if (ScreenManager.topModal === root.modalLetterJump)
+            ScreenManager.popModal();
+    }
+
     function openSettingNeedsRestartModal(): void {
         root._requestModal(root.modalSettingNeedsRestart);
         root.settingNeedsRestartModalVisible = true;
@@ -2010,6 +2064,12 @@ MainLayout {
     }
 
     onListPickerAccepted: (fieldId, selectedId) => {
+        if (fieldId === "page_menu") {
+            root.closeListPickerModal();
+            if (selectedId === "jump_letter")
+                root.openLetterJumpModal();
+            return;
+        }
         if (fieldId === "system_launcher_pending")
             return;
         if (fieldId === "system_launcher_error") {
@@ -2056,6 +2116,29 @@ MainLayout {
         root.closeListPickerModal();
     }
     onListPickerCloseRequested: root.handleListPickerCloseRequested()
+
+    onLetterJumpAccepted: offset => {
+        root.closeLetterJumpModal();
+        if (root.gamesScreen !== null)
+            root.gamesScreen.jumpToItem(offset);
+    }
+    onLetterJumpCloseRequested: root.closeLetterJumpModal()
+
+    // Keep the open grid in sync with the facet as it lands. The model clears
+    // its facet to the loading state on `load_letter_index`, then fills it; this
+    // re-parses into the live grid entries each time either changes.
+    Connections {
+        target: Browse.GamesModel
+        enabled: root.letterJumpModalRequested
+        function onLetter_index_jsonChanged(): void {
+            if (root.letterJumpModalVisible)
+                root._refreshLetterJumpEntries();
+        }
+        function onLetter_index_schemeChanged(): void {
+            if (root.letterJumpModalVisible)
+                root._refreshLetterJumpEntries();
+        }
+    }
 
     Connections {
         target: Browse.SystemLaunchers
@@ -2230,6 +2313,9 @@ MainLayout {
             } else if (ScreenManager.topModal === root.modalListPicker) {
                 if (root.listPickerModal !== null)
                     root.listPickerModal.handleAction(action);
+            } else if (ScreenManager.topModal === root.modalLetterJump) {
+                if (root.letterJumpModal !== null)
+                    root.letterJumpModal.handleAction(action);
             }
             // While a modal owns input, swallow everything not handled
             // above rather than leak it to the root screen.

--- a/src/ui/app/MainLayout.qml
+++ b/src/ui/app/MainLayout.qml
@@ -92,6 +92,7 @@ ApplicationWindow {
     property bool logUploadModalRequested: false
     property bool quitConfirmModalRequested: false
     property bool listPickerModalRequested: false
+    property bool letterJumpModalRequested: false
 
     function _startupTrace(): void {
         if (!root._startupTraceActive)
@@ -231,6 +232,12 @@ ApplicationWindow {
     }
 
     Binding {
+        target: Motion
+        property: "crtNativePath"
+        value: root.crtNativePath
+    }
+
+    Binding {
         target: Sizing
         property: "swapPercentageAxes"
         value: root._sceneRotated
@@ -257,6 +264,7 @@ ApplicationWindow {
     property var quitConfirmModal: quitConfirmModalLoader.item
     property var settingNeedsRestartModal: settingNeedsRestartModalLoader.item
     property var listPickerModal: listPickerModalLoader.item
+    property var letterJumpModal: letterJumpModalLoader.item
     property alias headerBar: headerBar
     property alias screensaverOverlay: screensaverOverlay
     // Exposed so Main.qml binds Sizing.screenWidth/Height to the
@@ -274,6 +282,12 @@ ApplicationWindow {
     property bool quitConfirmModalVisible: false
     property bool listPickerModalVisible: false
     property bool settingNeedsRestartModalVisible: false
+    // Letter-jump grid. Entries are bound live from
+    // Browse.GamesModel.letter_index_json so the grid fills in when the facet
+    // lands; `letterJumpLoading` distinguishes "still fetching" from "no rail".
+    property bool letterJumpModalVisible: false
+    property var letterJumpEntries: []
+    property bool letterJumpLoading: false
     // Round-trip state for the list picker. The router writes these
     // when opening the modal (Settings emits requestListPicker with
     // fieldId so the accept handler can dispatch back to the right
@@ -383,6 +397,8 @@ ApplicationWindow {
     signal quitConfirmAccepted
     signal listPickerAccepted(string fieldId, string selectedId)
     signal listPickerCloseRequested(string fieldId)
+    signal letterJumpAccepted(int itemOffset)
+    signal letterJumpCloseRequested
     signal acceptRestart
     signal cancelRestart
 
@@ -839,6 +855,24 @@ ApplicationWindow {
                 }
             }
 
+            // Jump-to-letter grid (West button → "Jump to letter"). Entries are
+            // bound live so the grid populates when the facet lands.
+            Loader {
+                id: letterJumpModalLoader
+                anchors.fill: parent
+                active: root.letterJumpModalRequested
+                sourceComponent: Component {
+                    LetterJumpModal {
+                        anchors.fill: parent
+                        open: root.letterJumpModalVisible
+                        entries: root.letterJumpEntries
+                        loading: root.letterJumpLoading
+                        onAccepted: offset => root.letterJumpAccepted(offset)
+                        onCloseRequested: root.letterJumpCloseRequested()
+                    }
+                }
+            }
+
             // ── Instructions bar ──────────────────────────────────────────────────────
 
             Rectangle {
@@ -959,7 +993,7 @@ ApplicationWindow {
                                 label: qsTr("I understand")
                             }
                         ];
-                    if (root.quitConfirmModalVisible || root.settingNeedsRestartModalVisible || root.listPickerModalVisible)
+                    if (root.quitConfirmModalVisible || root.settingNeedsRestartModalVisible || root.listPickerModalVisible || root.letterJumpModalVisible)
                         return [
                             {
                                 button: "Dpad",
@@ -1038,22 +1072,17 @@ ApplicationWindow {
                         if (root.systemsScreenState === "ready") {
                             if (root.systemsScreen === null)
                                 return [];
-                            // L/R shoulders page jump; only advertise the cue
-                            // when there's a second page to jump to, so we
-                            // don't promise a press that no-ops on a single
-                            // page of systems.
+                            // D-pad moves; L/R shoulders page-jump. Folded into
+                            // one "Move" cue, with the shoulder glyphs shown only
+                            // when there's a second page to jump to so we don't
+                            // promise a press that no-ops on a single page.
                             const pages = root.systemsScreen.systemsGrid.pageCount;
                             let row = [
                                 {
-                                    button: "Dpad",
+                                    buttons: pages > 1 ? ["ButtonL", "ButtonR", "Dpad"] : ["Dpad"],
                                     label: qsTr("Move")
                                 }
                             ];
-                            if (pages > 1)
-                                row.push({
-                                    buttons: ["ButtonL", "ButtonR"],
-                                    label: qsTr("Page")
-                                });
                             row.push({
                                 button: "ButtonA",
                                 label: qsTr("Open")
@@ -1093,17 +1122,15 @@ ApplicationWindow {
                             ];
                         if (state === "ready") {
                             const pages = grid.pageCount;
+                            // D-pad moves; L/R shoulders page-jump. Folded into
+                            // one "Move" cue; shoulder glyphs appear only with a
+                            // second page.
                             let row = [
                                 {
-                                    button: "Dpad",
+                                    buttons: pages > 1 ? ["ButtonL", "ButtonR", "Dpad"] : ["Dpad"],
                                     label: qsTr("Move")
                                 }
                             ];
-                            if (pages > 1)
-                                row.push({
-                                    buttons: ["ButtonL", "ButtonR"],
-                                    label: qsTr("Page")
-                                });
                             row.push({
                                 button: "ButtonA",
                                 label: qsTr("Open")
@@ -1228,17 +1255,15 @@ ApplicationWindow {
                         // so they should advertise Options too.
                         const idx = root.gamesScreen.gamesGrid.currentIndex;
                         const mediaCapable = Browse.GamesModel.is_media_capable_at(idx);
+                        // D-pad moves; L/R shoulders page-jump. Folded into one
+                        // "Move" cue; shoulder glyphs appear only with a second
+                        // page.
                         let row = [
                             {
-                                button: "Dpad",
+                                buttons: pages > 1 ? ["ButtonL", "ButtonR", "Dpad"] : ["Dpad"],
                                 label: qsTr("Move")
                             }
                         ];
-                        if (pages > 1)
-                            row.push({
-                                buttons: ["ButtonL", "ButtonR"],
-                                label: qsTr("Page")
-                            });
                         row.push({
                             button: "ButtonA",
                             label: qsTr("Open")
@@ -1248,6 +1273,13 @@ ApplicationWindow {
                                 button: "ButtonX",
                                 label: qsTr("Options")
                             });
+                        // West (Y) opens the list-scoped "View" menu (go to
+                        // letter, and later sort/filter/layout). Mirrors North's
+                        // item-scoped Options; the menu stays page/list-scoped.
+                        row.push({
+                            button: "ButtonY",
+                            label: qsTr("View")
+                        });
                         row.push({
                             button: "ButtonB",
                             label: qsTr("Back")

--- a/src/ui/components/CMakeLists.txt
+++ b/src/ui/components/CMakeLists.txt
@@ -24,6 +24,7 @@ qt_add_qml_module(
         FocusedMediaDetailController.qml
         GameInfoModal.qml
         HeaderBar.qml
+        LetterJumpModal.qml
         LoadingIndicator.qml
         ListPickerModal.qml
         LogUploadModal.qml

--- a/src/ui/components/LetterJumpModal.qml
+++ b/src/ui/components/LetterJumpModal.qml
@@ -56,7 +56,7 @@ Item {
     // width and content margins below mirror `Modal`'s own math so the column
     // count we navigate by matches the grid the user sees.
     readonly property int _panelMax: Sizing.pctW(92)
-    readonly property int _panelWidth: Sizing.px(Math.min(width * 0.78, _panelMax))
+    readonly property int _panelWidth: Math.min(Sizing.pctW(78), _panelMax)
     readonly property int _contentWidth: Math.max(Sizing.pctW(10), _panelWidth - 2 * Sizing.pctW(4))
     readonly property int _gap: Sizing.pctW(1)
     // Cell-size bounds: a legibility floor and a cap so a few-bucket scope
@@ -77,6 +77,15 @@ Item {
     visible: modal.open
     anchors.fill: parent
     z: 300
+
+    // Clamp the cursor if the bucket list shrank under it (e.g. a facet
+    // refetch landed while the picker was open) so navigation and accept keep
+    // targeting a live cell instead of an empty index.
+    onEntriesChanged: {
+        const last = modal.entries.length - 1;
+        if (modal.currentIndex > last)
+            modal.currentIndex = last < 0 ? 0 : last;
+    }
 
     onOpenChanged: {
         if (!modal.open) {

--- a/src/ui/components/LetterJumpModal.qml
+++ b/src/ui/components/LetterJumpModal.qml
@@ -1,0 +1,285 @@
+// Zaparoo Frontend
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Zaparoo.Theme
+
+// `entries` is a `var` array of plain JS objects
+// (`{ key, label, count, cursor }`). The AOT compiler can't infer the shape of
+// `var`, so reads of `entries.length`/`modelData.label` fall back to the JS
+// interpreter and trip the compiler category. Suppress file-wide.
+// qmllint disable compiler
+
+// Software-rendering safe "jump to letter" grid picker. Wraps the shared
+// `Modal` shell (`kind: "shell"`) so it inherits the standard chrome (scrim,
+// panel fill, corner radius, title) used by every other modal.
+//
+// The buckets come from `media.browse.index` (only non-empty sections, in sort
+// order), so the grid is data-driven: no dead letters to skip over. Each cell
+// shows the bucket label and its item count; accepting one emits the bucket's
+// opaque `media.browse` cursor for the router to seek to.
+//
+// Pure presentation. Mounting and dispatching `handleAction` belong to the
+// consumer that plumbs the modal into `Main.qml`'s modal stack. The component
+// renders, navigates `currentIndex` in 2D, emits `accepted(cursor)` on accept,
+// and `closeRequested()` on cancel.
+Item {
+    id: modal
+
+    property bool open: false
+    property string title: qsTr("Go to...")
+    // Each entry is `{ key, label, count, cursor, offset }`. `label` is the
+    // display text; `count` is the bucket size (dim subscript); `offset` is the
+    // bucket's authoritative position (from Core), emitted on accept so the
+    // router can jump there. The `cursor` field is unused by this UX (the jump
+    // is a position jump, not a forward-only cursor seek).
+    property var entries: []
+    property int currentIndex: 0
+    // True while the facet is still being fetched (no scheme resolved yet). When
+    // false and `entries` is empty, no rail applies for this scope.
+    property bool loading: false
+
+    // Push-in scale for the activated cell, mirroring the tile push-in.
+    property real _pressScale: 1.0
+    property int _pendingOffset: 0
+    property bool _hasPendingAccept: false
+
+    // Emits the index of the selected bucket's first item within the grouped
+    // sequence (cumulative count of all earlier buckets). The router adds the
+    // leading directory count and jumps the grid to that absolute position.
+    signal accepted(int itemOffset)
+    signal closeRequested
+
+    // Wider than the default modal so the grid has room to breathe. The panel
+    // width and content margins below mirror `Modal`'s own math so the column
+    // count we navigate by matches the grid the user sees.
+    readonly property int _panelMax: Sizing.pctW(92)
+    readonly property int _panelWidth: Sizing.px(Math.min(width * 0.78, _panelMax))
+    readonly property int _contentWidth: Math.max(Sizing.pctW(10), _panelWidth - 2 * Sizing.pctW(4))
+    readonly property int _gap: Sizing.pctW(1)
+    // Cell-size bounds: a legibility floor and a cap so a few-bucket scope
+    // doesn't blow the cells up to fill the panel.
+    readonly property int _minCell: Sizing.pctW(7)
+    readonly property int _maxCell: Sizing.pctW(13)
+    // Vertical budget for the grid block. Bounds the row count so a full
+    // alphabet (`#`, `0-9`, A-Z) can't grow the panel past the screen; the
+    // remaining height holds the panel title and margins.
+    readonly property int _availHeight: Sizing.pctH(52)
+    readonly property int _count: entries.length
+    readonly property int _columns: Math.max(1, modal._fitColumns(_count, _contentWidth, _availHeight, _gap))
+    readonly property int _rows: Math.ceil(Math.max(1, _count) / _columns)
+    readonly property int _cellRaw: Math.min((_contentWidth - (_columns - 1) * _gap) / _columns, (_availHeight - (_rows - 1) * _gap) / _rows)
+    readonly property int _cell: Sizing.px(Math.max(_minCell, Math.min(_maxCell, _cellRaw)))
+    readonly property int _gridHeight: _rows * _cell + Math.max(0, _rows - 1) * _gap
+
+    visible: modal.open
+    anchors.fill: parent
+    z: 300
+
+    onOpenChanged: {
+        if (!modal.open) {
+            // Disarm a pending accept so a press-then-close inside the deferred
+            // window cannot jump after the modal is dismissed.
+            acceptCommit.stop();
+            return;
+        }
+        modal.currentIndex = 0;
+        modal._pressScale = 1.0;
+        pressAnim.stop();
+        modal._pendingOffset = 0;
+        modal._hasPendingAccept = false;
+    }
+
+    // The bucket's authoritative offset (its first item's position among the
+    // scope's files), supplied by Core. 0 when absent.
+    function _offsetForIndex(index: int): int {
+        if (index < 0 || index >= modal.entries.length)
+            return 0;
+        return modal.entries[index].offset ?? 0;
+    }
+
+    // Pure layout helper. Picks the column count whose square cell - bounded
+    // by both the available width per column and the available height per row -
+    // is largest, so the grid uses the area well and always fits within
+    // `availH`. Kept side-effect free so it is unit-testable in isolation.
+    function _fitColumns(count: int, availW: int, availH: int, gap: int): int {
+        if (count <= 0)
+            return 1;
+        let best = 1;
+        let bestCell = 0;
+        for (let c = 1; c <= count; ++c) {
+            const rows = Math.ceil(count / c);
+            const cw = (availW - (c - 1) * gap) / c;
+            const ch = (availH - (rows - 1) * gap) / rows;
+            const cell = Math.min(cw, ch);
+            if (cell > bestCell) {
+                bestCell = cell;
+                best = c;
+            }
+        }
+        return best;
+    }
+
+    // Pure 2D grid move. Clamps within bounds; `down` past the last full row
+    // lands on the final cell so scanning down the alphabet always reaches the
+    // tail bucket. Kept side-effect free so it is unit-testable in isolation.
+    function nextIndex(action: string, index: int, count: int, columns: int): int {
+        if (count <= 0)
+            return 0;
+        const cols = Math.max(1, columns);
+        let next = index;
+        if (action === "left")
+            next = index - 1;
+        else if (action === "right")
+            next = index + 1;
+        else if (action === "up")
+            next = index - cols;
+        else if (action === "down") {
+            next = index + cols;
+            if (next >= count) {
+                const lastRowStart = (Math.ceil(count / cols) - 1) * cols;
+                next = index < lastRowStart ? count - 1 : index;
+            }
+        }
+        if (next < 0 || next >= count)
+            return index;
+        return next;
+    }
+
+    function handleAction(action: string): void {
+        if (action === "up" || action === "down" || action === "left" || action === "right") {
+            modal.currentIndex = modal.nextIndex(action, modal.currentIndex, modal.entries.length, modal._columns);
+        } else if (action === "accept") {
+            if (modal.currentIndex >= 0 && modal.currentIndex < modal.entries.length) {
+                modal._commitAccept(modal._offsetForIndex(modal.currentIndex));
+            }
+        } else if (action === "cancel" || action === "page_menu") {
+            modal.closeRequested();
+        }
+    }
+
+    function _commitAccept(itemOffset: int): void {
+        modal._pendingOffset = itemOffset;
+        modal._hasPendingAccept = true;
+        pressAnim.restart();
+        acceptCommit.arm();
+    }
+
+    NumberAnimation {
+        id: pressAnim
+        target: modal
+        property: "_pressScale"
+        to: Motion.rowPressScale
+        duration: Motion.dur(Motion.pressMs)
+        easing.type: Easing.OutQuad
+    }
+
+    DeferredAction {
+        id: acceptCommit
+        onDeferred: {
+            const offset = modal._pendingOffset;
+            const had = modal._hasPendingAccept;
+            modal._pendingOffset = 0;
+            modal._hasPendingAccept = false;
+            if (had)
+                modal.accepted(offset);
+        }
+    }
+
+    Modal {
+        id: shell
+
+        open: modal.open
+        kind: "shell"
+        title: modal.title
+        panelMaxWidth: modal._panelMax
+
+        Item {
+            id: gridSlot
+
+            width: parent.width
+            height: modal._count > 0 ? modal._gridHeight : Sizing.pctH(10)
+
+            // Loading / no-sections cue. Shown only when there are no buckets:
+            // "loading" while the facet is still resolving, otherwise this scope
+            // has no first-character rail (e.g. a non-alphabetical sort).
+            Text {
+                anchors.centerIn: parent
+                visible: modal._count <= 0
+                text: modal.loading ? qsTr("Loading…") : qsTr("No sections")
+                color: Theme.textLabel
+                font.family: Theme.fontUi
+                font.pixelSize: Sizing.fontSize(2.6)
+                renderType: Text.NativeRendering
+            }
+
+            Grid {
+                id: grid
+
+                visible: modal._count > 0
+                x: Sizing.center(gridSlot.width, width)
+                columns: modal._columns
+                spacing: modal._gap
+
+                Repeater {
+                    model: modal.entries
+
+                    Rectangle {
+                        id: cell
+
+                        required property int index
+                        required property var modelData
+
+                        width: modal._cell
+                        height: modal._cell
+                        color: Theme.surfaceCard
+                        border.width: cell.index === modal.currentIndex ? Sizing.stroke(2) : Sizing.stroke(1)
+                        border.color: cell.index === modal.currentIndex ? Theme.accent : Theme.borderMid
+                        radius: Sizing.cornerRadius
+                        transformOrigin: Item.Center
+                        scale: cell.index === modal.currentIndex ? modal._pressScale : 1.0
+
+                        Column {
+                            // Centered as one block via Sizing.center on the
+                            // Column itself; glyphs render left-aligned so no
+                            // run straddles a half-pixel (see Integer-pixel
+                            // rules).
+                            x: Sizing.center(cell.width, width)
+                            y: Sizing.center(cell.height, height)
+                            spacing: Sizing.pctH(0.4)
+
+                            Text {
+                                x: Sizing.center(parent.width, width)
+                                text: cell.modelData.label
+                                color: Theme.textPrimary
+                                font.family: Theme.fontUi
+                                font.pixelSize: Sizing.fontSize(3.4)
+                                renderType: Text.NativeRendering
+                            }
+
+                            Text {
+                                x: Sizing.center(parent.width, width)
+                                text: cell.modelData.count
+                                color: Theme.textLabel
+                                font.family: Theme.fontUi
+                                font.pixelSize: Sizing.fontSize(1.8)
+                                renderType: Text.NativeRendering
+                            }
+                        }
+
+                        MouseArea {
+                            anchors.fill: parent
+                            hoverEnabled: true
+                            acceptedButtons: Qt.LeftButton
+                            cursorShape: Qt.PointingHandCursor
+                            onEntered: modal.currentIndex = cell.index
+                            onClicked: modal._commitAccept(modal._offsetForIndex(cell.index))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/ui/components/PagedGrid.qml
+++ b/src/ui/components/PagedGrid.qml
@@ -176,12 +176,40 @@ Item {
     property int _pendingTargetRow: 0
     property int _pendingTargetCol: 0
 
-    // True while a wrap / shoulder-jump / hold-Down-past-edge move is
-    // stashed waiting on a fetch. Screens use this to gate the
+    // Pending jump-to-index state. Set by `jumpToIndex` when the absolute
+    // target isn't loaded yet; the grid fetches until `itemCount` passes it
+    // and `_commitPendingTarget` lands on this exact index. Distinct from the
+    // page/row/col wrap-target above: a jump preserves the absolute position
+    // (pages stay fixed/global, the cursor lands mid-page on the true target),
+    // so it must not be re-derived from page/row/col. The two are mutually
+    // exclusive at any moment. -1 means "no pending jump".
+    property int _pendingTargetIndex: -1
+
+    // True while a wrap / shoulder-jump / hold-Down-past-edge / jump-to-index
+    // move is stashed waiting on a fetch. Screens use this to gate the
     // "Loading more..." indicator so background prefetches stay
     // silent — the indicator only paints when the user is genuinely
     // waiting on input they've already given.
-    readonly property bool hasPendingTarget: _pendingTargetPage >= 0
+    readonly property bool hasPendingTarget: _pendingTargetPage >= 0 || _pendingTargetIndex >= 0
+
+    // True only while a jump-to-index (letter jump) is waiting on a fetch, as
+    // opposed to a page-wrap target. Lets callers bulk-load aggressively for a
+    // jump (loading overlay up, target far away) while keeping ordinary
+    // page-turn prefetches on the gentle trickle.
+    readonly property bool hasPendingJump: _pendingTargetIndex >= 0
+
+    // Absolute row the pending jump will land on, or -1 when no jump is
+    // pending. Lets the model size its jump fetch to the gap remaining rather
+    // than always pulling the full remainder.
+    readonly property int pendingJumpIndex: _pendingTargetIndex
+
+    // Clear every pending-target channel at once. Used by all the
+    // "intent changed / resolved / reset" sites so neither the page/row/col
+    // wrap-target nor the jump-to-index target can leak across.
+    function _clearPendingTarget(): void {
+        root._pendingTargetPage = -1;
+        root._pendingTargetIndex = -1;
+    }
 
     // Reserved chrome around the cell area. Vertical insets must be
     // large enough to contain the focused tile's 1.06× scale bleed
@@ -263,14 +291,16 @@ Item {
             return false;
         if (targetPage > root.pageCount - 1) {
             // Target page hasn't been fetched yet. Stash the intent and
-            // let the itemCount-change watcher commit it.
+            // let the itemCount-change watcher commit it. A fresh page-nav
+            // supersedes any pending jump-to-index.
+            root._pendingTargetIndex = -1;
             root._pendingTargetPage = targetPage;
             root._pendingTargetRow = root.currentRow;
             root._pendingTargetCol = root.currentColumn;
             root.loadMoreRequested(true);
             return false;
         }
-        root._pendingTargetPage = -1;
+        root._clearPendingTarget();
         const targetSlot = targetPage * root.pageSize + root.currentRow * root.columns + root.currentColumn;
         const lastIdxOnPage = Math.min((targetPage + 1) * root.pageSize, root.itemCount) - 1;
         if (lastIdxOnPage < 0)
@@ -287,6 +317,36 @@ Item {
         return true;
     }
 
+    // Jump the selection to an exact absolute index over the full dataset
+    // (`totalItems`), loading the intervening pages if the target hasn't been
+    // fetched yet — the basis for "jump to letter". Mirrors `pageBy`'s
+    // pending-target machinery but lands on the exact index rather than
+    // preserving the current row/col. A target that is already loaded (e.g. a
+    // backward jump to an earlier letter) lands immediately; an unrealised
+    // target stashes the exact (page,row,col) slot and `_commitPendingTarget`
+    // commits it once `fetch_more` has loaded that far. Returns true if the
+    // index changed synchronously, false if a pending-jump was stashed.
+    function jumpToIndex(targetIndex: int): bool {
+        if (root.itemCount <= 0 || root.totalItems <= 0)
+            return false;
+        const target = Math.max(0, Math.min(targetIndex, root.totalItems - 1));
+        if (target < root.itemCount) {
+            // Already loaded — land immediately (no walk needed).
+            root._clearPendingTarget();
+            if (target !== root.currentIndex)
+                root.currentIndex = target;
+            if (root.currentPage >= root.pageCount - root.loadAheadPages - 1)
+                root.loadMoreRequested(false);
+            return true;
+        }
+        // Not fetched yet — stash the absolute target and load until the
+        // model has grown past it, then commit on the exact index.
+        root._pendingTargetPage = -1;
+        root._pendingTargetIndex = target;
+        root.loadMoreRequested(true);
+        return false;
+    }
+
     // Commit the pending target move once the destination slot is
     // loaded, or settle on the loaded last when the model says no more
     // pages are coming. Wired into `onItemCountChanged` so every
@@ -297,6 +357,33 @@ Item {
     // materialisation: the target page may report `pageCount` reached
     // while the row/col slot itself isn't realised yet.
     function _commitPendingTarget(): void {
+        // Jump-to-index: land on the exact absolute target. Pages stay
+        // fixed/global; the cursor lands mid-page on the true target and
+        // never a page early. No page-clamp and no settle-back fallback —
+        // those only existed to cope with a slow page-at-a-time walk.
+        if (root._pendingTargetIndex >= 0) {
+            const want = root._pendingTargetIndex;
+            if (want < root.itemCount) {
+                root._clearPendingTarget();
+                if (want !== root.currentIndex)
+                    root.currentIndex = want;
+                return;
+            }
+            if (root.hasMorePages) {
+                // Keep loading; `fetch_more_*` is debounced model-side via
+                // `loading_more`, so a redundant emit is cheap.
+                root.loadMoreRequested(true);
+                return;
+            }
+            // Dataset genuinely can't reach the target (Core revised the
+            // total down, or the listing is shorter than expected). Land on
+            // the nearest loaded item to the target — never a full page back.
+            root._clearPendingTarget();
+            const nearest = Math.min(want, root.itemCount - 1);
+            if (nearest >= 0 && nearest !== root.currentIndex)
+                root.currentIndex = nearest;
+            return;
+        }
         if (root._pendingTargetPage < 0)
             return;
         // Total may have shrunk under us (e.g. Core revised total_files
@@ -376,8 +463,8 @@ Item {
         // among its own items rather than walking through a hole.
         if (dCol !== 0) {
             // Sideways step changes the user's intent — drop any
-            // pending wrap-target chain we were waiting on.
-            root._pendingTargetPage = -1;
+            // pending wrap-target / jump we were waiting on.
+            root._clearPendingTarget();
             const rowFirstIndex = root.currentPage * root.pageSize + root.currentRow * root.columns;
             const rowLastIndex = Math.min(root.itemCount - 1, rowFirstIndex + root.columns - 1);
             const maxColOnRow = rowLastIndex - rowFirstIndex;
@@ -412,6 +499,7 @@ Item {
             if (rowCandidate < 0) {
                 const targetPage = root.currentPage === 0 ? root.totalPageCount - 1 : root.currentPage - 1;
                 if (targetPage > root.pageCount - 1) {
+                    root._pendingTargetIndex = -1;
                     root._pendingTargetPage = targetPage;
                     root._pendingTargetRow = root.rows - 1;
                     root._pendingTargetCol = root.currentColumn;
@@ -424,6 +512,7 @@ Item {
                 const lastPage = root.totalPageCount - 1;
                 const targetPage = root.currentPage === lastPage ? 0 : root.currentPage + 1;
                 if (targetPage > root.pageCount - 1) {
+                    root._pendingTargetIndex = -1;
                     root._pendingTargetPage = targetPage;
                     root._pendingTargetRow = 0;
                     root._pendingTargetCol = root.currentColumn;
@@ -458,9 +547,9 @@ Item {
                 root.loadMoreRequested(false);
             return false;
         }
-        // Successful directional move clears any pending wrap-target;
+        // Successful directional move clears any pending wrap-target / jump;
         // the user is no longer waiting on it.
-        root._pendingTargetPage = -1;
+        root._clearPendingTarget();
         root.currentIndex = newIndex;
         // Pre-fetch early - when the user enters within `loadAheadPages`
         // of the loaded edge, kick off the next fetch so the network
@@ -486,7 +575,7 @@ Item {
     // covers the case where the flag is updated without an item delta
     // (e.g. a final empty append).
     onHasMorePagesChanged: {
-        if (root._pendingTargetPage >= 0)
+        if (root.hasPendingTarget)
             root._commitPendingTarget();
     }
 
@@ -495,7 +584,7 @@ Item {
             // Model shed rows (reset, system change, path change). The
             // pending-target context no longer applies — drop it before
             // the row-count check below moves currentIndex.
-            root._pendingTargetPage = -1;
+            root._clearPendingTarget();
             if (root.currentIndex >= root.itemCount)
                 root.currentIndex = Math.max(0, root.itemCount - 1);
         } else if (root.itemCount > root._previousItemCount) {

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -145,7 +145,12 @@ MediaListScreen {
     gridTotalItemsOverride: Browse.GamesModel.dir_count + Browse.GamesModel.total_files
     gridHasMorePages: Browse.GamesModel.has_next_page
     gridLoadMoreAction: urgent => {
-        if (urgent || games.detailRapidScrollActive)
+        // A letter jump bulk-loads to the target in one shot (overlay is up);
+        // page-wrap targets and fast-scroll stay on the rapid trickle, ordinary
+        // prefetch on the gentle one.
+        if (games.gamesGrid.hasPendingJump)
+            Browse.GamesModel.fetch_more_jump(games.gamesGrid.pendingJumpIndex);
+        else if (urgent || games.detailRapidScrollActive)
             Browse.GamesModel.fetch_more_rapid();
         else
             Browse.GamesModel.fetch_more();
@@ -321,5 +326,32 @@ MediaListScreen {
     // Drives folder-aware cancel routing.
     function _atFolderLevel(): bool {
         return Browse.GamesState.path_stack.length > 1;
+    }
+
+    // Jump-to-letter. `itemOffset` is the cumulative count of all buckets before
+    // the chosen letter (from the letter-index facet); the leading directories
+    // come first in the grid, so the letter's first item sits at
+    // `dir_count + itemOffset`. Driving the grid's page-jump there loads the
+    // intervening pages and lands on that absolute index, so the full list stays
+    // navigable both ways and the page counter reflects the real position.
+    function jumpToItem(itemOffset: int): void {
+        const absolute = Browse.GamesModel.dir_count + itemOffset;
+        const landed = games.gamesGrid.jumpToIndex(absolute);
+        // A deferred walk (target not yet loaded) returns false; show the
+        // standard centered loading cue over the stale source page until the
+        // walk commits. An already-loaded backward jump lands immediately, so
+        // no cue is needed.
+        games.jumpLoading = !landed;
+    }
+
+    // Clear the jump cue once the grid's pending-target walk resolves - on
+    // commit, or on an abort (model reset / directional clear) that flips
+    // `hasPendingTarget` back to false.
+    Connections {
+        target: games.gamesGrid
+        function onHasPendingTargetChanged(): void {
+            if (!games.gamesGrid.hasPendingTarget)
+                games.jumpLoading = false;
+        }
     }
 }

--- a/src/ui/screens/MediaListScreen.qml
+++ b/src/ui/screens/MediaListScreen.qml
@@ -81,6 +81,11 @@ Item {
     property bool active: true
     property bool gridFocused: true
     property bool optimisticLoading: false
+    // True while a jump-to-letter walk is loading the intervening pages. Folded
+    // into `_loading()` so the standard centered loading cue paints over the
+    // (stale) source page instead of leaving it frozen. Set/cleared by the
+    // consumer that owns the jump (GamesScreen).
+    property bool jumpLoading: false
     // False until the user takes control of focus (first input). Combined with
     // `_restoreDone` into `_focusReady`, which gates whether the grid tiles and
     // list rows render selection at all.
@@ -138,6 +143,10 @@ Item {
 
     signal requestHubScreen
     signal requestContextMenu(int index, var anchorRect)
+    // Page-scoped operations entry point (West button). The router decides
+    // what the menu contains; the screen just reports the press when the list
+    // is in a usable state.
+    signal requestPageMenu
 
     on_ListLayoutChanged: {
         if (!root._listLayout)
@@ -175,7 +184,7 @@ Item {
     }
 
     function _loading(): bool {
-        return root.optimisticLoading || (root.mediaModel !== null ? root.mediaModel.loading : false);
+        return root.optimisticLoading || root.jumpLoading || (root.mediaModel !== null ? root.mediaModel.loading : false);
     }
 
     function _errorMessage(): string {
@@ -353,6 +362,9 @@ Item {
         } else if (action === "page_next") {
             if (root._state() === "ready")
                 root._performPage(1);
+        } else if (action === "page_menu") {
+            if (root._state() === "ready")
+                root.requestPageMenu();
         } else if (action === "accept") {
             const state = root._state();
             if (state === "loading")

--- a/src/ui/theme/Motion.qml
+++ b/src/ui/theme/Motion.qml
@@ -18,6 +18,12 @@ QtObject {
     // Master switch. Written from Main.qml via a Binding.
     property bool enabled: true
 
+    // CRT native path. Bound from MainLayout (like Theme/Sizing) so this
+    // singleton stays dependency-free (no Theme import). At 240p the default
+    // press scales move an edge by under a pixel, so the push-in cue is
+    // deepened on this path to read as a tactile snap.
+    property bool crtNativePath: false
+
     // Duration buckets (milliseconds). The practical floor here is the frame
     // budget, not perception: on MiSTer's software renderer (~30fps) motion the
     // eye tracks needs ~3 frames (~100ms) to read as smooth rather than a
@@ -31,13 +37,14 @@ QtObject {
     readonly property int settleMs: 110
 
     // Scale target for the one-shot push-in cue on squarish surfaces — tiles
-    // and dialog buttons.
-    readonly property real pressScale: 0.96
+    // and dialog buttons. Deeper on the CRT path so a sub-pixel HD nudge
+    // becomes a visible snap at 240p.
+    readonly property real pressScale: crtNativePath ? 0.90 : 0.96
     // Gentler target for wide, short rows (list-detail rows, settings fields,
     // menu/picker rows). The same scale factor moves a full-width row's edges
     // far more than a squarish tile's, so a wider row needs a value closer to
-    // 1.0 to read as the same subtle press.
-    readonly property real rowPressScale: 0.985
+    // 1.0 to read as the same subtle press. Same CRT deepening as above.
+    readonly property real rowPressScale: crtNativePath ? 0.95 : 0.985
 
     // Collapse all durations to 0 under reduce-motion so Behaviors that
     // use dur() resolve instantly without per-call branching.

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -517,12 +517,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <location filename="../components/LetterJumpModal.qml" line="220"/>
         <source>Loading…</source>
         <translation type="unfinished">جارٍ التحميل…</translation>
     </message>
     <message>
-        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <location filename="../components/LetterJumpModal.qml" line="220"/>
         <source>No sections</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -426,7 +426,7 @@ Euskara - devilschile2</source>
     <name>GamesScreen</name>
     <message>
         <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="166"/>
+        <location filename="../screens/GamesScreen.qml" line="171"/>
         <source>%1 files</source>
         <translation>%1 ملفات</translation>
     </message>
@@ -437,7 +437,7 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../screens/GamesScreen.qml" line="140"/>
-        <location filename="../screens/GamesScreen.qml" line="167"/>
+        <location filename="../screens/GamesScreen.qml" line="172"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -510,6 +510,24 @@ Euskara - devilschile2</source>
     </message>
 </context>
 <context>
+    <name>LetterJumpModal</name>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="32"/>
+        <source>Go to...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <source>Loading…</source>
+        <translation type="unfinished">جارٍ التحميل…</translation>
+    </message>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <source>No sections</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LoadingIndicator</name>
     <message>
         <location filename="../components/LoadingIndicator.qml" line="26"/>
@@ -553,138 +571,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1408"/>
         <source>Launch core</source>
         <translation>تشغيل النواة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1408"/>
-        <location filename="../app/Main.qml" line="1647"/>
+        <location filename="../app/Main.qml" line="1414"/>
+        <location filename="../app/Main.qml" line="1653"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1415"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1421"/>
+        <location filename="../app/Main.qml" line="1444"/>
         <source>Update media database</source>
         <translation type="unfinished">تحديث قاعدة بيانات الوسائط</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1418"/>
-        <location filename="../app/Main.qml" line="1441"/>
+        <location filename="../app/Main.qml" line="1424"/>
+        <location filename="../app/Main.qml" line="1447"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">استخراج البيانات الوصفية</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1423"/>
-        <location filename="../app/Main.qml" line="1432"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1438"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1423"/>
-        <location filename="../app/Main.qml" line="1432"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1438"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1450"/>
-        <location filename="../app/Main.qml" line="1485"/>
+        <location filename="../app/Main.qml" line="1456"/>
+        <location filename="../app/Main.qml" line="1491"/>
         <source>Launch game</source>
         <translation>تشغيل اللعبة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1472"/>
         <source>Remove from favorites</source>
         <translation>إزالة من المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1472"/>
         <source>Add to favorites</source>
         <translation>أضف إلى المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1471"/>
+        <location filename="../app/Main.qml" line="1477"/>
         <source>Write to NFC token</source>
         <translation>الكتابة إلى رمز NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1475"/>
+        <location filename="../app/Main.qml" line="1481"/>
         <source>QR code</source>
         <translation>رمز QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1643"/>
+        <location filename="../app/Main.qml" line="1649"/>
         <source>Default</source>
         <translation type="unfinished">افتراضي</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1643"/>
+        <location filename="../app/Main.qml" line="1649"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1967"/>
+        <location filename="../app/Main.qml" line="1937"/>
+        <source>Go to...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1940"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2021"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1971"/>
+        <location filename="../app/Main.qml" line="2025"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1985"/>
+        <location filename="../app/Main.qml" line="2039"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1989"/>
+        <location filename="../app/Main.qml" line="2043"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1993"/>
+        <location filename="../app/Main.qml" line="2047"/>
         <source>Retry</source>
         <translation type="unfinished">إعادة المحاولة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1997"/>
+        <location filename="../app/Main.qml" line="2051"/>
         <source>Cancel</source>
         <translation type="unfinished">إلغاء</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2645"/>
+        <location filename="../app/Main.qml" line="2731"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2647"/>
+        <location filename="../app/Main.qml" line="2733"/>
         <source>Loading games…</source>
         <translation>جارٍ تحميل الألعاب…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2649"/>
+        <location filename="../app/Main.qml" line="2735"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2651"/>
+        <location filename="../app/Main.qml" line="2737"/>
         <source>Loading favorites…</source>
         <translation>جارٍ تحميل المفضلة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2653"/>
+        <location filename="../app/Main.qml" line="2739"/>
         <source>Loading recently played…</source>
         <translation>جارٍ تحميل آخر ما تم لعبه…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2655"/>
+        <location filename="../app/Main.qml" line="2741"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2657"/>
+        <location filename="../app/Main.qml" line="2743"/>
         <source>Loading…</source>
         <translation>جارٍ التحميل…</translation>
     </message>
@@ -692,166 +720,168 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="685"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Writing failed</source>
         <translation>فشلت الكتابة</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="685"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Put a writable card near the reader</source>
         <translation>ضع بطاقة قابلة للكتابة بالقرب من القارئ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="171"/>
+        <location filename="../app/MainLayout.qml" line="172"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="368"/>
+        <location filename="../app/MainLayout.qml" line="382"/>
         <source>Favorites</source>
         <translation type="unfinished">المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="370"/>
+        <location filename="../app/MainLayout.qml" line="384"/>
         <source>Recently Played</source>
         <translation type="unfinished">تم لعبها مؤخرًا</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="701"/>
+        <location filename="../app/MainLayout.qml" line="717"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="702"/>
+        <location filename="../app/MainLayout.qml" line="718"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="812"/>
+        <location filename="../app/MainLayout.qml" line="828"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="813"/>
+        <location filename="../app/MainLayout.qml" line="829"/>
         <source>Are you sure you want to exit?</source>
         <translation>هل أنت متأكد أنك تريد الخروج؟</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="892"/>
-        <location filename="../app/MainLayout.qml" line="966"/>
-        <location filename="../app/MainLayout.qml" line="1012"/>
-        <location filename="../app/MainLayout.qml" line="1049"/>
-        <location filename="../app/MainLayout.qml" line="1099"/>
-        <location filename="../app/MainLayout.qml" line="1148"/>
-        <location filename="../app/MainLayout.qml" line="1167"/>
-        <location filename="../app/MainLayout.qml" line="1234"/>
+        <location filename="../app/MainLayout.qml" line="926"/>
+        <location filename="../app/MainLayout.qml" line="1000"/>
+        <location filename="../app/MainLayout.qml" line="1046"/>
+        <location filename="../app/MainLayout.qml" line="1083"/>
+        <location filename="../app/MainLayout.qml" line="1131"/>
+        <location filename="../app/MainLayout.qml" line="1175"/>
+        <location filename="../app/MainLayout.qml" line="1194"/>
+        <location filename="../app/MainLayout.qml" line="1264"/>
         <source>Move</source>
         <translation>تحريك</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="896"/>
-        <location filename="../app/MainLayout.qml" line="970"/>
+        <location filename="../app/MainLayout.qml" line="930"/>
+        <location filename="../app/MainLayout.qml" line="1004"/>
         <source>Select</source>
         <translation>تحديد</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="900"/>
-        <location filename="../app/MainLayout.qml" line="904"/>
-        <location filename="../app/MainLayout.qml" line="918"/>
-        <location filename="../app/MainLayout.qml" line="933"/>
-        <location filename="../app/MainLayout.qml" line="944"/>
+        <location filename="../app/MainLayout.qml" line="934"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="952"/>
+        <location filename="../app/MainLayout.qml" line="967"/>
+        <location filename="../app/MainLayout.qml" line="978"/>
         <source>Close</source>
         <translation>إغلاق</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="911"/>
-        <location filename="../app/MainLayout.qml" line="951"/>
-        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="945"/>
         <location filename="../app/MainLayout.qml" line="985"/>
+        <location filename="../app/MainLayout.qml" line="1008"/>
+        <location filename="../app/MainLayout.qml" line="1019"/>
         <source>Cancel</source>
         <translation>إلغاء</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="929"/>
+        <location filename="../app/MainLayout.qml" line="963"/>
         <source>Done</source>
         <translation>تم</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="940"/>
-        <location filename="../app/MainLayout.qml" line="1072"/>
-        <location filename="../app/MainLayout.qml" line="1125"/>
-        <location filename="../app/MainLayout.qml" line="1260"/>
+        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="1101"/>
+        <location filename="../app/MainLayout.qml" line="1152"/>
+        <location filename="../app/MainLayout.qml" line="1292"/>
         <source>Retry</source>
         <translation>إعادة المحاولة</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="959"/>
+        <location filename="../app/MainLayout.qml" line="993"/>
         <source>I understand</source>
         <translation>أفهم</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="993"/>
+        <location filename="../app/MainLayout.qml" line="1027"/>
         <source>Start</source>
         <translation>ابدأ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1016"/>
-        <location filename="../app/MainLayout.qml" line="1059"/>
-        <location filename="../app/MainLayout.qml" line="1109"/>
-        <location filename="../app/MainLayout.qml" line="1153"/>
-        <location filename="../app/MainLayout.qml" line="1244"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1088"/>
+        <location filename="../app/MainLayout.qml" line="1136"/>
+        <location filename="../app/MainLayout.qml" line="1180"/>
+        <location filename="../app/MainLayout.qml" line="1269"/>
         <source>Open</source>
         <translation>فتح</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1026"/>
+        <location filename="../app/MainLayout.qml" line="1060"/>
         <source>Quit</source>
         <translation>إنهاء</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1035"/>
-        <location filename="../app/MainLayout.qml" line="1065"/>
-        <location filename="../app/MainLayout.qml" line="1076"/>
-        <location filename="../app/MainLayout.qml" line="1091"/>
-        <location filename="../app/MainLayout.qml" line="1118"/>
-        <location filename="../app/MainLayout.qml" line="1129"/>
-        <location filename="../app/MainLayout.qml" line="1141"/>
-        <location filename="../app/MainLayout.qml" line="1157"/>
-        <location filename="../app/MainLayout.qml" line="1191"/>
-        <location filename="../app/MainLayout.qml" line="1209"/>
+        <location filename="../app/MainLayout.qml" line="1069"/>
+        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
+        <location filename="../app/MainLayout.qml" line="1120"/>
+        <location filename="../app/MainLayout.qml" line="1145"/>
+        <location filename="../app/MainLayout.qml" line="1156"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
+        <location filename="../app/MainLayout.qml" line="1184"/>
         <location filename="../app/MainLayout.qml" line="1218"/>
-        <location filename="../app/MainLayout.qml" line="1253"/>
-        <location filename="../app/MainLayout.qml" line="1264"/>
+        <location filename="../app/MainLayout.qml" line="1236"/>
+        <location filename="../app/MainLayout.qml" line="1245"/>
+        <location filename="../app/MainLayout.qml" line="1285"/>
+        <location filename="../app/MainLayout.qml" line="1296"/>
         <source>Back</source>
         <translation>رجوع</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1055"/>
-        <location filename="../app/MainLayout.qml" line="1105"/>
-        <location filename="../app/MainLayout.qml" line="1240"/>
-        <source>Page</source>
-        <translation>صفحة</translation>
+        <location filename="../app/MainLayout.qml" line="1281"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1022"/>
-        <location filename="../app/MainLayout.qml" line="1062"/>
-        <location filename="../app/MainLayout.qml" line="1114"/>
-        <location filename="../app/MainLayout.qml" line="1249"/>
+        <source>Page</source>
+        <translation type="vanished">صفحة</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="1056"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
+        <location filename="../app/MainLayout.qml" line="1141"/>
+        <location filename="../app/MainLayout.qml" line="1274"/>
         <source>Options</source>
         <translation>الخيارات</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1176"/>
+        <location filename="../app/MainLayout.qml" line="1203"/>
         <source>Change</source>
         <translation>تغيير</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1182"/>
+        <location filename="../app/MainLayout.qml" line="1209"/>
         <source>Toggle</source>
         <translation>تبديل</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1205"/>
+        <location filename="../app/MainLayout.qml" line="1232"/>
         <source>Scroll</source>
         <translation>تمرير</translation>
     </message>
@@ -864,12 +894,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">جارٍ التحميل…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="437"/>
+        <location filename="../screens/MediaListScreen.qml" line="449"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 عناصر</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="438"/>
+        <location filename="../screens/MediaListScreen.qml" line="450"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -517,12 +517,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <location filename="../components/LetterJumpModal.qml" line="220"/>
         <source>Loading…</source>
         <translation type="unfinished">Wird geladen…</translation>
     </message>
     <message>
-        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <location filename="../components/LetterJumpModal.qml" line="220"/>
         <source>No sections</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -426,7 +426,7 @@ Euskara - devilschile2</source>
     <name>GamesScreen</name>
     <message>
         <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="166"/>
+        <location filename="../screens/GamesScreen.qml" line="171"/>
         <source>%1 files</source>
         <translation>%1 Dateien</translation>
     </message>
@@ -437,7 +437,7 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../screens/GamesScreen.qml" line="140"/>
-        <location filename="../screens/GamesScreen.qml" line="167"/>
+        <location filename="../screens/GamesScreen.qml" line="172"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -510,6 +510,24 @@ Euskara - devilschile2</source>
     </message>
 </context>
 <context>
+    <name>LetterJumpModal</name>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="32"/>
+        <source>Go to...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <source>Loading…</source>
+        <translation type="unfinished">Wird geladen…</translation>
+    </message>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <source>No sections</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LoadingIndicator</name>
     <message>
         <location filename="../components/LoadingIndicator.qml" line="26"/>
@@ -553,138 +571,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1408"/>
         <source>Launch core</source>
         <translation>Core starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1408"/>
-        <location filename="../app/Main.qml" line="1647"/>
+        <location filename="../app/Main.qml" line="1414"/>
+        <location filename="../app/Main.qml" line="1653"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1472"/>
         <source>Remove from favorites</source>
         <translation>Aus Favoriten entfernen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1472"/>
         <source>Add to favorites</source>
         <translation>Zu Favoriten hinzufügen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1471"/>
+        <location filename="../app/Main.qml" line="1477"/>
         <source>Write to NFC token</source>
         <translation>Auf NFC-Token schreiben</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1475"/>
+        <location filename="../app/Main.qml" line="1481"/>
         <source>QR code</source>
         <translation>QR-Code</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1450"/>
-        <location filename="../app/Main.qml" line="1485"/>
+        <location filename="../app/Main.qml" line="1456"/>
+        <location filename="../app/Main.qml" line="1491"/>
         <source>Launch game</source>
         <translation>Spiel starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2645"/>
+        <location filename="../app/Main.qml" line="1937"/>
+        <source>Go to...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1940"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2731"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2651"/>
+        <location filename="../app/Main.qml" line="2737"/>
         <source>Loading favorites…</source>
         <translation>Favoriten werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2647"/>
+        <location filename="../app/Main.qml" line="2733"/>
         <source>Loading games…</source>
         <translation>Spiele werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1415"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1421"/>
+        <location filename="../app/Main.qml" line="1444"/>
         <source>Update media database</source>
         <translation type="unfinished">Mediendatenbank aktualisieren</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1418"/>
-        <location filename="../app/Main.qml" line="1441"/>
+        <location filename="../app/Main.qml" line="1424"/>
+        <location filename="../app/Main.qml" line="1447"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadaten abrufen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1423"/>
-        <location filename="../app/Main.qml" line="1432"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1438"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1423"/>
-        <location filename="../app/Main.qml" line="1432"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1438"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1643"/>
+        <location filename="../app/Main.qml" line="1649"/>
         <source>Default</source>
         <translation type="unfinished">Standard</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1643"/>
+        <location filename="../app/Main.qml" line="1649"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1967"/>
+        <location filename="../app/Main.qml" line="2021"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1971"/>
+        <location filename="../app/Main.qml" line="2025"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1985"/>
+        <location filename="../app/Main.qml" line="2039"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1989"/>
+        <location filename="../app/Main.qml" line="2043"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1993"/>
+        <location filename="../app/Main.qml" line="2047"/>
         <source>Retry</source>
         <translation type="unfinished">Wiederholen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1997"/>
+        <location filename="../app/Main.qml" line="2051"/>
         <source>Cancel</source>
         <translation type="unfinished">Abbrechen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2649"/>
+        <location filename="../app/Main.qml" line="2735"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2653"/>
+        <location filename="../app/Main.qml" line="2739"/>
         <source>Loading recently played…</source>
         <translation>Zuletzt gespielte werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2655"/>
+        <location filename="../app/Main.qml" line="2741"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2657"/>
+        <location filename="../app/Main.qml" line="2743"/>
         <source>Loading…</source>
         <translation>Wird geladen…</translation>
     </message>
@@ -692,166 +720,168 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="685"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Writing failed</source>
         <translation>Schreiben fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="685"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Put a writable card near the reader</source>
         <translation>Beschreibbare Karte an den Leser halten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="813"/>
+        <location filename="../app/MainLayout.qml" line="829"/>
         <source>Are you sure you want to exit?</source>
         <translation>Wirklich beenden?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="896"/>
-        <location filename="../app/MainLayout.qml" line="970"/>
+        <location filename="../app/MainLayout.qml" line="930"/>
+        <location filename="../app/MainLayout.qml" line="1004"/>
         <source>Select</source>
         <translation>Auswählen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="900"/>
-        <location filename="../app/MainLayout.qml" line="904"/>
-        <location filename="../app/MainLayout.qml" line="918"/>
-        <location filename="../app/MainLayout.qml" line="933"/>
-        <location filename="../app/MainLayout.qml" line="944"/>
+        <location filename="../app/MainLayout.qml" line="934"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="952"/>
+        <location filename="../app/MainLayout.qml" line="967"/>
+        <location filename="../app/MainLayout.qml" line="978"/>
         <source>Close</source>
         <translation>Schließen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="911"/>
-        <location filename="../app/MainLayout.qml" line="951"/>
-        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="945"/>
         <location filename="../app/MainLayout.qml" line="985"/>
+        <location filename="../app/MainLayout.qml" line="1008"/>
+        <location filename="../app/MainLayout.qml" line="1019"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="929"/>
+        <location filename="../app/MainLayout.qml" line="963"/>
         <source>Done</source>
         <translation>Fertig</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="959"/>
+        <location filename="../app/MainLayout.qml" line="993"/>
         <source>I understand</source>
         <translation>Ich verstehe</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="993"/>
+        <location filename="../app/MainLayout.qml" line="1027"/>
         <source>Start</source>
         <translation>Starten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1205"/>
+        <location filename="../app/MainLayout.qml" line="1232"/>
         <source>Scroll</source>
         <translation>Scrollen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="892"/>
-        <location filename="../app/MainLayout.qml" line="966"/>
-        <location filename="../app/MainLayout.qml" line="1012"/>
-        <location filename="../app/MainLayout.qml" line="1049"/>
-        <location filename="../app/MainLayout.qml" line="1099"/>
-        <location filename="../app/MainLayout.qml" line="1148"/>
-        <location filename="../app/MainLayout.qml" line="1167"/>
-        <location filename="../app/MainLayout.qml" line="1234"/>
+        <location filename="../app/MainLayout.qml" line="1281"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="926"/>
+        <location filename="../app/MainLayout.qml" line="1000"/>
+        <location filename="../app/MainLayout.qml" line="1046"/>
+        <location filename="../app/MainLayout.qml" line="1083"/>
+        <location filename="../app/MainLayout.qml" line="1131"/>
+        <location filename="../app/MainLayout.qml" line="1175"/>
+        <location filename="../app/MainLayout.qml" line="1194"/>
+        <location filename="../app/MainLayout.qml" line="1264"/>
         <source>Move</source>
         <translation>Bewegen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="171"/>
+        <location filename="../app/MainLayout.qml" line="172"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="368"/>
+        <location filename="../app/MainLayout.qml" line="382"/>
         <source>Favorites</source>
         <translation type="unfinished">Favoriten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="370"/>
+        <location filename="../app/MainLayout.qml" line="384"/>
         <source>Recently Played</source>
         <translation type="unfinished">Zuletzt gespielt</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="701"/>
+        <location filename="../app/MainLayout.qml" line="717"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="702"/>
+        <location filename="../app/MainLayout.qml" line="718"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="812"/>
+        <location filename="../app/MainLayout.qml" line="828"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1016"/>
-        <location filename="../app/MainLayout.qml" line="1059"/>
-        <location filename="../app/MainLayout.qml" line="1109"/>
-        <location filename="../app/MainLayout.qml" line="1153"/>
-        <location filename="../app/MainLayout.qml" line="1244"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1088"/>
+        <location filename="../app/MainLayout.qml" line="1136"/>
+        <location filename="../app/MainLayout.qml" line="1180"/>
+        <location filename="../app/MainLayout.qml" line="1269"/>
         <source>Open</source>
         <translation>Öffnen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1026"/>
+        <location filename="../app/MainLayout.qml" line="1060"/>
         <source>Quit</source>
         <translation>Beenden</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1035"/>
-        <location filename="../app/MainLayout.qml" line="1065"/>
-        <location filename="../app/MainLayout.qml" line="1076"/>
-        <location filename="../app/MainLayout.qml" line="1091"/>
-        <location filename="../app/MainLayout.qml" line="1118"/>
-        <location filename="../app/MainLayout.qml" line="1129"/>
-        <location filename="../app/MainLayout.qml" line="1141"/>
-        <location filename="../app/MainLayout.qml" line="1157"/>
-        <location filename="../app/MainLayout.qml" line="1191"/>
-        <location filename="../app/MainLayout.qml" line="1209"/>
+        <location filename="../app/MainLayout.qml" line="1069"/>
+        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
+        <location filename="../app/MainLayout.qml" line="1120"/>
+        <location filename="../app/MainLayout.qml" line="1145"/>
+        <location filename="../app/MainLayout.qml" line="1156"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
+        <location filename="../app/MainLayout.qml" line="1184"/>
         <location filename="../app/MainLayout.qml" line="1218"/>
-        <location filename="../app/MainLayout.qml" line="1253"/>
-        <location filename="../app/MainLayout.qml" line="1264"/>
+        <location filename="../app/MainLayout.qml" line="1236"/>
+        <location filename="../app/MainLayout.qml" line="1245"/>
+        <location filename="../app/MainLayout.qml" line="1285"/>
+        <location filename="../app/MainLayout.qml" line="1296"/>
         <source>Back</source>
         <translation>Zurück</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1055"/>
-        <location filename="../app/MainLayout.qml" line="1105"/>
-        <location filename="../app/MainLayout.qml" line="1240"/>
         <source>Page</source>
-        <translation>Seite</translation>
+        <translation type="vanished">Seite</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1022"/>
-        <location filename="../app/MainLayout.qml" line="1062"/>
-        <location filename="../app/MainLayout.qml" line="1114"/>
-        <location filename="../app/MainLayout.qml" line="1249"/>
+        <location filename="../app/MainLayout.qml" line="1056"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
+        <location filename="../app/MainLayout.qml" line="1141"/>
+        <location filename="../app/MainLayout.qml" line="1274"/>
         <source>Options</source>
         <translation>Optionen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="940"/>
-        <location filename="../app/MainLayout.qml" line="1072"/>
-        <location filename="../app/MainLayout.qml" line="1125"/>
-        <location filename="../app/MainLayout.qml" line="1260"/>
+        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="1101"/>
+        <location filename="../app/MainLayout.qml" line="1152"/>
+        <location filename="../app/MainLayout.qml" line="1292"/>
         <source>Retry</source>
         <translation>Wiederholen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1176"/>
+        <location filename="../app/MainLayout.qml" line="1203"/>
         <source>Change</source>
         <translation>Ändern</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1182"/>
+        <location filename="../app/MainLayout.qml" line="1209"/>
         <source>Toggle</source>
         <translation>Umschalten</translation>
     </message>
@@ -864,12 +894,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Wird geladen…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="437"/>
+        <location filename="../screens/MediaListScreen.qml" line="449"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 Einträge</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="438"/>
+        <location filename="../screens/MediaListScreen.qml" line="450"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -426,7 +426,7 @@ Euskara - devilschile2</source>
     <name>GamesScreen</name>
     <message>
         <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="166"/>
+        <location filename="../screens/GamesScreen.qml" line="171"/>
         <source>%1 files</source>
         <translation>%1 αρχεία</translation>
     </message>
@@ -437,7 +437,7 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../screens/GamesScreen.qml" line="140"/>
-        <location filename="../screens/GamesScreen.qml" line="167"/>
+        <location filename="../screens/GamesScreen.qml" line="172"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -510,6 +510,24 @@ Euskara - devilschile2</source>
     </message>
 </context>
 <context>
+    <name>LetterJumpModal</name>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="32"/>
+        <source>Go to...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <source>Loading…</source>
+        <translation type="unfinished">Φόρτωση…</translation>
+    </message>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <source>No sections</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LoadingIndicator</name>
     <message>
         <location filename="../components/LoadingIndicator.qml" line="26"/>
@@ -553,138 +571,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1408"/>
         <source>Launch core</source>
         <translation>Εκκίνηση Core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1408"/>
-        <location filename="../app/Main.qml" line="1647"/>
+        <location filename="../app/Main.qml" line="1414"/>
+        <location filename="../app/Main.qml" line="1653"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1472"/>
         <source>Remove from favorites</source>
         <translation>Αφαίρεση από αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1472"/>
         <source>Add to favorites</source>
         <translation>Προσθήκη στα αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1471"/>
+        <location filename="../app/Main.qml" line="1477"/>
         <source>Write to NFC token</source>
         <translation>Εγγραφή σε NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1475"/>
+        <location filename="../app/Main.qml" line="1481"/>
         <source>QR code</source>
         <translation>Κωδικός QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1450"/>
-        <location filename="../app/Main.qml" line="1485"/>
+        <location filename="../app/Main.qml" line="1456"/>
+        <location filename="../app/Main.qml" line="1491"/>
         <source>Launch game</source>
         <translation>Εκκίνηση παιχνιδιού</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2645"/>
+        <location filename="../app/Main.qml" line="1937"/>
+        <source>Go to...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1940"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2731"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2651"/>
+        <location filename="../app/Main.qml" line="2737"/>
         <source>Loading favorites…</source>
         <translation>Φόρτωση αγαπημένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2647"/>
+        <location filename="../app/Main.qml" line="2733"/>
         <source>Loading games…</source>
         <translation>Φόρτωση παιχνιδιών…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1415"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1421"/>
+        <location filename="../app/Main.qml" line="1444"/>
         <source>Update media database</source>
         <translation type="unfinished">Ενημέρωση βάσης δεδομένων</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1418"/>
-        <location filename="../app/Main.qml" line="1441"/>
+        <location filename="../app/Main.qml" line="1424"/>
+        <location filename="../app/Main.qml" line="1447"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Ανάκτηση μεταδεδομένων</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1423"/>
-        <location filename="../app/Main.qml" line="1432"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1438"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1423"/>
-        <location filename="../app/Main.qml" line="1432"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1438"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1643"/>
+        <location filename="../app/Main.qml" line="1649"/>
         <source>Default</source>
         <translation type="unfinished">Προεπιλογή</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1643"/>
+        <location filename="../app/Main.qml" line="1649"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1967"/>
+        <location filename="../app/Main.qml" line="2021"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1971"/>
+        <location filename="../app/Main.qml" line="2025"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1985"/>
+        <location filename="../app/Main.qml" line="2039"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1989"/>
+        <location filename="../app/Main.qml" line="2043"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1993"/>
+        <location filename="../app/Main.qml" line="2047"/>
         <source>Retry</source>
         <translation type="unfinished">Επανάληψη</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1997"/>
+        <location filename="../app/Main.qml" line="2051"/>
         <source>Cancel</source>
         <translation type="unfinished">Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2649"/>
+        <location filename="../app/Main.qml" line="2735"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2653"/>
+        <location filename="../app/Main.qml" line="2739"/>
         <source>Loading recently played…</source>
         <translation>Φόρτωση πρόσφατα παιγμένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2655"/>
+        <location filename="../app/Main.qml" line="2741"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2657"/>
+        <location filename="../app/Main.qml" line="2743"/>
         <source>Loading…</source>
         <translation>Φόρτωση…</translation>
     </message>
@@ -692,166 +720,168 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="685"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Writing failed</source>
         <translation>Αποτυχία εγγραφής</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="685"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Put a writable card near the reader</source>
         <translation>Τοποθετήστε μια εγγράψιμη κάρτα κοντά στον αναγνώστη</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="813"/>
+        <location filename="../app/MainLayout.qml" line="829"/>
         <source>Are you sure you want to exit?</source>
         <translation>Είστε σίγουροι ότι θέλετε να βγείτε;</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="896"/>
-        <location filename="../app/MainLayout.qml" line="970"/>
+        <location filename="../app/MainLayout.qml" line="930"/>
+        <location filename="../app/MainLayout.qml" line="1004"/>
         <source>Select</source>
         <translation>Επιλογή</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="900"/>
-        <location filename="../app/MainLayout.qml" line="904"/>
-        <location filename="../app/MainLayout.qml" line="918"/>
-        <location filename="../app/MainLayout.qml" line="933"/>
-        <location filename="../app/MainLayout.qml" line="944"/>
+        <location filename="../app/MainLayout.qml" line="934"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="952"/>
+        <location filename="../app/MainLayout.qml" line="967"/>
+        <location filename="../app/MainLayout.qml" line="978"/>
         <source>Close</source>
         <translation>Κλείσιμο</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="911"/>
-        <location filename="../app/MainLayout.qml" line="951"/>
-        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="945"/>
         <location filename="../app/MainLayout.qml" line="985"/>
+        <location filename="../app/MainLayout.qml" line="1008"/>
+        <location filename="../app/MainLayout.qml" line="1019"/>
         <source>Cancel</source>
         <translation>Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="929"/>
+        <location filename="../app/MainLayout.qml" line="963"/>
         <source>Done</source>
         <translation>Ολοκληρώθηκε</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="959"/>
+        <location filename="../app/MainLayout.qml" line="993"/>
         <source>I understand</source>
         <translation>Κατανοώ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="993"/>
+        <location filename="../app/MainLayout.qml" line="1027"/>
         <source>Start</source>
         <translation>Έναρξη</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1205"/>
+        <location filename="../app/MainLayout.qml" line="1232"/>
         <source>Scroll</source>
         <translation>Κύλιση</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="892"/>
-        <location filename="../app/MainLayout.qml" line="966"/>
-        <location filename="../app/MainLayout.qml" line="1012"/>
-        <location filename="../app/MainLayout.qml" line="1049"/>
-        <location filename="../app/MainLayout.qml" line="1099"/>
-        <location filename="../app/MainLayout.qml" line="1148"/>
-        <location filename="../app/MainLayout.qml" line="1167"/>
-        <location filename="../app/MainLayout.qml" line="1234"/>
+        <location filename="../app/MainLayout.qml" line="1281"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="926"/>
+        <location filename="../app/MainLayout.qml" line="1000"/>
+        <location filename="../app/MainLayout.qml" line="1046"/>
+        <location filename="../app/MainLayout.qml" line="1083"/>
+        <location filename="../app/MainLayout.qml" line="1131"/>
+        <location filename="../app/MainLayout.qml" line="1175"/>
+        <location filename="../app/MainLayout.qml" line="1194"/>
+        <location filename="../app/MainLayout.qml" line="1264"/>
         <source>Move</source>
         <translation>Μετακίνηση</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="171"/>
+        <location filename="../app/MainLayout.qml" line="172"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="368"/>
+        <location filename="../app/MainLayout.qml" line="382"/>
         <source>Favorites</source>
         <translation type="unfinished">Αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="370"/>
+        <location filename="../app/MainLayout.qml" line="384"/>
         <source>Recently Played</source>
         <translation type="unfinished">Πρόσφατα Παιγμένα</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="701"/>
+        <location filename="../app/MainLayout.qml" line="717"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="702"/>
+        <location filename="../app/MainLayout.qml" line="718"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="812"/>
+        <location filename="../app/MainLayout.qml" line="828"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1016"/>
-        <location filename="../app/MainLayout.qml" line="1059"/>
-        <location filename="../app/MainLayout.qml" line="1109"/>
-        <location filename="../app/MainLayout.qml" line="1153"/>
-        <location filename="../app/MainLayout.qml" line="1244"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1088"/>
+        <location filename="../app/MainLayout.qml" line="1136"/>
+        <location filename="../app/MainLayout.qml" line="1180"/>
+        <location filename="../app/MainLayout.qml" line="1269"/>
         <source>Open</source>
         <translation>Άνοιγμα</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1026"/>
+        <location filename="../app/MainLayout.qml" line="1060"/>
         <source>Quit</source>
         <translation>Έξοδος</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1035"/>
-        <location filename="../app/MainLayout.qml" line="1065"/>
-        <location filename="../app/MainLayout.qml" line="1076"/>
-        <location filename="../app/MainLayout.qml" line="1091"/>
-        <location filename="../app/MainLayout.qml" line="1118"/>
-        <location filename="../app/MainLayout.qml" line="1129"/>
-        <location filename="../app/MainLayout.qml" line="1141"/>
-        <location filename="../app/MainLayout.qml" line="1157"/>
-        <location filename="../app/MainLayout.qml" line="1191"/>
-        <location filename="../app/MainLayout.qml" line="1209"/>
+        <location filename="../app/MainLayout.qml" line="1069"/>
+        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
+        <location filename="../app/MainLayout.qml" line="1120"/>
+        <location filename="../app/MainLayout.qml" line="1145"/>
+        <location filename="../app/MainLayout.qml" line="1156"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
+        <location filename="../app/MainLayout.qml" line="1184"/>
         <location filename="../app/MainLayout.qml" line="1218"/>
-        <location filename="../app/MainLayout.qml" line="1253"/>
-        <location filename="../app/MainLayout.qml" line="1264"/>
+        <location filename="../app/MainLayout.qml" line="1236"/>
+        <location filename="../app/MainLayout.qml" line="1245"/>
+        <location filename="../app/MainLayout.qml" line="1285"/>
+        <location filename="../app/MainLayout.qml" line="1296"/>
         <source>Back</source>
         <translation>Πίσω</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1055"/>
-        <location filename="../app/MainLayout.qml" line="1105"/>
-        <location filename="../app/MainLayout.qml" line="1240"/>
         <source>Page</source>
-        <translation>Σελίδα</translation>
+        <translation type="vanished">Σελίδα</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1022"/>
-        <location filename="../app/MainLayout.qml" line="1062"/>
-        <location filename="../app/MainLayout.qml" line="1114"/>
-        <location filename="../app/MainLayout.qml" line="1249"/>
+        <location filename="../app/MainLayout.qml" line="1056"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
+        <location filename="../app/MainLayout.qml" line="1141"/>
+        <location filename="../app/MainLayout.qml" line="1274"/>
         <source>Options</source>
         <translation>Επιλογές</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="940"/>
-        <location filename="../app/MainLayout.qml" line="1072"/>
-        <location filename="../app/MainLayout.qml" line="1125"/>
-        <location filename="../app/MainLayout.qml" line="1260"/>
+        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="1101"/>
+        <location filename="../app/MainLayout.qml" line="1152"/>
+        <location filename="../app/MainLayout.qml" line="1292"/>
         <source>Retry</source>
         <translation>Επανάληψη</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1176"/>
+        <location filename="../app/MainLayout.qml" line="1203"/>
         <source>Change</source>
         <translation>Αλλαγή</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1182"/>
+        <location filename="../app/MainLayout.qml" line="1209"/>
         <source>Toggle</source>
         <translation>Εναλλαγή</translation>
     </message>
@@ -864,12 +894,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Φόρτωση…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="437"/>
+        <location filename="../screens/MediaListScreen.qml" line="449"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 εγγραφές</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="438"/>
+        <location filename="../screens/MediaListScreen.qml" line="450"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -517,12 +517,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <location filename="../components/LetterJumpModal.qml" line="220"/>
         <source>Loading…</source>
         <translation type="unfinished">Φόρτωση…</translation>
     </message>
     <message>
-        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <location filename="../components/LetterJumpModal.qml" line="220"/>
         <source>No sections</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -505,12 +505,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <location filename="../components/LetterJumpModal.qml" line="220"/>
         <source>Loading…</source>
         <translation type="unfinished">Loading…</translation>
     </message>
     <message>
-        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <location filename="../components/LetterJumpModal.qml" line="220"/>
         <source>No sections</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -406,7 +406,7 @@ Euskara - devilschile2</source>
     <name>GamesScreen</name>
     <message>
         <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="166"/>
+        <location filename="../screens/GamesScreen.qml" line="171"/>
         <source>%1 files</source>
         <translation>%1 files</translation>
     </message>
@@ -417,7 +417,7 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../screens/GamesScreen.qml" line="140"/>
-        <location filename="../screens/GamesScreen.qml" line="167"/>
+        <location filename="../screens/GamesScreen.qml" line="172"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -498,6 +498,24 @@ Euskara - devilschile2</source>
     </message>
 </context>
 <context>
+    <name>LetterJumpModal</name>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="32"/>
+        <source>Go to...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <source>Loading…</source>
+        <translation type="unfinished">Loading…</translation>
+    </message>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <source>No sections</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LoadingIndicator</name>
     <message>
         <location filename="../components/LoadingIndicator.qml" line="26"/>
@@ -541,138 +559,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1408"/>
         <source>Launch core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1408"/>
-        <location filename="../app/Main.qml" line="1647"/>
+        <location filename="../app/Main.qml" line="1414"/>
+        <location filename="../app/Main.qml" line="1653"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1472"/>
         <source>Remove from favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1472"/>
         <source>Add to favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1471"/>
+        <location filename="../app/Main.qml" line="1477"/>
         <source>Write to NFC token</source>
         <translation type="unfinished">Write to NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1475"/>
+        <location filename="../app/Main.qml" line="1481"/>
         <source>QR code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1450"/>
-        <location filename="../app/Main.qml" line="1485"/>
+        <location filename="../app/Main.qml" line="1456"/>
+        <location filename="../app/Main.qml" line="1491"/>
         <source>Launch game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2645"/>
+        <location filename="../app/Main.qml" line="1937"/>
+        <source>Go to...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1940"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2731"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2651"/>
+        <location filename="../app/Main.qml" line="2737"/>
         <source>Loading favorites…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2647"/>
+        <location filename="../app/Main.qml" line="2733"/>
         <source>Loading games…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1415"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1421"/>
+        <location filename="../app/Main.qml" line="1444"/>
         <source>Update media database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1418"/>
-        <location filename="../app/Main.qml" line="1441"/>
+        <location filename="../app/Main.qml" line="1424"/>
+        <location filename="../app/Main.qml" line="1447"/>
         <source>Scrape metadata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1423"/>
-        <location filename="../app/Main.qml" line="1432"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1438"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1423"/>
-        <location filename="../app/Main.qml" line="1432"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1438"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1643"/>
+        <location filename="../app/Main.qml" line="1649"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1643"/>
+        <location filename="../app/Main.qml" line="1649"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1967"/>
+        <location filename="../app/Main.qml" line="2021"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1971"/>
+        <location filename="../app/Main.qml" line="2025"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1985"/>
+        <location filename="../app/Main.qml" line="2039"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1989"/>
+        <location filename="../app/Main.qml" line="2043"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1993"/>
+        <location filename="../app/Main.qml" line="2047"/>
         <source>Retry</source>
         <translation type="unfinished">Retry</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1997"/>
+        <location filename="../app/Main.qml" line="2051"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2649"/>
+        <location filename="../app/Main.qml" line="2735"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2653"/>
+        <location filename="../app/Main.qml" line="2739"/>
         <source>Loading recently played…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2655"/>
+        <location filename="../app/Main.qml" line="2741"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2657"/>
+        <location filename="../app/Main.qml" line="2743"/>
         <source>Loading…</source>
         <translation type="unfinished">Loading…</translation>
     </message>
@@ -680,166 +708,164 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="685"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Writing failed</source>
         <translation>Writing failed</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="685"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Put a writable card near the reader</source>
         <translation>Put a writable card near the reader</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="813"/>
+        <location filename="../app/MainLayout.qml" line="829"/>
         <source>Are you sure you want to exit?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="896"/>
-        <location filename="../app/MainLayout.qml" line="970"/>
+        <location filename="../app/MainLayout.qml" line="930"/>
+        <location filename="../app/MainLayout.qml" line="1004"/>
         <source>Select</source>
         <translation>Select</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="900"/>
-        <location filename="../app/MainLayout.qml" line="904"/>
-        <location filename="../app/MainLayout.qml" line="918"/>
-        <location filename="../app/MainLayout.qml" line="933"/>
-        <location filename="../app/MainLayout.qml" line="944"/>
+        <location filename="../app/MainLayout.qml" line="934"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="952"/>
+        <location filename="../app/MainLayout.qml" line="967"/>
+        <location filename="../app/MainLayout.qml" line="978"/>
         <source>Close</source>
         <translation>Close</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="911"/>
-        <location filename="../app/MainLayout.qml" line="951"/>
-        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="945"/>
         <location filename="../app/MainLayout.qml" line="985"/>
+        <location filename="../app/MainLayout.qml" line="1008"/>
+        <location filename="../app/MainLayout.qml" line="1019"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="929"/>
+        <location filename="../app/MainLayout.qml" line="963"/>
         <source>Done</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="959"/>
+        <location filename="../app/MainLayout.qml" line="993"/>
         <source>I understand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="993"/>
+        <location filename="../app/MainLayout.qml" line="1027"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1205"/>
+        <location filename="../app/MainLayout.qml" line="1232"/>
         <source>Scroll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="892"/>
-        <location filename="../app/MainLayout.qml" line="966"/>
-        <location filename="../app/MainLayout.qml" line="1012"/>
-        <location filename="../app/MainLayout.qml" line="1049"/>
-        <location filename="../app/MainLayout.qml" line="1099"/>
-        <location filename="../app/MainLayout.qml" line="1148"/>
-        <location filename="../app/MainLayout.qml" line="1167"/>
-        <location filename="../app/MainLayout.qml" line="1234"/>
+        <location filename="../app/MainLayout.qml" line="1281"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="926"/>
+        <location filename="../app/MainLayout.qml" line="1000"/>
+        <location filename="../app/MainLayout.qml" line="1046"/>
+        <location filename="../app/MainLayout.qml" line="1083"/>
+        <location filename="../app/MainLayout.qml" line="1131"/>
+        <location filename="../app/MainLayout.qml" line="1175"/>
+        <location filename="../app/MainLayout.qml" line="1194"/>
+        <location filename="../app/MainLayout.qml" line="1264"/>
         <source>Move</source>
         <translation>Move</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="171"/>
+        <location filename="../app/MainLayout.qml" line="172"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="368"/>
+        <location filename="../app/MainLayout.qml" line="382"/>
         <source>Favorites</source>
         <translation type="unfinished">Favorites</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="370"/>
+        <location filename="../app/MainLayout.qml" line="384"/>
         <source>Recently Played</source>
         <translation type="unfinished">Recently Played</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="701"/>
+        <location filename="../app/MainLayout.qml" line="717"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="702"/>
+        <location filename="../app/MainLayout.qml" line="718"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="812"/>
+        <location filename="../app/MainLayout.qml" line="828"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1016"/>
-        <location filename="../app/MainLayout.qml" line="1059"/>
-        <location filename="../app/MainLayout.qml" line="1109"/>
-        <location filename="../app/MainLayout.qml" line="1153"/>
-        <location filename="../app/MainLayout.qml" line="1244"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1088"/>
+        <location filename="../app/MainLayout.qml" line="1136"/>
+        <location filename="../app/MainLayout.qml" line="1180"/>
+        <location filename="../app/MainLayout.qml" line="1269"/>
         <source>Open</source>
         <translation>Open</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1026"/>
+        <location filename="../app/MainLayout.qml" line="1060"/>
         <source>Quit</source>
         <translation>Quit</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1035"/>
-        <location filename="../app/MainLayout.qml" line="1065"/>
-        <location filename="../app/MainLayout.qml" line="1076"/>
-        <location filename="../app/MainLayout.qml" line="1091"/>
-        <location filename="../app/MainLayout.qml" line="1118"/>
-        <location filename="../app/MainLayout.qml" line="1129"/>
-        <location filename="../app/MainLayout.qml" line="1141"/>
-        <location filename="../app/MainLayout.qml" line="1157"/>
-        <location filename="../app/MainLayout.qml" line="1191"/>
-        <location filename="../app/MainLayout.qml" line="1209"/>
+        <location filename="../app/MainLayout.qml" line="1069"/>
+        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
+        <location filename="../app/MainLayout.qml" line="1120"/>
+        <location filename="../app/MainLayout.qml" line="1145"/>
+        <location filename="../app/MainLayout.qml" line="1156"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
+        <location filename="../app/MainLayout.qml" line="1184"/>
         <location filename="../app/MainLayout.qml" line="1218"/>
-        <location filename="../app/MainLayout.qml" line="1253"/>
-        <location filename="../app/MainLayout.qml" line="1264"/>
+        <location filename="../app/MainLayout.qml" line="1236"/>
+        <location filename="../app/MainLayout.qml" line="1245"/>
+        <location filename="../app/MainLayout.qml" line="1285"/>
+        <location filename="../app/MainLayout.qml" line="1296"/>
         <source>Back</source>
         <translation>Back</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1055"/>
-        <location filename="../app/MainLayout.qml" line="1105"/>
-        <location filename="../app/MainLayout.qml" line="1240"/>
-        <source>Page</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/MainLayout.qml" line="1022"/>
-        <location filename="../app/MainLayout.qml" line="1062"/>
-        <location filename="../app/MainLayout.qml" line="1114"/>
-        <location filename="../app/MainLayout.qml" line="1249"/>
+        <location filename="../app/MainLayout.qml" line="1056"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
+        <location filename="../app/MainLayout.qml" line="1141"/>
+        <location filename="../app/MainLayout.qml" line="1274"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="940"/>
-        <location filename="../app/MainLayout.qml" line="1072"/>
-        <location filename="../app/MainLayout.qml" line="1125"/>
-        <location filename="../app/MainLayout.qml" line="1260"/>
+        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="1101"/>
+        <location filename="../app/MainLayout.qml" line="1152"/>
+        <location filename="../app/MainLayout.qml" line="1292"/>
         <source>Retry</source>
         <translation>Retry</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1176"/>
+        <location filename="../app/MainLayout.qml" line="1203"/>
         <source>Change</source>
         <translation>Change</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1182"/>
+        <location filename="../app/MainLayout.qml" line="1209"/>
         <source>Toggle</source>
         <translation>Toggle</translation>
     </message>
@@ -852,12 +878,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Loading…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="437"/>
+        <location filename="../screens/MediaListScreen.qml" line="449"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 entries</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="438"/>
+        <location filename="../screens/MediaListScreen.qml" line="450"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -426,7 +426,7 @@ Euskara - devilschile2</source>
     <name>GamesScreen</name>
     <message>
         <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="166"/>
+        <location filename="../screens/GamesScreen.qml" line="171"/>
         <source>%1 files</source>
         <translation>%1 archivos</translation>
     </message>
@@ -437,7 +437,7 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../screens/GamesScreen.qml" line="140"/>
-        <location filename="../screens/GamesScreen.qml" line="167"/>
+        <location filename="../screens/GamesScreen.qml" line="172"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -510,6 +510,24 @@ Euskara - devilschile2</source>
     </message>
 </context>
 <context>
+    <name>LetterJumpModal</name>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="32"/>
+        <source>Go to...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <source>Loading…</source>
+        <translation type="unfinished">Cargando…</translation>
+    </message>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <source>No sections</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LoadingIndicator</name>
     <message>
         <location filename="../components/LoadingIndicator.qml" line="26"/>
@@ -553,138 +571,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1408"/>
         <source>Launch core</source>
         <translation>Lanzar core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1408"/>
-        <location filename="../app/Main.qml" line="1647"/>
+        <location filename="../app/Main.qml" line="1414"/>
+        <location filename="../app/Main.qml" line="1653"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1472"/>
         <source>Remove from favorites</source>
         <translation>Eliminar de favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1472"/>
         <source>Add to favorites</source>
         <translation>Agregar a favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1471"/>
+        <location filename="../app/Main.qml" line="1477"/>
         <source>Write to NFC token</source>
         <translation>Escribir en token NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1475"/>
+        <location filename="../app/Main.qml" line="1481"/>
         <source>QR code</source>
         <translation>Código QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1450"/>
-        <location filename="../app/Main.qml" line="1485"/>
+        <location filename="../app/Main.qml" line="1456"/>
+        <location filename="../app/Main.qml" line="1491"/>
         <source>Launch game</source>
         <translation>Iniciar juego</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2645"/>
+        <location filename="../app/Main.qml" line="1937"/>
+        <source>Go to...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1940"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2731"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2651"/>
+        <location filename="../app/Main.qml" line="2737"/>
         <source>Loading favorites…</source>
         <translation>Cargando favoritos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2647"/>
+        <location filename="../app/Main.qml" line="2733"/>
         <source>Loading games…</source>
         <translation>Cargando juegos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1415"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1421"/>
+        <location filename="../app/Main.qml" line="1444"/>
         <source>Update media database</source>
         <translation type="unfinished">Actualizar base de datos de medios</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1418"/>
-        <location filename="../app/Main.qml" line="1441"/>
+        <location filename="../app/Main.qml" line="1424"/>
+        <location filename="../app/Main.qml" line="1447"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Extraer metadatos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1423"/>
-        <location filename="../app/Main.qml" line="1432"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1438"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1423"/>
-        <location filename="../app/Main.qml" line="1432"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1438"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1643"/>
+        <location filename="../app/Main.qml" line="1649"/>
         <source>Default</source>
         <translation type="unfinished">Por defecto</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1643"/>
+        <location filename="../app/Main.qml" line="1649"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1967"/>
+        <location filename="../app/Main.qml" line="2021"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1971"/>
+        <location filename="../app/Main.qml" line="2025"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1985"/>
+        <location filename="../app/Main.qml" line="2039"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1989"/>
+        <location filename="../app/Main.qml" line="2043"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1993"/>
+        <location filename="../app/Main.qml" line="2047"/>
         <source>Retry</source>
         <translation type="unfinished">Reintentar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1997"/>
+        <location filename="../app/Main.qml" line="2051"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2649"/>
+        <location filename="../app/Main.qml" line="2735"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2653"/>
+        <location filename="../app/Main.qml" line="2739"/>
         <source>Loading recently played…</source>
         <translation>Cargando jugados recientemente…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2655"/>
+        <location filename="../app/Main.qml" line="2741"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2657"/>
+        <location filename="../app/Main.qml" line="2743"/>
         <source>Loading…</source>
         <translation>Cargando…</translation>
     </message>
@@ -692,166 +720,168 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="685"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Writing failed</source>
         <translation>Error de escritura</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="685"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Put a writable card near the reader</source>
         <translation>Pon una tarjeta escribible junto al lector</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="813"/>
+        <location filename="../app/MainLayout.qml" line="829"/>
         <source>Are you sure you want to exit?</source>
         <translation>¿Seguro que quieres salir?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="896"/>
-        <location filename="../app/MainLayout.qml" line="970"/>
+        <location filename="../app/MainLayout.qml" line="930"/>
+        <location filename="../app/MainLayout.qml" line="1004"/>
         <source>Select</source>
         <translation>Seleccionar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="900"/>
-        <location filename="../app/MainLayout.qml" line="904"/>
-        <location filename="../app/MainLayout.qml" line="918"/>
-        <location filename="../app/MainLayout.qml" line="933"/>
-        <location filename="../app/MainLayout.qml" line="944"/>
+        <location filename="../app/MainLayout.qml" line="934"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="952"/>
+        <location filename="../app/MainLayout.qml" line="967"/>
+        <location filename="../app/MainLayout.qml" line="978"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="911"/>
-        <location filename="../app/MainLayout.qml" line="951"/>
-        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="945"/>
         <location filename="../app/MainLayout.qml" line="985"/>
+        <location filename="../app/MainLayout.qml" line="1008"/>
+        <location filename="../app/MainLayout.qml" line="1019"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="929"/>
+        <location filename="../app/MainLayout.qml" line="963"/>
         <source>Done</source>
         <translation>Hecho</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="959"/>
+        <location filename="../app/MainLayout.qml" line="993"/>
         <source>I understand</source>
         <translation>Entendido</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="993"/>
+        <location filename="../app/MainLayout.qml" line="1027"/>
         <source>Start</source>
         <translation>Iniciar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1205"/>
+        <location filename="../app/MainLayout.qml" line="1232"/>
         <source>Scroll</source>
         <translation>Desplazar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="892"/>
-        <location filename="../app/MainLayout.qml" line="966"/>
-        <location filename="../app/MainLayout.qml" line="1012"/>
-        <location filename="../app/MainLayout.qml" line="1049"/>
-        <location filename="../app/MainLayout.qml" line="1099"/>
-        <location filename="../app/MainLayout.qml" line="1148"/>
-        <location filename="../app/MainLayout.qml" line="1167"/>
-        <location filename="../app/MainLayout.qml" line="1234"/>
+        <location filename="../app/MainLayout.qml" line="1281"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="926"/>
+        <location filename="../app/MainLayout.qml" line="1000"/>
+        <location filename="../app/MainLayout.qml" line="1046"/>
+        <location filename="../app/MainLayout.qml" line="1083"/>
+        <location filename="../app/MainLayout.qml" line="1131"/>
+        <location filename="../app/MainLayout.qml" line="1175"/>
+        <location filename="../app/MainLayout.qml" line="1194"/>
+        <location filename="../app/MainLayout.qml" line="1264"/>
         <source>Move</source>
         <translation>Mover</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="171"/>
+        <location filename="../app/MainLayout.qml" line="172"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="368"/>
+        <location filename="../app/MainLayout.qml" line="382"/>
         <source>Favorites</source>
         <translation type="unfinished">Favoritos</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="370"/>
+        <location filename="../app/MainLayout.qml" line="384"/>
         <source>Recently Played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="701"/>
+        <location filename="../app/MainLayout.qml" line="717"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="702"/>
+        <location filename="../app/MainLayout.qml" line="718"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="812"/>
+        <location filename="../app/MainLayout.qml" line="828"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1016"/>
-        <location filename="../app/MainLayout.qml" line="1059"/>
-        <location filename="../app/MainLayout.qml" line="1109"/>
-        <location filename="../app/MainLayout.qml" line="1153"/>
-        <location filename="../app/MainLayout.qml" line="1244"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1088"/>
+        <location filename="../app/MainLayout.qml" line="1136"/>
+        <location filename="../app/MainLayout.qml" line="1180"/>
+        <location filename="../app/MainLayout.qml" line="1269"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1026"/>
+        <location filename="../app/MainLayout.qml" line="1060"/>
         <source>Quit</source>
         <translation>Salir</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1035"/>
-        <location filename="../app/MainLayout.qml" line="1065"/>
-        <location filename="../app/MainLayout.qml" line="1076"/>
-        <location filename="../app/MainLayout.qml" line="1091"/>
-        <location filename="../app/MainLayout.qml" line="1118"/>
-        <location filename="../app/MainLayout.qml" line="1129"/>
-        <location filename="../app/MainLayout.qml" line="1141"/>
-        <location filename="../app/MainLayout.qml" line="1157"/>
-        <location filename="../app/MainLayout.qml" line="1191"/>
-        <location filename="../app/MainLayout.qml" line="1209"/>
+        <location filename="../app/MainLayout.qml" line="1069"/>
+        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
+        <location filename="../app/MainLayout.qml" line="1120"/>
+        <location filename="../app/MainLayout.qml" line="1145"/>
+        <location filename="../app/MainLayout.qml" line="1156"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
+        <location filename="../app/MainLayout.qml" line="1184"/>
         <location filename="../app/MainLayout.qml" line="1218"/>
-        <location filename="../app/MainLayout.qml" line="1253"/>
-        <location filename="../app/MainLayout.qml" line="1264"/>
+        <location filename="../app/MainLayout.qml" line="1236"/>
+        <location filename="../app/MainLayout.qml" line="1245"/>
+        <location filename="../app/MainLayout.qml" line="1285"/>
+        <location filename="../app/MainLayout.qml" line="1296"/>
         <source>Back</source>
         <translation>Atrás</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1055"/>
-        <location filename="../app/MainLayout.qml" line="1105"/>
-        <location filename="../app/MainLayout.qml" line="1240"/>
         <source>Page</source>
-        <translation>Página</translation>
+        <translation type="vanished">Página</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1022"/>
-        <location filename="../app/MainLayout.qml" line="1062"/>
-        <location filename="../app/MainLayout.qml" line="1114"/>
-        <location filename="../app/MainLayout.qml" line="1249"/>
+        <location filename="../app/MainLayout.qml" line="1056"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
+        <location filename="../app/MainLayout.qml" line="1141"/>
+        <location filename="../app/MainLayout.qml" line="1274"/>
         <source>Options</source>
         <translation>Opciones</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="940"/>
-        <location filename="../app/MainLayout.qml" line="1072"/>
-        <location filename="../app/MainLayout.qml" line="1125"/>
-        <location filename="../app/MainLayout.qml" line="1260"/>
+        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="1101"/>
+        <location filename="../app/MainLayout.qml" line="1152"/>
+        <location filename="../app/MainLayout.qml" line="1292"/>
         <source>Retry</source>
         <translation>Reintentar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1176"/>
+        <location filename="../app/MainLayout.qml" line="1203"/>
         <source>Change</source>
         <translation>Cambiar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1182"/>
+        <location filename="../app/MainLayout.qml" line="1209"/>
         <source>Toggle</source>
         <translation>Alternar</translation>
     </message>
@@ -864,12 +894,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Cargando…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="437"/>
+        <location filename="../screens/MediaListScreen.qml" line="449"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 entradas</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="438"/>
+        <location filename="../screens/MediaListScreen.qml" line="450"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -517,12 +517,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <location filename="../components/LetterJumpModal.qml" line="220"/>
         <source>Loading…</source>
         <translation type="unfinished">Cargando…</translation>
     </message>
     <message>
-        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <location filename="../components/LetterJumpModal.qml" line="220"/>
         <source>No sections</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -525,12 +525,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <location filename="../components/LetterJumpModal.qml" line="220"/>
         <source>Loading…</source>
         <translation type="unfinished">Kargatzen…</translation>
     </message>
     <message>
-        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <location filename="../components/LetterJumpModal.qml" line="220"/>
         <source>No sections</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -426,7 +426,7 @@ Euskara - devilschile2</source>
     <name>GamesScreen</name>
     <message>
         <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="166"/>
+        <location filename="../screens/GamesScreen.qml" line="171"/>
         <source>%1 files</source>
         <translation>%1 fitxategi</translation>
     </message>
@@ -437,7 +437,7 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../screens/GamesScreen.qml" line="140"/>
-        <location filename="../screens/GamesScreen.qml" line="167"/>
+        <location filename="../screens/GamesScreen.qml" line="172"/>
         <source>%1 / %2</source>
         <translation type="unfinished">%1 / %2</translation>
     </message>
@@ -518,6 +518,24 @@ Euskara - devilschile2</source>
     </message>
 </context>
 <context>
+    <name>LetterJumpModal</name>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="32"/>
+        <source>Go to...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <source>Loading…</source>
+        <translation type="unfinished">Kargatzen…</translation>
+    </message>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <source>No sections</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LoadingIndicator</name>
     <message>
         <location filename="../components/LoadingIndicator.qml" line="26"/>
@@ -561,138 +579,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1408"/>
         <source>Launch core</source>
         <translation type="unfinished">Exekutatu nukleoa</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1408"/>
-        <location filename="../app/Main.qml" line="1647"/>
+        <location filename="../app/Main.qml" line="1414"/>
+        <location filename="../app/Main.qml" line="1653"/>
         <source>Change launcher</source>
         <translation type="unfinished">Aldatu abiarazlea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1472"/>
         <source>Remove from favorites</source>
         <translation type="unfinished">Kendu gogokoetatik</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1472"/>
         <source>Add to favorites</source>
         <translation type="unfinished">Gehitu gogokoetan</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1471"/>
+        <location filename="../app/Main.qml" line="1477"/>
         <source>Write to NFC token</source>
         <translation type="unfinished">Idatzi NFC token-a</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1475"/>
+        <location filename="../app/Main.qml" line="1481"/>
         <source>QR code</source>
         <translation type="unfinished">QR kodea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1450"/>
-        <location filename="../app/Main.qml" line="1485"/>
+        <location filename="../app/Main.qml" line="1456"/>
+        <location filename="../app/Main.qml" line="1491"/>
         <source>Launch game</source>
         <translation type="unfinished">Abiarazi jokua</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2645"/>
+        <location filename="../app/Main.qml" line="1937"/>
+        <source>Go to...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1940"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2731"/>
         <source>Loading systems…</source>
         <translation type="unfinished">Sistemak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2651"/>
+        <location filename="../app/Main.qml" line="2737"/>
         <source>Loading favorites…</source>
         <translation type="unfinished">Gogokoak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2647"/>
+        <location filename="../app/Main.qml" line="2733"/>
         <source>Loading games…</source>
         <translation type="unfinished">Jokoak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1415"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1421"/>
+        <location filename="../app/Main.qml" line="1444"/>
         <source>Update media database</source>
         <translation type="unfinished">Eguneratu multimedia datu-basea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1418"/>
-        <location filename="../app/Main.qml" line="1441"/>
+        <location filename="../app/Main.qml" line="1424"/>
+        <location filename="../app/Main.qml" line="1447"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadatuak scrapeatu</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1423"/>
-        <location filename="../app/Main.qml" line="1432"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1438"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1423"/>
-        <location filename="../app/Main.qml" line="1432"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1438"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1643"/>
+        <location filename="../app/Main.qml" line="1649"/>
         <source>Default</source>
         <translation type="unfinished">Lehenetsia</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1643"/>
+        <location filename="../app/Main.qml" line="1649"/>
         <source>Current: %1</source>
         <translation type="unfinished">Unekoa: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1967"/>
+        <location filename="../app/Main.qml" line="2021"/>
         <source>Saving launcher</source>
         <translation type="unfinished">Abiarazlea gordetzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1971"/>
+        <location filename="../app/Main.qml" line="2025"/>
         <source>Saving…</source>
         <translation type="unfinished">Gordetzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1985"/>
+        <location filename="../app/Main.qml" line="2039"/>
         <source>Launcher update failed</source>
         <translation type="unfinished">Abiarazle egukeraketak huts egin du</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1989"/>
+        <location filename="../app/Main.qml" line="2043"/>
         <source>Error: %1</source>
         <translation type="unfinished">Errorea: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1993"/>
+        <location filename="../app/Main.qml" line="2047"/>
         <source>Retry</source>
         <translation type="unfinished">Berriro saiatu</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1997"/>
+        <location filename="../app/Main.qml" line="2051"/>
         <source>Cancel</source>
         <translation type="unfinished">Utzi</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2649"/>
+        <location filename="../app/Main.qml" line="2735"/>
         <source>Loading game…</source>
         <translation type="unfinished">Jokua kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2653"/>
+        <location filename="../app/Main.qml" line="2739"/>
         <source>Loading recently played…</source>
         <translation type="unfinished">Duela gutxi jokatutakoak kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2655"/>
+        <location filename="../app/Main.qml" line="2741"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2657"/>
+        <location filename="../app/Main.qml" line="2743"/>
         <source>Loading…</source>
         <translation type="unfinished">Kargatzen…</translation>
     </message>
@@ -700,166 +728,168 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="685"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Writing failed</source>
         <translation>Idazketak huts egin du</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="685"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Put a writable card near the reader</source>
         <translation>Jarri idatzi daitekeen txartel bat irakurlearen ondoan</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="813"/>
+        <location filename="../app/MainLayout.qml" line="829"/>
         <source>Are you sure you want to exit?</source>
         <translation type="unfinished">Ziur zaude irten nahi duzula?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="896"/>
-        <location filename="../app/MainLayout.qml" line="970"/>
+        <location filename="../app/MainLayout.qml" line="930"/>
+        <location filename="../app/MainLayout.qml" line="1004"/>
         <source>Select</source>
         <translation>Aukeratu</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="900"/>
-        <location filename="../app/MainLayout.qml" line="904"/>
-        <location filename="../app/MainLayout.qml" line="918"/>
-        <location filename="../app/MainLayout.qml" line="933"/>
-        <location filename="../app/MainLayout.qml" line="944"/>
+        <location filename="../app/MainLayout.qml" line="934"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="952"/>
+        <location filename="../app/MainLayout.qml" line="967"/>
+        <location filename="../app/MainLayout.qml" line="978"/>
         <source>Close</source>
         <translation>Itxi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="911"/>
-        <location filename="../app/MainLayout.qml" line="951"/>
-        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="945"/>
         <location filename="../app/MainLayout.qml" line="985"/>
+        <location filename="../app/MainLayout.qml" line="1008"/>
+        <location filename="../app/MainLayout.qml" line="1019"/>
         <source>Cancel</source>
         <translation>Utzi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="929"/>
+        <location filename="../app/MainLayout.qml" line="963"/>
         <source>Done</source>
         <translation type="unfinished">Eginda</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="959"/>
+        <location filename="../app/MainLayout.qml" line="993"/>
         <source>I understand</source>
         <translation type="unfinished">Ulertzen dut</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="993"/>
+        <location filename="../app/MainLayout.qml" line="1027"/>
         <source>Start</source>
         <translation type="unfinished">Hasi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1205"/>
+        <location filename="../app/MainLayout.qml" line="1232"/>
         <source>Scroll</source>
         <translation type="unfinished">Scroll-a egin</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="892"/>
-        <location filename="../app/MainLayout.qml" line="966"/>
-        <location filename="../app/MainLayout.qml" line="1012"/>
-        <location filename="../app/MainLayout.qml" line="1049"/>
-        <location filename="../app/MainLayout.qml" line="1099"/>
-        <location filename="../app/MainLayout.qml" line="1148"/>
-        <location filename="../app/MainLayout.qml" line="1167"/>
-        <location filename="../app/MainLayout.qml" line="1234"/>
+        <location filename="../app/MainLayout.qml" line="1281"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="926"/>
+        <location filename="../app/MainLayout.qml" line="1000"/>
+        <location filename="../app/MainLayout.qml" line="1046"/>
+        <location filename="../app/MainLayout.qml" line="1083"/>
+        <location filename="../app/MainLayout.qml" line="1131"/>
+        <location filename="../app/MainLayout.qml" line="1175"/>
+        <location filename="../app/MainLayout.qml" line="1194"/>
+        <location filename="../app/MainLayout.qml" line="1264"/>
         <source>Move</source>
         <translation>Mugitu</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="171"/>
+        <location filename="../app/MainLayout.qml" line="172"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished">Zaparoo Frontend</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="368"/>
+        <location filename="../app/MainLayout.qml" line="382"/>
         <source>Favorites</source>
         <translation type="unfinished">Gogokoak</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="370"/>
+        <location filename="../app/MainLayout.qml" line="384"/>
         <source>Recently Played</source>
         <translation type="unfinished">Duela gutxi jokatuak</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="701"/>
+        <location filename="../app/MainLayout.qml" line="717"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished">Itxi eta Zaparoo Frontend berabiarazi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="702"/>
+        <location filename="../app/MainLayout.qml" line="718"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished">Ezarpenak indarrean jartzeko frontend-a berrabiarazi behar dugu</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="812"/>
+        <location filename="../app/MainLayout.qml" line="828"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished">Itxi Zaparoo Frontend?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1016"/>
-        <location filename="../app/MainLayout.qml" line="1059"/>
-        <location filename="../app/MainLayout.qml" line="1109"/>
-        <location filename="../app/MainLayout.qml" line="1153"/>
-        <location filename="../app/MainLayout.qml" line="1244"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1088"/>
+        <location filename="../app/MainLayout.qml" line="1136"/>
+        <location filename="../app/MainLayout.qml" line="1180"/>
+        <location filename="../app/MainLayout.qml" line="1269"/>
         <source>Open</source>
         <translation>Ireki</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1026"/>
+        <location filename="../app/MainLayout.qml" line="1060"/>
         <source>Quit</source>
         <translation>Irten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1035"/>
-        <location filename="../app/MainLayout.qml" line="1065"/>
-        <location filename="../app/MainLayout.qml" line="1076"/>
-        <location filename="../app/MainLayout.qml" line="1091"/>
-        <location filename="../app/MainLayout.qml" line="1118"/>
-        <location filename="../app/MainLayout.qml" line="1129"/>
-        <location filename="../app/MainLayout.qml" line="1141"/>
-        <location filename="../app/MainLayout.qml" line="1157"/>
-        <location filename="../app/MainLayout.qml" line="1191"/>
-        <location filename="../app/MainLayout.qml" line="1209"/>
+        <location filename="../app/MainLayout.qml" line="1069"/>
+        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
+        <location filename="../app/MainLayout.qml" line="1120"/>
+        <location filename="../app/MainLayout.qml" line="1145"/>
+        <location filename="../app/MainLayout.qml" line="1156"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
+        <location filename="../app/MainLayout.qml" line="1184"/>
         <location filename="../app/MainLayout.qml" line="1218"/>
-        <location filename="../app/MainLayout.qml" line="1253"/>
-        <location filename="../app/MainLayout.qml" line="1264"/>
+        <location filename="../app/MainLayout.qml" line="1236"/>
+        <location filename="../app/MainLayout.qml" line="1245"/>
+        <location filename="../app/MainLayout.qml" line="1285"/>
+        <location filename="../app/MainLayout.qml" line="1296"/>
         <source>Back</source>
         <translation>Atzera</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1055"/>
-        <location filename="../app/MainLayout.qml" line="1105"/>
-        <location filename="../app/MainLayout.qml" line="1240"/>
         <source>Page</source>
-        <translation type="unfinished">Orria</translation>
+        <translation type="obsolete">Orria</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1022"/>
-        <location filename="../app/MainLayout.qml" line="1062"/>
-        <location filename="../app/MainLayout.qml" line="1114"/>
-        <location filename="../app/MainLayout.qml" line="1249"/>
+        <location filename="../app/MainLayout.qml" line="1056"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
+        <location filename="../app/MainLayout.qml" line="1141"/>
+        <location filename="../app/MainLayout.qml" line="1274"/>
         <source>Options</source>
         <translation type="unfinished">Aukerak</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="940"/>
-        <location filename="../app/MainLayout.qml" line="1072"/>
-        <location filename="../app/MainLayout.qml" line="1125"/>
-        <location filename="../app/MainLayout.qml" line="1260"/>
+        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="1101"/>
+        <location filename="../app/MainLayout.qml" line="1152"/>
+        <location filename="../app/MainLayout.qml" line="1292"/>
         <source>Retry</source>
         <translation>Berriro saiatu</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1176"/>
+        <location filename="../app/MainLayout.qml" line="1203"/>
         <source>Change</source>
         <translation>Aldatu</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1182"/>
+        <location filename="../app/MainLayout.qml" line="1209"/>
         <source>Toggle</source>
         <translation>Txandakatu</translation>
     </message>
@@ -872,12 +902,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Kargatzen…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="437"/>
+        <location filename="../screens/MediaListScreen.qml" line="449"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 sarrera</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="438"/>
+        <location filename="../screens/MediaListScreen.qml" line="450"/>
         <source>%1 / %2</source>
         <translation type="unfinished">%1 / %2</translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -426,7 +426,7 @@ Euskara - devilschile2</source>
     <name>GamesScreen</name>
     <message>
         <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="166"/>
+        <location filename="../screens/GamesScreen.qml" line="171"/>
         <source>%1 files</source>
         <translation>%1 קבצים</translation>
     </message>
@@ -437,7 +437,7 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../screens/GamesScreen.qml" line="140"/>
-        <location filename="../screens/GamesScreen.qml" line="167"/>
+        <location filename="../screens/GamesScreen.qml" line="172"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -510,6 +510,24 @@ Euskara - devilschile2</source>
     </message>
 </context>
 <context>
+    <name>LetterJumpModal</name>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="32"/>
+        <source>Go to...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <source>Loading…</source>
+        <translation type="unfinished">טוען…</translation>
+    </message>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <source>No sections</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LoadingIndicator</name>
     <message>
         <location filename="../components/LoadingIndicator.qml" line="26"/>
@@ -553,138 +571,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1408"/>
         <source>Launch core</source>
         <translation>הפעל את הליבה</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1408"/>
-        <location filename="../app/Main.qml" line="1647"/>
+        <location filename="../app/Main.qml" line="1414"/>
+        <location filename="../app/Main.qml" line="1653"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1415"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1421"/>
+        <location filename="../app/Main.qml" line="1444"/>
         <source>Update media database</source>
         <translation type="unfinished">עדכון מסד נתוני המדיה</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1418"/>
-        <location filename="../app/Main.qml" line="1441"/>
+        <location filename="../app/Main.qml" line="1424"/>
+        <location filename="../app/Main.qml" line="1447"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">איסוף מטא-נתונים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1423"/>
-        <location filename="../app/Main.qml" line="1432"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1438"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1423"/>
-        <location filename="../app/Main.qml" line="1432"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1438"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1450"/>
-        <location filename="../app/Main.qml" line="1485"/>
+        <location filename="../app/Main.qml" line="1456"/>
+        <location filename="../app/Main.qml" line="1491"/>
         <source>Launch game</source>
         <translation>הפעל משחק</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1472"/>
         <source>Remove from favorites</source>
         <translation>הסר מהמועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1472"/>
         <source>Add to favorites</source>
         <translation>הוסף למועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1471"/>
+        <location filename="../app/Main.qml" line="1477"/>
         <source>Write to NFC token</source>
         <translation>כתוב לטוקן NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1475"/>
+        <location filename="../app/Main.qml" line="1481"/>
         <source>QR code</source>
         <translation>קוד QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1643"/>
+        <location filename="../app/Main.qml" line="1649"/>
         <source>Default</source>
         <translation type="unfinished">ברירת מחדל</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1643"/>
+        <location filename="../app/Main.qml" line="1649"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1967"/>
+        <location filename="../app/Main.qml" line="1937"/>
+        <source>Go to...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1940"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2021"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1971"/>
+        <location filename="../app/Main.qml" line="2025"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1985"/>
+        <location filename="../app/Main.qml" line="2039"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1989"/>
+        <location filename="../app/Main.qml" line="2043"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1993"/>
+        <location filename="../app/Main.qml" line="2047"/>
         <source>Retry</source>
         <translation type="unfinished">נסה שוב</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1997"/>
+        <location filename="../app/Main.qml" line="2051"/>
         <source>Cancel</source>
         <translation type="unfinished">ביטול</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2645"/>
+        <location filename="../app/Main.qml" line="2731"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2647"/>
+        <location filename="../app/Main.qml" line="2733"/>
         <source>Loading games…</source>
         <translation>טוען משחקים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2649"/>
+        <location filename="../app/Main.qml" line="2735"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2651"/>
+        <location filename="../app/Main.qml" line="2737"/>
         <source>Loading favorites…</source>
         <translation>טוען מועדפים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2653"/>
+        <location filename="../app/Main.qml" line="2739"/>
         <source>Loading recently played…</source>
         <translation>טוען את הפריטים ששוחקו לאחרונה…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2655"/>
+        <location filename="../app/Main.qml" line="2741"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2657"/>
+        <location filename="../app/Main.qml" line="2743"/>
         <source>Loading…</source>
         <translation>טוען…</translation>
     </message>
@@ -692,166 +720,168 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="685"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Writing failed</source>
         <translation>הכתיבה נכשלה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="685"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Put a writable card near the reader</source>
         <translation>הניחו כרטיס הניתן לכתיבה ליד הקורא</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="171"/>
+        <location filename="../app/MainLayout.qml" line="172"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="368"/>
+        <location filename="../app/MainLayout.qml" line="382"/>
         <source>Favorites</source>
         <translation type="unfinished">מועדפים</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="370"/>
+        <location filename="../app/MainLayout.qml" line="384"/>
         <source>Recently Played</source>
         <translation type="unfinished">שוחקו לאחרונה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="701"/>
+        <location filename="../app/MainLayout.qml" line="717"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="702"/>
+        <location filename="../app/MainLayout.qml" line="718"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="812"/>
+        <location filename="../app/MainLayout.qml" line="828"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="813"/>
+        <location filename="../app/MainLayout.qml" line="829"/>
         <source>Are you sure you want to exit?</source>
         <translation>האם אתה בטוח שברצונך לצאת?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="892"/>
-        <location filename="../app/MainLayout.qml" line="966"/>
-        <location filename="../app/MainLayout.qml" line="1012"/>
-        <location filename="../app/MainLayout.qml" line="1049"/>
-        <location filename="../app/MainLayout.qml" line="1099"/>
-        <location filename="../app/MainLayout.qml" line="1148"/>
-        <location filename="../app/MainLayout.qml" line="1167"/>
-        <location filename="../app/MainLayout.qml" line="1234"/>
+        <location filename="../app/MainLayout.qml" line="926"/>
+        <location filename="../app/MainLayout.qml" line="1000"/>
+        <location filename="../app/MainLayout.qml" line="1046"/>
+        <location filename="../app/MainLayout.qml" line="1083"/>
+        <location filename="../app/MainLayout.qml" line="1131"/>
+        <location filename="../app/MainLayout.qml" line="1175"/>
+        <location filename="../app/MainLayout.qml" line="1194"/>
+        <location filename="../app/MainLayout.qml" line="1264"/>
         <source>Move</source>
         <translation>הזזה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="896"/>
-        <location filename="../app/MainLayout.qml" line="970"/>
+        <location filename="../app/MainLayout.qml" line="930"/>
+        <location filename="../app/MainLayout.qml" line="1004"/>
         <source>Select</source>
         <translation>בחירה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="900"/>
-        <location filename="../app/MainLayout.qml" line="904"/>
-        <location filename="../app/MainLayout.qml" line="918"/>
-        <location filename="../app/MainLayout.qml" line="933"/>
-        <location filename="../app/MainLayout.qml" line="944"/>
+        <location filename="../app/MainLayout.qml" line="934"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="952"/>
+        <location filename="../app/MainLayout.qml" line="967"/>
+        <location filename="../app/MainLayout.qml" line="978"/>
         <source>Close</source>
         <translation>סגור</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="911"/>
-        <location filename="../app/MainLayout.qml" line="951"/>
-        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="945"/>
         <location filename="../app/MainLayout.qml" line="985"/>
+        <location filename="../app/MainLayout.qml" line="1008"/>
+        <location filename="../app/MainLayout.qml" line="1019"/>
         <source>Cancel</source>
         <translation>ביטול</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="929"/>
+        <location filename="../app/MainLayout.qml" line="963"/>
         <source>Done</source>
         <translation>הושלם</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="940"/>
-        <location filename="../app/MainLayout.qml" line="1072"/>
-        <location filename="../app/MainLayout.qml" line="1125"/>
-        <location filename="../app/MainLayout.qml" line="1260"/>
+        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="1101"/>
+        <location filename="../app/MainLayout.qml" line="1152"/>
+        <location filename="../app/MainLayout.qml" line="1292"/>
         <source>Retry</source>
         <translation>נסה שוב</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="959"/>
+        <location filename="../app/MainLayout.qml" line="993"/>
         <source>I understand</source>
         <translation>הבנתי</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="993"/>
+        <location filename="../app/MainLayout.qml" line="1027"/>
         <source>Start</source>
         <translation>התחל</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1016"/>
-        <location filename="../app/MainLayout.qml" line="1059"/>
-        <location filename="../app/MainLayout.qml" line="1109"/>
-        <location filename="../app/MainLayout.qml" line="1153"/>
-        <location filename="../app/MainLayout.qml" line="1244"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1088"/>
+        <location filename="../app/MainLayout.qml" line="1136"/>
+        <location filename="../app/MainLayout.qml" line="1180"/>
+        <location filename="../app/MainLayout.qml" line="1269"/>
         <source>Open</source>
         <translation>פתח</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1026"/>
+        <location filename="../app/MainLayout.qml" line="1060"/>
         <source>Quit</source>
         <translation>יציאה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1035"/>
-        <location filename="../app/MainLayout.qml" line="1065"/>
-        <location filename="../app/MainLayout.qml" line="1076"/>
-        <location filename="../app/MainLayout.qml" line="1091"/>
-        <location filename="../app/MainLayout.qml" line="1118"/>
-        <location filename="../app/MainLayout.qml" line="1129"/>
-        <location filename="../app/MainLayout.qml" line="1141"/>
-        <location filename="../app/MainLayout.qml" line="1157"/>
-        <location filename="../app/MainLayout.qml" line="1191"/>
-        <location filename="../app/MainLayout.qml" line="1209"/>
+        <location filename="../app/MainLayout.qml" line="1069"/>
+        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
+        <location filename="../app/MainLayout.qml" line="1120"/>
+        <location filename="../app/MainLayout.qml" line="1145"/>
+        <location filename="../app/MainLayout.qml" line="1156"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
+        <location filename="../app/MainLayout.qml" line="1184"/>
         <location filename="../app/MainLayout.qml" line="1218"/>
-        <location filename="../app/MainLayout.qml" line="1253"/>
-        <location filename="../app/MainLayout.qml" line="1264"/>
+        <location filename="../app/MainLayout.qml" line="1236"/>
+        <location filename="../app/MainLayout.qml" line="1245"/>
+        <location filename="../app/MainLayout.qml" line="1285"/>
+        <location filename="../app/MainLayout.qml" line="1296"/>
         <source>Back</source>
         <translation>חזרה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1055"/>
-        <location filename="../app/MainLayout.qml" line="1105"/>
-        <location filename="../app/MainLayout.qml" line="1240"/>
-        <source>Page</source>
-        <translation>עמוד</translation>
+        <location filename="../app/MainLayout.qml" line="1281"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1022"/>
-        <location filename="../app/MainLayout.qml" line="1062"/>
-        <location filename="../app/MainLayout.qml" line="1114"/>
-        <location filename="../app/MainLayout.qml" line="1249"/>
+        <source>Page</source>
+        <translation type="vanished">עמוד</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="1056"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
+        <location filename="../app/MainLayout.qml" line="1141"/>
+        <location filename="../app/MainLayout.qml" line="1274"/>
         <source>Options</source>
         <translation>אפשרויות</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1176"/>
+        <location filename="../app/MainLayout.qml" line="1203"/>
         <source>Change</source>
         <translation>שינוי</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1182"/>
+        <location filename="../app/MainLayout.qml" line="1209"/>
         <source>Toggle</source>
         <translation>החלף</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1205"/>
+        <location filename="../app/MainLayout.qml" line="1232"/>
         <source>Scroll</source>
         <translation>גלילה</translation>
     </message>
@@ -864,12 +894,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">טוען…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="437"/>
+        <location filename="../screens/MediaListScreen.qml" line="449"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 פריטים</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="438"/>
+        <location filename="../screens/MediaListScreen.qml" line="450"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -517,12 +517,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <location filename="../components/LetterJumpModal.qml" line="220"/>
         <source>Loading…</source>
         <translation type="unfinished">טוען…</translation>
     </message>
     <message>
-        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <location filename="../components/LetterJumpModal.qml" line="220"/>
         <source>No sections</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -426,7 +426,7 @@ Euskara - devilschile2</source>
     <name>GamesScreen</name>
     <message>
         <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="166"/>
+        <location filename="../screens/GamesScreen.qml" line="171"/>
         <source>%1 files</source>
         <translation>%1 फ़ाइलें</translation>
     </message>
@@ -437,7 +437,7 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../screens/GamesScreen.qml" line="140"/>
-        <location filename="../screens/GamesScreen.qml" line="167"/>
+        <location filename="../screens/GamesScreen.qml" line="172"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -510,6 +510,24 @@ Euskara - devilschile2</source>
     </message>
 </context>
 <context>
+    <name>LetterJumpModal</name>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="32"/>
+        <source>Go to...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <source>Loading…</source>
+        <translation type="unfinished">लोड हो रहा है…</translation>
+    </message>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <source>No sections</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LoadingIndicator</name>
     <message>
         <location filename="../components/LoadingIndicator.qml" line="26"/>
@@ -553,138 +571,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1408"/>
         <source>Launch core</source>
         <translation>कोर चलाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1408"/>
-        <location filename="../app/Main.qml" line="1647"/>
+        <location filename="../app/Main.qml" line="1414"/>
+        <location filename="../app/Main.qml" line="1653"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1415"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1421"/>
+        <location filename="../app/Main.qml" line="1444"/>
         <source>Update media database</source>
         <translation type="unfinished">मीडिया डेटाबेस अपडेट करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1418"/>
-        <location filename="../app/Main.qml" line="1441"/>
+        <location filename="../app/Main.qml" line="1424"/>
+        <location filename="../app/Main.qml" line="1447"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">मेटाडेटा स्क्रैप करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1423"/>
-        <location filename="../app/Main.qml" line="1432"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1438"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1423"/>
-        <location filename="../app/Main.qml" line="1432"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1438"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1450"/>
-        <location filename="../app/Main.qml" line="1485"/>
+        <location filename="../app/Main.qml" line="1456"/>
+        <location filename="../app/Main.qml" line="1491"/>
         <source>Launch game</source>
         <translation>गेम चलाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1472"/>
         <source>Remove from favorites</source>
         <translation>पसंदीदा से हटाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1472"/>
         <source>Add to favorites</source>
         <translation>पसंदीदा में जोड़ें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1471"/>
+        <location filename="../app/Main.qml" line="1477"/>
         <source>Write to NFC token</source>
         <translation>NFC टोकन पर लिखें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1475"/>
+        <location filename="../app/Main.qml" line="1481"/>
         <source>QR code</source>
         <translation>QR कोड</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1643"/>
+        <location filename="../app/Main.qml" line="1649"/>
         <source>Default</source>
         <translation type="unfinished">डिफ़ॉल्ट</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1643"/>
+        <location filename="../app/Main.qml" line="1649"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1967"/>
+        <location filename="../app/Main.qml" line="1937"/>
+        <source>Go to...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1940"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2021"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1971"/>
+        <location filename="../app/Main.qml" line="2025"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1985"/>
+        <location filename="../app/Main.qml" line="2039"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1989"/>
+        <location filename="../app/Main.qml" line="2043"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1993"/>
+        <location filename="../app/Main.qml" line="2047"/>
         <source>Retry</source>
         <translation type="unfinished">फिर से प्रयास करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1997"/>
+        <location filename="../app/Main.qml" line="2051"/>
         <source>Cancel</source>
         <translation type="unfinished">रद्द करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2645"/>
+        <location filename="../app/Main.qml" line="2731"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2647"/>
+        <location filename="../app/Main.qml" line="2733"/>
         <source>Loading games…</source>
         <translation>गेम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2649"/>
+        <location filename="../app/Main.qml" line="2735"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2651"/>
+        <location filename="../app/Main.qml" line="2737"/>
         <source>Loading favorites…</source>
         <translation>पसंदीदा लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2653"/>
+        <location filename="../app/Main.qml" line="2739"/>
         <source>Loading recently played…</source>
         <translation>हाल ही में खेले गए लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2655"/>
+        <location filename="../app/Main.qml" line="2741"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2657"/>
+        <location filename="../app/Main.qml" line="2743"/>
         <source>Loading…</source>
         <translation>लोड हो रहा है…</translation>
     </message>
@@ -692,166 +720,168 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="685"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Writing failed</source>
         <translation>लिखना विफल हुआ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="685"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Put a writable card near the reader</source>
         <translation>रीडर के पास लिखने योग्य कार्ड रखें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="171"/>
+        <location filename="../app/MainLayout.qml" line="172"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="368"/>
+        <location filename="../app/MainLayout.qml" line="382"/>
         <source>Favorites</source>
         <translation type="unfinished">पसंदीदा</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="370"/>
+        <location filename="../app/MainLayout.qml" line="384"/>
         <source>Recently Played</source>
         <translation type="unfinished">हाल ही में खेले गए</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="701"/>
+        <location filename="../app/MainLayout.qml" line="717"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="702"/>
+        <location filename="../app/MainLayout.qml" line="718"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="812"/>
+        <location filename="../app/MainLayout.qml" line="828"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="813"/>
+        <location filename="../app/MainLayout.qml" line="829"/>
         <source>Are you sure you want to exit?</source>
         <translation>क्या आप वाकई बाहर निकलना चाहते हैं?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="892"/>
-        <location filename="../app/MainLayout.qml" line="966"/>
-        <location filename="../app/MainLayout.qml" line="1012"/>
-        <location filename="../app/MainLayout.qml" line="1049"/>
-        <location filename="../app/MainLayout.qml" line="1099"/>
-        <location filename="../app/MainLayout.qml" line="1148"/>
-        <location filename="../app/MainLayout.qml" line="1167"/>
-        <location filename="../app/MainLayout.qml" line="1234"/>
+        <location filename="../app/MainLayout.qml" line="926"/>
+        <location filename="../app/MainLayout.qml" line="1000"/>
+        <location filename="../app/MainLayout.qml" line="1046"/>
+        <location filename="../app/MainLayout.qml" line="1083"/>
+        <location filename="../app/MainLayout.qml" line="1131"/>
+        <location filename="../app/MainLayout.qml" line="1175"/>
+        <location filename="../app/MainLayout.qml" line="1194"/>
+        <location filename="../app/MainLayout.qml" line="1264"/>
         <source>Move</source>
         <translation>स्थानांतरित करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="896"/>
-        <location filename="../app/MainLayout.qml" line="970"/>
+        <location filename="../app/MainLayout.qml" line="930"/>
+        <location filename="../app/MainLayout.qml" line="1004"/>
         <source>Select</source>
         <translation>चुनें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="900"/>
-        <location filename="../app/MainLayout.qml" line="904"/>
-        <location filename="../app/MainLayout.qml" line="918"/>
-        <location filename="../app/MainLayout.qml" line="933"/>
-        <location filename="../app/MainLayout.qml" line="944"/>
+        <location filename="../app/MainLayout.qml" line="934"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="952"/>
+        <location filename="../app/MainLayout.qml" line="967"/>
+        <location filename="../app/MainLayout.qml" line="978"/>
         <source>Close</source>
         <translation>बंद करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="911"/>
-        <location filename="../app/MainLayout.qml" line="951"/>
-        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="945"/>
         <location filename="../app/MainLayout.qml" line="985"/>
+        <location filename="../app/MainLayout.qml" line="1008"/>
+        <location filename="../app/MainLayout.qml" line="1019"/>
         <source>Cancel</source>
         <translation>रद्द करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="929"/>
+        <location filename="../app/MainLayout.qml" line="963"/>
         <source>Done</source>
         <translation>पूरा</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="940"/>
-        <location filename="../app/MainLayout.qml" line="1072"/>
-        <location filename="../app/MainLayout.qml" line="1125"/>
-        <location filename="../app/MainLayout.qml" line="1260"/>
+        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="1101"/>
+        <location filename="../app/MainLayout.qml" line="1152"/>
+        <location filename="../app/MainLayout.qml" line="1292"/>
         <source>Retry</source>
         <translation>फिर से प्रयास करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="959"/>
+        <location filename="../app/MainLayout.qml" line="993"/>
         <source>I understand</source>
         <translation>मैं समझ गया</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="993"/>
+        <location filename="../app/MainLayout.qml" line="1027"/>
         <source>Start</source>
         <translation>शुरू करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1016"/>
-        <location filename="../app/MainLayout.qml" line="1059"/>
-        <location filename="../app/MainLayout.qml" line="1109"/>
-        <location filename="../app/MainLayout.qml" line="1153"/>
-        <location filename="../app/MainLayout.qml" line="1244"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1088"/>
+        <location filename="../app/MainLayout.qml" line="1136"/>
+        <location filename="../app/MainLayout.qml" line="1180"/>
+        <location filename="../app/MainLayout.qml" line="1269"/>
         <source>Open</source>
         <translation>खोलें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1026"/>
+        <location filename="../app/MainLayout.qml" line="1060"/>
         <source>Quit</source>
         <translation>बंद करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1035"/>
-        <location filename="../app/MainLayout.qml" line="1065"/>
-        <location filename="../app/MainLayout.qml" line="1076"/>
-        <location filename="../app/MainLayout.qml" line="1091"/>
-        <location filename="../app/MainLayout.qml" line="1118"/>
-        <location filename="../app/MainLayout.qml" line="1129"/>
-        <location filename="../app/MainLayout.qml" line="1141"/>
-        <location filename="../app/MainLayout.qml" line="1157"/>
-        <location filename="../app/MainLayout.qml" line="1191"/>
-        <location filename="../app/MainLayout.qml" line="1209"/>
+        <location filename="../app/MainLayout.qml" line="1069"/>
+        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
+        <location filename="../app/MainLayout.qml" line="1120"/>
+        <location filename="../app/MainLayout.qml" line="1145"/>
+        <location filename="../app/MainLayout.qml" line="1156"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
+        <location filename="../app/MainLayout.qml" line="1184"/>
         <location filename="../app/MainLayout.qml" line="1218"/>
-        <location filename="../app/MainLayout.qml" line="1253"/>
-        <location filename="../app/MainLayout.qml" line="1264"/>
+        <location filename="../app/MainLayout.qml" line="1236"/>
+        <location filename="../app/MainLayout.qml" line="1245"/>
+        <location filename="../app/MainLayout.qml" line="1285"/>
+        <location filename="../app/MainLayout.qml" line="1296"/>
         <source>Back</source>
         <translation>वापस</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1055"/>
-        <location filename="../app/MainLayout.qml" line="1105"/>
-        <location filename="../app/MainLayout.qml" line="1240"/>
-        <source>Page</source>
-        <translation>पृष्ठ</translation>
+        <location filename="../app/MainLayout.qml" line="1281"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1022"/>
-        <location filename="../app/MainLayout.qml" line="1062"/>
-        <location filename="../app/MainLayout.qml" line="1114"/>
-        <location filename="../app/MainLayout.qml" line="1249"/>
+        <source>Page</source>
+        <translation type="vanished">पृष्ठ</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="1056"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
+        <location filename="../app/MainLayout.qml" line="1141"/>
+        <location filename="../app/MainLayout.qml" line="1274"/>
         <source>Options</source>
         <translation>विकल्प</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1176"/>
+        <location filename="../app/MainLayout.qml" line="1203"/>
         <source>Change</source>
         <translation>बदलें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1182"/>
+        <location filename="../app/MainLayout.qml" line="1209"/>
         <source>Toggle</source>
         <translation>टॉगल</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1205"/>
+        <location filename="../app/MainLayout.qml" line="1232"/>
         <source>Scroll</source>
         <translation>स्क्रॉल</translation>
     </message>
@@ -864,12 +894,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">लोड हो रहा है…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="437"/>
+        <location filename="../screens/MediaListScreen.qml" line="449"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 प्रविष्टियाँ</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="438"/>
+        <location filename="../screens/MediaListScreen.qml" line="450"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -517,12 +517,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <location filename="../components/LetterJumpModal.qml" line="220"/>
         <source>Loading…</source>
         <translation type="unfinished">लोड हो रहा है…</translation>
     </message>
     <message>
-        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <location filename="../components/LetterJumpModal.qml" line="220"/>
         <source>No sections</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -426,7 +426,7 @@ Euskara - devilschile2</source>
     <name>GamesScreen</name>
     <message>
         <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="166"/>
+        <location filename="../screens/GamesScreen.qml" line="171"/>
         <source>%1 files</source>
         <translation>%1 file</translation>
     </message>
@@ -437,7 +437,7 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../screens/GamesScreen.qml" line="140"/>
-        <location filename="../screens/GamesScreen.qml" line="167"/>
+        <location filename="../screens/GamesScreen.qml" line="172"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -510,6 +510,24 @@ Euskara - devilschile2</source>
     </message>
 </context>
 <context>
+    <name>LetterJumpModal</name>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="32"/>
+        <source>Go to...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <source>Loading…</source>
+        <translation type="unfinished">Caricamento…</translation>
+    </message>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <source>No sections</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LoadingIndicator</name>
     <message>
         <location filename="../components/LoadingIndicator.qml" line="26"/>
@@ -553,138 +571,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1408"/>
         <source>Launch core</source>
         <translation>Avvia core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1408"/>
-        <location filename="../app/Main.qml" line="1647"/>
+        <location filename="../app/Main.qml" line="1414"/>
+        <location filename="../app/Main.qml" line="1653"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1472"/>
         <source>Remove from favorites</source>
         <translation>Rimuovi dai preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1472"/>
         <source>Add to favorites</source>
         <translation>Aggiungi ai preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1471"/>
+        <location filename="../app/Main.qml" line="1477"/>
         <source>Write to NFC token</source>
         <translation>Scrivi sul token NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1475"/>
+        <location filename="../app/Main.qml" line="1481"/>
         <source>QR code</source>
         <translation>Codice QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1450"/>
-        <location filename="../app/Main.qml" line="1485"/>
+        <location filename="../app/Main.qml" line="1456"/>
+        <location filename="../app/Main.qml" line="1491"/>
         <source>Launch game</source>
         <translation>Avvia gioco</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2645"/>
+        <location filename="../app/Main.qml" line="1937"/>
+        <source>Go to...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1940"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2731"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2651"/>
+        <location filename="../app/Main.qml" line="2737"/>
         <source>Loading favorites…</source>
         <translation>Caricamento preferiti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2647"/>
+        <location filename="../app/Main.qml" line="2733"/>
         <source>Loading games…</source>
         <translation>Caricamento giochi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1415"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1421"/>
+        <location filename="../app/Main.qml" line="1444"/>
         <source>Update media database</source>
         <translation type="unfinished">Aggiorna database multimediale</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1418"/>
-        <location filename="../app/Main.qml" line="1441"/>
+        <location filename="../app/Main.qml" line="1424"/>
+        <location filename="../app/Main.qml" line="1447"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Recupera metadati</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1423"/>
-        <location filename="../app/Main.qml" line="1432"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1438"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1423"/>
-        <location filename="../app/Main.qml" line="1432"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1438"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1643"/>
+        <location filename="../app/Main.qml" line="1649"/>
         <source>Default</source>
         <translation type="unfinished">Predefinito</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1643"/>
+        <location filename="../app/Main.qml" line="1649"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1967"/>
+        <location filename="../app/Main.qml" line="2021"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1971"/>
+        <location filename="../app/Main.qml" line="2025"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1985"/>
+        <location filename="../app/Main.qml" line="2039"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1989"/>
+        <location filename="../app/Main.qml" line="2043"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1993"/>
+        <location filename="../app/Main.qml" line="2047"/>
         <source>Retry</source>
         <translation type="unfinished">Riprova</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1997"/>
+        <location filename="../app/Main.qml" line="2051"/>
         <source>Cancel</source>
         <translation type="unfinished">Annulla</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2649"/>
+        <location filename="../app/Main.qml" line="2735"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2653"/>
+        <location filename="../app/Main.qml" line="2739"/>
         <source>Loading recently played…</source>
         <translation>Caricamento recenti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2655"/>
+        <location filename="../app/Main.qml" line="2741"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2657"/>
+        <location filename="../app/Main.qml" line="2743"/>
         <source>Loading…</source>
         <translation>Caricamento…</translation>
     </message>
@@ -692,166 +720,168 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="685"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Writing failed</source>
         <translation>Scrittura non riuscita</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="685"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Put a writable card near the reader</source>
         <translation>Avvicina una scheda scrivibile al lettore</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="813"/>
+        <location filename="../app/MainLayout.qml" line="829"/>
         <source>Are you sure you want to exit?</source>
         <translation>Sei sicuro di voler uscire?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="896"/>
-        <location filename="../app/MainLayout.qml" line="970"/>
+        <location filename="../app/MainLayout.qml" line="930"/>
+        <location filename="../app/MainLayout.qml" line="1004"/>
         <source>Select</source>
         <translation>Seleziona</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="900"/>
-        <location filename="../app/MainLayout.qml" line="904"/>
-        <location filename="../app/MainLayout.qml" line="918"/>
-        <location filename="../app/MainLayout.qml" line="933"/>
-        <location filename="../app/MainLayout.qml" line="944"/>
+        <location filename="../app/MainLayout.qml" line="934"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="952"/>
+        <location filename="../app/MainLayout.qml" line="967"/>
+        <location filename="../app/MainLayout.qml" line="978"/>
         <source>Close</source>
         <translation>Chiudi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="911"/>
-        <location filename="../app/MainLayout.qml" line="951"/>
-        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="945"/>
         <location filename="../app/MainLayout.qml" line="985"/>
+        <location filename="../app/MainLayout.qml" line="1008"/>
+        <location filename="../app/MainLayout.qml" line="1019"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="929"/>
+        <location filename="../app/MainLayout.qml" line="963"/>
         <source>Done</source>
         <translation>Fatto</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="959"/>
+        <location filename="../app/MainLayout.qml" line="993"/>
         <source>I understand</source>
         <translation>Ho capito</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="993"/>
+        <location filename="../app/MainLayout.qml" line="1027"/>
         <source>Start</source>
         <translation>Avvia</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1205"/>
+        <location filename="../app/MainLayout.qml" line="1232"/>
         <source>Scroll</source>
         <translation>Scorri</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="892"/>
-        <location filename="../app/MainLayout.qml" line="966"/>
-        <location filename="../app/MainLayout.qml" line="1012"/>
-        <location filename="../app/MainLayout.qml" line="1049"/>
-        <location filename="../app/MainLayout.qml" line="1099"/>
-        <location filename="../app/MainLayout.qml" line="1148"/>
-        <location filename="../app/MainLayout.qml" line="1167"/>
-        <location filename="../app/MainLayout.qml" line="1234"/>
+        <location filename="../app/MainLayout.qml" line="1281"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="926"/>
+        <location filename="../app/MainLayout.qml" line="1000"/>
+        <location filename="../app/MainLayout.qml" line="1046"/>
+        <location filename="../app/MainLayout.qml" line="1083"/>
+        <location filename="../app/MainLayout.qml" line="1131"/>
+        <location filename="../app/MainLayout.qml" line="1175"/>
+        <location filename="../app/MainLayout.qml" line="1194"/>
+        <location filename="../app/MainLayout.qml" line="1264"/>
         <source>Move</source>
         <translation>Muovi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="171"/>
+        <location filename="../app/MainLayout.qml" line="172"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="368"/>
+        <location filename="../app/MainLayout.qml" line="382"/>
         <source>Favorites</source>
         <translation type="unfinished">Preferiti</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="370"/>
+        <location filename="../app/MainLayout.qml" line="384"/>
         <source>Recently Played</source>
         <translation type="unfinished">Giocati di recente</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="701"/>
+        <location filename="../app/MainLayout.qml" line="717"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="702"/>
+        <location filename="../app/MainLayout.qml" line="718"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="812"/>
+        <location filename="../app/MainLayout.qml" line="828"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1016"/>
-        <location filename="../app/MainLayout.qml" line="1059"/>
-        <location filename="../app/MainLayout.qml" line="1109"/>
-        <location filename="../app/MainLayout.qml" line="1153"/>
-        <location filename="../app/MainLayout.qml" line="1244"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1088"/>
+        <location filename="../app/MainLayout.qml" line="1136"/>
+        <location filename="../app/MainLayout.qml" line="1180"/>
+        <location filename="../app/MainLayout.qml" line="1269"/>
         <source>Open</source>
         <translation>Apri</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1026"/>
+        <location filename="../app/MainLayout.qml" line="1060"/>
         <source>Quit</source>
         <translation>Esci</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1035"/>
-        <location filename="../app/MainLayout.qml" line="1065"/>
-        <location filename="../app/MainLayout.qml" line="1076"/>
-        <location filename="../app/MainLayout.qml" line="1091"/>
-        <location filename="../app/MainLayout.qml" line="1118"/>
-        <location filename="../app/MainLayout.qml" line="1129"/>
-        <location filename="../app/MainLayout.qml" line="1141"/>
-        <location filename="../app/MainLayout.qml" line="1157"/>
-        <location filename="../app/MainLayout.qml" line="1191"/>
-        <location filename="../app/MainLayout.qml" line="1209"/>
+        <location filename="../app/MainLayout.qml" line="1069"/>
+        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
+        <location filename="../app/MainLayout.qml" line="1120"/>
+        <location filename="../app/MainLayout.qml" line="1145"/>
+        <location filename="../app/MainLayout.qml" line="1156"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
+        <location filename="../app/MainLayout.qml" line="1184"/>
         <location filename="../app/MainLayout.qml" line="1218"/>
-        <location filename="../app/MainLayout.qml" line="1253"/>
-        <location filename="../app/MainLayout.qml" line="1264"/>
+        <location filename="../app/MainLayout.qml" line="1236"/>
+        <location filename="../app/MainLayout.qml" line="1245"/>
+        <location filename="../app/MainLayout.qml" line="1285"/>
+        <location filename="../app/MainLayout.qml" line="1296"/>
         <source>Back</source>
         <translation>Indietro</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1055"/>
-        <location filename="../app/MainLayout.qml" line="1105"/>
-        <location filename="../app/MainLayout.qml" line="1240"/>
         <source>Page</source>
-        <translation>Pagina</translation>
+        <translation type="vanished">Pagina</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1022"/>
-        <location filename="../app/MainLayout.qml" line="1062"/>
-        <location filename="../app/MainLayout.qml" line="1114"/>
-        <location filename="../app/MainLayout.qml" line="1249"/>
+        <location filename="../app/MainLayout.qml" line="1056"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
+        <location filename="../app/MainLayout.qml" line="1141"/>
+        <location filename="../app/MainLayout.qml" line="1274"/>
         <source>Options</source>
         <translation>Opzioni</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="940"/>
-        <location filename="../app/MainLayout.qml" line="1072"/>
-        <location filename="../app/MainLayout.qml" line="1125"/>
-        <location filename="../app/MainLayout.qml" line="1260"/>
+        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="1101"/>
+        <location filename="../app/MainLayout.qml" line="1152"/>
+        <location filename="../app/MainLayout.qml" line="1292"/>
         <source>Retry</source>
         <translation>Riprova</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1176"/>
+        <location filename="../app/MainLayout.qml" line="1203"/>
         <source>Change</source>
         <translation>Cambia</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1182"/>
+        <location filename="../app/MainLayout.qml" line="1209"/>
         <source>Toggle</source>
         <translation>Alterna</translation>
     </message>
@@ -864,12 +894,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Caricamento…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="437"/>
+        <location filename="../screens/MediaListScreen.qml" line="449"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 elementi</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="438"/>
+        <location filename="../screens/MediaListScreen.qml" line="450"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -517,12 +517,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <location filename="../components/LetterJumpModal.qml" line="220"/>
         <source>Loading…</source>
         <translation type="unfinished">Caricamento…</translation>
     </message>
     <message>
-        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <location filename="../components/LetterJumpModal.qml" line="220"/>
         <source>No sections</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -517,12 +517,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <location filename="../components/LetterJumpModal.qml" line="220"/>
         <source>Loading…</source>
         <translation type="unfinished">読み込み中…</translation>
     </message>
     <message>
-        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <location filename="../components/LetterJumpModal.qml" line="220"/>
         <source>No sections</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -426,7 +426,7 @@ Euskara - devilschile2</source>
     <name>GamesScreen</name>
     <message>
         <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="166"/>
+        <location filename="../screens/GamesScreen.qml" line="171"/>
         <source>%1 files</source>
         <translation>%1 ファイル</translation>
     </message>
@@ -437,7 +437,7 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../screens/GamesScreen.qml" line="140"/>
-        <location filename="../screens/GamesScreen.qml" line="167"/>
+        <location filename="../screens/GamesScreen.qml" line="172"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -510,6 +510,24 @@ Euskara - devilschile2</source>
     </message>
 </context>
 <context>
+    <name>LetterJumpModal</name>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="32"/>
+        <source>Go to...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <source>Loading…</source>
+        <translation type="unfinished">読み込み中…</translation>
+    </message>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <source>No sections</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LoadingIndicator</name>
     <message>
         <location filename="../components/LoadingIndicator.qml" line="26"/>
@@ -553,138 +571,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1408"/>
         <source>Launch core</source>
         <translation>コアを起動</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1408"/>
-        <location filename="../app/Main.qml" line="1647"/>
+        <location filename="../app/Main.qml" line="1414"/>
+        <location filename="../app/Main.qml" line="1653"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1472"/>
         <source>Remove from favorites</source>
         <translation>お気に入りから削除</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1472"/>
         <source>Add to favorites</source>
         <translation>お気に入りに追加</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1471"/>
+        <location filename="../app/Main.qml" line="1477"/>
         <source>Write to NFC token</source>
         <translation>NFC トークンに書き込む</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1475"/>
+        <location filename="../app/Main.qml" line="1481"/>
         <source>QR code</source>
         <translation>QR コード</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1450"/>
-        <location filename="../app/Main.qml" line="1485"/>
+        <location filename="../app/Main.qml" line="1456"/>
+        <location filename="../app/Main.qml" line="1491"/>
         <source>Launch game</source>
         <translation>ゲームを起動</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2645"/>
+        <location filename="../app/Main.qml" line="1937"/>
+        <source>Go to...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1940"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2731"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2651"/>
+        <location filename="../app/Main.qml" line="2737"/>
         <source>Loading favorites…</source>
         <translation>お気に入りを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2647"/>
+        <location filename="../app/Main.qml" line="2733"/>
         <source>Loading games…</source>
         <translation>ゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1415"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1421"/>
+        <location filename="../app/Main.qml" line="1444"/>
         <source>Update media database</source>
         <translation type="unfinished">メディアデータベースを更新</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1418"/>
-        <location filename="../app/Main.qml" line="1441"/>
+        <location filename="../app/Main.qml" line="1424"/>
+        <location filename="../app/Main.qml" line="1447"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">メタデータをスクレイピング</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1423"/>
-        <location filename="../app/Main.qml" line="1432"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1438"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1423"/>
-        <location filename="../app/Main.qml" line="1432"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1438"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1643"/>
+        <location filename="../app/Main.qml" line="1649"/>
         <source>Default</source>
         <translation type="unfinished">デフォルト</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1643"/>
+        <location filename="../app/Main.qml" line="1649"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1967"/>
+        <location filename="../app/Main.qml" line="2021"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1971"/>
+        <location filename="../app/Main.qml" line="2025"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1985"/>
+        <location filename="../app/Main.qml" line="2039"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1989"/>
+        <location filename="../app/Main.qml" line="2043"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1993"/>
+        <location filename="../app/Main.qml" line="2047"/>
         <source>Retry</source>
         <translation type="unfinished">再試行</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1997"/>
+        <location filename="../app/Main.qml" line="2051"/>
         <source>Cancel</source>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2649"/>
+        <location filename="../app/Main.qml" line="2735"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2653"/>
+        <location filename="../app/Main.qml" line="2739"/>
         <source>Loading recently played…</source>
         <translation>最近プレイしたゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2655"/>
+        <location filename="../app/Main.qml" line="2741"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2657"/>
+        <location filename="../app/Main.qml" line="2743"/>
         <source>Loading…</source>
         <translation>読み込み中…</translation>
     </message>
@@ -692,166 +720,168 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="685"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Writing failed</source>
         <translation>書き込み失敗</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="685"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Put a writable card near the reader</source>
         <translation>書き込み可能なカードをリーダーに近づけてください</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="813"/>
+        <location filename="../app/MainLayout.qml" line="829"/>
         <source>Are you sure you want to exit?</source>
         <translation>本当に終了しますか？</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="896"/>
-        <location filename="../app/MainLayout.qml" line="970"/>
+        <location filename="../app/MainLayout.qml" line="930"/>
+        <location filename="../app/MainLayout.qml" line="1004"/>
         <source>Select</source>
         <translation>選択</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="900"/>
-        <location filename="../app/MainLayout.qml" line="904"/>
-        <location filename="../app/MainLayout.qml" line="918"/>
-        <location filename="../app/MainLayout.qml" line="933"/>
-        <location filename="../app/MainLayout.qml" line="944"/>
+        <location filename="../app/MainLayout.qml" line="934"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="952"/>
+        <location filename="../app/MainLayout.qml" line="967"/>
+        <location filename="../app/MainLayout.qml" line="978"/>
         <source>Close</source>
         <translation>閉じる</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="911"/>
-        <location filename="../app/MainLayout.qml" line="951"/>
-        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="945"/>
         <location filename="../app/MainLayout.qml" line="985"/>
+        <location filename="../app/MainLayout.qml" line="1008"/>
+        <location filename="../app/MainLayout.qml" line="1019"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="929"/>
+        <location filename="../app/MainLayout.qml" line="963"/>
         <source>Done</source>
         <translation>完了</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="959"/>
+        <location filename="../app/MainLayout.qml" line="993"/>
         <source>I understand</source>
         <translation>了解しました</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="993"/>
+        <location filename="../app/MainLayout.qml" line="1027"/>
         <source>Start</source>
         <translation>開始</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1205"/>
+        <location filename="../app/MainLayout.qml" line="1232"/>
         <source>Scroll</source>
         <translation>スクロール</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="892"/>
-        <location filename="../app/MainLayout.qml" line="966"/>
-        <location filename="../app/MainLayout.qml" line="1012"/>
-        <location filename="../app/MainLayout.qml" line="1049"/>
-        <location filename="../app/MainLayout.qml" line="1099"/>
-        <location filename="../app/MainLayout.qml" line="1148"/>
-        <location filename="../app/MainLayout.qml" line="1167"/>
-        <location filename="../app/MainLayout.qml" line="1234"/>
+        <location filename="../app/MainLayout.qml" line="1281"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="926"/>
+        <location filename="../app/MainLayout.qml" line="1000"/>
+        <location filename="../app/MainLayout.qml" line="1046"/>
+        <location filename="../app/MainLayout.qml" line="1083"/>
+        <location filename="../app/MainLayout.qml" line="1131"/>
+        <location filename="../app/MainLayout.qml" line="1175"/>
+        <location filename="../app/MainLayout.qml" line="1194"/>
+        <location filename="../app/MainLayout.qml" line="1264"/>
         <source>Move</source>
         <translation>移動</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="171"/>
+        <location filename="../app/MainLayout.qml" line="172"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="368"/>
+        <location filename="../app/MainLayout.qml" line="382"/>
         <source>Favorites</source>
         <translation type="unfinished">お気に入り</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="370"/>
+        <location filename="../app/MainLayout.qml" line="384"/>
         <source>Recently Played</source>
         <translation type="unfinished">最近プレイしたゲーム</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="701"/>
+        <location filename="../app/MainLayout.qml" line="717"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="702"/>
+        <location filename="../app/MainLayout.qml" line="718"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="812"/>
+        <location filename="../app/MainLayout.qml" line="828"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1016"/>
-        <location filename="../app/MainLayout.qml" line="1059"/>
-        <location filename="../app/MainLayout.qml" line="1109"/>
-        <location filename="../app/MainLayout.qml" line="1153"/>
-        <location filename="../app/MainLayout.qml" line="1244"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1088"/>
+        <location filename="../app/MainLayout.qml" line="1136"/>
+        <location filename="../app/MainLayout.qml" line="1180"/>
+        <location filename="../app/MainLayout.qml" line="1269"/>
         <source>Open</source>
         <translation>開く</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1026"/>
+        <location filename="../app/MainLayout.qml" line="1060"/>
         <source>Quit</source>
         <translation>終了</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1035"/>
-        <location filename="../app/MainLayout.qml" line="1065"/>
-        <location filename="../app/MainLayout.qml" line="1076"/>
-        <location filename="../app/MainLayout.qml" line="1091"/>
-        <location filename="../app/MainLayout.qml" line="1118"/>
-        <location filename="../app/MainLayout.qml" line="1129"/>
-        <location filename="../app/MainLayout.qml" line="1141"/>
-        <location filename="../app/MainLayout.qml" line="1157"/>
-        <location filename="../app/MainLayout.qml" line="1191"/>
-        <location filename="../app/MainLayout.qml" line="1209"/>
+        <location filename="../app/MainLayout.qml" line="1069"/>
+        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
+        <location filename="../app/MainLayout.qml" line="1120"/>
+        <location filename="../app/MainLayout.qml" line="1145"/>
+        <location filename="../app/MainLayout.qml" line="1156"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
+        <location filename="../app/MainLayout.qml" line="1184"/>
         <location filename="../app/MainLayout.qml" line="1218"/>
-        <location filename="../app/MainLayout.qml" line="1253"/>
-        <location filename="../app/MainLayout.qml" line="1264"/>
+        <location filename="../app/MainLayout.qml" line="1236"/>
+        <location filename="../app/MainLayout.qml" line="1245"/>
+        <location filename="../app/MainLayout.qml" line="1285"/>
+        <location filename="../app/MainLayout.qml" line="1296"/>
         <source>Back</source>
         <translation>戻る</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1055"/>
-        <location filename="../app/MainLayout.qml" line="1105"/>
-        <location filename="../app/MainLayout.qml" line="1240"/>
         <source>Page</source>
-        <translation>ページ</translation>
+        <translation type="vanished">ページ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1022"/>
-        <location filename="../app/MainLayout.qml" line="1062"/>
-        <location filename="../app/MainLayout.qml" line="1114"/>
-        <location filename="../app/MainLayout.qml" line="1249"/>
+        <location filename="../app/MainLayout.qml" line="1056"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
+        <location filename="../app/MainLayout.qml" line="1141"/>
+        <location filename="../app/MainLayout.qml" line="1274"/>
         <source>Options</source>
         <translation>オプション</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="940"/>
-        <location filename="../app/MainLayout.qml" line="1072"/>
-        <location filename="../app/MainLayout.qml" line="1125"/>
-        <location filename="../app/MainLayout.qml" line="1260"/>
+        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="1101"/>
+        <location filename="../app/MainLayout.qml" line="1152"/>
+        <location filename="../app/MainLayout.qml" line="1292"/>
         <source>Retry</source>
         <translation>再試行</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1176"/>
+        <location filename="../app/MainLayout.qml" line="1203"/>
         <source>Change</source>
         <translation>変更</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1182"/>
+        <location filename="../app/MainLayout.qml" line="1209"/>
         <source>Toggle</source>
         <translation>切り替え</translation>
     </message>
@@ -864,12 +894,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">読み込み中…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="437"/>
+        <location filename="../screens/MediaListScreen.qml" line="449"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 件</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="438"/>
+        <location filename="../screens/MediaListScreen.qml" line="450"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -517,12 +517,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <location filename="../components/LetterJumpModal.qml" line="220"/>
         <source>Loading…</source>
         <translation type="unfinished">불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <location filename="../components/LetterJumpModal.qml" line="220"/>
         <source>No sections</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -426,7 +426,7 @@ Euskara - devilschile2</source>
     <name>GamesScreen</name>
     <message>
         <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="166"/>
+        <location filename="../screens/GamesScreen.qml" line="171"/>
         <source>%1 files</source>
         <translation>파일 %1개</translation>
     </message>
@@ -437,7 +437,7 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../screens/GamesScreen.qml" line="140"/>
-        <location filename="../screens/GamesScreen.qml" line="167"/>
+        <location filename="../screens/GamesScreen.qml" line="172"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -510,6 +510,24 @@ Euskara - devilschile2</source>
     </message>
 </context>
 <context>
+    <name>LetterJumpModal</name>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="32"/>
+        <source>Go to...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <source>Loading…</source>
+        <translation type="unfinished">불러오는 중…</translation>
+    </message>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <source>No sections</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LoadingIndicator</name>
     <message>
         <location filename="../components/LoadingIndicator.qml" line="26"/>
@@ -553,138 +571,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1408"/>
         <source>Launch core</source>
         <translation>코어 실행</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1408"/>
-        <location filename="../app/Main.qml" line="1647"/>
+        <location filename="../app/Main.qml" line="1414"/>
+        <location filename="../app/Main.qml" line="1653"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1415"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1421"/>
+        <location filename="../app/Main.qml" line="1444"/>
         <source>Update media database</source>
         <translation type="unfinished">미디어 데이터베이스 업데이트</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1418"/>
-        <location filename="../app/Main.qml" line="1441"/>
+        <location filename="../app/Main.qml" line="1424"/>
+        <location filename="../app/Main.qml" line="1447"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">메타데이터 수집</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1423"/>
-        <location filename="../app/Main.qml" line="1432"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1438"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1423"/>
-        <location filename="../app/Main.qml" line="1432"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1438"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1450"/>
-        <location filename="../app/Main.qml" line="1485"/>
+        <location filename="../app/Main.qml" line="1456"/>
+        <location filename="../app/Main.qml" line="1491"/>
         <source>Launch game</source>
         <translation>게임 실행</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1472"/>
         <source>Remove from favorites</source>
         <translation>즐겨찾기에서 제거</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1472"/>
         <source>Add to favorites</source>
         <translation>즐겨찾기에 추가</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1471"/>
+        <location filename="../app/Main.qml" line="1477"/>
         <source>Write to NFC token</source>
         <translation>NFC 토큰에 쓰기</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1475"/>
+        <location filename="../app/Main.qml" line="1481"/>
         <source>QR code</source>
         <translation>QR 코드</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1643"/>
+        <location filename="../app/Main.qml" line="1649"/>
         <source>Default</source>
         <translation type="unfinished">기본값</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1643"/>
+        <location filename="../app/Main.qml" line="1649"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1967"/>
+        <location filename="../app/Main.qml" line="1937"/>
+        <source>Go to...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1940"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2021"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1971"/>
+        <location filename="../app/Main.qml" line="2025"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1985"/>
+        <location filename="../app/Main.qml" line="2039"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1989"/>
+        <location filename="../app/Main.qml" line="2043"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1993"/>
+        <location filename="../app/Main.qml" line="2047"/>
         <source>Retry</source>
         <translation type="unfinished">다시 시도</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1997"/>
+        <location filename="../app/Main.qml" line="2051"/>
         <source>Cancel</source>
         <translation type="unfinished">취소</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2645"/>
+        <location filename="../app/Main.qml" line="2731"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2647"/>
+        <location filename="../app/Main.qml" line="2733"/>
         <source>Loading games…</source>
         <translation>게임 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2649"/>
+        <location filename="../app/Main.qml" line="2735"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2651"/>
+        <location filename="../app/Main.qml" line="2737"/>
         <source>Loading favorites…</source>
         <translation>즐겨찾기 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2653"/>
+        <location filename="../app/Main.qml" line="2739"/>
         <source>Loading recently played…</source>
         <translation>최근 플레이 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2655"/>
+        <location filename="../app/Main.qml" line="2741"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2657"/>
+        <location filename="../app/Main.qml" line="2743"/>
         <source>Loading…</source>
         <translation>불러오는 중…</translation>
     </message>
@@ -692,166 +720,168 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="685"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Writing failed</source>
         <translation>쓰기 실패</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="685"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Put a writable card near the reader</source>
         <translation>기록 가능한 카드를 리더 근처에 놓으세요</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="171"/>
+        <location filename="../app/MainLayout.qml" line="172"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="368"/>
+        <location filename="../app/MainLayout.qml" line="382"/>
         <source>Favorites</source>
         <translation type="unfinished">즐겨찾기</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="370"/>
+        <location filename="../app/MainLayout.qml" line="384"/>
         <source>Recently Played</source>
         <translation type="unfinished">최근 플레이</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="701"/>
+        <location filename="../app/MainLayout.qml" line="717"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="702"/>
+        <location filename="../app/MainLayout.qml" line="718"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="812"/>
+        <location filename="../app/MainLayout.qml" line="828"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="813"/>
+        <location filename="../app/MainLayout.qml" line="829"/>
         <source>Are you sure you want to exit?</source>
         <translation>정말 종료하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="892"/>
-        <location filename="../app/MainLayout.qml" line="966"/>
-        <location filename="../app/MainLayout.qml" line="1012"/>
-        <location filename="../app/MainLayout.qml" line="1049"/>
-        <location filename="../app/MainLayout.qml" line="1099"/>
-        <location filename="../app/MainLayout.qml" line="1148"/>
-        <location filename="../app/MainLayout.qml" line="1167"/>
-        <location filename="../app/MainLayout.qml" line="1234"/>
+        <location filename="../app/MainLayout.qml" line="926"/>
+        <location filename="../app/MainLayout.qml" line="1000"/>
+        <location filename="../app/MainLayout.qml" line="1046"/>
+        <location filename="../app/MainLayout.qml" line="1083"/>
+        <location filename="../app/MainLayout.qml" line="1131"/>
+        <location filename="../app/MainLayout.qml" line="1175"/>
+        <location filename="../app/MainLayout.qml" line="1194"/>
+        <location filename="../app/MainLayout.qml" line="1264"/>
         <source>Move</source>
         <translation>이동</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="896"/>
-        <location filename="../app/MainLayout.qml" line="970"/>
+        <location filename="../app/MainLayout.qml" line="930"/>
+        <location filename="../app/MainLayout.qml" line="1004"/>
         <source>Select</source>
         <translation>선택</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="900"/>
-        <location filename="../app/MainLayout.qml" line="904"/>
-        <location filename="../app/MainLayout.qml" line="918"/>
-        <location filename="../app/MainLayout.qml" line="933"/>
-        <location filename="../app/MainLayout.qml" line="944"/>
+        <location filename="../app/MainLayout.qml" line="934"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="952"/>
+        <location filename="../app/MainLayout.qml" line="967"/>
+        <location filename="../app/MainLayout.qml" line="978"/>
         <source>Close</source>
         <translation>닫기</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="911"/>
-        <location filename="../app/MainLayout.qml" line="951"/>
-        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="945"/>
         <location filename="../app/MainLayout.qml" line="985"/>
+        <location filename="../app/MainLayout.qml" line="1008"/>
+        <location filename="../app/MainLayout.qml" line="1019"/>
         <source>Cancel</source>
         <translation>취소</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="929"/>
+        <location filename="../app/MainLayout.qml" line="963"/>
         <source>Done</source>
         <translation>완료</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="940"/>
-        <location filename="../app/MainLayout.qml" line="1072"/>
-        <location filename="../app/MainLayout.qml" line="1125"/>
-        <location filename="../app/MainLayout.qml" line="1260"/>
+        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="1101"/>
+        <location filename="../app/MainLayout.qml" line="1152"/>
+        <location filename="../app/MainLayout.qml" line="1292"/>
         <source>Retry</source>
         <translation>다시 시도</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="959"/>
+        <location filename="../app/MainLayout.qml" line="993"/>
         <source>I understand</source>
         <translation>이해했습니다</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="993"/>
+        <location filename="../app/MainLayout.qml" line="1027"/>
         <source>Start</source>
         <translation>시작</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1016"/>
-        <location filename="../app/MainLayout.qml" line="1059"/>
-        <location filename="../app/MainLayout.qml" line="1109"/>
-        <location filename="../app/MainLayout.qml" line="1153"/>
-        <location filename="../app/MainLayout.qml" line="1244"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1088"/>
+        <location filename="../app/MainLayout.qml" line="1136"/>
+        <location filename="../app/MainLayout.qml" line="1180"/>
+        <location filename="../app/MainLayout.qml" line="1269"/>
         <source>Open</source>
         <translation>열기</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1026"/>
+        <location filename="../app/MainLayout.qml" line="1060"/>
         <source>Quit</source>
         <translation>종료</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1035"/>
-        <location filename="../app/MainLayout.qml" line="1065"/>
-        <location filename="../app/MainLayout.qml" line="1076"/>
-        <location filename="../app/MainLayout.qml" line="1091"/>
-        <location filename="../app/MainLayout.qml" line="1118"/>
-        <location filename="../app/MainLayout.qml" line="1129"/>
-        <location filename="../app/MainLayout.qml" line="1141"/>
-        <location filename="../app/MainLayout.qml" line="1157"/>
-        <location filename="../app/MainLayout.qml" line="1191"/>
-        <location filename="../app/MainLayout.qml" line="1209"/>
+        <location filename="../app/MainLayout.qml" line="1069"/>
+        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
+        <location filename="../app/MainLayout.qml" line="1120"/>
+        <location filename="../app/MainLayout.qml" line="1145"/>
+        <location filename="../app/MainLayout.qml" line="1156"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
+        <location filename="../app/MainLayout.qml" line="1184"/>
         <location filename="../app/MainLayout.qml" line="1218"/>
-        <location filename="../app/MainLayout.qml" line="1253"/>
-        <location filename="../app/MainLayout.qml" line="1264"/>
+        <location filename="../app/MainLayout.qml" line="1236"/>
+        <location filename="../app/MainLayout.qml" line="1245"/>
+        <location filename="../app/MainLayout.qml" line="1285"/>
+        <location filename="../app/MainLayout.qml" line="1296"/>
         <source>Back</source>
         <translation>뒤로</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1055"/>
-        <location filename="../app/MainLayout.qml" line="1105"/>
-        <location filename="../app/MainLayout.qml" line="1240"/>
-        <source>Page</source>
-        <translation>페이지</translation>
+        <location filename="../app/MainLayout.qml" line="1281"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1022"/>
-        <location filename="../app/MainLayout.qml" line="1062"/>
-        <location filename="../app/MainLayout.qml" line="1114"/>
-        <location filename="../app/MainLayout.qml" line="1249"/>
+        <source>Page</source>
+        <translation type="vanished">페이지</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="1056"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
+        <location filename="../app/MainLayout.qml" line="1141"/>
+        <location filename="../app/MainLayout.qml" line="1274"/>
         <source>Options</source>
         <translation>옵션</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1176"/>
+        <location filename="../app/MainLayout.qml" line="1203"/>
         <source>Change</source>
         <translation>변경</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1182"/>
+        <location filename="../app/MainLayout.qml" line="1209"/>
         <source>Toggle</source>
         <translation>전환</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1205"/>
+        <location filename="../app/MainLayout.qml" line="1232"/>
         <source>Scroll</source>
         <translation>스크롤</translation>
     </message>
@@ -864,12 +894,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="437"/>
+        <location filename="../screens/MediaListScreen.qml" line="449"/>
         <source>%1 entries</source>
         <translation type="unfinished">항목 %1개</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="438"/>
+        <location filename="../screens/MediaListScreen.qml" line="450"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -426,7 +426,7 @@ Euskara - devilschile2</source>
     <name>GamesScreen</name>
     <message>
         <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="166"/>
+        <location filename="../screens/GamesScreen.qml" line="171"/>
         <source>%1 files</source>
         <translation>%1 bestanden</translation>
     </message>
@@ -437,7 +437,7 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../screens/GamesScreen.qml" line="140"/>
-        <location filename="../screens/GamesScreen.qml" line="167"/>
+        <location filename="../screens/GamesScreen.qml" line="172"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -510,6 +510,24 @@ Euskara - devilschile2</source>
     </message>
 </context>
 <context>
+    <name>LetterJumpModal</name>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="32"/>
+        <source>Go to...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <source>Loading…</source>
+        <translation type="unfinished">Laden…</translation>
+    </message>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <source>No sections</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LoadingIndicator</name>
     <message>
         <location filename="../components/LoadingIndicator.qml" line="26"/>
@@ -553,138 +571,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1408"/>
         <source>Launch core</source>
         <translation>Core starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1408"/>
-        <location filename="../app/Main.qml" line="1647"/>
+        <location filename="../app/Main.qml" line="1414"/>
+        <location filename="../app/Main.qml" line="1653"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1472"/>
         <source>Remove from favorites</source>
         <translation>Uit favorieten verwijderen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1472"/>
         <source>Add to favorites</source>
         <translation>Aan favorieten toevoegen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1471"/>
+        <location filename="../app/Main.qml" line="1477"/>
         <source>Write to NFC token</source>
         <translation>Naar NFC-token schrijven</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1475"/>
+        <location filename="../app/Main.qml" line="1481"/>
         <source>QR code</source>
         <translation>QR-code</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1450"/>
-        <location filename="../app/Main.qml" line="1485"/>
+        <location filename="../app/Main.qml" line="1456"/>
+        <location filename="../app/Main.qml" line="1491"/>
         <source>Launch game</source>
         <translation>Game starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2645"/>
+        <location filename="../app/Main.qml" line="1937"/>
+        <source>Go to...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1940"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2731"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2651"/>
+        <location filename="../app/Main.qml" line="2737"/>
         <source>Loading favorites…</source>
         <translation>Favorieten laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2647"/>
+        <location filename="../app/Main.qml" line="2733"/>
         <source>Loading games…</source>
         <translation>Games laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1415"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1421"/>
+        <location filename="../app/Main.qml" line="1444"/>
         <source>Update media database</source>
         <translation type="unfinished">Mediadatabase bijwerken</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1418"/>
-        <location filename="../app/Main.qml" line="1441"/>
+        <location filename="../app/Main.qml" line="1424"/>
+        <location filename="../app/Main.qml" line="1447"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadata ophalen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1423"/>
-        <location filename="../app/Main.qml" line="1432"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1438"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1423"/>
-        <location filename="../app/Main.qml" line="1432"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1438"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1643"/>
+        <location filename="../app/Main.qml" line="1649"/>
         <source>Default</source>
         <translation type="unfinished">Standaard</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1643"/>
+        <location filename="../app/Main.qml" line="1649"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1967"/>
+        <location filename="../app/Main.qml" line="2021"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1971"/>
+        <location filename="../app/Main.qml" line="2025"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1985"/>
+        <location filename="../app/Main.qml" line="2039"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1989"/>
+        <location filename="../app/Main.qml" line="2043"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1993"/>
+        <location filename="../app/Main.qml" line="2047"/>
         <source>Retry</source>
         <translation type="unfinished">Opnieuw proberen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1997"/>
+        <location filename="../app/Main.qml" line="2051"/>
         <source>Cancel</source>
         <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2649"/>
+        <location filename="../app/Main.qml" line="2735"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2653"/>
+        <location filename="../app/Main.qml" line="2739"/>
         <source>Loading recently played…</source>
         <translation>Recent gespeeld laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2655"/>
+        <location filename="../app/Main.qml" line="2741"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2657"/>
+        <location filename="../app/Main.qml" line="2743"/>
         <source>Loading…</source>
         <translation>Laden…</translation>
     </message>
@@ -692,166 +720,168 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="685"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Writing failed</source>
         <translation>Schrijven mislukt</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="685"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Put a writable card near the reader</source>
         <translation>Houd een beschrijfbare kaart bij de lezer</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="813"/>
+        <location filename="../app/MainLayout.qml" line="829"/>
         <source>Are you sure you want to exit?</source>
         <translation>Weet u zeker dat u wilt afsluiten?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="896"/>
-        <location filename="../app/MainLayout.qml" line="970"/>
+        <location filename="../app/MainLayout.qml" line="930"/>
+        <location filename="../app/MainLayout.qml" line="1004"/>
         <source>Select</source>
         <translation>Selecteren</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="900"/>
-        <location filename="../app/MainLayout.qml" line="904"/>
-        <location filename="../app/MainLayout.qml" line="918"/>
-        <location filename="../app/MainLayout.qml" line="933"/>
-        <location filename="../app/MainLayout.qml" line="944"/>
+        <location filename="../app/MainLayout.qml" line="934"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="952"/>
+        <location filename="../app/MainLayout.qml" line="967"/>
+        <location filename="../app/MainLayout.qml" line="978"/>
         <source>Close</source>
         <translation>Sluiten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="911"/>
-        <location filename="../app/MainLayout.qml" line="951"/>
-        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="945"/>
         <location filename="../app/MainLayout.qml" line="985"/>
+        <location filename="../app/MainLayout.qml" line="1008"/>
+        <location filename="../app/MainLayout.qml" line="1019"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="929"/>
+        <location filename="../app/MainLayout.qml" line="963"/>
         <source>Done</source>
         <translation>Klaar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="959"/>
+        <location filename="../app/MainLayout.qml" line="993"/>
         <source>I understand</source>
         <translation>Ik begrijp het</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="993"/>
+        <location filename="../app/MainLayout.qml" line="1027"/>
         <source>Start</source>
         <translation>Starten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1205"/>
+        <location filename="../app/MainLayout.qml" line="1232"/>
         <source>Scroll</source>
         <translation>Scrollen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="892"/>
-        <location filename="../app/MainLayout.qml" line="966"/>
-        <location filename="../app/MainLayout.qml" line="1012"/>
-        <location filename="../app/MainLayout.qml" line="1049"/>
-        <location filename="../app/MainLayout.qml" line="1099"/>
-        <location filename="../app/MainLayout.qml" line="1148"/>
-        <location filename="../app/MainLayout.qml" line="1167"/>
-        <location filename="../app/MainLayout.qml" line="1234"/>
+        <location filename="../app/MainLayout.qml" line="1281"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="926"/>
+        <location filename="../app/MainLayout.qml" line="1000"/>
+        <location filename="../app/MainLayout.qml" line="1046"/>
+        <location filename="../app/MainLayout.qml" line="1083"/>
+        <location filename="../app/MainLayout.qml" line="1131"/>
+        <location filename="../app/MainLayout.qml" line="1175"/>
+        <location filename="../app/MainLayout.qml" line="1194"/>
+        <location filename="../app/MainLayout.qml" line="1264"/>
         <source>Move</source>
         <translation>Bewegen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="171"/>
+        <location filename="../app/MainLayout.qml" line="172"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="368"/>
+        <location filename="../app/MainLayout.qml" line="382"/>
         <source>Favorites</source>
         <translation type="unfinished">Favorieten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="370"/>
+        <location filename="../app/MainLayout.qml" line="384"/>
         <source>Recently Played</source>
         <translation type="unfinished">Recent gespeeld</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="701"/>
+        <location filename="../app/MainLayout.qml" line="717"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="702"/>
+        <location filename="../app/MainLayout.qml" line="718"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="812"/>
+        <location filename="../app/MainLayout.qml" line="828"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1016"/>
-        <location filename="../app/MainLayout.qml" line="1059"/>
-        <location filename="../app/MainLayout.qml" line="1109"/>
-        <location filename="../app/MainLayout.qml" line="1153"/>
-        <location filename="../app/MainLayout.qml" line="1244"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1088"/>
+        <location filename="../app/MainLayout.qml" line="1136"/>
+        <location filename="../app/MainLayout.qml" line="1180"/>
+        <location filename="../app/MainLayout.qml" line="1269"/>
         <source>Open</source>
         <translation>Openen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1026"/>
+        <location filename="../app/MainLayout.qml" line="1060"/>
         <source>Quit</source>
         <translation>Afsluiten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1035"/>
-        <location filename="../app/MainLayout.qml" line="1065"/>
-        <location filename="../app/MainLayout.qml" line="1076"/>
-        <location filename="../app/MainLayout.qml" line="1091"/>
-        <location filename="../app/MainLayout.qml" line="1118"/>
-        <location filename="../app/MainLayout.qml" line="1129"/>
-        <location filename="../app/MainLayout.qml" line="1141"/>
-        <location filename="../app/MainLayout.qml" line="1157"/>
-        <location filename="../app/MainLayout.qml" line="1191"/>
-        <location filename="../app/MainLayout.qml" line="1209"/>
+        <location filename="../app/MainLayout.qml" line="1069"/>
+        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
+        <location filename="../app/MainLayout.qml" line="1120"/>
+        <location filename="../app/MainLayout.qml" line="1145"/>
+        <location filename="../app/MainLayout.qml" line="1156"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
+        <location filename="../app/MainLayout.qml" line="1184"/>
         <location filename="../app/MainLayout.qml" line="1218"/>
-        <location filename="../app/MainLayout.qml" line="1253"/>
-        <location filename="../app/MainLayout.qml" line="1264"/>
+        <location filename="../app/MainLayout.qml" line="1236"/>
+        <location filename="../app/MainLayout.qml" line="1245"/>
+        <location filename="../app/MainLayout.qml" line="1285"/>
+        <location filename="../app/MainLayout.qml" line="1296"/>
         <source>Back</source>
         <translation>Terug</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1055"/>
-        <location filename="../app/MainLayout.qml" line="1105"/>
-        <location filename="../app/MainLayout.qml" line="1240"/>
         <source>Page</source>
-        <translation>Pagina</translation>
+        <translation type="vanished">Pagina</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1022"/>
-        <location filename="../app/MainLayout.qml" line="1062"/>
-        <location filename="../app/MainLayout.qml" line="1114"/>
-        <location filename="../app/MainLayout.qml" line="1249"/>
+        <location filename="../app/MainLayout.qml" line="1056"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
+        <location filename="../app/MainLayout.qml" line="1141"/>
+        <location filename="../app/MainLayout.qml" line="1274"/>
         <source>Options</source>
         <translation>Opties</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="940"/>
-        <location filename="../app/MainLayout.qml" line="1072"/>
-        <location filename="../app/MainLayout.qml" line="1125"/>
-        <location filename="../app/MainLayout.qml" line="1260"/>
+        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="1101"/>
+        <location filename="../app/MainLayout.qml" line="1152"/>
+        <location filename="../app/MainLayout.qml" line="1292"/>
         <source>Retry</source>
         <translation>Opnieuw proberen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1176"/>
+        <location filename="../app/MainLayout.qml" line="1203"/>
         <source>Change</source>
         <translation>Wijzigen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1182"/>
+        <location filename="../app/MainLayout.qml" line="1209"/>
         <source>Toggle</source>
         <translation>Schakelen</translation>
     </message>
@@ -864,12 +894,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Laden…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="437"/>
+        <location filename="../screens/MediaListScreen.qml" line="449"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 items</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="438"/>
+        <location filename="../screens/MediaListScreen.qml" line="450"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -517,12 +517,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <location filename="../components/LetterJumpModal.qml" line="220"/>
         <source>Loading…</source>
         <translation type="unfinished">Laden…</translation>
     </message>
     <message>
-        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <location filename="../components/LetterJumpModal.qml" line="220"/>
         <source>No sections</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -426,7 +426,7 @@ Euskara - devilschile2</source>
     <name>GamesScreen</name>
     <message>
         <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="166"/>
+        <location filename="../screens/GamesScreen.qml" line="171"/>
         <source>%1 files</source>
         <translation>%1 fișiere</translation>
     </message>
@@ -437,7 +437,7 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../screens/GamesScreen.qml" line="140"/>
-        <location filename="../screens/GamesScreen.qml" line="167"/>
+        <location filename="../screens/GamesScreen.qml" line="172"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -510,6 +510,24 @@ Euskara - devilschile2</source>
     </message>
 </context>
 <context>
+    <name>LetterJumpModal</name>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="32"/>
+        <source>Go to...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <source>Loading…</source>
+        <translation type="unfinished">Se încarcă…</translation>
+    </message>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <source>No sections</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LoadingIndicator</name>
     <message>
         <location filename="../components/LoadingIndicator.qml" line="26"/>
@@ -553,138 +571,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1408"/>
         <source>Launch core</source>
         <translation>Lansare core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1408"/>
-        <location filename="../app/Main.qml" line="1647"/>
+        <location filename="../app/Main.qml" line="1414"/>
+        <location filename="../app/Main.qml" line="1653"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1472"/>
         <source>Remove from favorites</source>
         <translation>Elimină din favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1472"/>
         <source>Add to favorites</source>
         <translation>Adaugă la favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1471"/>
+        <location filename="../app/Main.qml" line="1477"/>
         <source>Write to NFC token</source>
         <translation>Scriere pe token NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1475"/>
+        <location filename="../app/Main.qml" line="1481"/>
         <source>QR code</source>
         <translation>Cod QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1450"/>
-        <location filename="../app/Main.qml" line="1485"/>
+        <location filename="../app/Main.qml" line="1456"/>
+        <location filename="../app/Main.qml" line="1491"/>
         <source>Launch game</source>
         <translation>Lansare joc</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2645"/>
+        <location filename="../app/Main.qml" line="1937"/>
+        <source>Go to...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1940"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2731"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2651"/>
+        <location filename="../app/Main.qml" line="2737"/>
         <source>Loading favorites…</source>
         <translation>Se încarcă favoritele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2647"/>
+        <location filename="../app/Main.qml" line="2733"/>
         <source>Loading games…</source>
         <translation>Se încarcă jocurile…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1415"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1421"/>
+        <location filename="../app/Main.qml" line="1444"/>
         <source>Update media database</source>
         <translation type="unfinished">Actualizare bază de date media</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1418"/>
-        <location filename="../app/Main.qml" line="1441"/>
+        <location filename="../app/Main.qml" line="1424"/>
+        <location filename="../app/Main.qml" line="1447"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Extragere metadate</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1423"/>
-        <location filename="../app/Main.qml" line="1432"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1438"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1423"/>
-        <location filename="../app/Main.qml" line="1432"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1438"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1643"/>
+        <location filename="../app/Main.qml" line="1649"/>
         <source>Default</source>
         <translation type="unfinished">Implicit</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1643"/>
+        <location filename="../app/Main.qml" line="1649"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1967"/>
+        <location filename="../app/Main.qml" line="2021"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1971"/>
+        <location filename="../app/Main.qml" line="2025"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1985"/>
+        <location filename="../app/Main.qml" line="2039"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1989"/>
+        <location filename="../app/Main.qml" line="2043"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1993"/>
+        <location filename="../app/Main.qml" line="2047"/>
         <source>Retry</source>
         <translation type="unfinished">Reîncercare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1997"/>
+        <location filename="../app/Main.qml" line="2051"/>
         <source>Cancel</source>
         <translation type="unfinished">Anulare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2649"/>
+        <location filename="../app/Main.qml" line="2735"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2653"/>
+        <location filename="../app/Main.qml" line="2739"/>
         <source>Loading recently played…</source>
         <translation>Se încarcă recent jucatele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2655"/>
+        <location filename="../app/Main.qml" line="2741"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2657"/>
+        <location filename="../app/Main.qml" line="2743"/>
         <source>Loading…</source>
         <translation>Se încarcă…</translation>
     </message>
@@ -692,166 +720,168 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="685"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Writing failed</source>
         <translation>Scriere eșuată</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="685"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Put a writable card near the reader</source>
         <translation>Apropiați un card inscriptibil de cititor</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="813"/>
+        <location filename="../app/MainLayout.qml" line="829"/>
         <source>Are you sure you want to exit?</source>
         <translation>Sigur doriți să ieșiți?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="896"/>
-        <location filename="../app/MainLayout.qml" line="970"/>
+        <location filename="../app/MainLayout.qml" line="930"/>
+        <location filename="../app/MainLayout.qml" line="1004"/>
         <source>Select</source>
         <translation>Selectare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="900"/>
-        <location filename="../app/MainLayout.qml" line="904"/>
-        <location filename="../app/MainLayout.qml" line="918"/>
-        <location filename="../app/MainLayout.qml" line="933"/>
-        <location filename="../app/MainLayout.qml" line="944"/>
+        <location filename="../app/MainLayout.qml" line="934"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="952"/>
+        <location filename="../app/MainLayout.qml" line="967"/>
+        <location filename="../app/MainLayout.qml" line="978"/>
         <source>Close</source>
         <translation>Închidere</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="911"/>
-        <location filename="../app/MainLayout.qml" line="951"/>
-        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="945"/>
         <location filename="../app/MainLayout.qml" line="985"/>
+        <location filename="../app/MainLayout.qml" line="1008"/>
+        <location filename="../app/MainLayout.qml" line="1019"/>
         <source>Cancel</source>
         <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="929"/>
+        <location filename="../app/MainLayout.qml" line="963"/>
         <source>Done</source>
         <translation>Gata</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="959"/>
+        <location filename="../app/MainLayout.qml" line="993"/>
         <source>I understand</source>
         <translation>Am înțeles</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="993"/>
+        <location filename="../app/MainLayout.qml" line="1027"/>
         <source>Start</source>
         <translation>Pornire</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1205"/>
+        <location filename="../app/MainLayout.qml" line="1232"/>
         <source>Scroll</source>
         <translation>Derulare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="892"/>
-        <location filename="../app/MainLayout.qml" line="966"/>
-        <location filename="../app/MainLayout.qml" line="1012"/>
-        <location filename="../app/MainLayout.qml" line="1049"/>
-        <location filename="../app/MainLayout.qml" line="1099"/>
-        <location filename="../app/MainLayout.qml" line="1148"/>
-        <location filename="../app/MainLayout.qml" line="1167"/>
-        <location filename="../app/MainLayout.qml" line="1234"/>
+        <location filename="../app/MainLayout.qml" line="1281"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="926"/>
+        <location filename="../app/MainLayout.qml" line="1000"/>
+        <location filename="../app/MainLayout.qml" line="1046"/>
+        <location filename="../app/MainLayout.qml" line="1083"/>
+        <location filename="../app/MainLayout.qml" line="1131"/>
+        <location filename="../app/MainLayout.qml" line="1175"/>
+        <location filename="../app/MainLayout.qml" line="1194"/>
+        <location filename="../app/MainLayout.qml" line="1264"/>
         <source>Move</source>
         <translation>Mutare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="171"/>
+        <location filename="../app/MainLayout.qml" line="172"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="368"/>
+        <location filename="../app/MainLayout.qml" line="382"/>
         <source>Favorites</source>
         <translation type="unfinished">Favorite</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="370"/>
+        <location filename="../app/MainLayout.qml" line="384"/>
         <source>Recently Played</source>
         <translation type="unfinished">Recent Jucate</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="701"/>
+        <location filename="../app/MainLayout.qml" line="717"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="702"/>
+        <location filename="../app/MainLayout.qml" line="718"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="812"/>
+        <location filename="../app/MainLayout.qml" line="828"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1016"/>
-        <location filename="../app/MainLayout.qml" line="1059"/>
-        <location filename="../app/MainLayout.qml" line="1109"/>
-        <location filename="../app/MainLayout.qml" line="1153"/>
-        <location filename="../app/MainLayout.qml" line="1244"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1088"/>
+        <location filename="../app/MainLayout.qml" line="1136"/>
+        <location filename="../app/MainLayout.qml" line="1180"/>
+        <location filename="../app/MainLayout.qml" line="1269"/>
         <source>Open</source>
         <translation>Deschidere</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1026"/>
+        <location filename="../app/MainLayout.qml" line="1060"/>
         <source>Quit</source>
         <translation>Ieșire</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1035"/>
-        <location filename="../app/MainLayout.qml" line="1065"/>
-        <location filename="../app/MainLayout.qml" line="1076"/>
-        <location filename="../app/MainLayout.qml" line="1091"/>
-        <location filename="../app/MainLayout.qml" line="1118"/>
-        <location filename="../app/MainLayout.qml" line="1129"/>
-        <location filename="../app/MainLayout.qml" line="1141"/>
-        <location filename="../app/MainLayout.qml" line="1157"/>
-        <location filename="../app/MainLayout.qml" line="1191"/>
-        <location filename="../app/MainLayout.qml" line="1209"/>
+        <location filename="../app/MainLayout.qml" line="1069"/>
+        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
+        <location filename="../app/MainLayout.qml" line="1120"/>
+        <location filename="../app/MainLayout.qml" line="1145"/>
+        <location filename="../app/MainLayout.qml" line="1156"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
+        <location filename="../app/MainLayout.qml" line="1184"/>
         <location filename="../app/MainLayout.qml" line="1218"/>
-        <location filename="../app/MainLayout.qml" line="1253"/>
-        <location filename="../app/MainLayout.qml" line="1264"/>
+        <location filename="../app/MainLayout.qml" line="1236"/>
+        <location filename="../app/MainLayout.qml" line="1245"/>
+        <location filename="../app/MainLayout.qml" line="1285"/>
+        <location filename="../app/MainLayout.qml" line="1296"/>
         <source>Back</source>
         <translation>Înapoi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1055"/>
-        <location filename="../app/MainLayout.qml" line="1105"/>
-        <location filename="../app/MainLayout.qml" line="1240"/>
         <source>Page</source>
-        <translation>Pagină</translation>
+        <translation type="vanished">Pagină</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1022"/>
-        <location filename="../app/MainLayout.qml" line="1062"/>
-        <location filename="../app/MainLayout.qml" line="1114"/>
-        <location filename="../app/MainLayout.qml" line="1249"/>
+        <location filename="../app/MainLayout.qml" line="1056"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
+        <location filename="../app/MainLayout.qml" line="1141"/>
+        <location filename="../app/MainLayout.qml" line="1274"/>
         <source>Options</source>
         <translation>Opțiuni</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="940"/>
-        <location filename="../app/MainLayout.qml" line="1072"/>
-        <location filename="../app/MainLayout.qml" line="1125"/>
-        <location filename="../app/MainLayout.qml" line="1260"/>
+        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="1101"/>
+        <location filename="../app/MainLayout.qml" line="1152"/>
+        <location filename="../app/MainLayout.qml" line="1292"/>
         <source>Retry</source>
         <translation>Reîncercare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1176"/>
+        <location filename="../app/MainLayout.qml" line="1203"/>
         <source>Change</source>
         <translation>Schimbare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1182"/>
+        <location filename="../app/MainLayout.qml" line="1209"/>
         <source>Toggle</source>
         <translation>Comutare</translation>
     </message>
@@ -864,12 +894,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Se încarcă…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="437"/>
+        <location filename="../screens/MediaListScreen.qml" line="449"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 intrări</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="438"/>
+        <location filename="../screens/MediaListScreen.qml" line="450"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -517,12 +517,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <location filename="../components/LetterJumpModal.qml" line="220"/>
         <source>Loading…</source>
         <translation type="unfinished">Se încarcă…</translation>
     </message>
     <message>
-        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <location filename="../components/LetterJumpModal.qml" line="220"/>
         <source>No sections</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -517,12 +517,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <location filename="../components/LetterJumpModal.qml" line="220"/>
         <source>Loading…</source>
         <translation type="unfinished">Načítanie…</translation>
     </message>
     <message>
-        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <location filename="../components/LetterJumpModal.qml" line="220"/>
         <source>No sections</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -426,7 +426,7 @@ Euskara - devilschile2</source>
     <name>GamesScreen</name>
     <message>
         <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="166"/>
+        <location filename="../screens/GamesScreen.qml" line="171"/>
         <source>%1 files</source>
         <translation>%1 súborov</translation>
     </message>
@@ -437,7 +437,7 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../screens/GamesScreen.qml" line="140"/>
-        <location filename="../screens/GamesScreen.qml" line="167"/>
+        <location filename="../screens/GamesScreen.qml" line="172"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -510,6 +510,24 @@ Euskara - devilschile2</source>
     </message>
 </context>
 <context>
+    <name>LetterJumpModal</name>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="32"/>
+        <source>Go to...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <source>Loading…</source>
+        <translation type="unfinished">Načítanie…</translation>
+    </message>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <source>No sections</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LoadingIndicator</name>
     <message>
         <location filename="../components/LoadingIndicator.qml" line="26"/>
@@ -553,138 +571,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1408"/>
         <source>Launch core</source>
         <translation>Spustiť core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1408"/>
-        <location filename="../app/Main.qml" line="1647"/>
+        <location filename="../app/Main.qml" line="1414"/>
+        <location filename="../app/Main.qml" line="1653"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1472"/>
         <source>Remove from favorites</source>
         <translation>Odstrániť z obľúbených</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1472"/>
         <source>Add to favorites</source>
         <translation>Pridať do obľúbených</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1471"/>
+        <location filename="../app/Main.qml" line="1477"/>
         <source>Write to NFC token</source>
         <translation>Zapísať na NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1475"/>
+        <location filename="../app/Main.qml" line="1481"/>
         <source>QR code</source>
         <translation>QR kód</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1450"/>
-        <location filename="../app/Main.qml" line="1485"/>
+        <location filename="../app/Main.qml" line="1456"/>
+        <location filename="../app/Main.qml" line="1491"/>
         <source>Launch game</source>
         <translation>Spustiť hru</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2645"/>
+        <location filename="../app/Main.qml" line="1937"/>
+        <source>Go to...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1940"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2731"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2651"/>
+        <location filename="../app/Main.qml" line="2737"/>
         <source>Loading favorites…</source>
         <translation>Načítanie obľúbených…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2647"/>
+        <location filename="../app/Main.qml" line="2733"/>
         <source>Loading games…</source>
         <translation>Načítanie hier…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1415"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1421"/>
+        <location filename="../app/Main.qml" line="1444"/>
         <source>Update media database</source>
         <translation type="unfinished">Aktualizovať databázu médií</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1418"/>
-        <location filename="../app/Main.qml" line="1441"/>
+        <location filename="../app/Main.qml" line="1424"/>
+        <location filename="../app/Main.qml" line="1447"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Získať metadáta</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1423"/>
-        <location filename="../app/Main.qml" line="1432"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1438"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1423"/>
-        <location filename="../app/Main.qml" line="1432"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1438"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1643"/>
+        <location filename="../app/Main.qml" line="1649"/>
         <source>Default</source>
         <translation type="unfinished">Predvolené</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1643"/>
+        <location filename="../app/Main.qml" line="1649"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1967"/>
+        <location filename="../app/Main.qml" line="2021"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1971"/>
+        <location filename="../app/Main.qml" line="2025"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1985"/>
+        <location filename="../app/Main.qml" line="2039"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1989"/>
+        <location filename="../app/Main.qml" line="2043"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1993"/>
+        <location filename="../app/Main.qml" line="2047"/>
         <source>Retry</source>
         <translation type="unfinished">Skúsiť znova</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1997"/>
+        <location filename="../app/Main.qml" line="2051"/>
         <source>Cancel</source>
         <translation type="unfinished">Zrušiť</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2649"/>
+        <location filename="../app/Main.qml" line="2735"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2653"/>
+        <location filename="../app/Main.qml" line="2739"/>
         <source>Loading recently played…</source>
         <translation>Načítanie nedávno hraných…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2655"/>
+        <location filename="../app/Main.qml" line="2741"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2657"/>
+        <location filename="../app/Main.qml" line="2743"/>
         <source>Loading…</source>
         <translation>Načítanie…</translation>
     </message>
@@ -692,166 +720,168 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="685"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Writing failed</source>
         <translation>Zápis zlyhal</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="685"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Put a writable card near the reader</source>
         <translation>Priložte zapisovateľnú kartu k čítačke</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="813"/>
+        <location filename="../app/MainLayout.qml" line="829"/>
         <source>Are you sure you want to exit?</source>
         <translation>Naozaj chcete ukončiť?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="896"/>
-        <location filename="../app/MainLayout.qml" line="970"/>
+        <location filename="../app/MainLayout.qml" line="930"/>
+        <location filename="../app/MainLayout.qml" line="1004"/>
         <source>Select</source>
         <translation>Vybrať</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="900"/>
-        <location filename="../app/MainLayout.qml" line="904"/>
-        <location filename="../app/MainLayout.qml" line="918"/>
-        <location filename="../app/MainLayout.qml" line="933"/>
-        <location filename="../app/MainLayout.qml" line="944"/>
+        <location filename="../app/MainLayout.qml" line="934"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="952"/>
+        <location filename="../app/MainLayout.qml" line="967"/>
+        <location filename="../app/MainLayout.qml" line="978"/>
         <source>Close</source>
         <translation>Zavrieť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="911"/>
-        <location filename="../app/MainLayout.qml" line="951"/>
-        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="945"/>
         <location filename="../app/MainLayout.qml" line="985"/>
+        <location filename="../app/MainLayout.qml" line="1008"/>
+        <location filename="../app/MainLayout.qml" line="1019"/>
         <source>Cancel</source>
         <translation>Zrušiť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="929"/>
+        <location filename="../app/MainLayout.qml" line="963"/>
         <source>Done</source>
         <translation>Hotovo</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="959"/>
+        <location filename="../app/MainLayout.qml" line="993"/>
         <source>I understand</source>
         <translation>Rozumiem</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="993"/>
+        <location filename="../app/MainLayout.qml" line="1027"/>
         <source>Start</source>
         <translation>Spustiť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1205"/>
+        <location filename="../app/MainLayout.qml" line="1232"/>
         <source>Scroll</source>
         <translation>Posúvať</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="892"/>
-        <location filename="../app/MainLayout.qml" line="966"/>
-        <location filename="../app/MainLayout.qml" line="1012"/>
-        <location filename="../app/MainLayout.qml" line="1049"/>
-        <location filename="../app/MainLayout.qml" line="1099"/>
-        <location filename="../app/MainLayout.qml" line="1148"/>
-        <location filename="../app/MainLayout.qml" line="1167"/>
-        <location filename="../app/MainLayout.qml" line="1234"/>
+        <location filename="../app/MainLayout.qml" line="1281"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="926"/>
+        <location filename="../app/MainLayout.qml" line="1000"/>
+        <location filename="../app/MainLayout.qml" line="1046"/>
+        <location filename="../app/MainLayout.qml" line="1083"/>
+        <location filename="../app/MainLayout.qml" line="1131"/>
+        <location filename="../app/MainLayout.qml" line="1175"/>
+        <location filename="../app/MainLayout.qml" line="1194"/>
+        <location filename="../app/MainLayout.qml" line="1264"/>
         <source>Move</source>
         <translation>Presunúť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="171"/>
+        <location filename="../app/MainLayout.qml" line="172"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="368"/>
+        <location filename="../app/MainLayout.qml" line="382"/>
         <source>Favorites</source>
         <translation type="unfinished">Obľúbené</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="370"/>
+        <location filename="../app/MainLayout.qml" line="384"/>
         <source>Recently Played</source>
         <translation type="unfinished">Nedávno hrané</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="701"/>
+        <location filename="../app/MainLayout.qml" line="717"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="702"/>
+        <location filename="../app/MainLayout.qml" line="718"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="812"/>
+        <location filename="../app/MainLayout.qml" line="828"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1016"/>
-        <location filename="../app/MainLayout.qml" line="1059"/>
-        <location filename="../app/MainLayout.qml" line="1109"/>
-        <location filename="../app/MainLayout.qml" line="1153"/>
-        <location filename="../app/MainLayout.qml" line="1244"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1088"/>
+        <location filename="../app/MainLayout.qml" line="1136"/>
+        <location filename="../app/MainLayout.qml" line="1180"/>
+        <location filename="../app/MainLayout.qml" line="1269"/>
         <source>Open</source>
         <translation>Otvoriť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1026"/>
+        <location filename="../app/MainLayout.qml" line="1060"/>
         <source>Quit</source>
         <translation>Ukončiť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1035"/>
-        <location filename="../app/MainLayout.qml" line="1065"/>
-        <location filename="../app/MainLayout.qml" line="1076"/>
-        <location filename="../app/MainLayout.qml" line="1091"/>
-        <location filename="../app/MainLayout.qml" line="1118"/>
-        <location filename="../app/MainLayout.qml" line="1129"/>
-        <location filename="../app/MainLayout.qml" line="1141"/>
-        <location filename="../app/MainLayout.qml" line="1157"/>
-        <location filename="../app/MainLayout.qml" line="1191"/>
-        <location filename="../app/MainLayout.qml" line="1209"/>
+        <location filename="../app/MainLayout.qml" line="1069"/>
+        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
+        <location filename="../app/MainLayout.qml" line="1120"/>
+        <location filename="../app/MainLayout.qml" line="1145"/>
+        <location filename="../app/MainLayout.qml" line="1156"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
+        <location filename="../app/MainLayout.qml" line="1184"/>
         <location filename="../app/MainLayout.qml" line="1218"/>
-        <location filename="../app/MainLayout.qml" line="1253"/>
-        <location filename="../app/MainLayout.qml" line="1264"/>
+        <location filename="../app/MainLayout.qml" line="1236"/>
+        <location filename="../app/MainLayout.qml" line="1245"/>
+        <location filename="../app/MainLayout.qml" line="1285"/>
+        <location filename="../app/MainLayout.qml" line="1296"/>
         <source>Back</source>
         <translation>Späť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1055"/>
-        <location filename="../app/MainLayout.qml" line="1105"/>
-        <location filename="../app/MainLayout.qml" line="1240"/>
         <source>Page</source>
-        <translation>Stránka</translation>
+        <translation type="vanished">Stránka</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1022"/>
-        <location filename="../app/MainLayout.qml" line="1062"/>
-        <location filename="../app/MainLayout.qml" line="1114"/>
-        <location filename="../app/MainLayout.qml" line="1249"/>
+        <location filename="../app/MainLayout.qml" line="1056"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
+        <location filename="../app/MainLayout.qml" line="1141"/>
+        <location filename="../app/MainLayout.qml" line="1274"/>
         <source>Options</source>
         <translation>Možnosti</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="940"/>
-        <location filename="../app/MainLayout.qml" line="1072"/>
-        <location filename="../app/MainLayout.qml" line="1125"/>
-        <location filename="../app/MainLayout.qml" line="1260"/>
+        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="1101"/>
+        <location filename="../app/MainLayout.qml" line="1152"/>
+        <location filename="../app/MainLayout.qml" line="1292"/>
         <source>Retry</source>
         <translation>Skúsiť znova</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1176"/>
+        <location filename="../app/MainLayout.qml" line="1203"/>
         <source>Change</source>
         <translation>Zmeniť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1182"/>
+        <location filename="../app/MainLayout.qml" line="1209"/>
         <source>Toggle</source>
         <translation>Prepínať</translation>
     </message>
@@ -864,12 +894,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Načítanie…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="437"/>
+        <location filename="../screens/MediaListScreen.qml" line="449"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 položiek</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="438"/>
+        <location filename="../screens/MediaListScreen.qml" line="450"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -517,12 +517,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <location filename="../components/LetterJumpModal.qml" line="220"/>
         <source>Loading…</source>
         <translation type="unfinished">Завантаження…</translation>
     </message>
     <message>
-        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <location filename="../components/LetterJumpModal.qml" line="220"/>
         <source>No sections</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -426,7 +426,7 @@ Euskara - devilschile2</source>
     <name>GamesScreen</name>
     <message>
         <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="166"/>
+        <location filename="../screens/GamesScreen.qml" line="171"/>
         <source>%1 files</source>
         <translation>%1 файлів</translation>
     </message>
@@ -437,7 +437,7 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../screens/GamesScreen.qml" line="140"/>
-        <location filename="../screens/GamesScreen.qml" line="167"/>
+        <location filename="../screens/GamesScreen.qml" line="172"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -510,6 +510,24 @@ Euskara - devilschile2</source>
     </message>
 </context>
 <context>
+    <name>LetterJumpModal</name>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="32"/>
+        <source>Go to...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <source>Loading…</source>
+        <translation type="unfinished">Завантаження…</translation>
+    </message>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <source>No sections</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LoadingIndicator</name>
     <message>
         <location filename="../components/LoadingIndicator.qml" line="26"/>
@@ -553,138 +571,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1408"/>
         <source>Launch core</source>
         <translation>Запустити core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1408"/>
-        <location filename="../app/Main.qml" line="1647"/>
+        <location filename="../app/Main.qml" line="1414"/>
+        <location filename="../app/Main.qml" line="1653"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1472"/>
         <source>Remove from favorites</source>
         <translation>Видалити з вибраного</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1472"/>
         <source>Add to favorites</source>
         <translation>Додати до вибраного</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1471"/>
+        <location filename="../app/Main.qml" line="1477"/>
         <source>Write to NFC token</source>
         <translation>Записати на NFC-токен</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1475"/>
+        <location filename="../app/Main.qml" line="1481"/>
         <source>QR code</source>
         <translation>QR-код</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1450"/>
-        <location filename="../app/Main.qml" line="1485"/>
+        <location filename="../app/Main.qml" line="1456"/>
+        <location filename="../app/Main.qml" line="1491"/>
         <source>Launch game</source>
         <translation>Запустити гру</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2645"/>
+        <location filename="../app/Main.qml" line="1937"/>
+        <source>Go to...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1940"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2731"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2651"/>
+        <location filename="../app/Main.qml" line="2737"/>
         <source>Loading favorites…</source>
         <translation>Завантаження вибраного…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2647"/>
+        <location filename="../app/Main.qml" line="2733"/>
         <source>Loading games…</source>
         <translation>Завантаження ігор…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1415"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1421"/>
+        <location filename="../app/Main.qml" line="1444"/>
         <source>Update media database</source>
         <translation type="unfinished">Оновити базу медіа</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1418"/>
-        <location filename="../app/Main.qml" line="1441"/>
+        <location filename="../app/Main.qml" line="1424"/>
+        <location filename="../app/Main.qml" line="1447"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Отримати метадані</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1423"/>
-        <location filename="../app/Main.qml" line="1432"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1438"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1423"/>
-        <location filename="../app/Main.qml" line="1432"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1438"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1643"/>
+        <location filename="../app/Main.qml" line="1649"/>
         <source>Default</source>
         <translation type="unfinished">Типовий</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1643"/>
+        <location filename="../app/Main.qml" line="1649"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1967"/>
+        <location filename="../app/Main.qml" line="2021"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1971"/>
+        <location filename="../app/Main.qml" line="2025"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1985"/>
+        <location filename="../app/Main.qml" line="2039"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1989"/>
+        <location filename="../app/Main.qml" line="2043"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1993"/>
+        <location filename="../app/Main.qml" line="2047"/>
         <source>Retry</source>
         <translation type="unfinished">Повторити</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1997"/>
+        <location filename="../app/Main.qml" line="2051"/>
         <source>Cancel</source>
         <translation type="unfinished">Скасувати</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2649"/>
+        <location filename="../app/Main.qml" line="2735"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2653"/>
+        <location filename="../app/Main.qml" line="2739"/>
         <source>Loading recently played…</source>
         <translation>Завантаження нещодавніх…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2655"/>
+        <location filename="../app/Main.qml" line="2741"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2657"/>
+        <location filename="../app/Main.qml" line="2743"/>
         <source>Loading…</source>
         <translation>Завантаження…</translation>
     </message>
@@ -692,166 +720,168 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="685"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Writing failed</source>
         <translation>Помилка запису</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="685"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Put a writable card near the reader</source>
         <translation>Прикладіть картку для запису до зчитувача</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="813"/>
+        <location filename="../app/MainLayout.qml" line="829"/>
         <source>Are you sure you want to exit?</source>
         <translation>Ви впевнені, що хочете вийти?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="896"/>
-        <location filename="../app/MainLayout.qml" line="970"/>
+        <location filename="../app/MainLayout.qml" line="930"/>
+        <location filename="../app/MainLayout.qml" line="1004"/>
         <source>Select</source>
         <translation>Вибрати</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="900"/>
-        <location filename="../app/MainLayout.qml" line="904"/>
-        <location filename="../app/MainLayout.qml" line="918"/>
-        <location filename="../app/MainLayout.qml" line="933"/>
-        <location filename="../app/MainLayout.qml" line="944"/>
+        <location filename="../app/MainLayout.qml" line="934"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="952"/>
+        <location filename="../app/MainLayout.qml" line="967"/>
+        <location filename="../app/MainLayout.qml" line="978"/>
         <source>Close</source>
         <translation>Закрити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="911"/>
-        <location filename="../app/MainLayout.qml" line="951"/>
-        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="945"/>
         <location filename="../app/MainLayout.qml" line="985"/>
+        <location filename="../app/MainLayout.qml" line="1008"/>
+        <location filename="../app/MainLayout.qml" line="1019"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="929"/>
+        <location filename="../app/MainLayout.qml" line="963"/>
         <source>Done</source>
         <translation>Готово</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="959"/>
+        <location filename="../app/MainLayout.qml" line="993"/>
         <source>I understand</source>
         <translation>Я розумію</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="993"/>
+        <location filename="../app/MainLayout.qml" line="1027"/>
         <source>Start</source>
         <translation>Почати</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1205"/>
+        <location filename="../app/MainLayout.qml" line="1232"/>
         <source>Scroll</source>
         <translation>Прокрутка</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="892"/>
-        <location filename="../app/MainLayout.qml" line="966"/>
-        <location filename="../app/MainLayout.qml" line="1012"/>
-        <location filename="../app/MainLayout.qml" line="1049"/>
-        <location filename="../app/MainLayout.qml" line="1099"/>
-        <location filename="../app/MainLayout.qml" line="1148"/>
-        <location filename="../app/MainLayout.qml" line="1167"/>
-        <location filename="../app/MainLayout.qml" line="1234"/>
+        <location filename="../app/MainLayout.qml" line="1281"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="926"/>
+        <location filename="../app/MainLayout.qml" line="1000"/>
+        <location filename="../app/MainLayout.qml" line="1046"/>
+        <location filename="../app/MainLayout.qml" line="1083"/>
+        <location filename="../app/MainLayout.qml" line="1131"/>
+        <location filename="../app/MainLayout.qml" line="1175"/>
+        <location filename="../app/MainLayout.qml" line="1194"/>
+        <location filename="../app/MainLayout.qml" line="1264"/>
         <source>Move</source>
         <translation>Переміщення</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="171"/>
+        <location filename="../app/MainLayout.qml" line="172"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="368"/>
+        <location filename="../app/MainLayout.qml" line="382"/>
         <source>Favorites</source>
         <translation type="unfinished">Вибране</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="370"/>
+        <location filename="../app/MainLayout.qml" line="384"/>
         <source>Recently Played</source>
         <translation type="unfinished">Нещодавно зіграні</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="701"/>
+        <location filename="../app/MainLayout.qml" line="717"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="702"/>
+        <location filename="../app/MainLayout.qml" line="718"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="812"/>
+        <location filename="../app/MainLayout.qml" line="828"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1016"/>
-        <location filename="../app/MainLayout.qml" line="1059"/>
-        <location filename="../app/MainLayout.qml" line="1109"/>
-        <location filename="../app/MainLayout.qml" line="1153"/>
-        <location filename="../app/MainLayout.qml" line="1244"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1088"/>
+        <location filename="../app/MainLayout.qml" line="1136"/>
+        <location filename="../app/MainLayout.qml" line="1180"/>
+        <location filename="../app/MainLayout.qml" line="1269"/>
         <source>Open</source>
         <translation>Відкрити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1026"/>
+        <location filename="../app/MainLayout.qml" line="1060"/>
         <source>Quit</source>
         <translation>Вийти</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1035"/>
-        <location filename="../app/MainLayout.qml" line="1065"/>
-        <location filename="../app/MainLayout.qml" line="1076"/>
-        <location filename="../app/MainLayout.qml" line="1091"/>
-        <location filename="../app/MainLayout.qml" line="1118"/>
-        <location filename="../app/MainLayout.qml" line="1129"/>
-        <location filename="../app/MainLayout.qml" line="1141"/>
-        <location filename="../app/MainLayout.qml" line="1157"/>
-        <location filename="../app/MainLayout.qml" line="1191"/>
-        <location filename="../app/MainLayout.qml" line="1209"/>
+        <location filename="../app/MainLayout.qml" line="1069"/>
+        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
+        <location filename="../app/MainLayout.qml" line="1120"/>
+        <location filename="../app/MainLayout.qml" line="1145"/>
+        <location filename="../app/MainLayout.qml" line="1156"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
+        <location filename="../app/MainLayout.qml" line="1184"/>
         <location filename="../app/MainLayout.qml" line="1218"/>
-        <location filename="../app/MainLayout.qml" line="1253"/>
-        <location filename="../app/MainLayout.qml" line="1264"/>
+        <location filename="../app/MainLayout.qml" line="1236"/>
+        <location filename="../app/MainLayout.qml" line="1245"/>
+        <location filename="../app/MainLayout.qml" line="1285"/>
+        <location filename="../app/MainLayout.qml" line="1296"/>
         <source>Back</source>
         <translation>Назад</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1055"/>
-        <location filename="../app/MainLayout.qml" line="1105"/>
-        <location filename="../app/MainLayout.qml" line="1240"/>
         <source>Page</source>
-        <translation>Сторінка</translation>
+        <translation type="vanished">Сторінка</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1022"/>
-        <location filename="../app/MainLayout.qml" line="1062"/>
-        <location filename="../app/MainLayout.qml" line="1114"/>
-        <location filename="../app/MainLayout.qml" line="1249"/>
+        <location filename="../app/MainLayout.qml" line="1056"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
+        <location filename="../app/MainLayout.qml" line="1141"/>
+        <location filename="../app/MainLayout.qml" line="1274"/>
         <source>Options</source>
         <translation>Параметри</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="940"/>
-        <location filename="../app/MainLayout.qml" line="1072"/>
-        <location filename="../app/MainLayout.qml" line="1125"/>
-        <location filename="../app/MainLayout.qml" line="1260"/>
+        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="1101"/>
+        <location filename="../app/MainLayout.qml" line="1152"/>
+        <location filename="../app/MainLayout.qml" line="1292"/>
         <source>Retry</source>
         <translation>Повторити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1176"/>
+        <location filename="../app/MainLayout.qml" line="1203"/>
         <source>Change</source>
         <translation>Змінити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1182"/>
+        <location filename="../app/MainLayout.qml" line="1209"/>
         <source>Toggle</source>
         <translation>Перемкнути</translation>
     </message>
@@ -864,12 +894,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Завантаження…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="437"/>
+        <location filename="../screens/MediaListScreen.qml" line="449"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 записів</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="438"/>
+        <location filename="../screens/MediaListScreen.qml" line="450"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -517,12 +517,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <location filename="../components/LetterJumpModal.qml" line="220"/>
         <source>Loading…</source>
         <translation type="unfinished">正在加载…</translation>
     </message>
     <message>
-        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <location filename="../components/LetterJumpModal.qml" line="220"/>
         <source>No sections</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -426,7 +426,7 @@ Euskara - devilschile2</source>
     <name>GamesScreen</name>
     <message>
         <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="166"/>
+        <location filename="../screens/GamesScreen.qml" line="171"/>
         <source>%1 files</source>
         <translation>%1 个文件</translation>
     </message>
@@ -437,7 +437,7 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../screens/GamesScreen.qml" line="140"/>
-        <location filename="../screens/GamesScreen.qml" line="167"/>
+        <location filename="../screens/GamesScreen.qml" line="172"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -510,6 +510,24 @@ Euskara - devilschile2</source>
     </message>
 </context>
 <context>
+    <name>LetterJumpModal</name>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="32"/>
+        <source>Go to...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <source>Loading…</source>
+        <translation type="unfinished">正在加载…</translation>
+    </message>
+    <message>
+        <location filename="../components/LetterJumpModal.qml" line="211"/>
+        <source>No sections</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LoadingIndicator</name>
     <message>
         <location filename="../components/LoadingIndicator.qml" line="26"/>
@@ -553,138 +571,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1402"/>
+        <location filename="../app/Main.qml" line="1408"/>
         <source>Launch core</source>
         <translation>启动核心</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1408"/>
-        <location filename="../app/Main.qml" line="1647"/>
+        <location filename="../app/Main.qml" line="1414"/>
+        <location filename="../app/Main.qml" line="1653"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1415"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1421"/>
+        <location filename="../app/Main.qml" line="1444"/>
         <source>Update media database</source>
         <translation type="unfinished">更新媒体数据库</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1418"/>
-        <location filename="../app/Main.qml" line="1441"/>
+        <location filename="../app/Main.qml" line="1424"/>
+        <location filename="../app/Main.qml" line="1447"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">抓取元数据</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1423"/>
-        <location filename="../app/Main.qml" line="1432"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1438"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1423"/>
-        <location filename="../app/Main.qml" line="1432"/>
+        <location filename="../app/Main.qml" line="1429"/>
+        <location filename="../app/Main.qml" line="1438"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1450"/>
-        <location filename="../app/Main.qml" line="1485"/>
+        <location filename="../app/Main.qml" line="1456"/>
+        <location filename="../app/Main.qml" line="1491"/>
         <source>Launch game</source>
         <translation>启动游戏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1472"/>
         <source>Remove from favorites</source>
         <translation>从收藏中移除</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1472"/>
         <source>Add to favorites</source>
         <translation>添加到收藏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1471"/>
+        <location filename="../app/Main.qml" line="1477"/>
         <source>Write to NFC token</source>
         <translation>写入 NFC 令牌</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1475"/>
+        <location filename="../app/Main.qml" line="1481"/>
         <source>QR code</source>
         <translation>二维码</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1643"/>
+        <location filename="../app/Main.qml" line="1649"/>
         <source>Default</source>
         <translation type="unfinished">默认</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1643"/>
+        <location filename="../app/Main.qml" line="1649"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1967"/>
+        <location filename="../app/Main.qml" line="1937"/>
+        <source>Go to...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="1940"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2021"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1971"/>
+        <location filename="../app/Main.qml" line="2025"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1985"/>
+        <location filename="../app/Main.qml" line="2039"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1989"/>
+        <location filename="../app/Main.qml" line="2043"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1993"/>
+        <location filename="../app/Main.qml" line="2047"/>
         <source>Retry</source>
         <translation type="unfinished">重试</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1997"/>
+        <location filename="../app/Main.qml" line="2051"/>
         <source>Cancel</source>
         <translation type="unfinished">取消</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2645"/>
+        <location filename="../app/Main.qml" line="2731"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2647"/>
+        <location filename="../app/Main.qml" line="2733"/>
         <source>Loading games…</source>
         <translation>正在加载游戏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2649"/>
+        <location filename="../app/Main.qml" line="2735"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2651"/>
+        <location filename="../app/Main.qml" line="2737"/>
         <source>Loading favorites…</source>
         <translation>正在加载收藏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2653"/>
+        <location filename="../app/Main.qml" line="2739"/>
         <source>Loading recently played…</source>
         <translation>正在加载最近游玩…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2655"/>
+        <location filename="../app/Main.qml" line="2741"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2657"/>
+        <location filename="../app/Main.qml" line="2743"/>
         <source>Loading…</source>
         <translation>正在加载…</translation>
     </message>
@@ -692,166 +720,168 @@ Euskara - devilschile2</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="685"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Writing failed</source>
         <translation>写入失败</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="685"/>
+        <location filename="../app/MainLayout.qml" line="701"/>
         <source>Put a writable card near the reader</source>
         <translation>将可写卡片放在读卡器附近</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="171"/>
+        <location filename="../app/MainLayout.qml" line="172"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="368"/>
+        <location filename="../app/MainLayout.qml" line="382"/>
         <source>Favorites</source>
         <translation type="unfinished">收藏</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="370"/>
+        <location filename="../app/MainLayout.qml" line="384"/>
         <source>Recently Played</source>
         <translation type="unfinished">最近游玩</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="701"/>
+        <location filename="../app/MainLayout.qml" line="717"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="702"/>
+        <location filename="../app/MainLayout.qml" line="718"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="812"/>
+        <location filename="../app/MainLayout.qml" line="828"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="813"/>
+        <location filename="../app/MainLayout.qml" line="829"/>
         <source>Are you sure you want to exit?</source>
         <translation>确定要退出吗？</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="892"/>
-        <location filename="../app/MainLayout.qml" line="966"/>
-        <location filename="../app/MainLayout.qml" line="1012"/>
-        <location filename="../app/MainLayout.qml" line="1049"/>
-        <location filename="../app/MainLayout.qml" line="1099"/>
-        <location filename="../app/MainLayout.qml" line="1148"/>
-        <location filename="../app/MainLayout.qml" line="1167"/>
-        <location filename="../app/MainLayout.qml" line="1234"/>
+        <location filename="../app/MainLayout.qml" line="926"/>
+        <location filename="../app/MainLayout.qml" line="1000"/>
+        <location filename="../app/MainLayout.qml" line="1046"/>
+        <location filename="../app/MainLayout.qml" line="1083"/>
+        <location filename="../app/MainLayout.qml" line="1131"/>
+        <location filename="../app/MainLayout.qml" line="1175"/>
+        <location filename="../app/MainLayout.qml" line="1194"/>
+        <location filename="../app/MainLayout.qml" line="1264"/>
         <source>Move</source>
         <translation>移动</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="896"/>
-        <location filename="../app/MainLayout.qml" line="970"/>
+        <location filename="../app/MainLayout.qml" line="930"/>
+        <location filename="../app/MainLayout.qml" line="1004"/>
         <source>Select</source>
         <translation>选择</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="900"/>
-        <location filename="../app/MainLayout.qml" line="904"/>
-        <location filename="../app/MainLayout.qml" line="918"/>
-        <location filename="../app/MainLayout.qml" line="933"/>
-        <location filename="../app/MainLayout.qml" line="944"/>
+        <location filename="../app/MainLayout.qml" line="934"/>
+        <location filename="../app/MainLayout.qml" line="938"/>
+        <location filename="../app/MainLayout.qml" line="952"/>
+        <location filename="../app/MainLayout.qml" line="967"/>
+        <location filename="../app/MainLayout.qml" line="978"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="911"/>
-        <location filename="../app/MainLayout.qml" line="951"/>
-        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="945"/>
         <location filename="../app/MainLayout.qml" line="985"/>
+        <location filename="../app/MainLayout.qml" line="1008"/>
+        <location filename="../app/MainLayout.qml" line="1019"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="929"/>
+        <location filename="../app/MainLayout.qml" line="963"/>
         <source>Done</source>
         <translation>完成</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="940"/>
-        <location filename="../app/MainLayout.qml" line="1072"/>
-        <location filename="../app/MainLayout.qml" line="1125"/>
-        <location filename="../app/MainLayout.qml" line="1260"/>
+        <location filename="../app/MainLayout.qml" line="974"/>
+        <location filename="../app/MainLayout.qml" line="1101"/>
+        <location filename="../app/MainLayout.qml" line="1152"/>
+        <location filename="../app/MainLayout.qml" line="1292"/>
         <source>Retry</source>
         <translation>重试</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="959"/>
+        <location filename="../app/MainLayout.qml" line="993"/>
         <source>I understand</source>
         <translation>我明白了</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="993"/>
+        <location filename="../app/MainLayout.qml" line="1027"/>
         <source>Start</source>
         <translation>开始</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1016"/>
-        <location filename="../app/MainLayout.qml" line="1059"/>
-        <location filename="../app/MainLayout.qml" line="1109"/>
-        <location filename="../app/MainLayout.qml" line="1153"/>
-        <location filename="../app/MainLayout.qml" line="1244"/>
+        <location filename="../app/MainLayout.qml" line="1050"/>
+        <location filename="../app/MainLayout.qml" line="1088"/>
+        <location filename="../app/MainLayout.qml" line="1136"/>
+        <location filename="../app/MainLayout.qml" line="1180"/>
+        <location filename="../app/MainLayout.qml" line="1269"/>
         <source>Open</source>
         <translation>打开</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1026"/>
+        <location filename="../app/MainLayout.qml" line="1060"/>
         <source>Quit</source>
         <translation>退出</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1035"/>
-        <location filename="../app/MainLayout.qml" line="1065"/>
-        <location filename="../app/MainLayout.qml" line="1076"/>
-        <location filename="../app/MainLayout.qml" line="1091"/>
-        <location filename="../app/MainLayout.qml" line="1118"/>
-        <location filename="../app/MainLayout.qml" line="1129"/>
-        <location filename="../app/MainLayout.qml" line="1141"/>
-        <location filename="../app/MainLayout.qml" line="1157"/>
-        <location filename="../app/MainLayout.qml" line="1191"/>
-        <location filename="../app/MainLayout.qml" line="1209"/>
+        <location filename="../app/MainLayout.qml" line="1069"/>
+        <location filename="../app/MainLayout.qml" line="1094"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
+        <location filename="../app/MainLayout.qml" line="1120"/>
+        <location filename="../app/MainLayout.qml" line="1145"/>
+        <location filename="../app/MainLayout.qml" line="1156"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
+        <location filename="../app/MainLayout.qml" line="1184"/>
         <location filename="../app/MainLayout.qml" line="1218"/>
-        <location filename="../app/MainLayout.qml" line="1253"/>
-        <location filename="../app/MainLayout.qml" line="1264"/>
+        <location filename="../app/MainLayout.qml" line="1236"/>
+        <location filename="../app/MainLayout.qml" line="1245"/>
+        <location filename="../app/MainLayout.qml" line="1285"/>
+        <location filename="../app/MainLayout.qml" line="1296"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1055"/>
-        <location filename="../app/MainLayout.qml" line="1105"/>
-        <location filename="../app/MainLayout.qml" line="1240"/>
-        <source>Page</source>
-        <translation>页面</translation>
+        <location filename="../app/MainLayout.qml" line="1281"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1022"/>
-        <location filename="../app/MainLayout.qml" line="1062"/>
-        <location filename="../app/MainLayout.qml" line="1114"/>
-        <location filename="../app/MainLayout.qml" line="1249"/>
+        <source>Page</source>
+        <translation type="vanished">页面</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="1056"/>
+        <location filename="../app/MainLayout.qml" line="1091"/>
+        <location filename="../app/MainLayout.qml" line="1141"/>
+        <location filename="../app/MainLayout.qml" line="1274"/>
         <source>Options</source>
         <translation>选项</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1176"/>
+        <location filename="../app/MainLayout.qml" line="1203"/>
         <source>Change</source>
         <translation>更改</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1182"/>
+        <location filename="../app/MainLayout.qml" line="1209"/>
         <source>Toggle</source>
         <translation>切换</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1205"/>
+        <location filename="../app/MainLayout.qml" line="1232"/>
         <source>Scroll</source>
         <translation>滚动</translation>
     </message>
@@ -864,12 +894,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">正在加载…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="437"/>
+        <location filename="../screens/MediaListScreen.qml" line="449"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 个条目</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="438"/>
+        <location filename="../screens/MediaListScreen.qml" line="450"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/tests/ui/CMakeLists.txt
+++ b/tests/ui/CMakeLists.txt
@@ -19,6 +19,7 @@ qt_add_qml_module(
         tst_browse_detail_pane.qml
         tst_media_list_titles.qml
         tst_list_picker_modal.qml
+        tst_letter_jump_modal.qml
         tst_motion.qml
         tst_deferred_action.qml
     IMPORTS

--- a/tests/ui/tst_letter_jump_modal.qml
+++ b/tests/ui/tst_letter_jump_modal.qml
@@ -1,0 +1,202 @@
+// Zaparoo Frontend
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+import QtQuick
+import QtTest
+import Zaparoo.Theme
+import Zaparoo.Ui
+
+// `_entries` returns a plain JS array of `{ key, label, count, cursor }`
+// objects. The AOT compiler can't infer the shape, so leaving it untyped trips
+// the compiler category for that one helper. Same pattern the production
+// `entries`-consuming files use (LetterJumpModal.qml, ListPickerModal.qml).
+// qmllint disable compiler
+
+// Direct LetterJumpModal coverage. `nextIndex` is a pure 2D-grid move, so we
+// exercise it (and the accept/close dispatch) on the component itself - no
+// screens involved, staying inside the "test reusable components, not screens"
+// rule.
+TestCase {
+    id: testCase
+    name: "UiLetterJumpModal"
+    when: windowShown
+    width: 640
+    height: 480
+    visible: true
+
+    Component.onCompleted: {
+        Sizing.screenWidth = testCase.width;
+        Sizing.screenHeight = testCase.height;
+    }
+
+    LetterJumpModal {
+        id: grid
+        anchors.fill: parent
+    }
+
+    SignalSpy {
+        id: acceptedSpy
+        target: grid
+        signalName: "accepted"
+    }
+
+    SignalSpy {
+        id: closeSpy
+        target: grid
+        signalName: "closeRequested"
+    }
+
+    function init(): void {
+        Sizing.screenWidth = testCase.width;
+        Sizing.screenHeight = testCase.height;
+        grid.open = false;
+        grid.entries = [];
+        grid.currentIndex = 0;
+        grid.loading = false;
+        acceptedSpy.clear();
+        closeSpy.clear();
+    }
+
+    function _entries(count) {
+        const list = [];
+        for (let i = 0; i < count; ++i)
+            list.push({
+                key: "K" + i,
+                label: "L" + i,
+                count: i,
+                cursor: "c" + i,
+                // Distinct from count so the test proves the modal emits the
+                // server-supplied offset, not a client-side count sum.
+                offset: i * 100
+            });
+        return list;
+    }
+
+    // ── nextIndex: pure 2D grid move ──────────────────────────────────────────
+
+    function test_next_index_left_right_clamps_within_bounds(): void {
+        // 8 cells, 4 columns. right advances; right at the end stays.
+        compare(grid.nextIndex("right", 0, 8, 4), 1);
+        compare(grid.nextIndex("right", 7, 8, 4), 7);
+        compare(grid.nextIndex("left", 3, 8, 4), 2);
+        compare(grid.nextIndex("left", 0, 8, 4), 0);
+    }
+
+    function test_next_index_up_down_step_by_columns(): void {
+        // 8 cells, 4 columns → two full rows.
+        compare(grid.nextIndex("down", 1, 8, 4), 5);
+        compare(grid.nextIndex("up", 5, 8, 4), 1);
+        // up from the top row stays put.
+        compare(grid.nextIndex("up", 2, 8, 4), 2);
+    }
+
+    function test_next_index_down_lands_on_last_cell_from_partial_row(): void {
+        // 6 cells, 4 columns → row 0 = 0..3, row 1 = 4..5 (partial).
+        // down from index 2 would be 6 (out of range) → clamp to last cell 5.
+        compare(grid.nextIndex("down", 2, 6, 4), 5);
+        // down from the last row stays put.
+        compare(grid.nextIndex("down", 5, 6, 4), 5);
+    }
+
+    function test_next_index_empty_returns_zero(): void {
+        compare(grid.nextIndex("down", 0, 0, 4), 0);
+        compare(grid.nextIndex("right", 0, 0, 4), 0);
+    }
+
+    // ── _fitColumns: area-bounded column packing ──────────────────────────────
+
+    function test_fit_columns_zero_returns_one(): void {
+        compare(grid._fitColumns(0, 1000, 500, 10), 1);
+    }
+
+    function test_fit_columns_few_buckets_single_row(): void {
+        // A handful of buckets in a wide, short area pack into one row (more
+        // rows would only shrink the cells), so columns == bucket count.
+        const cols = grid._fitColumns(5, 1200, 120, 10);
+        compare(cols, 5);
+        compare(Math.ceil(5 / cols), 1);
+    }
+
+    function test_fit_columns_prefers_larger_cells_in_tall_area(): void {
+        // In a tall area, packing into multiple rows yields larger square cells
+        // than a single wide row, so the helper picks fewer columns.
+        const cols = grid._fitColumns(5, 1000, 500, 10);
+        verify(cols < 5);
+        verify(Math.ceil(5 / cols) > 1);
+    }
+
+    function test_fit_columns_full_alphabet_fits_height(): void {
+        // 28 buckets (#, 0-9, A-Z) in a typical area must not pick so few
+        // columns that the rows overflow the height budget. Verify the chosen
+        // layout's grid height fits within availH, and it isn't a single row.
+        const count = 28;
+        const availW = 1000;
+        const availH = 500;
+        const gap = 10;
+        const cols = grid._fitColumns(count, availW, availH, gap);
+        verify(cols > 1);
+        const rows = Math.ceil(count / cols);
+        const cellH = (availH - (rows - 1) * gap) / rows;
+        const cellW = (availW - (cols - 1) * gap) / cols;
+        const cell = Math.min(cellW, cellH);
+        // The packed grid (square cells) fits inside both dimensions.
+        verify(rows * cell + (rows - 1) * gap <= availH + 1);
+        verify(cols * cell + (cols - 1) * gap <= availW + 1);
+    }
+
+    // ── handleAction dispatch ────────────────────────────────────────────────
+
+    function test_handle_action_accept_emits_item_offset(): void {
+        // _entries(n) sets each bucket's offset to index*100. The modal emits
+        // the selected bucket's offset verbatim, so picking index 3 emits 300.
+        grid.entries = _entries(6);
+        grid.open = true;
+        grid.currentIndex = 3;
+        grid.handleAction("accept");
+        // accepted() is deferred via DeferredAction so the push-in animation
+        // completes first. tryCompare polls until it fires.
+        tryCompare(acceptedSpy, "count", 1);
+        compare(acceptedSpy.signalArguments[0][0], 300);
+    }
+
+    function test_offset_for_index_reads_server_offset(): void {
+        // Offsets are index*100; the helper returns the entry's offset field
+        // directly (no client-side summing), and 0 for out-of-range.
+        grid.entries = _entries(5);
+        compare(grid._offsetForIndex(0), 0);
+        compare(grid._offsetForIndex(3), 300);
+        compare(grid._offsetForIndex(4), 400);
+        compare(grid._offsetForIndex(5), 0);
+    }
+
+    function test_handle_action_accept_with_empty_entries_no_signal(): void {
+        grid.entries = [];
+        grid.open = true;
+        grid.currentIndex = 0;
+        grid.handleAction("accept");
+        compare(acceptedSpy.count, 0);
+    }
+
+    function test_handle_action_cancel_emits_close(): void {
+        grid.entries = _entries(4);
+        grid.open = true;
+        grid.handleAction("cancel");
+        compare(closeSpy.count, 1);
+    }
+
+    function test_handle_action_page_menu_emits_close(): void {
+        // West again while the grid is open closes it (page-scoped toggle).
+        grid.entries = _entries(4);
+        grid.open = true;
+        grid.handleAction("page_menu");
+        compare(closeSpy.count, 1);
+    }
+
+    function test_open_resets_index_to_zero(): void {
+        grid.entries = _entries(6);
+        grid.currentIndex = 4;
+        grid.open = true;
+        compare(grid.currentIndex, 0);
+    }
+}

--- a/tests/ui/tst_paged_grid.qml
+++ b/tests/ui/tst_paged_grid.qml
@@ -616,4 +616,134 @@ TestCase {
         compare(grid.hasPendingTarget, false, "commit must clear hasPendingTarget");
         _resetPartialLoadState();
     }
+
+    // ── jumpToIndex (jump-to-letter position jump) ──────────────────────
+
+    function test_jumpToIndex_loaded_target_lands_immediately(): void {
+        // Fully loaded — a jump to any in-range index lands at once (the
+        // backward-jump-to-already-loaded-letter case).
+        fillModel(60);
+        grid.setCurrentIndexImmediate(0);
+        compare(grid.jumpToIndex(37), true);
+        compare(grid.currentIndex, 37);
+    }
+
+    function test_jumpToIndex_clamps_to_last_item(): void {
+        fillModel(20);
+        compare(grid.jumpToIndex(999), true);
+        compare(grid.currentIndex, 19);
+    }
+
+    function test_jumpToIndex_unloaded_stashes_absolute_index(): void {
+        // 24/60 loaded. Jump to index 50 (unloaded): stash the ABSOLUTE
+        // target (not a page/row/col decomposition), fire loadMore, leave
+        // selection put. The page-wrap channel must stay clear so the two
+        // can't be confused at commit time.
+        _setupPartialLoad(24, 60);
+        loadMoreSpy.clear();
+        compare(grid.jumpToIndex(50), false);
+        compare(grid.currentIndex, 0, "must not move while loading");
+        compare(grid._pendingTargetIndex, 50, "stash the exact absolute target");
+        compare(grid._pendingTargetPage, -1, "page-wrap channel stays clear for a jump");
+        compare(grid.hasPendingJump, true);
+        verify(loadMoreSpy.count >= 1, "expected loadMoreRequested to fire");
+        _resetPartialLoadState();
+    }
+
+    function test_jumpToIndex_commits_exact_index_when_loaded(): void {
+        // The pending jump commits on the exact absolute target index once
+        // the data has loaded that far — never a page-aligned slot, never a
+        // page early.
+        _setupPartialLoad(24, 60);
+        compare(grid.jumpToIndex(50), false);
+        compare(grid._pendingTargetIndex, 50);
+        for (let i = 24; i < 60; i++)
+            model.append({
+                "name": "item-" + i,
+                "coverKey": "",
+                "favorite": 0
+            });
+        tryCompare(grid, "itemCount", 60);
+        compare(grid.currentIndex, 50, "lands on the exact target, mid-page");
+        compare(grid._pendingTargetIndex, -1, "pending jump clears after commit");
+        compare(grid.hasPendingJump, false);
+        _resetPartialLoadState();
+    }
+
+    function test_jumpToIndex_commits_on_first_crossing_not_a_page_early(): void {
+        // Grow the model one short of the target, then exactly across it.
+        // The commit must wait until itemCount actually passes the target and
+        // then land on the target itself — not settle a page (or any amount)
+        // early while the intervening rows trickle in.
+        _setupPartialLoad(24, 60);
+        compare(grid.jumpToIndex(50), false);
+        // Up to 50 rows loaded => target index 50 still not present
+        // (indices 0..49). Must remain pending, selection unmoved.
+        for (let i = 24; i < 50; i++)
+            model.append({
+                "name": "item-" + i,
+                "coverKey": "",
+                "favorite": 0
+            });
+        tryCompare(grid, "itemCount", 50);
+        compare(grid.currentIndex, 0, "target index 50 not loaded yet — stay parked");
+        compare(grid._pendingTargetIndex, 50);
+        // One more row => index 50 exists; commit lands exactly there.
+        model.append({
+            "name": "item-50",
+            "coverKey": "",
+            "favorite": 0
+        });
+        tryCompare(grid, "itemCount", 51);
+        compare(grid.currentIndex, 50);
+        compare(grid._pendingTargetIndex, -1);
+        _resetPartialLoadState();
+    }
+
+    function test_jumpToIndex_truncated_dataset_lands_on_nearest_loaded(): void {
+        // Jump to 50, but the dataset turns out shorter: only 45 rows ever
+        // arrive and the model declares no more pages. Settle on the nearest
+        // loaded item (44), never a full page back to a page boundary.
+        _setupPartialLoad(24, 60);
+        compare(grid.jumpToIndex(50), false);
+        compare(grid._pendingTargetIndex, 50);
+        for (let i = 24; i < 45; i++)
+            model.append({
+                "name": "item-" + i,
+                "coverKey": "",
+                "favorite": 0
+            });
+        tryCompare(grid, "itemCount", 45);
+        compare(grid.currentIndex, 0, "still pending — target 50 not loaded");
+        grid.hasMorePages = false;
+        compare(grid.currentIndex, 44, "settle on nearest loaded item, not a page early");
+        compare(grid._pendingTargetIndex, -1);
+        _resetPartialLoadState();
+    }
+
+    function test_jumpToIndex_pending_cleared_by_directional_move(): void {
+        // A pending jump is the user's last expressed intent only until they
+        // press a direction; a successful move must drop it.
+        fillModel(60);
+        grid.hasMorePages = true;
+        grid.totalItemsOverride = 120;
+        grid.setCurrentIndexImmediate(0);
+        compare(grid.jumpToIndex(100), false);
+        compare(grid.hasPendingJump, true);
+        compare(grid.moveSelection(1, 0), true, "right step within row succeeds");
+        compare(grid.hasPendingJump, false, "directional move clears the pending jump");
+        compare(grid._pendingTargetIndex, -1);
+        _resetPartialLoadState();
+    }
+
+    function test_hasPendingJump_false_for_page_wrap_target(): void {
+        // A page-wrap (pageBy / vertical wrap) onto an unloaded page arms
+        // hasPendingTarget but NOT hasPendingJump — only true letter jumps
+        // bulk-load.
+        _setupPartialLoad(24, 60);
+        compare(grid.moveSelection(0, -1), false);
+        compare(grid.hasPendingTarget, true, "page-wrap arms the generic pending flag");
+        compare(grid.hasPendingJump, false, "page-wrap is not a jump");
+        _resetPartialLoadState();
+    }
 }


### PR DESCRIPTION
## Summary

Adds a position-jump **go to letter** picker to the games grid, reached through a new list-scoped West-button menu (**View**), plus a cosmetic/UX pass on the surrounding browse chrome.

### Core client / models
- New `media.browse.index` client method with `MediaBrowseIndexParams` and `LetterIndexSection` (opaque `key`/`label`/`offset` so a future locale-aware scheme needs no client change).
- New `page_menu` input action (West button, defaults to Space).

### Grid + picker
- `LetterJumpModal`: software-safe grid picker on the shared `Modal` shell; cells show the bucket label and count.
- `PagedGrid` carries an absolute target index so a jump lands **exactly** on the target item (no more landing a page early).
- Jump-optimized fetch: sizes the request to the gap-to-target and pauses cover fetching during the bulk load, so the first jump is no longer a multi-second, cover-storm-contended trickle.

### UI/UX pass
- West menu is **View** (the list-scoped counterpart to item-scoped **Options**); first entry is **Go to...**.
- CRT native path deepens the press-in scale (`Motion`) so the push-in reads at 240p; HD unchanged.
- Help bar folds the L/R page cue into the Move cue across all grid screens (`[L][R][Dpad] Move`, shoulders shown only with a 2nd page).
- Letter and count centered within each jump cell.

## Tests
- `tst_letter_jump_modal.qml` (fit-columns / next-index pure helpers) and added `PagedGrid` jump cases.
- Gates green locally: `just test` (530 Rust + UI), `just test-qml` (100%), `just lint` (0).
- Translation catalogs regenerated.

## Verification (on device / desktop)
1. West menu over a grid: title **View**, entry **Go to...**, help bar `[X] Options  [Y] View`.
2. Cold-enter a large folder, jump to a mid letter: lands fast and exactly on the target's first item.
3. Jump grid cells: letter + count both centered (check a wide count like `830`).
4. CRT mode: push-in on tiles/rows/modal buttons is clearly visible; HD unchanged.
5. `Move` cue shows/hides L/R glyphs by page count on Games, Systems, Favorites, Recents.

> Note: the local `media.db` (342 MB Arcade test database used for replaying Core queries) is intentionally **not** included; consider gitignoring it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Go to…” letter-jump modal for Games list navigation via the new View menu entry.
  * Displays available letter sections for the current scope and supports loading/empty states in the modal.
  * Updated navigation cues so shoulder buttons act as page-jump shortcuts when multiple pages exist.
* **Bug Fixes**
  * Improved jump pagination handling to ensure selection updates reliably during rapid browsing and prevents loading/covers from getting stuck.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->