### PR TITLE
fix: hide category index/scrape actions when no indexable systems exist

### DIFF
--- a/rust/frontend/src/models/systems.rs
+++ b/rust/frontend/src/models/systems.rs
@@ -703,17 +703,26 @@ impl ffi::SystemsModel {
         let cat = category.to_string();
         let mut list = QStringList::default();
         if let Some(ref c) = self.rust().last_ready {
-            for sys in c.systems_by_category(&cat) {
-                // Skip launch-only systems: they have no indexed media, so
-                // category-level index/scrape must never target them.
-                if !sys.zap_script.trim().is_empty() {
-                    continue;
-                }
-                list.append(QString::from(sys.id.as_str()));
+            for id in indexable_system_ids(c, &cat) {
+                list.append(QString::from(id.as_str()));
             }
         }
         list
     }
+}
+
+/// Ids of the indexable systems in `category` (the ones a category-level
+/// index/scrape can act on). Launch-only systems carry a `zap_script` and
+/// have no indexed media, so they are skipped. A category whose members are
+/// all launch-only yields an empty list, which is how the systems context
+/// menu decides to omit the dead index/scrape actions.
+fn indexable_system_ids(catalog: &CatalogData, category: &str) -> Vec<String> {
+    catalog
+        .systems_by_category(category)
+        .into_iter()
+        .filter(|s| s.zap_script.trim().is_empty())
+        .map(|s| s.id)
+        .collect()
 }
 
 fn detail_tags_for_system(system: &SystemInfo) -> String {
@@ -758,8 +767,8 @@ mod tests {
     )]
 
     use super::{
-        detail_tags_for_system, is_launchable, launch_text_for, position_of_system_id, project,
-        rows_for_category, SystemInfo,
+        detail_tags_for_system, indexable_system_ids, is_launchable, launch_text_for,
+        position_of_system_id, project, rows_for_category, SystemInfo,
     };
     use crate::system_region::Region;
     use zaparoo_core::media_types::SystemInfo as MediaSystemInfo;
@@ -1011,5 +1020,35 @@ mod tests {
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].zap_script, "zaparoo://abc/Chess");
         assert!(is_launchable(&rows[0]));
+    }
+
+    #[test]
+    fn indexable_system_ids_excludes_launch_only_in_mixed_category() {
+        // A category can mix indexable systems (NESMusic) with launch-only
+        // ones (a launchable in the same bucket). The category-level
+        // index/scrape must target only the indexable members, so the
+        // launch-only system's id must not appear.
+        let mut launchable = sys("chess", "Chess", "Other");
+        launchable.zap_script = "zaparoo://abc/Chess".into();
+        let catalog = catalog_with(vec![
+            sys("NESMusic", "NES Music", "Other"),
+            launchable,
+            sys("SNESMusic", "SNES Music", "Other"),
+        ]);
+        let ids = indexable_system_ids(&catalog, "Other");
+        assert_eq!(ids, vec!["NESMusic".to_string(), "SNESMusic".to_string()]);
+    }
+
+    #[test]
+    fn indexable_system_ids_empty_when_category_all_launch_only() {
+        // A category whose members are all launch-only yields no indexable
+        // ids; the context menu uses this to omit the dead index/scrape
+        // actions entirely.
+        let mut a = sys("a", "A", "Other");
+        a.zap_script = "zaparoo://abc/A".into();
+        let mut b = sys("b", "B", "Other");
+        b.zap_script = "zaparoo://abc/B".into();
+        let catalog = catalog_with(vec![a, b]);
+        assert!(indexable_system_ids(&catalog, "Other").is_empty());
     }
 }

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -1407,7 +1407,7 @@ MainLayout {
     // caller saw `entries.length === 0` despite the function pushing 3
     // items in. Plain `var` round-trips cleanly and silences the
     // "insufficiently annotated" coercion warning at the call site.
-    function buildContextMenuEntries(owner: string, entryType: string, mediaCapable: bool, hasNfc: bool, isFavorite: bool, systemId: string, isHidden: bool) {
+    function buildContextMenuEntries(owner: string, entryType: string, mediaCapable: bool, hasNfc: bool, isFavorite: bool, systemId: string, isHidden: bool, category: string) {
         if (owner === "systems") {
             const entries = [
                 {
@@ -1448,7 +1448,13 @@ MainLayout {
                     label: isHidden ? qsTr("Unhide") : qsTr("Hide")
                 }
             ];
-            if (!mediaBusy) {
+            // Index/scrape act on the category's indexable systems, which
+            // excludes launch-only ones. Show the actions only when the
+            // category has at least one indexable system; a category whose
+            // members are all launch-only yields none and the actions would
+            // no-op, so omit them rather than show dead entries.
+            const hasIndexable = category !== "" && Browse.SystemsModel.system_ids_for_category(category).length > 0;
+            if (!mediaBusy && hasIndexable) {
                 entries.push({
                     id: "index_category",
                     label: qsTr("Update media database")
@@ -1578,7 +1584,7 @@ MainLayout {
             if (index >= Browse.RecentsModel.count)
                 return;
         }
-        const entries = root.buildContextMenuEntries(owner, entryType, mediaCapable, Browse.SystemStatus.has_nfc, isFavorite, systemId, isHidden);
+        const entries = root.buildContextMenuEntries(owner, entryType, mediaCapable, Browse.SystemStatus.has_nfc, isFavorite, systemId, isHidden, category);
         if (entries.length === 0)
             return;
         root.contextMenuEntries = entries;

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -577,19 +577,19 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1663"/>
+        <location filename="../app/Main.qml" line="1668"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1431"/>
-        <location filename="../app/Main.qml" line="1454"/>
+        <location filename="../app/Main.qml" line="1459"/>
         <source>Update media database</source>
         <translation type="unfinished">تحديث قاعدة بيانات الوسائط</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1434"/>
-        <location filename="../app/Main.qml" line="1457"/>
+        <location filename="../app/Main.qml" line="1462"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">استخراج البيانات الوصفية</translation>
     </message>
@@ -606,113 +606,113 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
-        <location filename="../app/Main.qml" line="1501"/>
+        <location filename="../app/Main.qml" line="1471"/>
+        <location filename="../app/Main.qml" line="1506"/>
         <source>Launch game</source>
         <translation>تشغيل اللعبة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1482"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Remove from favorites</source>
         <translation>إزالة من المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1482"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Add to favorites</source>
         <translation>أضف إلى المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1492"/>
         <source>Write to NFC token</source>
         <translation>الكتابة إلى رمز NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1491"/>
+        <location filename="../app/Main.qml" line="1496"/>
         <source>QR code</source>
         <translation>رمز QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1659"/>
+        <location filename="../app/Main.qml" line="1664"/>
         <source>Default</source>
         <translation type="unfinished">افتراضي</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1659"/>
+        <location filename="../app/Main.qml" line="1664"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1947"/>
+        <location filename="../app/Main.qml" line="1952"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1950"/>
+        <location filename="../app/Main.qml" line="1955"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2031"/>
+        <location filename="../app/Main.qml" line="2036"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2035"/>
+        <location filename="../app/Main.qml" line="2040"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2049"/>
+        <location filename="../app/Main.qml" line="2054"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2053"/>
+        <location filename="../app/Main.qml" line="2058"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2057"/>
+        <location filename="../app/Main.qml" line="2062"/>
         <source>Retry</source>
         <translation type="unfinished">إعادة المحاولة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2061"/>
+        <location filename="../app/Main.qml" line="2066"/>
         <source>Cancel</source>
         <translation type="unfinished">إلغاء</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2741"/>
+        <location filename="../app/Main.qml" line="2746"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2743"/>
+        <location filename="../app/Main.qml" line="2748"/>
         <source>Loading games…</source>
         <translation>جارٍ تحميل الألعاب…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2745"/>
+        <location filename="../app/Main.qml" line="2750"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2747"/>
+        <location filename="../app/Main.qml" line="2752"/>
         <source>Loading favorites…</source>
         <translation>جارٍ تحميل المفضلة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2749"/>
+        <location filename="../app/Main.qml" line="2754"/>
         <source>Loading recently played…</source>
         <translation>جارٍ تحميل آخر ما تم لعبه…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2756"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2753"/>
+        <location filename="../app/Main.qml" line="2758"/>
         <source>Loading…</source>
         <translation>جارٍ التحميل…</translation>
     </message>

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -577,19 +577,19 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1668"/>
+        <location filename="../app/Main.qml" line="1669"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1431"/>
-        <location filename="../app/Main.qml" line="1459"/>
+        <location filename="../app/Main.qml" line="1460"/>
         <source>Update media database</source>
         <translation type="unfinished">تحديث قاعدة بيانات الوسائط</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1434"/>
-        <location filename="../app/Main.qml" line="1462"/>
+        <location filename="../app/Main.qml" line="1463"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">استخراج البيانات الوصفية</translation>
     </message>
@@ -606,113 +606,113 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1471"/>
-        <location filename="../app/Main.qml" line="1506"/>
+        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1507"/>
         <source>Launch game</source>
         <translation>تشغيل اللعبة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1488"/>
         <source>Remove from favorites</source>
         <translation>إزالة من المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1488"/>
         <source>Add to favorites</source>
         <translation>أضف إلى المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1492"/>
+        <location filename="../app/Main.qml" line="1493"/>
         <source>Write to NFC token</source>
         <translation>الكتابة إلى رمز NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1496"/>
+        <location filename="../app/Main.qml" line="1497"/>
         <source>QR code</source>
         <translation>رمز QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1664"/>
+        <location filename="../app/Main.qml" line="1665"/>
         <source>Default</source>
         <translation type="unfinished">افتراضي</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1664"/>
+        <location filename="../app/Main.qml" line="1665"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1952"/>
+        <location filename="../app/Main.qml" line="1953"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1955"/>
+        <location filename="../app/Main.qml" line="1956"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2036"/>
+        <location filename="../app/Main.qml" line="2037"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2040"/>
+        <location filename="../app/Main.qml" line="2041"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2054"/>
+        <location filename="../app/Main.qml" line="2055"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2058"/>
+        <location filename="../app/Main.qml" line="2059"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2062"/>
+        <location filename="../app/Main.qml" line="2063"/>
         <source>Retry</source>
         <translation type="unfinished">إعادة المحاولة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2066"/>
+        <location filename="../app/Main.qml" line="2067"/>
         <source>Cancel</source>
         <translation type="unfinished">إلغاء</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2746"/>
+        <location filename="../app/Main.qml" line="2747"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2748"/>
+        <location filename="../app/Main.qml" line="2749"/>
         <source>Loading games…</source>
         <translation>جارٍ تحميل الألعاب…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2750"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2752"/>
+        <location filename="../app/Main.qml" line="2753"/>
         <source>Loading favorites…</source>
         <translation>جارٍ تحميل المفضلة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2754"/>
+        <location filename="../app/Main.qml" line="2755"/>
         <source>Loading recently played…</source>
         <translation>جارٍ تحميل آخر ما تم لعبه…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2756"/>
+        <location filename="../app/Main.qml" line="2757"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2758"/>
+        <location filename="../app/Main.qml" line="2759"/>
         <source>Loading…</source>
         <translation>جارٍ التحميل…</translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -577,70 +577,70 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1663"/>
+        <location filename="../app/Main.qml" line="1668"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1482"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Remove from favorites</source>
         <translation>Aus Favoriten entfernen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1482"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Add to favorites</source>
         <translation>Zu Favoriten hinzufügen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1492"/>
         <source>Write to NFC token</source>
         <translation>Auf NFC-Token schreiben</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1491"/>
+        <location filename="../app/Main.qml" line="1496"/>
         <source>QR code</source>
         <translation>QR-Code</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
-        <location filename="../app/Main.qml" line="1501"/>
+        <location filename="../app/Main.qml" line="1471"/>
+        <location filename="../app/Main.qml" line="1506"/>
         <source>Launch game</source>
         <translation>Spiel starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1947"/>
+        <location filename="../app/Main.qml" line="1952"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1950"/>
+        <location filename="../app/Main.qml" line="1955"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2741"/>
+        <location filename="../app/Main.qml" line="2746"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2747"/>
+        <location filename="../app/Main.qml" line="2752"/>
         <source>Loading favorites…</source>
         <translation>Favoriten werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2743"/>
+        <location filename="../app/Main.qml" line="2748"/>
         <source>Loading games…</source>
         <translation>Spiele werden geladen…</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1431"/>
-        <location filename="../app/Main.qml" line="1454"/>
+        <location filename="../app/Main.qml" line="1459"/>
         <source>Update media database</source>
         <translation type="unfinished">Mediendatenbank aktualisieren</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1434"/>
-        <location filename="../app/Main.qml" line="1457"/>
+        <location filename="../app/Main.qml" line="1462"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadaten abrufen</translation>
     </message>
@@ -657,62 +657,62 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1659"/>
+        <location filename="../app/Main.qml" line="1664"/>
         <source>Default</source>
         <translation type="unfinished">Standard</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1659"/>
+        <location filename="../app/Main.qml" line="1664"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2031"/>
+        <location filename="../app/Main.qml" line="2036"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2035"/>
+        <location filename="../app/Main.qml" line="2040"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2049"/>
+        <location filename="../app/Main.qml" line="2054"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2053"/>
+        <location filename="../app/Main.qml" line="2058"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2057"/>
+        <location filename="../app/Main.qml" line="2062"/>
         <source>Retry</source>
         <translation type="unfinished">Wiederholen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2061"/>
+        <location filename="../app/Main.qml" line="2066"/>
         <source>Cancel</source>
         <translation type="unfinished">Abbrechen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2745"/>
+        <location filename="../app/Main.qml" line="2750"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2749"/>
+        <location filename="../app/Main.qml" line="2754"/>
         <source>Loading recently played…</source>
         <translation>Zuletzt gespielte werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2756"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2753"/>
+        <location filename="../app/Main.qml" line="2758"/>
         <source>Loading…</source>
         <translation>Wird geladen…</translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -577,70 +577,70 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1668"/>
+        <location filename="../app/Main.qml" line="1669"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1488"/>
         <source>Remove from favorites</source>
         <translation>Aus Favoriten entfernen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1488"/>
         <source>Add to favorites</source>
         <translation>Zu Favoriten hinzufügen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1492"/>
+        <location filename="../app/Main.qml" line="1493"/>
         <source>Write to NFC token</source>
         <translation>Auf NFC-Token schreiben</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1496"/>
+        <location filename="../app/Main.qml" line="1497"/>
         <source>QR code</source>
         <translation>QR-Code</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1471"/>
-        <location filename="../app/Main.qml" line="1506"/>
+        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1507"/>
         <source>Launch game</source>
         <translation>Spiel starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1952"/>
+        <location filename="../app/Main.qml" line="1953"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1955"/>
+        <location filename="../app/Main.qml" line="1956"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2746"/>
+        <location filename="../app/Main.qml" line="2747"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2752"/>
+        <location filename="../app/Main.qml" line="2753"/>
         <source>Loading favorites…</source>
         <translation>Favoriten werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2748"/>
+        <location filename="../app/Main.qml" line="2749"/>
         <source>Loading games…</source>
         <translation>Spiele werden geladen…</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1431"/>
-        <location filename="../app/Main.qml" line="1459"/>
+        <location filename="../app/Main.qml" line="1460"/>
         <source>Update media database</source>
         <translation type="unfinished">Mediendatenbank aktualisieren</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1434"/>
-        <location filename="../app/Main.qml" line="1462"/>
+        <location filename="../app/Main.qml" line="1463"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadaten abrufen</translation>
     </message>
@@ -657,62 +657,62 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1664"/>
+        <location filename="../app/Main.qml" line="1665"/>
         <source>Default</source>
         <translation type="unfinished">Standard</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1664"/>
+        <location filename="../app/Main.qml" line="1665"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2036"/>
+        <location filename="../app/Main.qml" line="2037"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2040"/>
+        <location filename="../app/Main.qml" line="2041"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2054"/>
+        <location filename="../app/Main.qml" line="2055"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2058"/>
+        <location filename="../app/Main.qml" line="2059"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2062"/>
+        <location filename="../app/Main.qml" line="2063"/>
         <source>Retry</source>
         <translation type="unfinished">Wiederholen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2066"/>
+        <location filename="../app/Main.qml" line="2067"/>
         <source>Cancel</source>
         <translation type="unfinished">Abbrechen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2750"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2754"/>
+        <location filename="../app/Main.qml" line="2755"/>
         <source>Loading recently played…</source>
         <translation>Zuletzt gespielte werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2756"/>
+        <location filename="../app/Main.qml" line="2757"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2758"/>
+        <location filename="../app/Main.qml" line="2759"/>
         <source>Loading…</source>
         <translation>Wird geladen…</translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -577,70 +577,70 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1668"/>
+        <location filename="../app/Main.qml" line="1669"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1488"/>
         <source>Remove from favorites</source>
         <translation>Αφαίρεση από αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1488"/>
         <source>Add to favorites</source>
         <translation>Προσθήκη στα αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1492"/>
+        <location filename="../app/Main.qml" line="1493"/>
         <source>Write to NFC token</source>
         <translation>Εγγραφή σε NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1496"/>
+        <location filename="../app/Main.qml" line="1497"/>
         <source>QR code</source>
         <translation>Κωδικός QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1471"/>
-        <location filename="../app/Main.qml" line="1506"/>
+        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1507"/>
         <source>Launch game</source>
         <translation>Εκκίνηση παιχνιδιού</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1952"/>
+        <location filename="../app/Main.qml" line="1953"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1955"/>
+        <location filename="../app/Main.qml" line="1956"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2746"/>
+        <location filename="../app/Main.qml" line="2747"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2752"/>
+        <location filename="../app/Main.qml" line="2753"/>
         <source>Loading favorites…</source>
         <translation>Φόρτωση αγαπημένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2748"/>
+        <location filename="../app/Main.qml" line="2749"/>
         <source>Loading games…</source>
         <translation>Φόρτωση παιχνιδιών…</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1431"/>
-        <location filename="../app/Main.qml" line="1459"/>
+        <location filename="../app/Main.qml" line="1460"/>
         <source>Update media database</source>
         <translation type="unfinished">Ενημέρωση βάσης δεδομένων</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1434"/>
-        <location filename="../app/Main.qml" line="1462"/>
+        <location filename="../app/Main.qml" line="1463"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Ανάκτηση μεταδεδομένων</translation>
     </message>
@@ -657,62 +657,62 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1664"/>
+        <location filename="../app/Main.qml" line="1665"/>
         <source>Default</source>
         <translation type="unfinished">Προεπιλογή</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1664"/>
+        <location filename="../app/Main.qml" line="1665"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2036"/>
+        <location filename="../app/Main.qml" line="2037"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2040"/>
+        <location filename="../app/Main.qml" line="2041"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2054"/>
+        <location filename="../app/Main.qml" line="2055"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2058"/>
+        <location filename="../app/Main.qml" line="2059"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2062"/>
+        <location filename="../app/Main.qml" line="2063"/>
         <source>Retry</source>
         <translation type="unfinished">Επανάληψη</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2066"/>
+        <location filename="../app/Main.qml" line="2067"/>
         <source>Cancel</source>
         <translation type="unfinished">Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2750"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2754"/>
+        <location filename="../app/Main.qml" line="2755"/>
         <source>Loading recently played…</source>
         <translation>Φόρτωση πρόσφατα παιγμένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2756"/>
+        <location filename="../app/Main.qml" line="2757"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2758"/>
+        <location filename="../app/Main.qml" line="2759"/>
         <source>Loading…</source>
         <translation>Φόρτωση…</translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -577,70 +577,70 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1663"/>
+        <location filename="../app/Main.qml" line="1668"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1482"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Remove from favorites</source>
         <translation>Αφαίρεση από αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1482"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Add to favorites</source>
         <translation>Προσθήκη στα αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1492"/>
         <source>Write to NFC token</source>
         <translation>Εγγραφή σε NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1491"/>
+        <location filename="../app/Main.qml" line="1496"/>
         <source>QR code</source>
         <translation>Κωδικός QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
-        <location filename="../app/Main.qml" line="1501"/>
+        <location filename="../app/Main.qml" line="1471"/>
+        <location filename="../app/Main.qml" line="1506"/>
         <source>Launch game</source>
         <translation>Εκκίνηση παιχνιδιού</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1947"/>
+        <location filename="../app/Main.qml" line="1952"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1950"/>
+        <location filename="../app/Main.qml" line="1955"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2741"/>
+        <location filename="../app/Main.qml" line="2746"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2747"/>
+        <location filename="../app/Main.qml" line="2752"/>
         <source>Loading favorites…</source>
         <translation>Φόρτωση αγαπημένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2743"/>
+        <location filename="../app/Main.qml" line="2748"/>
         <source>Loading games…</source>
         <translation>Φόρτωση παιχνιδιών…</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1431"/>
-        <location filename="../app/Main.qml" line="1454"/>
+        <location filename="../app/Main.qml" line="1459"/>
         <source>Update media database</source>
         <translation type="unfinished">Ενημέρωση βάσης δεδομένων</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1434"/>
-        <location filename="../app/Main.qml" line="1457"/>
+        <location filename="../app/Main.qml" line="1462"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Ανάκτηση μεταδεδομένων</translation>
     </message>
@@ -657,62 +657,62 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1659"/>
+        <location filename="../app/Main.qml" line="1664"/>
         <source>Default</source>
         <translation type="unfinished">Προεπιλογή</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1659"/>
+        <location filename="../app/Main.qml" line="1664"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2031"/>
+        <location filename="../app/Main.qml" line="2036"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2035"/>
+        <location filename="../app/Main.qml" line="2040"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2049"/>
+        <location filename="../app/Main.qml" line="2054"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2053"/>
+        <location filename="../app/Main.qml" line="2058"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2057"/>
+        <location filename="../app/Main.qml" line="2062"/>
         <source>Retry</source>
         <translation type="unfinished">Επανάληψη</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2061"/>
+        <location filename="../app/Main.qml" line="2066"/>
         <source>Cancel</source>
         <translation type="unfinished">Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2745"/>
+        <location filename="../app/Main.qml" line="2750"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2749"/>
+        <location filename="../app/Main.qml" line="2754"/>
         <source>Loading recently played…</source>
         <translation>Φόρτωση πρόσφατα παιγμένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2756"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2753"/>
+        <location filename="../app/Main.qml" line="2758"/>
         <source>Loading…</source>
         <translation>Φόρτωση…</translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -565,70 +565,70 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1663"/>
+        <location filename="../app/Main.qml" line="1668"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1482"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Remove from favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1482"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Add to favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1492"/>
         <source>Write to NFC token</source>
         <translation type="unfinished">Write to NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1491"/>
+        <location filename="../app/Main.qml" line="1496"/>
         <source>QR code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
-        <location filename="../app/Main.qml" line="1501"/>
+        <location filename="../app/Main.qml" line="1471"/>
+        <location filename="../app/Main.qml" line="1506"/>
         <source>Launch game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1947"/>
+        <location filename="../app/Main.qml" line="1952"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1950"/>
+        <location filename="../app/Main.qml" line="1955"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2741"/>
+        <location filename="../app/Main.qml" line="2746"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2747"/>
+        <location filename="../app/Main.qml" line="2752"/>
         <source>Loading favorites…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2743"/>
+        <location filename="../app/Main.qml" line="2748"/>
         <source>Loading games…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1431"/>
-        <location filename="../app/Main.qml" line="1454"/>
+        <location filename="../app/Main.qml" line="1459"/>
         <source>Update media database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1434"/>
-        <location filename="../app/Main.qml" line="1457"/>
+        <location filename="../app/Main.qml" line="1462"/>
         <source>Scrape metadata</source>
         <translation type="unfinished"></translation>
     </message>
@@ -645,62 +645,62 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1659"/>
+        <location filename="../app/Main.qml" line="1664"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1659"/>
+        <location filename="../app/Main.qml" line="1664"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2031"/>
+        <location filename="../app/Main.qml" line="2036"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2035"/>
+        <location filename="../app/Main.qml" line="2040"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2049"/>
+        <location filename="../app/Main.qml" line="2054"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2053"/>
+        <location filename="../app/Main.qml" line="2058"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2057"/>
+        <location filename="../app/Main.qml" line="2062"/>
         <source>Retry</source>
         <translation type="unfinished">Retry</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2061"/>
+        <location filename="../app/Main.qml" line="2066"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2745"/>
+        <location filename="../app/Main.qml" line="2750"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2749"/>
+        <location filename="../app/Main.qml" line="2754"/>
         <source>Loading recently played…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2756"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2753"/>
+        <location filename="../app/Main.qml" line="2758"/>
         <source>Loading…</source>
         <translation type="unfinished">Loading…</translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -565,70 +565,70 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1668"/>
+        <location filename="../app/Main.qml" line="1669"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1488"/>
         <source>Remove from favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1488"/>
         <source>Add to favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1492"/>
+        <location filename="../app/Main.qml" line="1493"/>
         <source>Write to NFC token</source>
         <translation type="unfinished">Write to NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1496"/>
+        <location filename="../app/Main.qml" line="1497"/>
         <source>QR code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1471"/>
-        <location filename="../app/Main.qml" line="1506"/>
+        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1507"/>
         <source>Launch game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1952"/>
+        <location filename="../app/Main.qml" line="1953"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1955"/>
+        <location filename="../app/Main.qml" line="1956"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2746"/>
+        <location filename="../app/Main.qml" line="2747"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2752"/>
+        <location filename="../app/Main.qml" line="2753"/>
         <source>Loading favorites…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2748"/>
+        <location filename="../app/Main.qml" line="2749"/>
         <source>Loading games…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1431"/>
-        <location filename="../app/Main.qml" line="1459"/>
+        <location filename="../app/Main.qml" line="1460"/>
         <source>Update media database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1434"/>
-        <location filename="../app/Main.qml" line="1462"/>
+        <location filename="../app/Main.qml" line="1463"/>
         <source>Scrape metadata</source>
         <translation type="unfinished"></translation>
     </message>
@@ -645,62 +645,62 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1664"/>
+        <location filename="../app/Main.qml" line="1665"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1664"/>
+        <location filename="../app/Main.qml" line="1665"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2036"/>
+        <location filename="../app/Main.qml" line="2037"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2040"/>
+        <location filename="../app/Main.qml" line="2041"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2054"/>
+        <location filename="../app/Main.qml" line="2055"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2058"/>
+        <location filename="../app/Main.qml" line="2059"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2062"/>
+        <location filename="../app/Main.qml" line="2063"/>
         <source>Retry</source>
         <translation type="unfinished">Retry</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2066"/>
+        <location filename="../app/Main.qml" line="2067"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2750"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2754"/>
+        <location filename="../app/Main.qml" line="2755"/>
         <source>Loading recently played…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2756"/>
+        <location filename="../app/Main.qml" line="2757"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2758"/>
+        <location filename="../app/Main.qml" line="2759"/>
         <source>Loading…</source>
         <translation type="unfinished">Loading…</translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -577,70 +577,70 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1668"/>
+        <location filename="../app/Main.qml" line="1669"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1488"/>
         <source>Remove from favorites</source>
         <translation>Eliminar de favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1488"/>
         <source>Add to favorites</source>
         <translation>Agregar a favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1492"/>
+        <location filename="../app/Main.qml" line="1493"/>
         <source>Write to NFC token</source>
         <translation>Escribir en token NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1496"/>
+        <location filename="../app/Main.qml" line="1497"/>
         <source>QR code</source>
         <translation>Código QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1471"/>
-        <location filename="../app/Main.qml" line="1506"/>
+        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1507"/>
         <source>Launch game</source>
         <translation>Iniciar juego</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1952"/>
+        <location filename="../app/Main.qml" line="1953"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1955"/>
+        <location filename="../app/Main.qml" line="1956"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2746"/>
+        <location filename="../app/Main.qml" line="2747"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2752"/>
+        <location filename="../app/Main.qml" line="2753"/>
         <source>Loading favorites…</source>
         <translation>Cargando favoritos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2748"/>
+        <location filename="../app/Main.qml" line="2749"/>
         <source>Loading games…</source>
         <translation>Cargando juegos…</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1431"/>
-        <location filename="../app/Main.qml" line="1459"/>
+        <location filename="../app/Main.qml" line="1460"/>
         <source>Update media database</source>
         <translation type="unfinished">Actualizar base de datos de medios</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1434"/>
-        <location filename="../app/Main.qml" line="1462"/>
+        <location filename="../app/Main.qml" line="1463"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Extraer metadatos</translation>
     </message>
@@ -657,62 +657,62 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1664"/>
+        <location filename="../app/Main.qml" line="1665"/>
         <source>Default</source>
         <translation type="unfinished">Por defecto</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1664"/>
+        <location filename="../app/Main.qml" line="1665"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2036"/>
+        <location filename="../app/Main.qml" line="2037"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2040"/>
+        <location filename="../app/Main.qml" line="2041"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2054"/>
+        <location filename="../app/Main.qml" line="2055"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2058"/>
+        <location filename="../app/Main.qml" line="2059"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2062"/>
+        <location filename="../app/Main.qml" line="2063"/>
         <source>Retry</source>
         <translation type="unfinished">Reintentar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2066"/>
+        <location filename="../app/Main.qml" line="2067"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2750"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2754"/>
+        <location filename="../app/Main.qml" line="2755"/>
         <source>Loading recently played…</source>
         <translation>Cargando jugados recientemente…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2756"/>
+        <location filename="../app/Main.qml" line="2757"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2758"/>
+        <location filename="../app/Main.qml" line="2759"/>
         <source>Loading…</source>
         <translation>Cargando…</translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -577,70 +577,70 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1663"/>
+        <location filename="../app/Main.qml" line="1668"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1482"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Remove from favorites</source>
         <translation>Eliminar de favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1482"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Add to favorites</source>
         <translation>Agregar a favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1492"/>
         <source>Write to NFC token</source>
         <translation>Escribir en token NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1491"/>
+        <location filename="../app/Main.qml" line="1496"/>
         <source>QR code</source>
         <translation>Código QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
-        <location filename="../app/Main.qml" line="1501"/>
+        <location filename="../app/Main.qml" line="1471"/>
+        <location filename="../app/Main.qml" line="1506"/>
         <source>Launch game</source>
         <translation>Iniciar juego</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1947"/>
+        <location filename="../app/Main.qml" line="1952"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1950"/>
+        <location filename="../app/Main.qml" line="1955"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2741"/>
+        <location filename="../app/Main.qml" line="2746"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2747"/>
+        <location filename="../app/Main.qml" line="2752"/>
         <source>Loading favorites…</source>
         <translation>Cargando favoritos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2743"/>
+        <location filename="../app/Main.qml" line="2748"/>
         <source>Loading games…</source>
         <translation>Cargando juegos…</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1431"/>
-        <location filename="../app/Main.qml" line="1454"/>
+        <location filename="../app/Main.qml" line="1459"/>
         <source>Update media database</source>
         <translation type="unfinished">Actualizar base de datos de medios</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1434"/>
-        <location filename="../app/Main.qml" line="1457"/>
+        <location filename="../app/Main.qml" line="1462"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Extraer metadatos</translation>
     </message>
@@ -657,62 +657,62 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1659"/>
+        <location filename="../app/Main.qml" line="1664"/>
         <source>Default</source>
         <translation type="unfinished">Por defecto</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1659"/>
+        <location filename="../app/Main.qml" line="1664"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2031"/>
+        <location filename="../app/Main.qml" line="2036"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2035"/>
+        <location filename="../app/Main.qml" line="2040"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2049"/>
+        <location filename="../app/Main.qml" line="2054"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2053"/>
+        <location filename="../app/Main.qml" line="2058"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2057"/>
+        <location filename="../app/Main.qml" line="2062"/>
         <source>Retry</source>
         <translation type="unfinished">Reintentar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2061"/>
+        <location filename="../app/Main.qml" line="2066"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2745"/>
+        <location filename="../app/Main.qml" line="2750"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2749"/>
+        <location filename="../app/Main.qml" line="2754"/>
         <source>Loading recently played…</source>
         <translation>Cargando jugados recientemente…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2756"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2753"/>
+        <location filename="../app/Main.qml" line="2758"/>
         <source>Loading…</source>
         <translation>Cargando…</translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -585,70 +585,70 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1668"/>
+        <location filename="../app/Main.qml" line="1669"/>
         <source>Change launcher</source>
         <translation type="unfinished">Aldatu abiarazlea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1488"/>
         <source>Remove from favorites</source>
         <translation type="unfinished">Kendu gogokoetatik</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1488"/>
         <source>Add to favorites</source>
         <translation type="unfinished">Gehitu gogokoetan</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1492"/>
+        <location filename="../app/Main.qml" line="1493"/>
         <source>Write to NFC token</source>
         <translation type="unfinished">Idatzi NFC token-a</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1496"/>
+        <location filename="../app/Main.qml" line="1497"/>
         <source>QR code</source>
         <translation type="unfinished">QR kodea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1471"/>
-        <location filename="../app/Main.qml" line="1506"/>
+        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1507"/>
         <source>Launch game</source>
         <translation type="unfinished">Abiarazi jokua</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1952"/>
+        <location filename="../app/Main.qml" line="1953"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1955"/>
+        <location filename="../app/Main.qml" line="1956"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2746"/>
+        <location filename="../app/Main.qml" line="2747"/>
         <source>Loading systems…</source>
         <translation type="unfinished">Sistemak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2752"/>
+        <location filename="../app/Main.qml" line="2753"/>
         <source>Loading favorites…</source>
         <translation type="unfinished">Gogokoak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2748"/>
+        <location filename="../app/Main.qml" line="2749"/>
         <source>Loading games…</source>
         <translation type="unfinished">Jokoak kargatzen</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1431"/>
-        <location filename="../app/Main.qml" line="1459"/>
+        <location filename="../app/Main.qml" line="1460"/>
         <source>Update media database</source>
         <translation type="unfinished">Eguneratu multimedia datu-basea</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1434"/>
-        <location filename="../app/Main.qml" line="1462"/>
+        <location filename="../app/Main.qml" line="1463"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadatuak scrapeatu</translation>
     </message>
@@ -665,62 +665,62 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1664"/>
+        <location filename="../app/Main.qml" line="1665"/>
         <source>Default</source>
         <translation type="unfinished">Lehenetsia</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1664"/>
+        <location filename="../app/Main.qml" line="1665"/>
         <source>Current: %1</source>
         <translation type="unfinished">Unekoa: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2036"/>
+        <location filename="../app/Main.qml" line="2037"/>
         <source>Saving launcher</source>
         <translation type="unfinished">Abiarazlea gordetzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2040"/>
+        <location filename="../app/Main.qml" line="2041"/>
         <source>Saving…</source>
         <translation type="unfinished">Gordetzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2054"/>
+        <location filename="../app/Main.qml" line="2055"/>
         <source>Launcher update failed</source>
         <translation type="unfinished">Abiarazle egukeraketak huts egin du</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2058"/>
+        <location filename="../app/Main.qml" line="2059"/>
         <source>Error: %1</source>
         <translation type="unfinished">Errorea: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2062"/>
+        <location filename="../app/Main.qml" line="2063"/>
         <source>Retry</source>
         <translation type="unfinished">Berriro saiatu</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2066"/>
+        <location filename="../app/Main.qml" line="2067"/>
         <source>Cancel</source>
         <translation type="unfinished">Utzi</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2750"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Loading game…</source>
         <translation type="unfinished">Jokua kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2754"/>
+        <location filename="../app/Main.qml" line="2755"/>
         <source>Loading recently played…</source>
         <translation type="unfinished">Duela gutxi jokatutakoak kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2756"/>
+        <location filename="../app/Main.qml" line="2757"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2758"/>
+        <location filename="../app/Main.qml" line="2759"/>
         <source>Loading…</source>
         <translation type="unfinished">Kargatzen…</translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -585,70 +585,70 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1663"/>
+        <location filename="../app/Main.qml" line="1668"/>
         <source>Change launcher</source>
         <translation type="unfinished">Aldatu abiarazlea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1482"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Remove from favorites</source>
         <translation type="unfinished">Kendu gogokoetatik</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1482"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Add to favorites</source>
         <translation type="unfinished">Gehitu gogokoetan</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1492"/>
         <source>Write to NFC token</source>
         <translation type="unfinished">Idatzi NFC token-a</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1491"/>
+        <location filename="../app/Main.qml" line="1496"/>
         <source>QR code</source>
         <translation type="unfinished">QR kodea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
-        <location filename="../app/Main.qml" line="1501"/>
+        <location filename="../app/Main.qml" line="1471"/>
+        <location filename="../app/Main.qml" line="1506"/>
         <source>Launch game</source>
         <translation type="unfinished">Abiarazi jokua</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1947"/>
+        <location filename="../app/Main.qml" line="1952"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1950"/>
+        <location filename="../app/Main.qml" line="1955"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2741"/>
+        <location filename="../app/Main.qml" line="2746"/>
         <source>Loading systems…</source>
         <translation type="unfinished">Sistemak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2747"/>
+        <location filename="../app/Main.qml" line="2752"/>
         <source>Loading favorites…</source>
         <translation type="unfinished">Gogokoak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2743"/>
+        <location filename="../app/Main.qml" line="2748"/>
         <source>Loading games…</source>
         <translation type="unfinished">Jokoak kargatzen</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1431"/>
-        <location filename="../app/Main.qml" line="1454"/>
+        <location filename="../app/Main.qml" line="1459"/>
         <source>Update media database</source>
         <translation type="unfinished">Eguneratu multimedia datu-basea</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1434"/>
-        <location filename="../app/Main.qml" line="1457"/>
+        <location filename="../app/Main.qml" line="1462"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadatuak scrapeatu</translation>
     </message>
@@ -665,62 +665,62 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1659"/>
+        <location filename="../app/Main.qml" line="1664"/>
         <source>Default</source>
         <translation type="unfinished">Lehenetsia</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1659"/>
+        <location filename="../app/Main.qml" line="1664"/>
         <source>Current: %1</source>
         <translation type="unfinished">Unekoa: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2031"/>
+        <location filename="../app/Main.qml" line="2036"/>
         <source>Saving launcher</source>
         <translation type="unfinished">Abiarazlea gordetzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2035"/>
+        <location filename="../app/Main.qml" line="2040"/>
         <source>Saving…</source>
         <translation type="unfinished">Gordetzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2049"/>
+        <location filename="../app/Main.qml" line="2054"/>
         <source>Launcher update failed</source>
         <translation type="unfinished">Abiarazle egukeraketak huts egin du</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2053"/>
+        <location filename="../app/Main.qml" line="2058"/>
         <source>Error: %1</source>
         <translation type="unfinished">Errorea: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2057"/>
+        <location filename="../app/Main.qml" line="2062"/>
         <source>Retry</source>
         <translation type="unfinished">Berriro saiatu</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2061"/>
+        <location filename="../app/Main.qml" line="2066"/>
         <source>Cancel</source>
         <translation type="unfinished">Utzi</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2745"/>
+        <location filename="../app/Main.qml" line="2750"/>
         <source>Loading game…</source>
         <translation type="unfinished">Jokua kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2749"/>
+        <location filename="../app/Main.qml" line="2754"/>
         <source>Loading recently played…</source>
         <translation type="unfinished">Duela gutxi jokatutakoak kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2756"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2753"/>
+        <location filename="../app/Main.qml" line="2758"/>
         <source>Loading…</source>
         <translation type="unfinished">Kargatzen…</translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -577,19 +577,19 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1668"/>
+        <location filename="../app/Main.qml" line="1669"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1431"/>
-        <location filename="../app/Main.qml" line="1459"/>
+        <location filename="../app/Main.qml" line="1460"/>
         <source>Update media database</source>
         <translation type="unfinished">עדכון מסד נתוני המדיה</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1434"/>
-        <location filename="../app/Main.qml" line="1462"/>
+        <location filename="../app/Main.qml" line="1463"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">איסוף מטא-נתונים</translation>
     </message>
@@ -606,113 +606,113 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1471"/>
-        <location filename="../app/Main.qml" line="1506"/>
+        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1507"/>
         <source>Launch game</source>
         <translation>הפעל משחק</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1488"/>
         <source>Remove from favorites</source>
         <translation>הסר מהמועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1488"/>
         <source>Add to favorites</source>
         <translation>הוסף למועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1492"/>
+        <location filename="../app/Main.qml" line="1493"/>
         <source>Write to NFC token</source>
         <translation>כתוב לטוקן NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1496"/>
+        <location filename="../app/Main.qml" line="1497"/>
         <source>QR code</source>
         <translation>קוד QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1664"/>
+        <location filename="../app/Main.qml" line="1665"/>
         <source>Default</source>
         <translation type="unfinished">ברירת מחדל</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1664"/>
+        <location filename="../app/Main.qml" line="1665"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1952"/>
+        <location filename="../app/Main.qml" line="1953"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1955"/>
+        <location filename="../app/Main.qml" line="1956"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2036"/>
+        <location filename="../app/Main.qml" line="2037"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2040"/>
+        <location filename="../app/Main.qml" line="2041"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2054"/>
+        <location filename="../app/Main.qml" line="2055"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2058"/>
+        <location filename="../app/Main.qml" line="2059"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2062"/>
+        <location filename="../app/Main.qml" line="2063"/>
         <source>Retry</source>
         <translation type="unfinished">נסה שוב</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2066"/>
+        <location filename="../app/Main.qml" line="2067"/>
         <source>Cancel</source>
         <translation type="unfinished">ביטול</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2746"/>
+        <location filename="../app/Main.qml" line="2747"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2748"/>
+        <location filename="../app/Main.qml" line="2749"/>
         <source>Loading games…</source>
         <translation>טוען משחקים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2750"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2752"/>
+        <location filename="../app/Main.qml" line="2753"/>
         <source>Loading favorites…</source>
         <translation>טוען מועדפים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2754"/>
+        <location filename="../app/Main.qml" line="2755"/>
         <source>Loading recently played…</source>
         <translation>טוען את הפריטים ששוחקו לאחרונה…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2756"/>
+        <location filename="../app/Main.qml" line="2757"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2758"/>
+        <location filename="../app/Main.qml" line="2759"/>
         <source>Loading…</source>
         <translation>טוען…</translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -577,19 +577,19 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1663"/>
+        <location filename="../app/Main.qml" line="1668"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1431"/>
-        <location filename="../app/Main.qml" line="1454"/>
+        <location filename="../app/Main.qml" line="1459"/>
         <source>Update media database</source>
         <translation type="unfinished">עדכון מסד נתוני המדיה</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1434"/>
-        <location filename="../app/Main.qml" line="1457"/>
+        <location filename="../app/Main.qml" line="1462"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">איסוף מטא-נתונים</translation>
     </message>
@@ -606,113 +606,113 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
-        <location filename="../app/Main.qml" line="1501"/>
+        <location filename="../app/Main.qml" line="1471"/>
+        <location filename="../app/Main.qml" line="1506"/>
         <source>Launch game</source>
         <translation>הפעל משחק</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1482"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Remove from favorites</source>
         <translation>הסר מהמועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1482"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Add to favorites</source>
         <translation>הוסף למועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1492"/>
         <source>Write to NFC token</source>
         <translation>כתוב לטוקן NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1491"/>
+        <location filename="../app/Main.qml" line="1496"/>
         <source>QR code</source>
         <translation>קוד QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1659"/>
+        <location filename="../app/Main.qml" line="1664"/>
         <source>Default</source>
         <translation type="unfinished">ברירת מחדל</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1659"/>
+        <location filename="../app/Main.qml" line="1664"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1947"/>
+        <location filename="../app/Main.qml" line="1952"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1950"/>
+        <location filename="../app/Main.qml" line="1955"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2031"/>
+        <location filename="../app/Main.qml" line="2036"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2035"/>
+        <location filename="../app/Main.qml" line="2040"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2049"/>
+        <location filename="../app/Main.qml" line="2054"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2053"/>
+        <location filename="../app/Main.qml" line="2058"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2057"/>
+        <location filename="../app/Main.qml" line="2062"/>
         <source>Retry</source>
         <translation type="unfinished">נסה שוב</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2061"/>
+        <location filename="../app/Main.qml" line="2066"/>
         <source>Cancel</source>
         <translation type="unfinished">ביטול</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2741"/>
+        <location filename="../app/Main.qml" line="2746"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2743"/>
+        <location filename="../app/Main.qml" line="2748"/>
         <source>Loading games…</source>
         <translation>טוען משחקים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2745"/>
+        <location filename="../app/Main.qml" line="2750"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2747"/>
+        <location filename="../app/Main.qml" line="2752"/>
         <source>Loading favorites…</source>
         <translation>טוען מועדפים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2749"/>
+        <location filename="../app/Main.qml" line="2754"/>
         <source>Loading recently played…</source>
         <translation>טוען את הפריטים ששוחקו לאחרונה…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2756"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2753"/>
+        <location filename="../app/Main.qml" line="2758"/>
         <source>Loading…</source>
         <translation>טוען…</translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -577,19 +577,19 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1668"/>
+        <location filename="../app/Main.qml" line="1669"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1431"/>
-        <location filename="../app/Main.qml" line="1459"/>
+        <location filename="../app/Main.qml" line="1460"/>
         <source>Update media database</source>
         <translation type="unfinished">मीडिया डेटाबेस अपडेट करें</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1434"/>
-        <location filename="../app/Main.qml" line="1462"/>
+        <location filename="../app/Main.qml" line="1463"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">मेटाडेटा स्क्रैप करें</translation>
     </message>
@@ -606,113 +606,113 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1471"/>
-        <location filename="../app/Main.qml" line="1506"/>
+        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1507"/>
         <source>Launch game</source>
         <translation>गेम चलाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1488"/>
         <source>Remove from favorites</source>
         <translation>पसंदीदा से हटाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1488"/>
         <source>Add to favorites</source>
         <translation>पसंदीदा में जोड़ें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1492"/>
+        <location filename="../app/Main.qml" line="1493"/>
         <source>Write to NFC token</source>
         <translation>NFC टोकन पर लिखें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1496"/>
+        <location filename="../app/Main.qml" line="1497"/>
         <source>QR code</source>
         <translation>QR कोड</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1664"/>
+        <location filename="../app/Main.qml" line="1665"/>
         <source>Default</source>
         <translation type="unfinished">डिफ़ॉल्ट</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1664"/>
+        <location filename="../app/Main.qml" line="1665"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1952"/>
+        <location filename="../app/Main.qml" line="1953"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1955"/>
+        <location filename="../app/Main.qml" line="1956"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2036"/>
+        <location filename="../app/Main.qml" line="2037"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2040"/>
+        <location filename="../app/Main.qml" line="2041"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2054"/>
+        <location filename="../app/Main.qml" line="2055"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2058"/>
+        <location filename="../app/Main.qml" line="2059"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2062"/>
+        <location filename="../app/Main.qml" line="2063"/>
         <source>Retry</source>
         <translation type="unfinished">फिर से प्रयास करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2066"/>
+        <location filename="../app/Main.qml" line="2067"/>
         <source>Cancel</source>
         <translation type="unfinished">रद्द करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2746"/>
+        <location filename="../app/Main.qml" line="2747"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2748"/>
+        <location filename="../app/Main.qml" line="2749"/>
         <source>Loading games…</source>
         <translation>गेम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2750"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2752"/>
+        <location filename="../app/Main.qml" line="2753"/>
         <source>Loading favorites…</source>
         <translation>पसंदीदा लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2754"/>
+        <location filename="../app/Main.qml" line="2755"/>
         <source>Loading recently played…</source>
         <translation>हाल ही में खेले गए लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2756"/>
+        <location filename="../app/Main.qml" line="2757"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2758"/>
+        <location filename="../app/Main.qml" line="2759"/>
         <source>Loading…</source>
         <translation>लोड हो रहा है…</translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -577,19 +577,19 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1663"/>
+        <location filename="../app/Main.qml" line="1668"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1431"/>
-        <location filename="../app/Main.qml" line="1454"/>
+        <location filename="../app/Main.qml" line="1459"/>
         <source>Update media database</source>
         <translation type="unfinished">मीडिया डेटाबेस अपडेट करें</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1434"/>
-        <location filename="../app/Main.qml" line="1457"/>
+        <location filename="../app/Main.qml" line="1462"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">मेटाडेटा स्क्रैप करें</translation>
     </message>
@@ -606,113 +606,113 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
-        <location filename="../app/Main.qml" line="1501"/>
+        <location filename="../app/Main.qml" line="1471"/>
+        <location filename="../app/Main.qml" line="1506"/>
         <source>Launch game</source>
         <translation>गेम चलाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1482"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Remove from favorites</source>
         <translation>पसंदीदा से हटाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1482"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Add to favorites</source>
         <translation>पसंदीदा में जोड़ें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1492"/>
         <source>Write to NFC token</source>
         <translation>NFC टोकन पर लिखें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1491"/>
+        <location filename="../app/Main.qml" line="1496"/>
         <source>QR code</source>
         <translation>QR कोड</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1659"/>
+        <location filename="../app/Main.qml" line="1664"/>
         <source>Default</source>
         <translation type="unfinished">डिफ़ॉल्ट</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1659"/>
+        <location filename="../app/Main.qml" line="1664"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1947"/>
+        <location filename="../app/Main.qml" line="1952"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1950"/>
+        <location filename="../app/Main.qml" line="1955"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2031"/>
+        <location filename="../app/Main.qml" line="2036"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2035"/>
+        <location filename="../app/Main.qml" line="2040"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2049"/>
+        <location filename="../app/Main.qml" line="2054"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2053"/>
+        <location filename="../app/Main.qml" line="2058"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2057"/>
+        <location filename="../app/Main.qml" line="2062"/>
         <source>Retry</source>
         <translation type="unfinished">फिर से प्रयास करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2061"/>
+        <location filename="../app/Main.qml" line="2066"/>
         <source>Cancel</source>
         <translation type="unfinished">रद्द करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2741"/>
+        <location filename="../app/Main.qml" line="2746"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2743"/>
+        <location filename="../app/Main.qml" line="2748"/>
         <source>Loading games…</source>
         <translation>गेम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2745"/>
+        <location filename="../app/Main.qml" line="2750"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2747"/>
+        <location filename="../app/Main.qml" line="2752"/>
         <source>Loading favorites…</source>
         <translation>पसंदीदा लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2749"/>
+        <location filename="../app/Main.qml" line="2754"/>
         <source>Loading recently played…</source>
         <translation>हाल ही में खेले गए लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2756"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2753"/>
+        <location filename="../app/Main.qml" line="2758"/>
         <source>Loading…</source>
         <translation>लोड हो रहा है…</translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -577,70 +577,70 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1663"/>
+        <location filename="../app/Main.qml" line="1668"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1482"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Remove from favorites</source>
         <translation>Rimuovi dai preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1482"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Add to favorites</source>
         <translation>Aggiungi ai preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1492"/>
         <source>Write to NFC token</source>
         <translation>Scrivi sul token NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1491"/>
+        <location filename="../app/Main.qml" line="1496"/>
         <source>QR code</source>
         <translation>Codice QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
-        <location filename="../app/Main.qml" line="1501"/>
+        <location filename="../app/Main.qml" line="1471"/>
+        <location filename="../app/Main.qml" line="1506"/>
         <source>Launch game</source>
         <translation>Avvia gioco</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1947"/>
+        <location filename="../app/Main.qml" line="1952"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1950"/>
+        <location filename="../app/Main.qml" line="1955"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2741"/>
+        <location filename="../app/Main.qml" line="2746"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2747"/>
+        <location filename="../app/Main.qml" line="2752"/>
         <source>Loading favorites…</source>
         <translation>Caricamento preferiti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2743"/>
+        <location filename="../app/Main.qml" line="2748"/>
         <source>Loading games…</source>
         <translation>Caricamento giochi…</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1431"/>
-        <location filename="../app/Main.qml" line="1454"/>
+        <location filename="../app/Main.qml" line="1459"/>
         <source>Update media database</source>
         <translation type="unfinished">Aggiorna database multimediale</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1434"/>
-        <location filename="../app/Main.qml" line="1457"/>
+        <location filename="../app/Main.qml" line="1462"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Recupera metadati</translation>
     </message>
@@ -657,62 +657,62 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1659"/>
+        <location filename="../app/Main.qml" line="1664"/>
         <source>Default</source>
         <translation type="unfinished">Predefinito</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1659"/>
+        <location filename="../app/Main.qml" line="1664"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2031"/>
+        <location filename="../app/Main.qml" line="2036"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2035"/>
+        <location filename="../app/Main.qml" line="2040"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2049"/>
+        <location filename="../app/Main.qml" line="2054"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2053"/>
+        <location filename="../app/Main.qml" line="2058"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2057"/>
+        <location filename="../app/Main.qml" line="2062"/>
         <source>Retry</source>
         <translation type="unfinished">Riprova</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2061"/>
+        <location filename="../app/Main.qml" line="2066"/>
         <source>Cancel</source>
         <translation type="unfinished">Annulla</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2745"/>
+        <location filename="../app/Main.qml" line="2750"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2749"/>
+        <location filename="../app/Main.qml" line="2754"/>
         <source>Loading recently played…</source>
         <translation>Caricamento recenti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2756"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2753"/>
+        <location filename="../app/Main.qml" line="2758"/>
         <source>Loading…</source>
         <translation>Caricamento…</translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -577,70 +577,70 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1668"/>
+        <location filename="../app/Main.qml" line="1669"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1488"/>
         <source>Remove from favorites</source>
         <translation>Rimuovi dai preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1488"/>
         <source>Add to favorites</source>
         <translation>Aggiungi ai preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1492"/>
+        <location filename="../app/Main.qml" line="1493"/>
         <source>Write to NFC token</source>
         <translation>Scrivi sul token NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1496"/>
+        <location filename="../app/Main.qml" line="1497"/>
         <source>QR code</source>
         <translation>Codice QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1471"/>
-        <location filename="../app/Main.qml" line="1506"/>
+        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1507"/>
         <source>Launch game</source>
         <translation>Avvia gioco</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1952"/>
+        <location filename="../app/Main.qml" line="1953"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1955"/>
+        <location filename="../app/Main.qml" line="1956"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2746"/>
+        <location filename="../app/Main.qml" line="2747"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2752"/>
+        <location filename="../app/Main.qml" line="2753"/>
         <source>Loading favorites…</source>
         <translation>Caricamento preferiti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2748"/>
+        <location filename="../app/Main.qml" line="2749"/>
         <source>Loading games…</source>
         <translation>Caricamento giochi…</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1431"/>
-        <location filename="../app/Main.qml" line="1459"/>
+        <location filename="../app/Main.qml" line="1460"/>
         <source>Update media database</source>
         <translation type="unfinished">Aggiorna database multimediale</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1434"/>
-        <location filename="../app/Main.qml" line="1462"/>
+        <location filename="../app/Main.qml" line="1463"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Recupera metadati</translation>
     </message>
@@ -657,62 +657,62 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1664"/>
+        <location filename="../app/Main.qml" line="1665"/>
         <source>Default</source>
         <translation type="unfinished">Predefinito</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1664"/>
+        <location filename="../app/Main.qml" line="1665"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2036"/>
+        <location filename="../app/Main.qml" line="2037"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2040"/>
+        <location filename="../app/Main.qml" line="2041"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2054"/>
+        <location filename="../app/Main.qml" line="2055"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2058"/>
+        <location filename="../app/Main.qml" line="2059"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2062"/>
+        <location filename="../app/Main.qml" line="2063"/>
         <source>Retry</source>
         <translation type="unfinished">Riprova</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2066"/>
+        <location filename="../app/Main.qml" line="2067"/>
         <source>Cancel</source>
         <translation type="unfinished">Annulla</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2750"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2754"/>
+        <location filename="../app/Main.qml" line="2755"/>
         <source>Loading recently played…</source>
         <translation>Caricamento recenti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2756"/>
+        <location filename="../app/Main.qml" line="2757"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2758"/>
+        <location filename="../app/Main.qml" line="2759"/>
         <source>Loading…</source>
         <translation>Caricamento…</translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -577,70 +577,70 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1663"/>
+        <location filename="../app/Main.qml" line="1668"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1482"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Remove from favorites</source>
         <translation>お気に入りから削除</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1482"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Add to favorites</source>
         <translation>お気に入りに追加</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1492"/>
         <source>Write to NFC token</source>
         <translation>NFC トークンに書き込む</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1491"/>
+        <location filename="../app/Main.qml" line="1496"/>
         <source>QR code</source>
         <translation>QR コード</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
-        <location filename="../app/Main.qml" line="1501"/>
+        <location filename="../app/Main.qml" line="1471"/>
+        <location filename="../app/Main.qml" line="1506"/>
         <source>Launch game</source>
         <translation>ゲームを起動</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1947"/>
+        <location filename="../app/Main.qml" line="1952"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1950"/>
+        <location filename="../app/Main.qml" line="1955"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2741"/>
+        <location filename="../app/Main.qml" line="2746"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2747"/>
+        <location filename="../app/Main.qml" line="2752"/>
         <source>Loading favorites…</source>
         <translation>お気に入りを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2743"/>
+        <location filename="../app/Main.qml" line="2748"/>
         <source>Loading games…</source>
         <translation>ゲームを読み込み中…</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1431"/>
-        <location filename="../app/Main.qml" line="1454"/>
+        <location filename="../app/Main.qml" line="1459"/>
         <source>Update media database</source>
         <translation type="unfinished">メディアデータベースを更新</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1434"/>
-        <location filename="../app/Main.qml" line="1457"/>
+        <location filename="../app/Main.qml" line="1462"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">メタデータをスクレイピング</translation>
     </message>
@@ -657,62 +657,62 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1659"/>
+        <location filename="../app/Main.qml" line="1664"/>
         <source>Default</source>
         <translation type="unfinished">デフォルト</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1659"/>
+        <location filename="../app/Main.qml" line="1664"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2031"/>
+        <location filename="../app/Main.qml" line="2036"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2035"/>
+        <location filename="../app/Main.qml" line="2040"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2049"/>
+        <location filename="../app/Main.qml" line="2054"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2053"/>
+        <location filename="../app/Main.qml" line="2058"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2057"/>
+        <location filename="../app/Main.qml" line="2062"/>
         <source>Retry</source>
         <translation type="unfinished">再試行</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2061"/>
+        <location filename="../app/Main.qml" line="2066"/>
         <source>Cancel</source>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2745"/>
+        <location filename="../app/Main.qml" line="2750"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2749"/>
+        <location filename="../app/Main.qml" line="2754"/>
         <source>Loading recently played…</source>
         <translation>最近プレイしたゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2756"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2753"/>
+        <location filename="../app/Main.qml" line="2758"/>
         <source>Loading…</source>
         <translation>読み込み中…</translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -577,70 +577,70 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1668"/>
+        <location filename="../app/Main.qml" line="1669"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1488"/>
         <source>Remove from favorites</source>
         <translation>お気に入りから削除</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1488"/>
         <source>Add to favorites</source>
         <translation>お気に入りに追加</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1492"/>
+        <location filename="../app/Main.qml" line="1493"/>
         <source>Write to NFC token</source>
         <translation>NFC トークンに書き込む</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1496"/>
+        <location filename="../app/Main.qml" line="1497"/>
         <source>QR code</source>
         <translation>QR コード</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1471"/>
-        <location filename="../app/Main.qml" line="1506"/>
+        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1507"/>
         <source>Launch game</source>
         <translation>ゲームを起動</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1952"/>
+        <location filename="../app/Main.qml" line="1953"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1955"/>
+        <location filename="../app/Main.qml" line="1956"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2746"/>
+        <location filename="../app/Main.qml" line="2747"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2752"/>
+        <location filename="../app/Main.qml" line="2753"/>
         <source>Loading favorites…</source>
         <translation>お気に入りを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2748"/>
+        <location filename="../app/Main.qml" line="2749"/>
         <source>Loading games…</source>
         <translation>ゲームを読み込み中…</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1431"/>
-        <location filename="../app/Main.qml" line="1459"/>
+        <location filename="../app/Main.qml" line="1460"/>
         <source>Update media database</source>
         <translation type="unfinished">メディアデータベースを更新</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1434"/>
-        <location filename="../app/Main.qml" line="1462"/>
+        <location filename="../app/Main.qml" line="1463"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">メタデータをスクレイピング</translation>
     </message>
@@ -657,62 +657,62 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1664"/>
+        <location filename="../app/Main.qml" line="1665"/>
         <source>Default</source>
         <translation type="unfinished">デフォルト</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1664"/>
+        <location filename="../app/Main.qml" line="1665"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2036"/>
+        <location filename="../app/Main.qml" line="2037"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2040"/>
+        <location filename="../app/Main.qml" line="2041"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2054"/>
+        <location filename="../app/Main.qml" line="2055"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2058"/>
+        <location filename="../app/Main.qml" line="2059"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2062"/>
+        <location filename="../app/Main.qml" line="2063"/>
         <source>Retry</source>
         <translation type="unfinished">再試行</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2066"/>
+        <location filename="../app/Main.qml" line="2067"/>
         <source>Cancel</source>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2750"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2754"/>
+        <location filename="../app/Main.qml" line="2755"/>
         <source>Loading recently played…</source>
         <translation>最近プレイしたゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2756"/>
+        <location filename="../app/Main.qml" line="2757"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2758"/>
+        <location filename="../app/Main.qml" line="2759"/>
         <source>Loading…</source>
         <translation>読み込み中…</translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -577,19 +577,19 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1663"/>
+        <location filename="../app/Main.qml" line="1668"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1431"/>
-        <location filename="../app/Main.qml" line="1454"/>
+        <location filename="../app/Main.qml" line="1459"/>
         <source>Update media database</source>
         <translation type="unfinished">미디어 데이터베이스 업데이트</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1434"/>
-        <location filename="../app/Main.qml" line="1457"/>
+        <location filename="../app/Main.qml" line="1462"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">메타데이터 수집</translation>
     </message>
@@ -606,113 +606,113 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
-        <location filename="../app/Main.qml" line="1501"/>
+        <location filename="../app/Main.qml" line="1471"/>
+        <location filename="../app/Main.qml" line="1506"/>
         <source>Launch game</source>
         <translation>게임 실행</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1482"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Remove from favorites</source>
         <translation>즐겨찾기에서 제거</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1482"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Add to favorites</source>
         <translation>즐겨찾기에 추가</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1492"/>
         <source>Write to NFC token</source>
         <translation>NFC 토큰에 쓰기</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1491"/>
+        <location filename="../app/Main.qml" line="1496"/>
         <source>QR code</source>
         <translation>QR 코드</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1659"/>
+        <location filename="../app/Main.qml" line="1664"/>
         <source>Default</source>
         <translation type="unfinished">기본값</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1659"/>
+        <location filename="../app/Main.qml" line="1664"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1947"/>
+        <location filename="../app/Main.qml" line="1952"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1950"/>
+        <location filename="../app/Main.qml" line="1955"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2031"/>
+        <location filename="../app/Main.qml" line="2036"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2035"/>
+        <location filename="../app/Main.qml" line="2040"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2049"/>
+        <location filename="../app/Main.qml" line="2054"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2053"/>
+        <location filename="../app/Main.qml" line="2058"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2057"/>
+        <location filename="../app/Main.qml" line="2062"/>
         <source>Retry</source>
         <translation type="unfinished">다시 시도</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2061"/>
+        <location filename="../app/Main.qml" line="2066"/>
         <source>Cancel</source>
         <translation type="unfinished">취소</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2741"/>
+        <location filename="../app/Main.qml" line="2746"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2743"/>
+        <location filename="../app/Main.qml" line="2748"/>
         <source>Loading games…</source>
         <translation>게임 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2745"/>
+        <location filename="../app/Main.qml" line="2750"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2747"/>
+        <location filename="../app/Main.qml" line="2752"/>
         <source>Loading favorites…</source>
         <translation>즐겨찾기 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2749"/>
+        <location filename="../app/Main.qml" line="2754"/>
         <source>Loading recently played…</source>
         <translation>최근 플레이 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2756"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2753"/>
+        <location filename="../app/Main.qml" line="2758"/>
         <source>Loading…</source>
         <translation>불러오는 중…</translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -577,19 +577,19 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1668"/>
+        <location filename="../app/Main.qml" line="1669"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1431"/>
-        <location filename="../app/Main.qml" line="1459"/>
+        <location filename="../app/Main.qml" line="1460"/>
         <source>Update media database</source>
         <translation type="unfinished">미디어 데이터베이스 업데이트</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1434"/>
-        <location filename="../app/Main.qml" line="1462"/>
+        <location filename="../app/Main.qml" line="1463"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">메타데이터 수집</translation>
     </message>
@@ -606,113 +606,113 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1471"/>
-        <location filename="../app/Main.qml" line="1506"/>
+        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1507"/>
         <source>Launch game</source>
         <translation>게임 실행</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1488"/>
         <source>Remove from favorites</source>
         <translation>즐겨찾기에서 제거</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1488"/>
         <source>Add to favorites</source>
         <translation>즐겨찾기에 추가</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1492"/>
+        <location filename="../app/Main.qml" line="1493"/>
         <source>Write to NFC token</source>
         <translation>NFC 토큰에 쓰기</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1496"/>
+        <location filename="../app/Main.qml" line="1497"/>
         <source>QR code</source>
         <translation>QR 코드</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1664"/>
+        <location filename="../app/Main.qml" line="1665"/>
         <source>Default</source>
         <translation type="unfinished">기본값</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1664"/>
+        <location filename="../app/Main.qml" line="1665"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1952"/>
+        <location filename="../app/Main.qml" line="1953"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1955"/>
+        <location filename="../app/Main.qml" line="1956"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2036"/>
+        <location filename="../app/Main.qml" line="2037"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2040"/>
+        <location filename="../app/Main.qml" line="2041"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2054"/>
+        <location filename="../app/Main.qml" line="2055"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2058"/>
+        <location filename="../app/Main.qml" line="2059"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2062"/>
+        <location filename="../app/Main.qml" line="2063"/>
         <source>Retry</source>
         <translation type="unfinished">다시 시도</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2066"/>
+        <location filename="../app/Main.qml" line="2067"/>
         <source>Cancel</source>
         <translation type="unfinished">취소</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2746"/>
+        <location filename="../app/Main.qml" line="2747"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2748"/>
+        <location filename="../app/Main.qml" line="2749"/>
         <source>Loading games…</source>
         <translation>게임 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2750"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2752"/>
+        <location filename="../app/Main.qml" line="2753"/>
         <source>Loading favorites…</source>
         <translation>즐겨찾기 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2754"/>
+        <location filename="../app/Main.qml" line="2755"/>
         <source>Loading recently played…</source>
         <translation>최근 플레이 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2756"/>
+        <location filename="../app/Main.qml" line="2757"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2758"/>
+        <location filename="../app/Main.qml" line="2759"/>
         <source>Loading…</source>
         <translation>불러오는 중…</translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -577,70 +577,70 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1668"/>
+        <location filename="../app/Main.qml" line="1669"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1488"/>
         <source>Remove from favorites</source>
         <translation>Uit favorieten verwijderen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1488"/>
         <source>Add to favorites</source>
         <translation>Aan favorieten toevoegen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1492"/>
+        <location filename="../app/Main.qml" line="1493"/>
         <source>Write to NFC token</source>
         <translation>Naar NFC-token schrijven</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1496"/>
+        <location filename="../app/Main.qml" line="1497"/>
         <source>QR code</source>
         <translation>QR-code</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1471"/>
-        <location filename="../app/Main.qml" line="1506"/>
+        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1507"/>
         <source>Launch game</source>
         <translation>Game starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1952"/>
+        <location filename="../app/Main.qml" line="1953"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1955"/>
+        <location filename="../app/Main.qml" line="1956"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2746"/>
+        <location filename="../app/Main.qml" line="2747"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2752"/>
+        <location filename="../app/Main.qml" line="2753"/>
         <source>Loading favorites…</source>
         <translation>Favorieten laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2748"/>
+        <location filename="../app/Main.qml" line="2749"/>
         <source>Loading games…</source>
         <translation>Games laden…</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1431"/>
-        <location filename="../app/Main.qml" line="1459"/>
+        <location filename="../app/Main.qml" line="1460"/>
         <source>Update media database</source>
         <translation type="unfinished">Mediadatabase bijwerken</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1434"/>
-        <location filename="../app/Main.qml" line="1462"/>
+        <location filename="../app/Main.qml" line="1463"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadata ophalen</translation>
     </message>
@@ -657,62 +657,62 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1664"/>
+        <location filename="../app/Main.qml" line="1665"/>
         <source>Default</source>
         <translation type="unfinished">Standaard</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1664"/>
+        <location filename="../app/Main.qml" line="1665"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2036"/>
+        <location filename="../app/Main.qml" line="2037"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2040"/>
+        <location filename="../app/Main.qml" line="2041"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2054"/>
+        <location filename="../app/Main.qml" line="2055"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2058"/>
+        <location filename="../app/Main.qml" line="2059"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2062"/>
+        <location filename="../app/Main.qml" line="2063"/>
         <source>Retry</source>
         <translation type="unfinished">Opnieuw proberen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2066"/>
+        <location filename="../app/Main.qml" line="2067"/>
         <source>Cancel</source>
         <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2750"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2754"/>
+        <location filename="../app/Main.qml" line="2755"/>
         <source>Loading recently played…</source>
         <translation>Recent gespeeld laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2756"/>
+        <location filename="../app/Main.qml" line="2757"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2758"/>
+        <location filename="../app/Main.qml" line="2759"/>
         <source>Loading…</source>
         <translation>Laden…</translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -577,70 +577,70 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1663"/>
+        <location filename="../app/Main.qml" line="1668"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1482"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Remove from favorites</source>
         <translation>Uit favorieten verwijderen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1482"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Add to favorites</source>
         <translation>Aan favorieten toevoegen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1492"/>
         <source>Write to NFC token</source>
         <translation>Naar NFC-token schrijven</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1491"/>
+        <location filename="../app/Main.qml" line="1496"/>
         <source>QR code</source>
         <translation>QR-code</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
-        <location filename="../app/Main.qml" line="1501"/>
+        <location filename="../app/Main.qml" line="1471"/>
+        <location filename="../app/Main.qml" line="1506"/>
         <source>Launch game</source>
         <translation>Game starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1947"/>
+        <location filename="../app/Main.qml" line="1952"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1950"/>
+        <location filename="../app/Main.qml" line="1955"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2741"/>
+        <location filename="../app/Main.qml" line="2746"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2747"/>
+        <location filename="../app/Main.qml" line="2752"/>
         <source>Loading favorites…</source>
         <translation>Favorieten laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2743"/>
+        <location filename="../app/Main.qml" line="2748"/>
         <source>Loading games…</source>
         <translation>Games laden…</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1431"/>
-        <location filename="../app/Main.qml" line="1454"/>
+        <location filename="../app/Main.qml" line="1459"/>
         <source>Update media database</source>
         <translation type="unfinished">Mediadatabase bijwerken</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1434"/>
-        <location filename="../app/Main.qml" line="1457"/>
+        <location filename="../app/Main.qml" line="1462"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadata ophalen</translation>
     </message>
@@ -657,62 +657,62 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1659"/>
+        <location filename="../app/Main.qml" line="1664"/>
         <source>Default</source>
         <translation type="unfinished">Standaard</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1659"/>
+        <location filename="../app/Main.qml" line="1664"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2031"/>
+        <location filename="../app/Main.qml" line="2036"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2035"/>
+        <location filename="../app/Main.qml" line="2040"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2049"/>
+        <location filename="../app/Main.qml" line="2054"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2053"/>
+        <location filename="../app/Main.qml" line="2058"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2057"/>
+        <location filename="../app/Main.qml" line="2062"/>
         <source>Retry</source>
         <translation type="unfinished">Opnieuw proberen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2061"/>
+        <location filename="../app/Main.qml" line="2066"/>
         <source>Cancel</source>
         <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2745"/>
+        <location filename="../app/Main.qml" line="2750"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2749"/>
+        <location filename="../app/Main.qml" line="2754"/>
         <source>Loading recently played…</source>
         <translation>Recent gespeeld laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2756"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2753"/>
+        <location filename="../app/Main.qml" line="2758"/>
         <source>Loading…</source>
         <translation>Laden…</translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -577,70 +577,70 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1663"/>
+        <location filename="../app/Main.qml" line="1668"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1482"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Remove from favorites</source>
         <translation>Elimină din favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1482"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Add to favorites</source>
         <translation>Adaugă la favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1492"/>
         <source>Write to NFC token</source>
         <translation>Scriere pe token NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1491"/>
+        <location filename="../app/Main.qml" line="1496"/>
         <source>QR code</source>
         <translation>Cod QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
-        <location filename="../app/Main.qml" line="1501"/>
+        <location filename="../app/Main.qml" line="1471"/>
+        <location filename="../app/Main.qml" line="1506"/>
         <source>Launch game</source>
         <translation>Lansare joc</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1947"/>
+        <location filename="../app/Main.qml" line="1952"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1950"/>
+        <location filename="../app/Main.qml" line="1955"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2741"/>
+        <location filename="../app/Main.qml" line="2746"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2747"/>
+        <location filename="../app/Main.qml" line="2752"/>
         <source>Loading favorites…</source>
         <translation>Se încarcă favoritele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2743"/>
+        <location filename="../app/Main.qml" line="2748"/>
         <source>Loading games…</source>
         <translation>Se încarcă jocurile…</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1431"/>
-        <location filename="../app/Main.qml" line="1454"/>
+        <location filename="../app/Main.qml" line="1459"/>
         <source>Update media database</source>
         <translation type="unfinished">Actualizare bază de date media</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1434"/>
-        <location filename="../app/Main.qml" line="1457"/>
+        <location filename="../app/Main.qml" line="1462"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Extragere metadate</translation>
     </message>
@@ -657,62 +657,62 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1659"/>
+        <location filename="../app/Main.qml" line="1664"/>
         <source>Default</source>
         <translation type="unfinished">Implicit</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1659"/>
+        <location filename="../app/Main.qml" line="1664"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2031"/>
+        <location filename="../app/Main.qml" line="2036"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2035"/>
+        <location filename="../app/Main.qml" line="2040"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2049"/>
+        <location filename="../app/Main.qml" line="2054"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2053"/>
+        <location filename="../app/Main.qml" line="2058"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2057"/>
+        <location filename="../app/Main.qml" line="2062"/>
         <source>Retry</source>
         <translation type="unfinished">Reîncercare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2061"/>
+        <location filename="../app/Main.qml" line="2066"/>
         <source>Cancel</source>
         <translation type="unfinished">Anulare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2745"/>
+        <location filename="../app/Main.qml" line="2750"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2749"/>
+        <location filename="../app/Main.qml" line="2754"/>
         <source>Loading recently played…</source>
         <translation>Se încarcă recent jucatele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2756"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2753"/>
+        <location filename="../app/Main.qml" line="2758"/>
         <source>Loading…</source>
         <translation>Se încarcă…</translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -577,70 +577,70 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1668"/>
+        <location filename="../app/Main.qml" line="1669"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1488"/>
         <source>Remove from favorites</source>
         <translation>Elimină din favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1488"/>
         <source>Add to favorites</source>
         <translation>Adaugă la favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1492"/>
+        <location filename="../app/Main.qml" line="1493"/>
         <source>Write to NFC token</source>
         <translation>Scriere pe token NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1496"/>
+        <location filename="../app/Main.qml" line="1497"/>
         <source>QR code</source>
         <translation>Cod QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1471"/>
-        <location filename="../app/Main.qml" line="1506"/>
+        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1507"/>
         <source>Launch game</source>
         <translation>Lansare joc</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1952"/>
+        <location filename="../app/Main.qml" line="1953"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1955"/>
+        <location filename="../app/Main.qml" line="1956"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2746"/>
+        <location filename="../app/Main.qml" line="2747"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2752"/>
+        <location filename="../app/Main.qml" line="2753"/>
         <source>Loading favorites…</source>
         <translation>Se încarcă favoritele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2748"/>
+        <location filename="../app/Main.qml" line="2749"/>
         <source>Loading games…</source>
         <translation>Se încarcă jocurile…</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1431"/>
-        <location filename="../app/Main.qml" line="1459"/>
+        <location filename="../app/Main.qml" line="1460"/>
         <source>Update media database</source>
         <translation type="unfinished">Actualizare bază de date media</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1434"/>
-        <location filename="../app/Main.qml" line="1462"/>
+        <location filename="../app/Main.qml" line="1463"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Extragere metadate</translation>
     </message>
@@ -657,62 +657,62 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1664"/>
+        <location filename="../app/Main.qml" line="1665"/>
         <source>Default</source>
         <translation type="unfinished">Implicit</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1664"/>
+        <location filename="../app/Main.qml" line="1665"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2036"/>
+        <location filename="../app/Main.qml" line="2037"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2040"/>
+        <location filename="../app/Main.qml" line="2041"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2054"/>
+        <location filename="../app/Main.qml" line="2055"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2058"/>
+        <location filename="../app/Main.qml" line="2059"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2062"/>
+        <location filename="../app/Main.qml" line="2063"/>
         <source>Retry</source>
         <translation type="unfinished">Reîncercare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2066"/>
+        <location filename="../app/Main.qml" line="2067"/>
         <source>Cancel</source>
         <translation type="unfinished">Anulare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2750"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2754"/>
+        <location filename="../app/Main.qml" line="2755"/>
         <source>Loading recently played…</source>
         <translation>Se încarcă recent jucatele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2756"/>
+        <location filename="../app/Main.qml" line="2757"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2758"/>
+        <location filename="../app/Main.qml" line="2759"/>
         <source>Loading…</source>
         <translation>Se încarcă…</translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -577,70 +577,70 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1663"/>
+        <location filename="../app/Main.qml" line="1668"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1482"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Remove from favorites</source>
         <translation>Odstrániť z obľúbených</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1482"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Add to favorites</source>
         <translation>Pridať do obľúbených</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1492"/>
         <source>Write to NFC token</source>
         <translation>Zapísať na NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1491"/>
+        <location filename="../app/Main.qml" line="1496"/>
         <source>QR code</source>
         <translation>QR kód</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
-        <location filename="../app/Main.qml" line="1501"/>
+        <location filename="../app/Main.qml" line="1471"/>
+        <location filename="../app/Main.qml" line="1506"/>
         <source>Launch game</source>
         <translation>Spustiť hru</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1947"/>
+        <location filename="../app/Main.qml" line="1952"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1950"/>
+        <location filename="../app/Main.qml" line="1955"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2741"/>
+        <location filename="../app/Main.qml" line="2746"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2747"/>
+        <location filename="../app/Main.qml" line="2752"/>
         <source>Loading favorites…</source>
         <translation>Načítanie obľúbených…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2743"/>
+        <location filename="../app/Main.qml" line="2748"/>
         <source>Loading games…</source>
         <translation>Načítanie hier…</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1431"/>
-        <location filename="../app/Main.qml" line="1454"/>
+        <location filename="../app/Main.qml" line="1459"/>
         <source>Update media database</source>
         <translation type="unfinished">Aktualizovať databázu médií</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1434"/>
-        <location filename="../app/Main.qml" line="1457"/>
+        <location filename="../app/Main.qml" line="1462"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Získať metadáta</translation>
     </message>
@@ -657,62 +657,62 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1659"/>
+        <location filename="../app/Main.qml" line="1664"/>
         <source>Default</source>
         <translation type="unfinished">Predvolené</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1659"/>
+        <location filename="../app/Main.qml" line="1664"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2031"/>
+        <location filename="../app/Main.qml" line="2036"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2035"/>
+        <location filename="../app/Main.qml" line="2040"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2049"/>
+        <location filename="../app/Main.qml" line="2054"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2053"/>
+        <location filename="../app/Main.qml" line="2058"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2057"/>
+        <location filename="../app/Main.qml" line="2062"/>
         <source>Retry</source>
         <translation type="unfinished">Skúsiť znova</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2061"/>
+        <location filename="../app/Main.qml" line="2066"/>
         <source>Cancel</source>
         <translation type="unfinished">Zrušiť</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2745"/>
+        <location filename="../app/Main.qml" line="2750"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2749"/>
+        <location filename="../app/Main.qml" line="2754"/>
         <source>Loading recently played…</source>
         <translation>Načítanie nedávno hraných…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2756"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2753"/>
+        <location filename="../app/Main.qml" line="2758"/>
         <source>Loading…</source>
         <translation>Načítanie…</translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -577,70 +577,70 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1668"/>
+        <location filename="../app/Main.qml" line="1669"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1488"/>
         <source>Remove from favorites</source>
         <translation>Odstrániť z obľúbených</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1488"/>
         <source>Add to favorites</source>
         <translation>Pridať do obľúbených</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1492"/>
+        <location filename="../app/Main.qml" line="1493"/>
         <source>Write to NFC token</source>
         <translation>Zapísať na NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1496"/>
+        <location filename="../app/Main.qml" line="1497"/>
         <source>QR code</source>
         <translation>QR kód</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1471"/>
-        <location filename="../app/Main.qml" line="1506"/>
+        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1507"/>
         <source>Launch game</source>
         <translation>Spustiť hru</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1952"/>
+        <location filename="../app/Main.qml" line="1953"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1955"/>
+        <location filename="../app/Main.qml" line="1956"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2746"/>
+        <location filename="../app/Main.qml" line="2747"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2752"/>
+        <location filename="../app/Main.qml" line="2753"/>
         <source>Loading favorites…</source>
         <translation>Načítanie obľúbených…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2748"/>
+        <location filename="../app/Main.qml" line="2749"/>
         <source>Loading games…</source>
         <translation>Načítanie hier…</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1431"/>
-        <location filename="../app/Main.qml" line="1459"/>
+        <location filename="../app/Main.qml" line="1460"/>
         <source>Update media database</source>
         <translation type="unfinished">Aktualizovať databázu médií</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1434"/>
-        <location filename="../app/Main.qml" line="1462"/>
+        <location filename="../app/Main.qml" line="1463"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Získať metadáta</translation>
     </message>
@@ -657,62 +657,62 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1664"/>
+        <location filename="../app/Main.qml" line="1665"/>
         <source>Default</source>
         <translation type="unfinished">Predvolené</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1664"/>
+        <location filename="../app/Main.qml" line="1665"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2036"/>
+        <location filename="../app/Main.qml" line="2037"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2040"/>
+        <location filename="../app/Main.qml" line="2041"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2054"/>
+        <location filename="../app/Main.qml" line="2055"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2058"/>
+        <location filename="../app/Main.qml" line="2059"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2062"/>
+        <location filename="../app/Main.qml" line="2063"/>
         <source>Retry</source>
         <translation type="unfinished">Skúsiť znova</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2066"/>
+        <location filename="../app/Main.qml" line="2067"/>
         <source>Cancel</source>
         <translation type="unfinished">Zrušiť</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2750"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2754"/>
+        <location filename="../app/Main.qml" line="2755"/>
         <source>Loading recently played…</source>
         <translation>Načítanie nedávno hraných…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2756"/>
+        <location filename="../app/Main.qml" line="2757"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2758"/>
+        <location filename="../app/Main.qml" line="2759"/>
         <source>Loading…</source>
         <translation>Načítanie…</translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -577,70 +577,70 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1668"/>
+        <location filename="../app/Main.qml" line="1669"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1488"/>
         <source>Remove from favorites</source>
         <translation>Видалити з вибраного</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1488"/>
         <source>Add to favorites</source>
         <translation>Додати до вибраного</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1492"/>
+        <location filename="../app/Main.qml" line="1493"/>
         <source>Write to NFC token</source>
         <translation>Записати на NFC-токен</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1496"/>
+        <location filename="../app/Main.qml" line="1497"/>
         <source>QR code</source>
         <translation>QR-код</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1471"/>
-        <location filename="../app/Main.qml" line="1506"/>
+        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1507"/>
         <source>Launch game</source>
         <translation>Запустити гру</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1952"/>
+        <location filename="../app/Main.qml" line="1953"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1955"/>
+        <location filename="../app/Main.qml" line="1956"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2746"/>
+        <location filename="../app/Main.qml" line="2747"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2752"/>
+        <location filename="../app/Main.qml" line="2753"/>
         <source>Loading favorites…</source>
         <translation>Завантаження вибраного…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2748"/>
+        <location filename="../app/Main.qml" line="2749"/>
         <source>Loading games…</source>
         <translation>Завантаження ігор…</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1431"/>
-        <location filename="../app/Main.qml" line="1459"/>
+        <location filename="../app/Main.qml" line="1460"/>
         <source>Update media database</source>
         <translation type="unfinished">Оновити базу медіа</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1434"/>
-        <location filename="../app/Main.qml" line="1462"/>
+        <location filename="../app/Main.qml" line="1463"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Отримати метадані</translation>
     </message>
@@ -657,62 +657,62 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1664"/>
+        <location filename="../app/Main.qml" line="1665"/>
         <source>Default</source>
         <translation type="unfinished">Типовий</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1664"/>
+        <location filename="../app/Main.qml" line="1665"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2036"/>
+        <location filename="../app/Main.qml" line="2037"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2040"/>
+        <location filename="../app/Main.qml" line="2041"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2054"/>
+        <location filename="../app/Main.qml" line="2055"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2058"/>
+        <location filename="../app/Main.qml" line="2059"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2062"/>
+        <location filename="../app/Main.qml" line="2063"/>
         <source>Retry</source>
         <translation type="unfinished">Повторити</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2066"/>
+        <location filename="../app/Main.qml" line="2067"/>
         <source>Cancel</source>
         <translation type="unfinished">Скасувати</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2750"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2754"/>
+        <location filename="../app/Main.qml" line="2755"/>
         <source>Loading recently played…</source>
         <translation>Завантаження нещодавніх…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2756"/>
+        <location filename="../app/Main.qml" line="2757"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2758"/>
+        <location filename="../app/Main.qml" line="2759"/>
         <source>Loading…</source>
         <translation>Завантаження…</translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -577,70 +577,70 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1663"/>
+        <location filename="../app/Main.qml" line="1668"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1482"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Remove from favorites</source>
         <translation>Видалити з вибраного</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1482"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Add to favorites</source>
         <translation>Додати до вибраного</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1492"/>
         <source>Write to NFC token</source>
         <translation>Записати на NFC-токен</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1491"/>
+        <location filename="../app/Main.qml" line="1496"/>
         <source>QR code</source>
         <translation>QR-код</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
-        <location filename="../app/Main.qml" line="1501"/>
+        <location filename="../app/Main.qml" line="1471"/>
+        <location filename="../app/Main.qml" line="1506"/>
         <source>Launch game</source>
         <translation>Запустити гру</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1947"/>
+        <location filename="../app/Main.qml" line="1952"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1950"/>
+        <location filename="../app/Main.qml" line="1955"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2741"/>
+        <location filename="../app/Main.qml" line="2746"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2747"/>
+        <location filename="../app/Main.qml" line="2752"/>
         <source>Loading favorites…</source>
         <translation>Завантаження вибраного…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2743"/>
+        <location filename="../app/Main.qml" line="2748"/>
         <source>Loading games…</source>
         <translation>Завантаження ігор…</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1431"/>
-        <location filename="../app/Main.qml" line="1454"/>
+        <location filename="../app/Main.qml" line="1459"/>
         <source>Update media database</source>
         <translation type="unfinished">Оновити базу медіа</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1434"/>
-        <location filename="../app/Main.qml" line="1457"/>
+        <location filename="../app/Main.qml" line="1462"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Отримати метадані</translation>
     </message>
@@ -657,62 +657,62 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1659"/>
+        <location filename="../app/Main.qml" line="1664"/>
         <source>Default</source>
         <translation type="unfinished">Типовий</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1659"/>
+        <location filename="../app/Main.qml" line="1664"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2031"/>
+        <location filename="../app/Main.qml" line="2036"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2035"/>
+        <location filename="../app/Main.qml" line="2040"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2049"/>
+        <location filename="../app/Main.qml" line="2054"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2053"/>
+        <location filename="../app/Main.qml" line="2058"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2057"/>
+        <location filename="../app/Main.qml" line="2062"/>
         <source>Retry</source>
         <translation type="unfinished">Повторити</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2061"/>
+        <location filename="../app/Main.qml" line="2066"/>
         <source>Cancel</source>
         <translation type="unfinished">Скасувати</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2745"/>
+        <location filename="../app/Main.qml" line="2750"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2749"/>
+        <location filename="../app/Main.qml" line="2754"/>
         <source>Loading recently played…</source>
         <translation>Завантаження нещодавніх…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2756"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2753"/>
+        <location filename="../app/Main.qml" line="2758"/>
         <source>Loading…</source>
         <translation>Завантаження…</translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -577,19 +577,19 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1663"/>
+        <location filename="../app/Main.qml" line="1668"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1431"/>
-        <location filename="../app/Main.qml" line="1454"/>
+        <location filename="../app/Main.qml" line="1459"/>
         <source>Update media database</source>
         <translation type="unfinished">更新媒体数据库</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1434"/>
-        <location filename="../app/Main.qml" line="1457"/>
+        <location filename="../app/Main.qml" line="1462"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">抓取元数据</translation>
     </message>
@@ -606,113 +606,113 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1466"/>
-        <location filename="../app/Main.qml" line="1501"/>
+        <location filename="../app/Main.qml" line="1471"/>
+        <location filename="../app/Main.qml" line="1506"/>
         <source>Launch game</source>
         <translation>启动游戏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1482"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Remove from favorites</source>
         <translation>从收藏中移除</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1482"/>
+        <location filename="../app/Main.qml" line="1487"/>
         <source>Add to favorites</source>
         <translation>添加到收藏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1492"/>
         <source>Write to NFC token</source>
         <translation>写入 NFC 令牌</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1491"/>
+        <location filename="../app/Main.qml" line="1496"/>
         <source>QR code</source>
         <translation>二维码</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1659"/>
+        <location filename="../app/Main.qml" line="1664"/>
         <source>Default</source>
         <translation type="unfinished">默认</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1659"/>
+        <location filename="../app/Main.qml" line="1664"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1947"/>
+        <location filename="../app/Main.qml" line="1952"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1950"/>
+        <location filename="../app/Main.qml" line="1955"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2031"/>
+        <location filename="../app/Main.qml" line="2036"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2035"/>
+        <location filename="../app/Main.qml" line="2040"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2049"/>
+        <location filename="../app/Main.qml" line="2054"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2053"/>
+        <location filename="../app/Main.qml" line="2058"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2057"/>
+        <location filename="../app/Main.qml" line="2062"/>
         <source>Retry</source>
         <translation type="unfinished">重试</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2061"/>
+        <location filename="../app/Main.qml" line="2066"/>
         <source>Cancel</source>
         <translation type="unfinished">取消</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2741"/>
+        <location filename="../app/Main.qml" line="2746"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2743"/>
+        <location filename="../app/Main.qml" line="2748"/>
         <source>Loading games…</source>
         <translation>正在加载游戏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2745"/>
+        <location filename="../app/Main.qml" line="2750"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2747"/>
+        <location filename="../app/Main.qml" line="2752"/>
         <source>Loading favorites…</source>
         <translation>正在加载收藏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2749"/>
+        <location filename="../app/Main.qml" line="2754"/>
         <source>Loading recently played…</source>
         <translation>正在加载最近游玩…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2756"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2753"/>
+        <location filename="../app/Main.qml" line="2758"/>
         <source>Loading…</source>
         <translation>正在加载…</translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -577,19 +577,19 @@ Euskara - devilschile2</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1424"/>
-        <location filename="../app/Main.qml" line="1668"/>
+        <location filename="../app/Main.qml" line="1669"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1431"/>
-        <location filename="../app/Main.qml" line="1459"/>
+        <location filename="../app/Main.qml" line="1460"/>
         <source>Update media database</source>
         <translation type="unfinished">更新媒体数据库</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1434"/>
-        <location filename="../app/Main.qml" line="1462"/>
+        <location filename="../app/Main.qml" line="1463"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">抓取元数据</translation>
     </message>
@@ -606,113 +606,113 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1471"/>
-        <location filename="../app/Main.qml" line="1506"/>
+        <location filename="../app/Main.qml" line="1472"/>
+        <location filename="../app/Main.qml" line="1507"/>
         <source>Launch game</source>
         <translation>启动游戏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1488"/>
         <source>Remove from favorites</source>
         <translation>从收藏中移除</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1487"/>
+        <location filename="../app/Main.qml" line="1488"/>
         <source>Add to favorites</source>
         <translation>添加到收藏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1492"/>
+        <location filename="../app/Main.qml" line="1493"/>
         <source>Write to NFC token</source>
         <translation>写入 NFC 令牌</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1496"/>
+        <location filename="../app/Main.qml" line="1497"/>
         <source>QR code</source>
         <translation>二维码</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1664"/>
+        <location filename="../app/Main.qml" line="1665"/>
         <source>Default</source>
         <translation type="unfinished">默认</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1664"/>
+        <location filename="../app/Main.qml" line="1665"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1952"/>
+        <location filename="../app/Main.qml" line="1953"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1955"/>
+        <location filename="../app/Main.qml" line="1956"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2036"/>
+        <location filename="../app/Main.qml" line="2037"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2040"/>
+        <location filename="../app/Main.qml" line="2041"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2054"/>
+        <location filename="../app/Main.qml" line="2055"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2058"/>
+        <location filename="../app/Main.qml" line="2059"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2062"/>
+        <location filename="../app/Main.qml" line="2063"/>
         <source>Retry</source>
         <translation type="unfinished">重试</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2066"/>
+        <location filename="../app/Main.qml" line="2067"/>
         <source>Cancel</source>
         <translation type="unfinished">取消</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2746"/>
+        <location filename="../app/Main.qml" line="2747"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2748"/>
+        <location filename="../app/Main.qml" line="2749"/>
         <source>Loading games…</source>
         <translation>正在加载游戏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2750"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2752"/>
+        <location filename="../app/Main.qml" line="2753"/>
         <source>Loading favorites…</source>
         <translation>正在加载收藏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2754"/>
+        <location filename="../app/Main.qml" line="2755"/>
         <source>Loading recently played…</source>
         <translation>正在加载最近游玩…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2756"/>
+        <location filename="../app/Main.qml" line="2757"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2758"/>
+        <location filename="../app/Main.qml" line="2759"/>
         <source>Loading…</source>
         <translation>正在加载…</translation>
     </message>

--- a/tests/ui/tst_navigation.qml
+++ b/tests/ui/tst_navigation.qml
@@ -491,6 +491,33 @@ TestCase {
         compare(_idsOf(entries), ["launch_system", "index_system", "scrape_system", "toggle_hide_system"], "has_nfc must not affect the systems menu");
     }
 
+    // Category index/scrape are gated on the category having at least one
+    // indexable (non-launch-only) system. The test Core is empty, so
+    // SystemsModel.system_ids_for_category returns nothing and the gate must
+    // omit the dead actions, leaving only Hide/Unhide. The positive branch
+    // (a mixed or fully-launchable category) is covered at the data layer by
+    // the Rust `indexable_system_ids` tests, which the empty test model can't
+    // exercise here.
+    function test_context_menu_categories_empty_category_omits_index_scrape(): void {
+        // Empty category short-circuits the gate (category !== "").
+        const entries = main.buildContextMenuEntries("categories", "", false, false, false, "", false, "");
+        compare(_idsOf(entries), ["toggle_hide_category"], "Empty category has no indexable systems, so index/scrape are omitted");
+    }
+
+    function test_context_menu_categories_no_indexable_systems_omits_index_scrape(): void {
+        // Non-empty category whose model yields no indexable systems.
+        const entries = main.buildContextMenuEntries("categories", "", false, false, false, "", false, "Other");
+        compare(_idsOf(entries), ["toggle_hide_category"], "A category with no indexable systems must not show index/scrape");
+    }
+
+    function test_context_menu_categories_hidden_label_toggles(): void {
+        const hideEntries = main.buildContextMenuEntries("categories", "", false, false, false, "", false, "Other");
+        const unhideEntries = main.buildContextMenuEntries("categories", "", false, false, false, "", true, "Other");
+        compare(hideEntries[0].id, "toggle_hide_category");
+        compare(unhideEntries[0].id, "toggle_hide_category");
+        verify(hideEntries[0].label !== unhideEntries[0].label, "Hide/Unhide label flips on isHidden");
+    }
+
     function test_context_menu_games_directory_returns_empty(): void {
         compare(main.buildContextMenuEntries("games", "directory", false, true, false, ""), [], "Folder tiles have no context menu, even with reader attached");
     }


### PR DESCRIPTION
- `system_ids_for_category()` excludes launch-only (zapScript) systems, so a category whose members are all launch-only returns no ids and the hub category context menu's "Update media database" / "Scrape metadata" actions would no-op.
- Gate those two entries on the presence of at least one indexable system in the category, so they are no longer shown as dead menu entries.
- Categories with a mix of indexable systems and launchables (e.g. "Other", which holds NESMusic/SNESMusic alongside launchables) still show the actions and operate only on the indexable members; normal categories are unaffected.

Follow-up to #259.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Refined the categories context menu to avoid showing dead/no-op index and scrape options when a category has no indexable systems.
- Improved correctness of the hide/unhide category menu toggle so the label changes while keeping the same underlying action.
- Added automated UI coverage for empty categories, categories with no indexable systems, and hide/unhide label behavior.

**Documentation**
- Updated translation metadata across multiple languages to match shifted UI locations (display text content unchanged).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->