### PR TITLE
Bump version to 1.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.22)
 
 project(
     zaparoo-frontend
-    VERSION 1.1.1
+    VERSION 1.2.0
     DESCRIPTION "Zaparoo Core frontend"
     HOMEPAGE_URL "https://zaparoo.org"
     LANGUAGES CXX

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "mock-core"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "futures-util",
  "serde",
@@ -1450,11 +1450,11 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zaparoo-build-info"
-version = "1.1.1"
+version = "1.2.0"
 
 [[package]]
 name = "zaparoo-core"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "dirs-next",
  "futures-util",
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "zaparoo-frontend-rs"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "base64",
  "cxx",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ members = ["build-info", "frontend", "mock-core", "zaparoo-core"]
 resolver = "2"
 
 [workspace.package]
-version      = "1.1.1"
+version      = "1.2.0"
 edition      = "2021"
 rust-version = "1.96"
 license      = "LicenseRef-PolyForm-Noncommercial-1.0.0"


### PR DESCRIPTION
## Summary
- bump CMake project version to 1.2.0
- bump Rust workspace and lockfile package versions to 1.2.0

## Validation
- cargo metadata --no-deps --format-version 1
- git diff --check
- just lint (started; aborted during Docker build after Rust fmt/clippy/deny completed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project version from **1.1.1** to **1.2.0** across the build and package configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->