### PR TITLE
feat: handle launchable systems and surface the Other category

### DIFF
--- a/resources/images/categories/Other.svg
+++ b/resources/images/categories/Other.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-ellipsis-icon lucide-ellipsis"><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/></svg>

--- a/resources/images/categories/README.txt
+++ b/resources/images/categories/README.txt
@@ -13,5 +13,8 @@ Media.svg is bundled ahead of the Media screen (tracked in #21). The
 "Media" category is currently filtered from the carousel via
 HIDDEN_CATEGORIES in models/categories.rs.
 
-Iconography: Handheld is from streamlinehq.com; the rest are from iconoir.com.
-See src/LICENSES/ for upstream attribution.
+Other.svg is the icon for Core's synthesized "Other" category, which holds
+launchables (launch-only virtual systems) and other uncategorized systems.
+
+Iconography: Handheld is from streamlinehq.com; Other is from lucide.dev;
+the rest are from iconoir.com. See src/LICENSES/ for upstream attribution.

--- a/rust/frontend/src/models/categories.rs
+++ b/rust/frontend/src/models/categories.rs
@@ -15,11 +15,12 @@ const NAME_ROLE: i32 = 256 + 1; // Qt::UserRole + 1
 const COVER_KEY_ROLE: i32 = 256 + 2;
 const HIDDEN_ROLE: i32 = 256 + 3;
 
-// Categories Core surfaces but the frontend doesn't expose. `Other` is
-// the synthesized bucket for systems with no upstream category and adds
-// no value in the UI; `Media` is reserved for non-game content the
-// frontend doesn't have a screen for yet. Tracked in #21.
-const HIDDEN_CATEGORIES: &[&str] = &["Other", "Media"];
+// Categories Core surfaces but the frontend doesn't expose. `Media` is
+// reserved for non-game content the frontend doesn't have a screen for
+// yet (tracked in #21). `Other` — the synthesized bucket for systems with
+// no upstream category — is now surfaced: Core's launchables (launch-only
+// virtual systems) land there, so it carries real, launchable content.
+const HIDDEN_CATEGORIES: &[&str] = &["Media"];
 
 #[derive(Default)]
 pub struct CategoriesModelRust {
@@ -327,7 +328,7 @@ mod tests {
     }
 
     #[test]
-    fn other_and_media_are_filtered_case_insensitively() {
+    fn media_is_filtered_case_insensitively_but_other_is_surfaced() {
         let raw = vec![
             "Arcade".to_string(),
             "Other".to_string(),
@@ -335,8 +336,9 @@ mod tests {
             "Consoles".to_string(),
         ];
         let (names, flags) = visible_categories(&raw, &[], false);
-        assert_eq!(names, vec!["Arcade", "Consoles"]);
-        assert_eq!(flags, vec![false, false]);
+        // `media` is dropped; `Other` now passes through (it holds launchables).
+        assert_eq!(names, vec!["Arcade", "Other", "Consoles"]);
+        assert_eq!(flags, vec![false, false, false]);
     }
 
     #[test]
@@ -383,14 +385,14 @@ mod tests {
 
     #[test]
     fn builtin_hidden_categories_never_user_unhideable() {
-        // Even if "Other" somehow ends up in user_hidden (which should never
+        // Even if "Media" somehow ends up in user_hidden (which should never
         // happen since it's never surfaced as a tile), the builtin filter
         // still drops it before we check user_hidden.
-        let raw = vec!["Arcade".to_string(), "Other".to_string()];
-        let user_hidden = vec!["Other".to_string(), "Media".to_string()];
+        let raw = vec!["Arcade".to_string(), "Media".to_string()];
+        let user_hidden = vec!["Media".to_string()];
         let (names_off, _) = visible_categories(&raw, &user_hidden, false);
         let (names_on, flags_on) = visible_categories(&raw, &user_hidden, true);
-        // Other is always gone, regardless of show_hidden.
+        // Media is always gone, regardless of show_hidden.
         assert_eq!(names_off, vec!["Arcade"]);
         assert_eq!(names_on, vec!["Arcade"]);
         assert_eq!(flags_on, vec![false]);

--- a/rust/frontend/src/models/systems.rs
+++ b/rust/frontend/src/models/systems.rs
@@ -50,6 +50,28 @@ pub struct SystemInfo {
     /// True when the user has hidden this system and `show_hidden` is on.
     /// The tile renders dimmed with a "Hidden" badge.
     pub hidden: bool,
+    /// `zaparoo://...` launch URI for launch-only "virtual" systems
+    /// (Core's launchables). Empty for normal systems. When present the
+    /// system is launched by running this script directly instead of
+    /// being browsed via `media.browse`.
+    pub zap_script: String,
+}
+
+/// A launch-only system carries a `zaparoo://...` launch URI instead of
+/// browsable media. Trimmed so whitespace-only never reads as launchable.
+fn is_launchable(system: &SystemInfo) -> bool {
+    !system.zap_script.trim().is_empty()
+}
+
+/// `ZapScript` to run (or write to a card) for a system. Launchables run
+/// their own `zaparoo://...` URI; normal systems use the `**launch.system`
+/// directive that launches the system's default core/launcher.
+fn launch_text_for(system: &SystemInfo) -> String {
+    if is_launchable(system) {
+        system.zap_script.clone()
+    } else {
+        format!("**launch.system:{}", system.id)
+    }
 }
 
 #[derive(Default)]
@@ -141,6 +163,15 @@ pub mod ffi {
 
         #[qinvokable]
         fn launch_text_at(self: &SystemsModel, index: i32) -> QString;
+
+        /// True when the system with `system_id` is a launch-only (virtual)
+        /// system. The router launches it directly rather than browsing.
+        #[qinvokable]
+        fn is_launchable_system(self: &SystemsModel, system_id: &QString) -> bool;
+
+        /// Run the launch script for the launch-only system `system_id`.
+        #[qinvokable]
+        fn launch_system_id(self: Pin<&mut SystemsModel>, system_id: &QString);
 
         #[qinvokable]
         fn cancel_card_write(self: Pin<&mut SystemsModel>);
@@ -270,6 +301,7 @@ fn rows_for_category(
                     release_date: s.release_date,
                     manufacturer: s.manufacturer,
                     hidden: is_hidden,
+                    zap_script: s.zap_script,
                 })
             })
             .collect()
@@ -521,7 +553,7 @@ impl ffi::SystemsModel {
         if system.id.is_empty() {
             return QString::default();
         }
-        QString::from(format!("**launch.system:{}", system.id).as_str())
+        QString::from(launch_text_for(system).as_str())
     }
 
     fn write_card_at(mut self: Pin<&mut Self>, index: i32) {
@@ -538,7 +570,7 @@ impl ffi::SystemsModel {
             self.as_mut().set_card_write_pending(false);
             return;
         }
-        let text = format!("**launch.system:{}", system.id);
+        let text = launch_text_for(system);
         let name = system.name.clone();
         let store = global_store();
         let seq = self.rust().card_write_seq.clone();
@@ -575,7 +607,39 @@ impl ffi::SystemsModel {
         if system.id.is_empty() {
             return;
         }
-        let text = format!("**launch.system:{}", system.id);
+        let text = launch_text_for(system);
+        let name = system.name.clone();
+        let store = global_store();
+        global_handle().spawn(async move {
+            if let Err(e) = store.run_mutation::<RunMutation>(RunParams { text }).await {
+                warn!("run failed for {name}: {}", e.message);
+            }
+        });
+    }
+
+    /// True when the system with `system_id` is a launch-only (virtual)
+    /// system carrying a `zaparoo://...` script. The router uses this to
+    /// launch the system directly instead of routing into a games browse.
+    fn is_launchable_system(&self, system_id: &QString) -> bool {
+        let id = system_id.to_string();
+        if id.is_empty() {
+            return false;
+        }
+        self.systems
+            .iter()
+            .find(|s| s.id == id)
+            .is_some_and(is_launchable)
+    }
+
+    /// Run the launch script for the system with `system_id`. Used by the
+    /// router for launchable systems, where selection is an action rather
+    /// than navigation; lookup is by id since the router has no index.
+    fn launch_system_id(self: Pin<&mut Self>, system_id: &QString) {
+        let id = system_id.to_string();
+        let Some(system) = self.systems.iter().find(|s| s.id == id) else {
+            return;
+        };
+        let text = launch_text_for(system);
         let name = system.name.clone();
         let store = global_store();
         global_handle().spawn(async move {
@@ -640,6 +704,11 @@ impl ffi::SystemsModel {
         let mut list = QStringList::default();
         if let Some(ref c) = self.rust().last_ready {
             for sys in c.systems_by_category(&cat) {
+                // Skip launch-only systems: they have no indexed media, so
+                // category-level index/scrape must never target them.
+                if !sys.zap_script.trim().is_empty() {
+                    continue;
+                }
                 list.append(QString::from(sys.id.as_str()));
             }
         }
@@ -669,7 +738,11 @@ fn detail_tags_for_system(system: &SystemInfo) -> String {
                 .to_string(),
         ),
     ];
+    // Drop rows with no value so a system missing metadata (common for
+    // launch-only systems, which carry no releaseDate/manufacturer) shows
+    // only the fields it actually has rather than blank detail rows.
     rows.into_iter()
+        .filter(|(_, value)| !value.is_empty())
         .map(|(label, value)| format!("{label}\t{value}"))
         .collect::<Vec<_>>()
         .join("\n")
@@ -685,7 +758,8 @@ mod tests {
     )]
 
     use super::{
-        detail_tags_for_system, position_of_system_id, project, rows_for_category, SystemInfo,
+        detail_tags_for_system, is_launchable, launch_text_for, position_of_system_id, project,
+        rows_for_category, SystemInfo,
     };
     use crate::system_region::Region;
     use zaparoo_core::media_types::SystemInfo as MediaSystemInfo;
@@ -851,6 +925,7 @@ mod tests {
             release_date: None,
             manufacturer: None,
             hidden: false,
+            zap_script: String::new(),
         }
     }
 
@@ -881,5 +956,60 @@ mod tests {
     fn position_of_system_id_missing_returns_minus_one() {
         let systems = vec![local_sys("NES")];
         assert_eq!(position_of_system_id(&systems, "Missing"), -1);
+    }
+
+    #[test]
+    fn detail_tags_for_system_omits_empty_metadata_rows() {
+        // A launch-only system typically has no release date or
+        // manufacturer; those rows must be dropped, not rendered blank.
+        let system = local_sys("Chess");
+        assert_eq!(detail_tags_for_system(&system), "Category\tConsoles");
+    }
+
+    #[test]
+    fn detail_tags_for_system_keeps_populated_rows_only() {
+        let mut system = local_sys("NES");
+        system.manufacturer = Some("Nintendo".into());
+        // Release date stays None -> its row is dropped, Manufacturer kept.
+        assert_eq!(
+            detail_tags_for_system(&system),
+            "Category\tConsoles\nManufacturer\tNintendo"
+        );
+    }
+
+    #[test]
+    fn launchable_detection_ignores_whitespace_only_script() {
+        let mut system = local_sys("NES");
+        assert!(!is_launchable(&system));
+        system.zap_script = "   ".into();
+        assert!(!is_launchable(&system));
+        system.zap_script = "zaparoo://abc/Chess".into();
+        assert!(is_launchable(&system));
+    }
+
+    #[test]
+    fn launch_text_uses_zap_script_for_launchables() {
+        let mut system = local_sys("Chess");
+        system.zap_script = "zaparoo://abc/Chess".into();
+        assert_eq!(launch_text_for(&system), "zaparoo://abc/Chess");
+    }
+
+    #[test]
+    fn launch_text_uses_launch_system_directive_for_normal_systems() {
+        let system = local_sys("NES");
+        assert_eq!(launch_text_for(&system), "**launch.system:NES");
+    }
+
+    #[test]
+    fn rows_for_category_propagates_zap_script() {
+        // Launchables land in the synthesized "Other" bucket, which matches
+        // systems with an empty upstream category.
+        let mut chess = sys("chess", "Chess", "");
+        chess.zap_script = "zaparoo://abc/Chess".into();
+        let catalog = catalog_with(vec![chess]);
+        let rows = rows_for_category(Some(&catalog), "Other", &[], false, Region::Us);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].zap_script, "zaparoo://abc/Chess");
+        assert!(is_launchable(&rows[0]));
     }
 }

--- a/rust/zaparoo-core/src/endpoints/snapshots/zaparoo_core__endpoints__catalog__tests__shape_catalog_snapshot_matches_fixture.snap
+++ b/rust/zaparoo-core/src/endpoints/snapshots/zaparoo_core__endpoints__catalog__tests__shape_catalog_snapshot_matches_fixture.snap
@@ -11,6 +11,7 @@ CatalogData {
             category: "Handhelds",
             release_date: None,
             manufacturer: None,
+            zap_script: "",
         },
         SystemInfo {
             id: "MAME",
@@ -18,6 +19,7 @@ CatalogData {
             category: "arcade",
             release_date: None,
             manufacturer: None,
+            zap_script: "",
         },
         SystemInfo {
             id: "NES",
@@ -25,6 +27,7 @@ CatalogData {
             category: "Consoles",
             release_date: None,
             manufacturer: None,
+            zap_script: "",
         },
         SystemInfo {
             id: "odd",
@@ -32,6 +35,7 @@ CatalogData {
             category: "",
             release_date: None,
             manufacturer: None,
+            zap_script: "",
         },
         SystemInfo {
             id: "SNES",
@@ -39,6 +43,7 @@ CatalogData {
             category: "Consoles",
             release_date: None,
             manufacturer: None,
+            zap_script: "",
         },
     ],
     categories: [

--- a/rust/zaparoo-core/src/media_types.rs
+++ b/rust/zaparoo-core/src/media_types.rs
@@ -35,6 +35,12 @@ pub struct SystemInfo {
     pub release_date: Option<String>,
     #[serde(default)]
     pub manufacturer: Option<String>,
+    /// `zaparoo://...` launch URI for launch-only "virtual" systems
+    /// (Core's launchables). Empty for normal indexed systems. When
+    /// present, the system must be launched by running this script
+    /// directly rather than used as a key for `media.browse`/search/tags.
+    #[serde(default)]
+    pub zap_script: String,
 }
 
 /// Parameters for `media.search`. Mirrors Core's `SearchParams`
@@ -127,6 +133,10 @@ pub struct System {
     pub release_date: Option<String>,
     #[serde(default)]
     pub manufacturer: Option<String>,
+    /// `zaparoo://...` launch URI for launch-only systems; mirrors
+    /// Core's `System.zapScript`. Empty for normal indexed systems.
+    #[serde(default)]
+    pub zap_script: String,
 }
 
 /// Trimmed `system` sub-object returned inside `media.meta`'s title
@@ -1214,6 +1224,19 @@ mod tests {
         let json = r#"{"systems":[{"id":"x","name":"X"}]}"#;
         let result: SystemsResult = serde_json::from_str(json).expect("parse");
         assert_eq!(result.systems[0].category, "");
+    }
+
+    #[test]
+    fn system_info_parses_zap_script_for_launchables() {
+        let json = r#"{"systems":[
+            {"id":"NES","name":"Nintendo","category":"Console"},
+            {"id":"abc","name":"Chess","category":"Other","zapScript":"zaparoo://abc/Chess"}
+        ]}"#;
+        let result: SystemsResult = serde_json::from_str(json).expect("parse");
+        // Normal system: no zapScript on the wire -> empty.
+        assert_eq!(result.systems[0].zap_script, "");
+        // Launchable virtual system carries its launch URI.
+        assert_eq!(result.systems[1].zap_script, "zaparoo://abc/Chess");
     }
 
     #[test]

--- a/rust/zaparoo-core/src/systems_catalog.rs
+++ b/rust/zaparoo-core/src/systems_catalog.rs
@@ -23,7 +23,12 @@ impl CatalogData {
             .iter()
             .filter(|s| {
                 if is_other {
-                    s.category.is_empty()
+                    // "Other" is the catch-all bucket: it collects both
+                    // systems with no upstream category (synthesized into
+                    // "Other" by `derive_categories`) and systems Core
+                    // tags with a literal "Other" category, such as the
+                    // MiSTer launchables (`misterLaunchableCategoryOther`).
+                    s.category.is_empty() || s.category.eq_ignore_ascii_case("Other")
                 } else {
                     s.category.eq_ignore_ascii_case(category)
                 }
@@ -64,18 +69,23 @@ mod tests {
     }
 
     #[test]
-    fn systems_by_category_other_selects_uncategorised() {
+    fn systems_by_category_other_selects_uncategorised_and_literal_other() {
         let data = CatalogData {
             systems: vec![
                 sys("a", "A", ""),
                 sys("b", "B", "Consoles"),
                 sys("c", "C", ""),
+                // A launchable Core tags with a literal "Other" category.
+                sys("chess", "Chess", "Other"),
             ],
             categories: vec!["Consoles".into(), "Other".into()],
         };
         let other = data.systems_by_category("Other");
-        assert_eq!(other.len(), 2);
-        assert!(other.iter().all(|s| s.category.is_empty()));
+        assert_eq!(other.len(), 3);
+        assert!(other
+            .iter()
+            .all(|s| s.category.is_empty() || s.category.eq_ignore_ascii_case("Other")));
+        assert!(other.iter().any(|s| s.id == "chess"));
     }
 
     #[test]

--- a/src/LICENSES/Lucide-ATTRIBUTION.txt
+++ b/src/LICENSES/Lucide-ATTRIBUTION.txt
@@ -1,7 +1,8 @@
 Lucide Attribution
 ==================
 
-This software bundles UI glyphs under resources/images/icons/ derived
+This software bundles UI glyphs under resources/images/icons/,
+resources/images/status/, and resources/images/categories/ derived
 from:
 
   Lucide
@@ -21,6 +22,7 @@ attribute on the SVG root):
   resources/images/icons/History.svg
   resources/images/icons/PlayOutline.svg
   resources/images/status/NFC.svg
+  resources/images/categories/Other.svg
 
 The ISC license text from the upstream project follows.
 

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -1293,6 +1293,13 @@ MainLayout {
                     Browse.SystemsModel.set_category(cat);
                 return;
             }
+            // Launch-only (virtual) systems carry a zapScript and have no
+            // browsable media. Run them directly and stay on the systems
+            // grid; never route into an empty games browse.
+            if (Browse.SystemsModel.is_launchable_system(systemId)) {
+                Browse.SystemsModel.launch_system_id(systemId);
+                return;
+            }
             root._navigateFromSystems(systemId);
         }
         function onRequestHubScreen(): void {
@@ -1408,14 +1415,17 @@ MainLayout {
                     label: qsTr("Launch core")
                 }
             ];
-            if (!Browse.SystemLaunchers.loading && Browse.SystemLaunchers.error_message === "" && Browse.SystemLaunchers.launcher_count_for_system(systemId) > 0) {
+            // Launch-only (virtual) systems have no media and no launcher
+            // choice, so omit launcher/index/scrape actions for them.
+            const launchable = Browse.SystemsModel.is_launchable_system(systemId);
+            if (!launchable && !Browse.SystemLaunchers.loading && Browse.SystemLaunchers.error_message === "" && Browse.SystemLaunchers.launcher_count_for_system(systemId) > 0) {
                 entries.push({
                     id: "change_launcher",
                     label: qsTr("Change launcher")
                 });
             }
             const mediaBusy = Browse.MediaStatus.indexing || Browse.MediaStatus.optimizing || Browse.MediaStatus.scraping;
-            if (!mediaBusy) {
+            if (!launchable && !mediaBusy) {
                 entries.push({
                     id: "index_system",
                     label: qsTr("Update media database")

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -571,148 +571,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1408"/>
+        <location filename="../app/Main.qml" line="1415"/>
         <source>Launch core</source>
         <translation>تشغيل النواة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1414"/>
-        <location filename="../app/Main.qml" line="1653"/>
+        <location filename="../app/Main.qml" line="1424"/>
+        <location filename="../app/Main.qml" line="1663"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1421"/>
-        <location filename="../app/Main.qml" line="1444"/>
+        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1454"/>
         <source>Update media database</source>
         <translation type="unfinished">تحديث قاعدة بيانات الوسائط</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1447"/>
+        <location filename="../app/Main.qml" line="1434"/>
+        <location filename="../app/Main.qml" line="1457"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">استخراج البيانات الوصفية</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1429"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1439"/>
+        <location filename="../app/Main.qml" line="1448"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1429"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1439"/>
+        <location filename="../app/Main.qml" line="1448"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1456"/>
-        <location filename="../app/Main.qml" line="1491"/>
+        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1501"/>
         <source>Launch game</source>
         <translation>تشغيل اللعبة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1482"/>
         <source>Remove from favorites</source>
         <translation>إزالة من المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1482"/>
         <source>Add to favorites</source>
         <translation>أضف إلى المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1477"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Write to NFC token</source>
         <translation>الكتابة إلى رمز NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1481"/>
+        <location filename="../app/Main.qml" line="1491"/>
         <source>QR code</source>
         <translation>رمز QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1649"/>
+        <location filename="../app/Main.qml" line="1659"/>
         <source>Default</source>
         <translation type="unfinished">افتراضي</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1649"/>
+        <location filename="../app/Main.qml" line="1659"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1937"/>
+        <location filename="../app/Main.qml" line="1947"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1940"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2021"/>
+        <location filename="../app/Main.qml" line="2031"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2025"/>
+        <location filename="../app/Main.qml" line="2035"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2039"/>
+        <location filename="../app/Main.qml" line="2049"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2043"/>
+        <location filename="../app/Main.qml" line="2053"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2047"/>
+        <location filename="../app/Main.qml" line="2057"/>
         <source>Retry</source>
         <translation type="unfinished">إعادة المحاولة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2051"/>
+        <location filename="../app/Main.qml" line="2061"/>
         <source>Cancel</source>
         <translation type="unfinished">إلغاء</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2731"/>
+        <location filename="../app/Main.qml" line="2741"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2733"/>
+        <location filename="../app/Main.qml" line="2743"/>
         <source>Loading games…</source>
         <translation>جارٍ تحميل الألعاب…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2735"/>
+        <location filename="../app/Main.qml" line="2745"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2737"/>
+        <location filename="../app/Main.qml" line="2747"/>
         <source>Loading favorites…</source>
         <translation>جارٍ تحميل المفضلة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2739"/>
+        <location filename="../app/Main.qml" line="2749"/>
         <source>Loading recently played…</source>
         <translation>جارٍ تحميل آخر ما تم لعبه…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2741"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2743"/>
+        <location filename="../app/Main.qml" line="2753"/>
         <source>Loading…</source>
         <translation>جارٍ التحميل…</translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -571,148 +571,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1408"/>
+        <location filename="../app/Main.qml" line="1415"/>
         <source>Launch core</source>
         <translation>Core starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1414"/>
-        <location filename="../app/Main.qml" line="1653"/>
+        <location filename="../app/Main.qml" line="1424"/>
+        <location filename="../app/Main.qml" line="1663"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1482"/>
         <source>Remove from favorites</source>
         <translation>Aus Favoriten entfernen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1482"/>
         <source>Add to favorites</source>
         <translation>Zu Favoriten hinzufügen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1477"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Write to NFC token</source>
         <translation>Auf NFC-Token schreiben</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1481"/>
+        <location filename="../app/Main.qml" line="1491"/>
         <source>QR code</source>
         <translation>QR-Code</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1456"/>
-        <location filename="../app/Main.qml" line="1491"/>
+        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1501"/>
         <source>Launch game</source>
         <translation>Spiel starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1937"/>
+        <location filename="../app/Main.qml" line="1947"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1940"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2731"/>
+        <location filename="../app/Main.qml" line="2741"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2737"/>
+        <location filename="../app/Main.qml" line="2747"/>
         <source>Loading favorites…</source>
         <translation>Favoriten werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2733"/>
+        <location filename="../app/Main.qml" line="2743"/>
         <source>Loading games…</source>
         <translation>Spiele werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1421"/>
-        <location filename="../app/Main.qml" line="1444"/>
+        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1454"/>
         <source>Update media database</source>
         <translation type="unfinished">Mediendatenbank aktualisieren</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1447"/>
+        <location filename="../app/Main.qml" line="1434"/>
+        <location filename="../app/Main.qml" line="1457"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadaten abrufen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1429"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1439"/>
+        <location filename="../app/Main.qml" line="1448"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1429"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1439"/>
+        <location filename="../app/Main.qml" line="1448"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1649"/>
+        <location filename="../app/Main.qml" line="1659"/>
         <source>Default</source>
         <translation type="unfinished">Standard</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1649"/>
+        <location filename="../app/Main.qml" line="1659"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2021"/>
+        <location filename="../app/Main.qml" line="2031"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2025"/>
+        <location filename="../app/Main.qml" line="2035"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2039"/>
+        <location filename="../app/Main.qml" line="2049"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2043"/>
+        <location filename="../app/Main.qml" line="2053"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2047"/>
+        <location filename="../app/Main.qml" line="2057"/>
         <source>Retry</source>
         <translation type="unfinished">Wiederholen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2051"/>
+        <location filename="../app/Main.qml" line="2061"/>
         <source>Cancel</source>
         <translation type="unfinished">Abbrechen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2735"/>
+        <location filename="../app/Main.qml" line="2745"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2739"/>
+        <location filename="../app/Main.qml" line="2749"/>
         <source>Loading recently played…</source>
         <translation>Zuletzt gespielte werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2741"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2743"/>
+        <location filename="../app/Main.qml" line="2753"/>
         <source>Loading…</source>
         <translation>Wird geladen…</translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -571,148 +571,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1408"/>
+        <location filename="../app/Main.qml" line="1415"/>
         <source>Launch core</source>
         <translation>Εκκίνηση Core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1414"/>
-        <location filename="../app/Main.qml" line="1653"/>
+        <location filename="../app/Main.qml" line="1424"/>
+        <location filename="../app/Main.qml" line="1663"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1482"/>
         <source>Remove from favorites</source>
         <translation>Αφαίρεση από αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1482"/>
         <source>Add to favorites</source>
         <translation>Προσθήκη στα αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1477"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Write to NFC token</source>
         <translation>Εγγραφή σε NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1481"/>
+        <location filename="../app/Main.qml" line="1491"/>
         <source>QR code</source>
         <translation>Κωδικός QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1456"/>
-        <location filename="../app/Main.qml" line="1491"/>
+        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1501"/>
         <source>Launch game</source>
         <translation>Εκκίνηση παιχνιδιού</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1937"/>
+        <location filename="../app/Main.qml" line="1947"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1940"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2731"/>
+        <location filename="../app/Main.qml" line="2741"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2737"/>
+        <location filename="../app/Main.qml" line="2747"/>
         <source>Loading favorites…</source>
         <translation>Φόρτωση αγαπημένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2733"/>
+        <location filename="../app/Main.qml" line="2743"/>
         <source>Loading games…</source>
         <translation>Φόρτωση παιχνιδιών…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1421"/>
-        <location filename="../app/Main.qml" line="1444"/>
+        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1454"/>
         <source>Update media database</source>
         <translation type="unfinished">Ενημέρωση βάσης δεδομένων</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1447"/>
+        <location filename="../app/Main.qml" line="1434"/>
+        <location filename="../app/Main.qml" line="1457"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Ανάκτηση μεταδεδομένων</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1429"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1439"/>
+        <location filename="../app/Main.qml" line="1448"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1429"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1439"/>
+        <location filename="../app/Main.qml" line="1448"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1649"/>
+        <location filename="../app/Main.qml" line="1659"/>
         <source>Default</source>
         <translation type="unfinished">Προεπιλογή</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1649"/>
+        <location filename="../app/Main.qml" line="1659"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2021"/>
+        <location filename="../app/Main.qml" line="2031"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2025"/>
+        <location filename="../app/Main.qml" line="2035"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2039"/>
+        <location filename="../app/Main.qml" line="2049"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2043"/>
+        <location filename="../app/Main.qml" line="2053"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2047"/>
+        <location filename="../app/Main.qml" line="2057"/>
         <source>Retry</source>
         <translation type="unfinished">Επανάληψη</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2051"/>
+        <location filename="../app/Main.qml" line="2061"/>
         <source>Cancel</source>
         <translation type="unfinished">Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2735"/>
+        <location filename="../app/Main.qml" line="2745"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2739"/>
+        <location filename="../app/Main.qml" line="2749"/>
         <source>Loading recently played…</source>
         <translation>Φόρτωση πρόσφατα παιγμένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2741"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2743"/>
+        <location filename="../app/Main.qml" line="2753"/>
         <source>Loading…</source>
         <translation>Φόρτωση…</translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -559,148 +559,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1408"/>
+        <location filename="../app/Main.qml" line="1415"/>
         <source>Launch core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1414"/>
-        <location filename="../app/Main.qml" line="1653"/>
+        <location filename="../app/Main.qml" line="1424"/>
+        <location filename="../app/Main.qml" line="1663"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1482"/>
         <source>Remove from favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1482"/>
         <source>Add to favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1477"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Write to NFC token</source>
         <translation type="unfinished">Write to NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1481"/>
+        <location filename="../app/Main.qml" line="1491"/>
         <source>QR code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1456"/>
-        <location filename="../app/Main.qml" line="1491"/>
+        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1501"/>
         <source>Launch game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1937"/>
+        <location filename="../app/Main.qml" line="1947"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1940"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2731"/>
+        <location filename="../app/Main.qml" line="2741"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2737"/>
+        <location filename="../app/Main.qml" line="2747"/>
         <source>Loading favorites…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2733"/>
+        <location filename="../app/Main.qml" line="2743"/>
         <source>Loading games…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1421"/>
-        <location filename="../app/Main.qml" line="1444"/>
+        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1454"/>
         <source>Update media database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1447"/>
+        <location filename="../app/Main.qml" line="1434"/>
+        <location filename="../app/Main.qml" line="1457"/>
         <source>Scrape metadata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1429"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1439"/>
+        <location filename="../app/Main.qml" line="1448"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1429"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1439"/>
+        <location filename="../app/Main.qml" line="1448"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1649"/>
+        <location filename="../app/Main.qml" line="1659"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1649"/>
+        <location filename="../app/Main.qml" line="1659"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2021"/>
+        <location filename="../app/Main.qml" line="2031"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2025"/>
+        <location filename="../app/Main.qml" line="2035"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2039"/>
+        <location filename="../app/Main.qml" line="2049"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2043"/>
+        <location filename="../app/Main.qml" line="2053"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2047"/>
+        <location filename="../app/Main.qml" line="2057"/>
         <source>Retry</source>
         <translation type="unfinished">Retry</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2051"/>
+        <location filename="../app/Main.qml" line="2061"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2735"/>
+        <location filename="../app/Main.qml" line="2745"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2739"/>
+        <location filename="../app/Main.qml" line="2749"/>
         <source>Loading recently played…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2741"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2743"/>
+        <location filename="../app/Main.qml" line="2753"/>
         <source>Loading…</source>
         <translation type="unfinished">Loading…</translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -571,148 +571,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1408"/>
+        <location filename="../app/Main.qml" line="1415"/>
         <source>Launch core</source>
         <translation>Lanzar core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1414"/>
-        <location filename="../app/Main.qml" line="1653"/>
+        <location filename="../app/Main.qml" line="1424"/>
+        <location filename="../app/Main.qml" line="1663"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1482"/>
         <source>Remove from favorites</source>
         <translation>Eliminar de favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1482"/>
         <source>Add to favorites</source>
         <translation>Agregar a favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1477"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Write to NFC token</source>
         <translation>Escribir en token NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1481"/>
+        <location filename="../app/Main.qml" line="1491"/>
         <source>QR code</source>
         <translation>Código QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1456"/>
-        <location filename="../app/Main.qml" line="1491"/>
+        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1501"/>
         <source>Launch game</source>
         <translation>Iniciar juego</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1937"/>
+        <location filename="../app/Main.qml" line="1947"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1940"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2731"/>
+        <location filename="../app/Main.qml" line="2741"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2737"/>
+        <location filename="../app/Main.qml" line="2747"/>
         <source>Loading favorites…</source>
         <translation>Cargando favoritos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2733"/>
+        <location filename="../app/Main.qml" line="2743"/>
         <source>Loading games…</source>
         <translation>Cargando juegos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1421"/>
-        <location filename="../app/Main.qml" line="1444"/>
+        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1454"/>
         <source>Update media database</source>
         <translation type="unfinished">Actualizar base de datos de medios</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1447"/>
+        <location filename="../app/Main.qml" line="1434"/>
+        <location filename="../app/Main.qml" line="1457"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Extraer metadatos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1429"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1439"/>
+        <location filename="../app/Main.qml" line="1448"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1429"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1439"/>
+        <location filename="../app/Main.qml" line="1448"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1649"/>
+        <location filename="../app/Main.qml" line="1659"/>
         <source>Default</source>
         <translation type="unfinished">Por defecto</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1649"/>
+        <location filename="../app/Main.qml" line="1659"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2021"/>
+        <location filename="../app/Main.qml" line="2031"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2025"/>
+        <location filename="../app/Main.qml" line="2035"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2039"/>
+        <location filename="../app/Main.qml" line="2049"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2043"/>
+        <location filename="../app/Main.qml" line="2053"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2047"/>
+        <location filename="../app/Main.qml" line="2057"/>
         <source>Retry</source>
         <translation type="unfinished">Reintentar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2051"/>
+        <location filename="../app/Main.qml" line="2061"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2735"/>
+        <location filename="../app/Main.qml" line="2745"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2739"/>
+        <location filename="../app/Main.qml" line="2749"/>
         <source>Loading recently played…</source>
         <translation>Cargando jugados recientemente…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2741"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2743"/>
+        <location filename="../app/Main.qml" line="2753"/>
         <source>Loading…</source>
         <translation>Cargando…</translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -579,148 +579,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1408"/>
+        <location filename="../app/Main.qml" line="1415"/>
         <source>Launch core</source>
         <translation type="unfinished">Exekutatu nukleoa</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1414"/>
-        <location filename="../app/Main.qml" line="1653"/>
+        <location filename="../app/Main.qml" line="1424"/>
+        <location filename="../app/Main.qml" line="1663"/>
         <source>Change launcher</source>
         <translation type="unfinished">Aldatu abiarazlea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1482"/>
         <source>Remove from favorites</source>
         <translation type="unfinished">Kendu gogokoetatik</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1482"/>
         <source>Add to favorites</source>
         <translation type="unfinished">Gehitu gogokoetan</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1477"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Write to NFC token</source>
         <translation type="unfinished">Idatzi NFC token-a</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1481"/>
+        <location filename="../app/Main.qml" line="1491"/>
         <source>QR code</source>
         <translation type="unfinished">QR kodea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1456"/>
-        <location filename="../app/Main.qml" line="1491"/>
+        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1501"/>
         <source>Launch game</source>
         <translation type="unfinished">Abiarazi jokua</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1937"/>
+        <location filename="../app/Main.qml" line="1947"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1940"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2731"/>
+        <location filename="../app/Main.qml" line="2741"/>
         <source>Loading systems…</source>
         <translation type="unfinished">Sistemak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2737"/>
+        <location filename="../app/Main.qml" line="2747"/>
         <source>Loading favorites…</source>
         <translation type="unfinished">Gogokoak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2733"/>
+        <location filename="../app/Main.qml" line="2743"/>
         <source>Loading games…</source>
         <translation type="unfinished">Jokoak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1421"/>
-        <location filename="../app/Main.qml" line="1444"/>
+        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1454"/>
         <source>Update media database</source>
         <translation type="unfinished">Eguneratu multimedia datu-basea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1447"/>
+        <location filename="../app/Main.qml" line="1434"/>
+        <location filename="../app/Main.qml" line="1457"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadatuak scrapeatu</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1429"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1439"/>
+        <location filename="../app/Main.qml" line="1448"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1429"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1439"/>
+        <location filename="../app/Main.qml" line="1448"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1649"/>
+        <location filename="../app/Main.qml" line="1659"/>
         <source>Default</source>
         <translation type="unfinished">Lehenetsia</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1649"/>
+        <location filename="../app/Main.qml" line="1659"/>
         <source>Current: %1</source>
         <translation type="unfinished">Unekoa: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2021"/>
+        <location filename="../app/Main.qml" line="2031"/>
         <source>Saving launcher</source>
         <translation type="unfinished">Abiarazlea gordetzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2025"/>
+        <location filename="../app/Main.qml" line="2035"/>
         <source>Saving…</source>
         <translation type="unfinished">Gordetzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2039"/>
+        <location filename="../app/Main.qml" line="2049"/>
         <source>Launcher update failed</source>
         <translation type="unfinished">Abiarazle egukeraketak huts egin du</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2043"/>
+        <location filename="../app/Main.qml" line="2053"/>
         <source>Error: %1</source>
         <translation type="unfinished">Errorea: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2047"/>
+        <location filename="../app/Main.qml" line="2057"/>
         <source>Retry</source>
         <translation type="unfinished">Berriro saiatu</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2051"/>
+        <location filename="../app/Main.qml" line="2061"/>
         <source>Cancel</source>
         <translation type="unfinished">Utzi</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2735"/>
+        <location filename="../app/Main.qml" line="2745"/>
         <source>Loading game…</source>
         <translation type="unfinished">Jokua kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2739"/>
+        <location filename="../app/Main.qml" line="2749"/>
         <source>Loading recently played…</source>
         <translation type="unfinished">Duela gutxi jokatutakoak kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2741"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2743"/>
+        <location filename="../app/Main.qml" line="2753"/>
         <source>Loading…</source>
         <translation type="unfinished">Kargatzen…</translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -571,148 +571,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1408"/>
+        <location filename="../app/Main.qml" line="1415"/>
         <source>Launch core</source>
         <translation>הפעל את הליבה</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1414"/>
-        <location filename="../app/Main.qml" line="1653"/>
+        <location filename="../app/Main.qml" line="1424"/>
+        <location filename="../app/Main.qml" line="1663"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1421"/>
-        <location filename="../app/Main.qml" line="1444"/>
+        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1454"/>
         <source>Update media database</source>
         <translation type="unfinished">עדכון מסד נתוני המדיה</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1447"/>
+        <location filename="../app/Main.qml" line="1434"/>
+        <location filename="../app/Main.qml" line="1457"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">איסוף מטא-נתונים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1429"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1439"/>
+        <location filename="../app/Main.qml" line="1448"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1429"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1439"/>
+        <location filename="../app/Main.qml" line="1448"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1456"/>
-        <location filename="../app/Main.qml" line="1491"/>
+        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1501"/>
         <source>Launch game</source>
         <translation>הפעל משחק</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1482"/>
         <source>Remove from favorites</source>
         <translation>הסר מהמועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1482"/>
         <source>Add to favorites</source>
         <translation>הוסף למועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1477"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Write to NFC token</source>
         <translation>כתוב לטוקן NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1481"/>
+        <location filename="../app/Main.qml" line="1491"/>
         <source>QR code</source>
         <translation>קוד QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1649"/>
+        <location filename="../app/Main.qml" line="1659"/>
         <source>Default</source>
         <translation type="unfinished">ברירת מחדל</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1649"/>
+        <location filename="../app/Main.qml" line="1659"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1937"/>
+        <location filename="../app/Main.qml" line="1947"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1940"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2021"/>
+        <location filename="../app/Main.qml" line="2031"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2025"/>
+        <location filename="../app/Main.qml" line="2035"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2039"/>
+        <location filename="../app/Main.qml" line="2049"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2043"/>
+        <location filename="../app/Main.qml" line="2053"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2047"/>
+        <location filename="../app/Main.qml" line="2057"/>
         <source>Retry</source>
         <translation type="unfinished">נסה שוב</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2051"/>
+        <location filename="../app/Main.qml" line="2061"/>
         <source>Cancel</source>
         <translation type="unfinished">ביטול</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2731"/>
+        <location filename="../app/Main.qml" line="2741"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2733"/>
+        <location filename="../app/Main.qml" line="2743"/>
         <source>Loading games…</source>
         <translation>טוען משחקים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2735"/>
+        <location filename="../app/Main.qml" line="2745"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2737"/>
+        <location filename="../app/Main.qml" line="2747"/>
         <source>Loading favorites…</source>
         <translation>טוען מועדפים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2739"/>
+        <location filename="../app/Main.qml" line="2749"/>
         <source>Loading recently played…</source>
         <translation>טוען את הפריטים ששוחקו לאחרונה…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2741"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2743"/>
+        <location filename="../app/Main.qml" line="2753"/>
         <source>Loading…</source>
         <translation>טוען…</translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -571,148 +571,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1408"/>
+        <location filename="../app/Main.qml" line="1415"/>
         <source>Launch core</source>
         <translation>कोर चलाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1414"/>
-        <location filename="../app/Main.qml" line="1653"/>
+        <location filename="../app/Main.qml" line="1424"/>
+        <location filename="../app/Main.qml" line="1663"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1421"/>
-        <location filename="../app/Main.qml" line="1444"/>
+        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1454"/>
         <source>Update media database</source>
         <translation type="unfinished">मीडिया डेटाबेस अपडेट करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1447"/>
+        <location filename="../app/Main.qml" line="1434"/>
+        <location filename="../app/Main.qml" line="1457"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">मेटाडेटा स्क्रैप करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1429"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1439"/>
+        <location filename="../app/Main.qml" line="1448"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1429"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1439"/>
+        <location filename="../app/Main.qml" line="1448"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1456"/>
-        <location filename="../app/Main.qml" line="1491"/>
+        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1501"/>
         <source>Launch game</source>
         <translation>गेम चलाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1482"/>
         <source>Remove from favorites</source>
         <translation>पसंदीदा से हटाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1482"/>
         <source>Add to favorites</source>
         <translation>पसंदीदा में जोड़ें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1477"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Write to NFC token</source>
         <translation>NFC टोकन पर लिखें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1481"/>
+        <location filename="../app/Main.qml" line="1491"/>
         <source>QR code</source>
         <translation>QR कोड</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1649"/>
+        <location filename="../app/Main.qml" line="1659"/>
         <source>Default</source>
         <translation type="unfinished">डिफ़ॉल्ट</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1649"/>
+        <location filename="../app/Main.qml" line="1659"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1937"/>
+        <location filename="../app/Main.qml" line="1947"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1940"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2021"/>
+        <location filename="../app/Main.qml" line="2031"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2025"/>
+        <location filename="../app/Main.qml" line="2035"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2039"/>
+        <location filename="../app/Main.qml" line="2049"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2043"/>
+        <location filename="../app/Main.qml" line="2053"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2047"/>
+        <location filename="../app/Main.qml" line="2057"/>
         <source>Retry</source>
         <translation type="unfinished">फिर से प्रयास करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2051"/>
+        <location filename="../app/Main.qml" line="2061"/>
         <source>Cancel</source>
         <translation type="unfinished">रद्द करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2731"/>
+        <location filename="../app/Main.qml" line="2741"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2733"/>
+        <location filename="../app/Main.qml" line="2743"/>
         <source>Loading games…</source>
         <translation>गेम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2735"/>
+        <location filename="../app/Main.qml" line="2745"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2737"/>
+        <location filename="../app/Main.qml" line="2747"/>
         <source>Loading favorites…</source>
         <translation>पसंदीदा लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2739"/>
+        <location filename="../app/Main.qml" line="2749"/>
         <source>Loading recently played…</source>
         <translation>हाल ही में खेले गए लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2741"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2743"/>
+        <location filename="../app/Main.qml" line="2753"/>
         <source>Loading…</source>
         <translation>लोड हो रहा है…</translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -571,148 +571,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1408"/>
+        <location filename="../app/Main.qml" line="1415"/>
         <source>Launch core</source>
         <translation>Avvia core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1414"/>
-        <location filename="../app/Main.qml" line="1653"/>
+        <location filename="../app/Main.qml" line="1424"/>
+        <location filename="../app/Main.qml" line="1663"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1482"/>
         <source>Remove from favorites</source>
         <translation>Rimuovi dai preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1482"/>
         <source>Add to favorites</source>
         <translation>Aggiungi ai preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1477"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Write to NFC token</source>
         <translation>Scrivi sul token NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1481"/>
+        <location filename="../app/Main.qml" line="1491"/>
         <source>QR code</source>
         <translation>Codice QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1456"/>
-        <location filename="../app/Main.qml" line="1491"/>
+        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1501"/>
         <source>Launch game</source>
         <translation>Avvia gioco</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1937"/>
+        <location filename="../app/Main.qml" line="1947"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1940"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2731"/>
+        <location filename="../app/Main.qml" line="2741"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2737"/>
+        <location filename="../app/Main.qml" line="2747"/>
         <source>Loading favorites…</source>
         <translation>Caricamento preferiti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2733"/>
+        <location filename="../app/Main.qml" line="2743"/>
         <source>Loading games…</source>
         <translation>Caricamento giochi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1421"/>
-        <location filename="../app/Main.qml" line="1444"/>
+        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1454"/>
         <source>Update media database</source>
         <translation type="unfinished">Aggiorna database multimediale</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1447"/>
+        <location filename="../app/Main.qml" line="1434"/>
+        <location filename="../app/Main.qml" line="1457"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Recupera metadati</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1429"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1439"/>
+        <location filename="../app/Main.qml" line="1448"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1429"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1439"/>
+        <location filename="../app/Main.qml" line="1448"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1649"/>
+        <location filename="../app/Main.qml" line="1659"/>
         <source>Default</source>
         <translation type="unfinished">Predefinito</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1649"/>
+        <location filename="../app/Main.qml" line="1659"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2021"/>
+        <location filename="../app/Main.qml" line="2031"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2025"/>
+        <location filename="../app/Main.qml" line="2035"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2039"/>
+        <location filename="../app/Main.qml" line="2049"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2043"/>
+        <location filename="../app/Main.qml" line="2053"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2047"/>
+        <location filename="../app/Main.qml" line="2057"/>
         <source>Retry</source>
         <translation type="unfinished">Riprova</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2051"/>
+        <location filename="../app/Main.qml" line="2061"/>
         <source>Cancel</source>
         <translation type="unfinished">Annulla</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2735"/>
+        <location filename="../app/Main.qml" line="2745"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2739"/>
+        <location filename="../app/Main.qml" line="2749"/>
         <source>Loading recently played…</source>
         <translation>Caricamento recenti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2741"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2743"/>
+        <location filename="../app/Main.qml" line="2753"/>
         <source>Loading…</source>
         <translation>Caricamento…</translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -571,148 +571,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1408"/>
+        <location filename="../app/Main.qml" line="1415"/>
         <source>Launch core</source>
         <translation>コアを起動</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1414"/>
-        <location filename="../app/Main.qml" line="1653"/>
+        <location filename="../app/Main.qml" line="1424"/>
+        <location filename="../app/Main.qml" line="1663"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1482"/>
         <source>Remove from favorites</source>
         <translation>お気に入りから削除</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1482"/>
         <source>Add to favorites</source>
         <translation>お気に入りに追加</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1477"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Write to NFC token</source>
         <translation>NFC トークンに書き込む</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1481"/>
+        <location filename="../app/Main.qml" line="1491"/>
         <source>QR code</source>
         <translation>QR コード</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1456"/>
-        <location filename="../app/Main.qml" line="1491"/>
+        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1501"/>
         <source>Launch game</source>
         <translation>ゲームを起動</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1937"/>
+        <location filename="../app/Main.qml" line="1947"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1940"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2731"/>
+        <location filename="../app/Main.qml" line="2741"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2737"/>
+        <location filename="../app/Main.qml" line="2747"/>
         <source>Loading favorites…</source>
         <translation>お気に入りを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2733"/>
+        <location filename="../app/Main.qml" line="2743"/>
         <source>Loading games…</source>
         <translation>ゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1421"/>
-        <location filename="../app/Main.qml" line="1444"/>
+        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1454"/>
         <source>Update media database</source>
         <translation type="unfinished">メディアデータベースを更新</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1447"/>
+        <location filename="../app/Main.qml" line="1434"/>
+        <location filename="../app/Main.qml" line="1457"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">メタデータをスクレイピング</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1429"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1439"/>
+        <location filename="../app/Main.qml" line="1448"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1429"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1439"/>
+        <location filename="../app/Main.qml" line="1448"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1649"/>
+        <location filename="../app/Main.qml" line="1659"/>
         <source>Default</source>
         <translation type="unfinished">デフォルト</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1649"/>
+        <location filename="../app/Main.qml" line="1659"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2021"/>
+        <location filename="../app/Main.qml" line="2031"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2025"/>
+        <location filename="../app/Main.qml" line="2035"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2039"/>
+        <location filename="../app/Main.qml" line="2049"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2043"/>
+        <location filename="../app/Main.qml" line="2053"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2047"/>
+        <location filename="../app/Main.qml" line="2057"/>
         <source>Retry</source>
         <translation type="unfinished">再試行</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2051"/>
+        <location filename="../app/Main.qml" line="2061"/>
         <source>Cancel</source>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2735"/>
+        <location filename="../app/Main.qml" line="2745"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2739"/>
+        <location filename="../app/Main.qml" line="2749"/>
         <source>Loading recently played…</source>
         <translation>最近プレイしたゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2741"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2743"/>
+        <location filename="../app/Main.qml" line="2753"/>
         <source>Loading…</source>
         <translation>読み込み中…</translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -571,148 +571,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1408"/>
+        <location filename="../app/Main.qml" line="1415"/>
         <source>Launch core</source>
         <translation>코어 실행</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1414"/>
-        <location filename="../app/Main.qml" line="1653"/>
+        <location filename="../app/Main.qml" line="1424"/>
+        <location filename="../app/Main.qml" line="1663"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1421"/>
-        <location filename="../app/Main.qml" line="1444"/>
+        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1454"/>
         <source>Update media database</source>
         <translation type="unfinished">미디어 데이터베이스 업데이트</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1447"/>
+        <location filename="../app/Main.qml" line="1434"/>
+        <location filename="../app/Main.qml" line="1457"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">메타데이터 수집</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1429"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1439"/>
+        <location filename="../app/Main.qml" line="1448"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1429"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1439"/>
+        <location filename="../app/Main.qml" line="1448"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1456"/>
-        <location filename="../app/Main.qml" line="1491"/>
+        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1501"/>
         <source>Launch game</source>
         <translation>게임 실행</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1482"/>
         <source>Remove from favorites</source>
         <translation>즐겨찾기에서 제거</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1482"/>
         <source>Add to favorites</source>
         <translation>즐겨찾기에 추가</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1477"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Write to NFC token</source>
         <translation>NFC 토큰에 쓰기</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1481"/>
+        <location filename="../app/Main.qml" line="1491"/>
         <source>QR code</source>
         <translation>QR 코드</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1649"/>
+        <location filename="../app/Main.qml" line="1659"/>
         <source>Default</source>
         <translation type="unfinished">기본값</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1649"/>
+        <location filename="../app/Main.qml" line="1659"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1937"/>
+        <location filename="../app/Main.qml" line="1947"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1940"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2021"/>
+        <location filename="../app/Main.qml" line="2031"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2025"/>
+        <location filename="../app/Main.qml" line="2035"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2039"/>
+        <location filename="../app/Main.qml" line="2049"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2043"/>
+        <location filename="../app/Main.qml" line="2053"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2047"/>
+        <location filename="../app/Main.qml" line="2057"/>
         <source>Retry</source>
         <translation type="unfinished">다시 시도</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2051"/>
+        <location filename="../app/Main.qml" line="2061"/>
         <source>Cancel</source>
         <translation type="unfinished">취소</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2731"/>
+        <location filename="../app/Main.qml" line="2741"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2733"/>
+        <location filename="../app/Main.qml" line="2743"/>
         <source>Loading games…</source>
         <translation>게임 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2735"/>
+        <location filename="../app/Main.qml" line="2745"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2737"/>
+        <location filename="../app/Main.qml" line="2747"/>
         <source>Loading favorites…</source>
         <translation>즐겨찾기 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2739"/>
+        <location filename="../app/Main.qml" line="2749"/>
         <source>Loading recently played…</source>
         <translation>최근 플레이 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2741"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2743"/>
+        <location filename="../app/Main.qml" line="2753"/>
         <source>Loading…</source>
         <translation>불러오는 중…</translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -571,148 +571,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1408"/>
+        <location filename="../app/Main.qml" line="1415"/>
         <source>Launch core</source>
         <translation>Core starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1414"/>
-        <location filename="../app/Main.qml" line="1653"/>
+        <location filename="../app/Main.qml" line="1424"/>
+        <location filename="../app/Main.qml" line="1663"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1482"/>
         <source>Remove from favorites</source>
         <translation>Uit favorieten verwijderen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1482"/>
         <source>Add to favorites</source>
         <translation>Aan favorieten toevoegen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1477"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Write to NFC token</source>
         <translation>Naar NFC-token schrijven</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1481"/>
+        <location filename="../app/Main.qml" line="1491"/>
         <source>QR code</source>
         <translation>QR-code</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1456"/>
-        <location filename="../app/Main.qml" line="1491"/>
+        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1501"/>
         <source>Launch game</source>
         <translation>Game starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1937"/>
+        <location filename="../app/Main.qml" line="1947"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1940"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2731"/>
+        <location filename="../app/Main.qml" line="2741"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2737"/>
+        <location filename="../app/Main.qml" line="2747"/>
         <source>Loading favorites…</source>
         <translation>Favorieten laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2733"/>
+        <location filename="../app/Main.qml" line="2743"/>
         <source>Loading games…</source>
         <translation>Games laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1421"/>
-        <location filename="../app/Main.qml" line="1444"/>
+        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1454"/>
         <source>Update media database</source>
         <translation type="unfinished">Mediadatabase bijwerken</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1447"/>
+        <location filename="../app/Main.qml" line="1434"/>
+        <location filename="../app/Main.qml" line="1457"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadata ophalen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1429"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1439"/>
+        <location filename="../app/Main.qml" line="1448"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1429"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1439"/>
+        <location filename="../app/Main.qml" line="1448"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1649"/>
+        <location filename="../app/Main.qml" line="1659"/>
         <source>Default</source>
         <translation type="unfinished">Standaard</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1649"/>
+        <location filename="../app/Main.qml" line="1659"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2021"/>
+        <location filename="../app/Main.qml" line="2031"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2025"/>
+        <location filename="../app/Main.qml" line="2035"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2039"/>
+        <location filename="../app/Main.qml" line="2049"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2043"/>
+        <location filename="../app/Main.qml" line="2053"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2047"/>
+        <location filename="../app/Main.qml" line="2057"/>
         <source>Retry</source>
         <translation type="unfinished">Opnieuw proberen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2051"/>
+        <location filename="../app/Main.qml" line="2061"/>
         <source>Cancel</source>
         <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2735"/>
+        <location filename="../app/Main.qml" line="2745"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2739"/>
+        <location filename="../app/Main.qml" line="2749"/>
         <source>Loading recently played…</source>
         <translation>Recent gespeeld laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2741"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2743"/>
+        <location filename="../app/Main.qml" line="2753"/>
         <source>Loading…</source>
         <translation>Laden…</translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -571,148 +571,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1408"/>
+        <location filename="../app/Main.qml" line="1415"/>
         <source>Launch core</source>
         <translation>Lansare core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1414"/>
-        <location filename="../app/Main.qml" line="1653"/>
+        <location filename="../app/Main.qml" line="1424"/>
+        <location filename="../app/Main.qml" line="1663"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1482"/>
         <source>Remove from favorites</source>
         <translation>Elimină din favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1482"/>
         <source>Add to favorites</source>
         <translation>Adaugă la favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1477"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Write to NFC token</source>
         <translation>Scriere pe token NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1481"/>
+        <location filename="../app/Main.qml" line="1491"/>
         <source>QR code</source>
         <translation>Cod QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1456"/>
-        <location filename="../app/Main.qml" line="1491"/>
+        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1501"/>
         <source>Launch game</source>
         <translation>Lansare joc</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1937"/>
+        <location filename="../app/Main.qml" line="1947"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1940"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2731"/>
+        <location filename="../app/Main.qml" line="2741"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2737"/>
+        <location filename="../app/Main.qml" line="2747"/>
         <source>Loading favorites…</source>
         <translation>Se încarcă favoritele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2733"/>
+        <location filename="../app/Main.qml" line="2743"/>
         <source>Loading games…</source>
         <translation>Se încarcă jocurile…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1421"/>
-        <location filename="../app/Main.qml" line="1444"/>
+        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1454"/>
         <source>Update media database</source>
         <translation type="unfinished">Actualizare bază de date media</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1447"/>
+        <location filename="../app/Main.qml" line="1434"/>
+        <location filename="../app/Main.qml" line="1457"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Extragere metadate</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1429"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1439"/>
+        <location filename="../app/Main.qml" line="1448"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1429"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1439"/>
+        <location filename="../app/Main.qml" line="1448"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1649"/>
+        <location filename="../app/Main.qml" line="1659"/>
         <source>Default</source>
         <translation type="unfinished">Implicit</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1649"/>
+        <location filename="../app/Main.qml" line="1659"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2021"/>
+        <location filename="../app/Main.qml" line="2031"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2025"/>
+        <location filename="../app/Main.qml" line="2035"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2039"/>
+        <location filename="../app/Main.qml" line="2049"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2043"/>
+        <location filename="../app/Main.qml" line="2053"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2047"/>
+        <location filename="../app/Main.qml" line="2057"/>
         <source>Retry</source>
         <translation type="unfinished">Reîncercare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2051"/>
+        <location filename="../app/Main.qml" line="2061"/>
         <source>Cancel</source>
         <translation type="unfinished">Anulare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2735"/>
+        <location filename="../app/Main.qml" line="2745"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2739"/>
+        <location filename="../app/Main.qml" line="2749"/>
         <source>Loading recently played…</source>
         <translation>Se încarcă recent jucatele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2741"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2743"/>
+        <location filename="../app/Main.qml" line="2753"/>
         <source>Loading…</source>
         <translation>Se încarcă…</translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -571,148 +571,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1408"/>
+        <location filename="../app/Main.qml" line="1415"/>
         <source>Launch core</source>
         <translation>Spustiť core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1414"/>
-        <location filename="../app/Main.qml" line="1653"/>
+        <location filename="../app/Main.qml" line="1424"/>
+        <location filename="../app/Main.qml" line="1663"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1482"/>
         <source>Remove from favorites</source>
         <translation>Odstrániť z obľúbených</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1482"/>
         <source>Add to favorites</source>
         <translation>Pridať do obľúbených</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1477"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Write to NFC token</source>
         <translation>Zapísať na NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1481"/>
+        <location filename="../app/Main.qml" line="1491"/>
         <source>QR code</source>
         <translation>QR kód</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1456"/>
-        <location filename="../app/Main.qml" line="1491"/>
+        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1501"/>
         <source>Launch game</source>
         <translation>Spustiť hru</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1937"/>
+        <location filename="../app/Main.qml" line="1947"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1940"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2731"/>
+        <location filename="../app/Main.qml" line="2741"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2737"/>
+        <location filename="../app/Main.qml" line="2747"/>
         <source>Loading favorites…</source>
         <translation>Načítanie obľúbených…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2733"/>
+        <location filename="../app/Main.qml" line="2743"/>
         <source>Loading games…</source>
         <translation>Načítanie hier…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1421"/>
-        <location filename="../app/Main.qml" line="1444"/>
+        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1454"/>
         <source>Update media database</source>
         <translation type="unfinished">Aktualizovať databázu médií</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1447"/>
+        <location filename="../app/Main.qml" line="1434"/>
+        <location filename="../app/Main.qml" line="1457"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Získať metadáta</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1429"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1439"/>
+        <location filename="../app/Main.qml" line="1448"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1429"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1439"/>
+        <location filename="../app/Main.qml" line="1448"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1649"/>
+        <location filename="../app/Main.qml" line="1659"/>
         <source>Default</source>
         <translation type="unfinished">Predvolené</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1649"/>
+        <location filename="../app/Main.qml" line="1659"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2021"/>
+        <location filename="../app/Main.qml" line="2031"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2025"/>
+        <location filename="../app/Main.qml" line="2035"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2039"/>
+        <location filename="../app/Main.qml" line="2049"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2043"/>
+        <location filename="../app/Main.qml" line="2053"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2047"/>
+        <location filename="../app/Main.qml" line="2057"/>
         <source>Retry</source>
         <translation type="unfinished">Skúsiť znova</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2051"/>
+        <location filename="../app/Main.qml" line="2061"/>
         <source>Cancel</source>
         <translation type="unfinished">Zrušiť</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2735"/>
+        <location filename="../app/Main.qml" line="2745"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2739"/>
+        <location filename="../app/Main.qml" line="2749"/>
         <source>Loading recently played…</source>
         <translation>Načítanie nedávno hraných…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2741"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2743"/>
+        <location filename="../app/Main.qml" line="2753"/>
         <source>Loading…</source>
         <translation>Načítanie…</translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -571,148 +571,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1408"/>
+        <location filename="../app/Main.qml" line="1415"/>
         <source>Launch core</source>
         <translation>Запустити core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1414"/>
-        <location filename="../app/Main.qml" line="1653"/>
+        <location filename="../app/Main.qml" line="1424"/>
+        <location filename="../app/Main.qml" line="1663"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1482"/>
         <source>Remove from favorites</source>
         <translation>Видалити з вибраного</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1482"/>
         <source>Add to favorites</source>
         <translation>Додати до вибраного</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1477"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Write to NFC token</source>
         <translation>Записати на NFC-токен</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1481"/>
+        <location filename="../app/Main.qml" line="1491"/>
         <source>QR code</source>
         <translation>QR-код</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1456"/>
-        <location filename="../app/Main.qml" line="1491"/>
+        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1501"/>
         <source>Launch game</source>
         <translation>Запустити гру</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1937"/>
+        <location filename="../app/Main.qml" line="1947"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1940"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2731"/>
+        <location filename="../app/Main.qml" line="2741"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2737"/>
+        <location filename="../app/Main.qml" line="2747"/>
         <source>Loading favorites…</source>
         <translation>Завантаження вибраного…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2733"/>
+        <location filename="../app/Main.qml" line="2743"/>
         <source>Loading games…</source>
         <translation>Завантаження ігор…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1421"/>
-        <location filename="../app/Main.qml" line="1444"/>
+        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1454"/>
         <source>Update media database</source>
         <translation type="unfinished">Оновити базу медіа</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1447"/>
+        <location filename="../app/Main.qml" line="1434"/>
+        <location filename="../app/Main.qml" line="1457"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Отримати метадані</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1429"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1439"/>
+        <location filename="../app/Main.qml" line="1448"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1429"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1439"/>
+        <location filename="../app/Main.qml" line="1448"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1649"/>
+        <location filename="../app/Main.qml" line="1659"/>
         <source>Default</source>
         <translation type="unfinished">Типовий</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1649"/>
+        <location filename="../app/Main.qml" line="1659"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2021"/>
+        <location filename="../app/Main.qml" line="2031"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2025"/>
+        <location filename="../app/Main.qml" line="2035"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2039"/>
+        <location filename="../app/Main.qml" line="2049"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2043"/>
+        <location filename="../app/Main.qml" line="2053"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2047"/>
+        <location filename="../app/Main.qml" line="2057"/>
         <source>Retry</source>
         <translation type="unfinished">Повторити</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2051"/>
+        <location filename="../app/Main.qml" line="2061"/>
         <source>Cancel</source>
         <translation type="unfinished">Скасувати</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2735"/>
+        <location filename="../app/Main.qml" line="2745"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2739"/>
+        <location filename="../app/Main.qml" line="2749"/>
         <source>Loading recently played…</source>
         <translation>Завантаження нещодавніх…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2741"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2743"/>
+        <location filename="../app/Main.qml" line="2753"/>
         <source>Loading…</source>
         <translation>Завантаження…</translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -571,148 +571,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1408"/>
+        <location filename="../app/Main.qml" line="1415"/>
         <source>Launch core</source>
         <translation>启动核心</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1414"/>
-        <location filename="../app/Main.qml" line="1653"/>
+        <location filename="../app/Main.qml" line="1424"/>
+        <location filename="../app/Main.qml" line="1663"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1421"/>
-        <location filename="../app/Main.qml" line="1444"/>
+        <location filename="../app/Main.qml" line="1431"/>
+        <location filename="../app/Main.qml" line="1454"/>
         <source>Update media database</source>
         <translation type="unfinished">更新媒体数据库</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1447"/>
+        <location filename="../app/Main.qml" line="1434"/>
+        <location filename="../app/Main.qml" line="1457"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">抓取元数据</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1429"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1439"/>
+        <location filename="../app/Main.qml" line="1448"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1429"/>
-        <location filename="../app/Main.qml" line="1438"/>
+        <location filename="../app/Main.qml" line="1439"/>
+        <location filename="../app/Main.qml" line="1448"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1456"/>
-        <location filename="../app/Main.qml" line="1491"/>
+        <location filename="../app/Main.qml" line="1466"/>
+        <location filename="../app/Main.qml" line="1501"/>
         <source>Launch game</source>
         <translation>启动游戏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1482"/>
         <source>Remove from favorites</source>
         <translation>从收藏中移除</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1482"/>
         <source>Add to favorites</source>
         <translation>添加到收藏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1477"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Write to NFC token</source>
         <translation>写入 NFC 令牌</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1481"/>
+        <location filename="../app/Main.qml" line="1491"/>
         <source>QR code</source>
         <translation>二维码</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1649"/>
+        <location filename="../app/Main.qml" line="1659"/>
         <source>Default</source>
         <translation type="unfinished">默认</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1649"/>
+        <location filename="../app/Main.qml" line="1659"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1937"/>
+        <location filename="../app/Main.qml" line="1947"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1940"/>
+        <location filename="../app/Main.qml" line="1950"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2021"/>
+        <location filename="../app/Main.qml" line="2031"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2025"/>
+        <location filename="../app/Main.qml" line="2035"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2039"/>
+        <location filename="../app/Main.qml" line="2049"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2043"/>
+        <location filename="../app/Main.qml" line="2053"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2047"/>
+        <location filename="../app/Main.qml" line="2057"/>
         <source>Retry</source>
         <translation type="unfinished">重试</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2051"/>
+        <location filename="../app/Main.qml" line="2061"/>
         <source>Cancel</source>
         <translation type="unfinished">取消</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2731"/>
+        <location filename="../app/Main.qml" line="2741"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2733"/>
+        <location filename="../app/Main.qml" line="2743"/>
         <source>Loading games…</source>
         <translation>正在加载游戏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2735"/>
+        <location filename="../app/Main.qml" line="2745"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2737"/>
+        <location filename="../app/Main.qml" line="2747"/>
         <source>Loading favorites…</source>
         <translation>正在加载收藏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2739"/>
+        <location filename="../app/Main.qml" line="2749"/>
         <source>Loading recently played…</source>
         <translation>正在加载最近游玩…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2741"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2743"/>
+        <location filename="../app/Main.qml" line="2753"/>
         <source>Loading…</source>
         <translation>正在加载…</translation>
     </message>


### PR DESCRIPTION
- Deserialize Core's new `zapScript` field on `SystemInfo` and the `System` sub-object; a non-empty `zapScript` marks a launch-only "virtual" system with no browsable media.
- Launch launchable systems directly by running their `zapScript` instead of routing into an empty `media.browse`, and stay on the systems grid; NFC card writes for these systems encode the `zapScript` too.
- Gate launcher / index / scrape context actions off for launchable systems and exclude them from category-level index/scrape, since they have no media.
- Drop empty metadata rows in the system detail pane so systems missing release date or manufacturer degrade gracefully rather than showing blank rows.
- Stop hiding the "Other" category on the hub (only "Media" stays hidden) and add its icon, a Lucide ellipsis glyph, with attribution.
- Match launchables in the "Other" bucket: Core tags them with a literal "Other" category rather than an empty one, which the previous synthesized-only filter dropped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Launch-only systems can now be activated directly from the Systems list without navigating to the Games screen.

* **Improvements**
  * The "Other" category is now visible and includes both uncategorized systems and those explicitly marked as "Other."
  * Launch-only systems no longer display launcher management or media database actions in context menus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->