### PR TITLE
Fix Systems list press state reset

### DIFF
--- a/src/ui/screens/SystemsScreen.qml
+++ b/src/ui/screens/SystemsScreen.qml
@@ -262,6 +262,7 @@ Item {
         model: Browse.SystemsModel
         currentIndex: systemsGrid.currentIndex
         focusReady: systems._focusReady
+        screenSettling: !systems.active
         layoutProfile: systems._viewProfile
         detailTitle: listCard.currentName
         detailCoverKey: listCard.currentCoverKey

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -1559,23 +1559,23 @@ Euskara - devilschile2</source>
     <name>SystemsScreen</name>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="245"/>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="347"/>
         <source>%1 systems</source>
         <translation>%1 أنظمة</translation>
     </message>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="246"/>
-        <location filename="../screens/SystemsScreen.qml" line="363"/>
+        <location filename="../screens/SystemsScreen.qml" line="364"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="381"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>No systems in this category</source>
         <translation>لا توجد أنظمة في هذه الفئة</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="382"/>
+        <location filename="../screens/SystemsScreen.qml" line="383"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -1559,23 +1559,23 @@ Euskara - devilschile2</source>
     <name>SystemsScreen</name>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="245"/>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="347"/>
         <source>%1 systems</source>
         <translation>%1 Systeme</translation>
     </message>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="246"/>
-        <location filename="../screens/SystemsScreen.qml" line="363"/>
+        <location filename="../screens/SystemsScreen.qml" line="364"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="381"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>No systems in this category</source>
         <translation>Keine Systeme in dieser Kategorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="382"/>
+        <location filename="../screens/SystemsScreen.qml" line="383"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -1559,23 +1559,23 @@ Euskara - devilschile2</source>
     <name>SystemsScreen</name>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="245"/>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="347"/>
         <source>%1 systems</source>
         <translation>%1 συστήματα</translation>
     </message>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="246"/>
-        <location filename="../screens/SystemsScreen.qml" line="363"/>
+        <location filename="../screens/SystemsScreen.qml" line="364"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="381"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>No systems in this category</source>
         <translation>Δεν υπάρχουν συστήματα σε αυτή την κατηγορία</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="382"/>
+        <location filename="../screens/SystemsScreen.qml" line="383"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -1535,23 +1535,23 @@ Euskara - devilschile2</source>
     <name>SystemsScreen</name>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="245"/>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="347"/>
         <source>%1 systems</source>
         <translation>%1 systems</translation>
     </message>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="246"/>
-        <location filename="../screens/SystemsScreen.qml" line="363"/>
+        <location filename="../screens/SystemsScreen.qml" line="364"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="381"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>No systems in this category</source>
         <translation>No systems in this category</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="382"/>
+        <location filename="../screens/SystemsScreen.qml" line="383"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -1559,23 +1559,23 @@ Euskara - devilschile2</source>
     <name>SystemsScreen</name>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="245"/>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="347"/>
         <source>%1 systems</source>
         <translation>%1 sistemas</translation>
     </message>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="246"/>
-        <location filename="../screens/SystemsScreen.qml" line="363"/>
+        <location filename="../screens/SystemsScreen.qml" line="364"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="381"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>No systems in this category</source>
         <translation>No hay sistemas en esta categoría</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="382"/>
+        <location filename="../screens/SystemsScreen.qml" line="383"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -1567,23 +1567,23 @@ Euskara - devilschile2</source>
     <name>SystemsScreen</name>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="245"/>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="347"/>
         <source>%1 systems</source>
         <translation>%1 sistema</translation>
     </message>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="246"/>
-        <location filename="../screens/SystemsScreen.qml" line="363"/>
+        <location filename="../screens/SystemsScreen.qml" line="364"/>
         <source>%1 / %2</source>
         <translation type="unfinished">%1 / %2</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="381"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>No systems in this category</source>
         <translation>Ez dago sistemarik kategoria honetan</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="382"/>
+        <location filename="../screens/SystemsScreen.qml" line="383"/>
         <source>Loading systems…</source>
         <translation type="unfinished">Sistemak kargatzen</translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -1559,23 +1559,23 @@ Euskara - devilschile2</source>
     <name>SystemsScreen</name>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="245"/>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="347"/>
         <source>%1 systems</source>
         <translation>%1 מערכות</translation>
     </message>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="246"/>
-        <location filename="../screens/SystemsScreen.qml" line="363"/>
+        <location filename="../screens/SystemsScreen.qml" line="364"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="381"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>No systems in this category</source>
         <translation>אין מערכות בקטגוריה זו</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="382"/>
+        <location filename="../screens/SystemsScreen.qml" line="383"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -1559,23 +1559,23 @@ Euskara - devilschile2</source>
     <name>SystemsScreen</name>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="245"/>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="347"/>
         <source>%1 systems</source>
         <translation>%1 सिस्टम</translation>
     </message>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="246"/>
-        <location filename="../screens/SystemsScreen.qml" line="363"/>
+        <location filename="../screens/SystemsScreen.qml" line="364"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="381"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>No systems in this category</source>
         <translation>इस श्रेणी में कोई सिस्टम नहीं है</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="382"/>
+        <location filename="../screens/SystemsScreen.qml" line="383"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -1559,23 +1559,23 @@ Euskara - devilschile2</source>
     <name>SystemsScreen</name>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="245"/>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="347"/>
         <source>%1 systems</source>
         <translation>%1 sistemi</translation>
     </message>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="246"/>
-        <location filename="../screens/SystemsScreen.qml" line="363"/>
+        <location filename="../screens/SystemsScreen.qml" line="364"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="381"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>No systems in this category</source>
         <translation>Nessun sistema in questa categoria</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="382"/>
+        <location filename="../screens/SystemsScreen.qml" line="383"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -1559,23 +1559,23 @@ Euskara - devilschile2</source>
     <name>SystemsScreen</name>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="245"/>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="347"/>
         <source>%1 systems</source>
         <translation>%1 システム</translation>
     </message>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="246"/>
-        <location filename="../screens/SystemsScreen.qml" line="363"/>
+        <location filename="../screens/SystemsScreen.qml" line="364"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="381"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>No systems in this category</source>
         <translation>このカテゴリにシステムはありません</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="382"/>
+        <location filename="../screens/SystemsScreen.qml" line="383"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -1559,23 +1559,23 @@ Euskara - devilschile2</source>
     <name>SystemsScreen</name>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="245"/>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="347"/>
         <source>%1 systems</source>
         <translation>시스템 %1개</translation>
     </message>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="246"/>
-        <location filename="../screens/SystemsScreen.qml" line="363"/>
+        <location filename="../screens/SystemsScreen.qml" line="364"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="381"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>No systems in this category</source>
         <translation>이 카테고리에는 시스템이 없습니다</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="382"/>
+        <location filename="../screens/SystemsScreen.qml" line="383"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -1559,23 +1559,23 @@ Euskara - devilschile2</source>
     <name>SystemsScreen</name>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="245"/>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="347"/>
         <source>%1 systems</source>
         <translation>%1 systemen</translation>
     </message>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="246"/>
-        <location filename="../screens/SystemsScreen.qml" line="363"/>
+        <location filename="../screens/SystemsScreen.qml" line="364"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="381"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>No systems in this category</source>
         <translation>Geen systemen in deze categorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="382"/>
+        <location filename="../screens/SystemsScreen.qml" line="383"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -1559,23 +1559,23 @@ Euskara - devilschile2</source>
     <name>SystemsScreen</name>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="245"/>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="347"/>
         <source>%1 systems</source>
         <translation>%1 sisteme</translation>
     </message>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="246"/>
-        <location filename="../screens/SystemsScreen.qml" line="363"/>
+        <location filename="../screens/SystemsScreen.qml" line="364"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="381"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>No systems in this category</source>
         <translation>Niciun sistem în această categorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="382"/>
+        <location filename="../screens/SystemsScreen.qml" line="383"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -1559,23 +1559,23 @@ Euskara - devilschile2</source>
     <name>SystemsScreen</name>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="245"/>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="347"/>
         <source>%1 systems</source>
         <translation>%1 systémov</translation>
     </message>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="246"/>
-        <location filename="../screens/SystemsScreen.qml" line="363"/>
+        <location filename="../screens/SystemsScreen.qml" line="364"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="381"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>No systems in this category</source>
         <translation>V tejto kategórii nie sú žiadne systémy</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="382"/>
+        <location filename="../screens/SystemsScreen.qml" line="383"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -1559,23 +1559,23 @@ Euskara - devilschile2</source>
     <name>SystemsScreen</name>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="245"/>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="347"/>
         <source>%1 systems</source>
         <translation>%1 систем</translation>
     </message>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="246"/>
-        <location filename="../screens/SystemsScreen.qml" line="363"/>
+        <location filename="../screens/SystemsScreen.qml" line="364"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="381"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>No systems in this category</source>
         <translation>У цій категорії немає систем</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="382"/>
+        <location filename="../screens/SystemsScreen.qml" line="383"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -1559,23 +1559,23 @@ Euskara - devilschile2</source>
     <name>SystemsScreen</name>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="245"/>
-        <location filename="../screens/SystemsScreen.qml" line="346"/>
+        <location filename="../screens/SystemsScreen.qml" line="347"/>
         <source>%1 systems</source>
         <translation>%1 个系统</translation>
     </message>
     <message>
         <location filename="../screens/SystemsScreen.qml" line="246"/>
-        <location filename="../screens/SystemsScreen.qml" line="363"/>
+        <location filename="../screens/SystemsScreen.qml" line="364"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="381"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>No systems in this category</source>
         <translation>此类别中没有系统</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="382"/>
+        <location filename="../screens/SystemsScreen.qml" line="383"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>


### PR DESCRIPTION
## Summary
- reset Systems detailed-list row push-in state when leaving the screen
- keep translation source line refs updated after the QML line shift

## Tests
- just test-qml
- just lint

Note: GitHub issue #267 currently describes a different enhancement, so this PR does not use a closing keyword.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * System browsing now keeps the list view in sync while the screen is settling, matching the behavior already used in the grid layout.
* **Documentation**
  * Updated translation references for several languages so the system-count and empty-category messages point to the current source locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->