### PR TITLE
Fix v1.2.0 analog snow: auto-resolve menu core, bump to 1.2.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,10 @@ on:
         description: 'Tag/version to build (e.g. v1.0.4)'
         required: true
         type: string
+      menu_tag:
+        description: 'Menu_MiSTer release tag to bundle (defaults to latest)'
+        required: false
+        type: string
       upload:
         description: 'Upload to GitHub release'
         required: false
@@ -87,6 +91,22 @@ jobs:
           fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve Menu_MiSTer release tag
+        id: menu-mister
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MENU_TAG_INPUT: ${{ inputs.menu_tag }}
+        run: |
+          tag="$MENU_TAG_INPUT"
+          if [ -z "$tag" ]; then
+            tag=$(gh api repos/ZaparooProject/Menu_MiSTer/releases/latest --jq '.tag_name')
+          fi
+          if [ -z "$tag" ] || [ "$tag" = "null" ]; then
+            echo "Could not resolve Menu_MiSTer release" >&2
+            exit 1
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
       - name: Install host build dependencies
         run: |
           sudo apt-get update
@@ -155,6 +175,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MAIN_MISTER_TAG: ${{ steps.main-mister.outputs.tag }}
+          MENU_MISTER_TAG: ${{ steps.menu-mister.outputs.tag }}
 
       - name: Record archive name
         id: archive

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,6 +234,24 @@ and clears `/tmp/zaparoo/frontend.log`.
 `/media/fat/MiSTer_Zaparoo` is the integration binary shipped with MiSTer. It
 starts our `frontend`; do not replace that flow with a new wrapper script.
 
+## Release
+
+A MiSTer release bundles three independently versioned components: the
+**frontend** (this repo), the **`MiSTer_Zaparoo`** host wrapper (`Main_MiSTer`),
+and the **`menu_zaparoo.rbf`** menu core (`Menu_MiSTer`). The analog video path
+depends on all three matching. Full checklist: `docs/building.md` → "Cutting a
+release". Key points:
+
+- The version lives in two places: `project(... VERSION ...)` in `CMakeLists.txt`
+  and `version` in `rust/Cargo.toml`. Bump both and regenerate `rust/Cargo.lock`
+  (`cargo update --workspace`). The About page derives its version from the CMake
+  version (`ZAPAROO_VERSION`); do not hardcode it in `main.cpp` or QML.
+- The release workflow auto-resolves the latest `Main_MiSTer` and `Menu_MiSTer`
+  releases; override with the `menu_tag` workflow input or
+  `MENU_MISTER_TAG` / `MAIN_MISTER_TAG` when running the packaging script.
+- After publishing, update the downloader DB in `Zaparoo_MiSTer` (`db.json` and
+  its distributed zip(s)).
+
 ## Further Reading
 
 - `docs/architecture.md` — module graph, data flow, runtime/platform split

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.22)
 
 project(
     zaparoo-frontend
-    VERSION 1.2.0
+    VERSION 1.2.1
     DESCRIPTION "Zaparoo Core frontend"
     HOMEPAGE_URL "https://zaparoo.org"
     LANGUAGES CXX

--- a/docs/building.md
+++ b/docs/building.md
@@ -351,6 +351,34 @@ height = 720
 debug = true
 ```
 
+## Cutting a release
+
+A MiSTer release bundles three independently versioned components: the
+**frontend** binary (this repo), the **`MiSTer_Zaparoo`** host wrapper
+(`ZaparooProject/Main_MiSTer`), and the **`menu_zaparoo.rbf`** menu core
+(`ZaparooProject/Menu_MiSTer`). The analog video path depends on all three
+matching. The release workflow resolves the host wrapper and menu core to their
+latest published releases automatically, so a normal release is just a version
+bump and a tag.
+
+1. **Bump the version.** Update `project(... VERSION ...)` in `CMakeLists.txt`
+   and `version` in `rust/Cargo.toml` (`[workspace.package]`), then regenerate
+   the lockfile with `cargo update --workspace` from `rust/`. These are the only
+   two places to edit; the About page version is derived from the CMake version
+   at build time.
+2. **Tag and publish.** Push a `vX.Y.Z` tag (or run the `Build release ZIP`
+   workflow with `upload` enabled). The workflow resolves the latest
+   `Main_MiSTer` and `Menu_MiSTer` releases, packages the bundle, and uploads the
+   GitHub release.
+3. **Update the downloader database.** In `ZaparooProject/Zaparoo_MiSTer`,
+   update `db.json` (`archives.zaparoo_frontend` url/hash/size and the
+   `summary_inline.files` hashes), then regenerate its distributed zip(s).
+4. **Verify** on a clean unit installed via the downloader.
+
+To bundle a specific menu or host build instead of latest, set the workflow's
+`menu_tag` input (or `MENU_MISTER_TAG` / `MAIN_MISTER_TAG` when running
+`scripts/package-mister-release.sh` directly).
+
 ## Run on framebuffer (desktop headless)
 
 Use this to reproduce the MiSTer rendering path on a desktop:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "mock-core"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "futures-util",
  "serde",
@@ -1450,11 +1450,11 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zaparoo-build-info"
-version = "1.2.0"
+version = "1.2.1"
 
 [[package]]
 name = "zaparoo-core"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "dirs-next",
  "futures-util",
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "zaparoo-frontend-rs"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "base64",
  "cxx",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ members = ["build-info", "frontend", "mock-core", "zaparoo-core"]
 resolver = "2"
 
 [workspace.package]
-version      = "1.2.0"
+version      = "1.2.1"
 edition      = "2021"
 rust-version = "1.96"
 license      = "LicenseRef-PolyForm-Noncommercial-1.0.0"

--- a/scripts/package-mister-release.sh
+++ b/scripts/package-mister-release.sh
@@ -10,7 +10,6 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 OUTPUT_DIR="${PROJECT_ROOT}/output"
 RELEASE_DIR="${OUTPUT_DIR}/release"
 MENU_REPO="ZaparooProject/Menu_MiSTer"
-MENU_TAG="v20260510"
 MENU_ASSET="menu_zaparoo.rbf"
 MAIN_REPO="ZaparooProject/Main_MiSTer"
 MAIN_ASSET="MiSTer_Zaparoo"
@@ -158,6 +157,11 @@ mkdir -p "$STAGE/zaparoo"
 MENU_DIR="$TMP_DIR/menu"
 MAIN_DIR="$TMP_DIR/main"
 mkdir -p "$MENU_DIR" "$MAIN_DIR"
+
+MENU_TAG="${MENU_MISTER_TAG:-${MENU_TAG:-}}"
+if [ -z "$MENU_TAG" ]; then
+    error "MENU_MISTER_TAG is required; pass the exact ${MENU_REPO} release tag to package reproducibly"
+fi
 
 echo "Downloading ${MENU_REPO}@${MENU_TAG}/${MENU_ASSET}"
 gh release download "$MENU_TAG" \

--- a/scripts/package-mister-release.sh
+++ b/scripts/package-mister-release.sh
@@ -158,7 +158,7 @@ MENU_DIR="$TMP_DIR/menu"
 MAIN_DIR="$TMP_DIR/main"
 mkdir -p "$MENU_DIR" "$MAIN_DIR"
 
-MENU_TAG="${MENU_MISTER_TAG:-${MENU_TAG:-}}"
+MENU_TAG="${MENU_MISTER_TAG:-}"
 if [ -z "$MENU_TAG" ]; then
     error "MENU_MISTER_TAG is required; pass the exact ${MENU_REPO} release tag to package reproducibly"
 fi
@@ -170,7 +170,7 @@ gh release download "$MENU_TAG" \
     --dir "$MENU_DIR" \
     --clobber
 
-MAIN_TAG="${MAIN_MISTER_TAG:-${MAIN_TAG:-}}"
+MAIN_TAG="${MAIN_MISTER_TAG:-}"
 if [ -z "$MAIN_TAG" ]; then
     error "MAIN_MISTER_TAG is required; pass the exact ${MAIN_REPO} release tag to package reproducibly"
 fi

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -191,7 +191,7 @@ int main(int argc, char* argv[]) // NOLINT
     }
 
     QGuiApplication::setApplicationName("Zaparoo Frontend");
-    QGuiApplication::setApplicationVersion("1.1.0");
+    QGuiApplication::setApplicationVersion(ZAPAROO_VERSION);
     QGuiApplication::setOrganizationName("Zaparoo");
     QGuiApplication::setOrganizationDomain("zaparoo.org");
 


### PR DESCRIPTION
## Problem

v1.2.0 shipped the analog/native-video v2 rework, but many users see only the
menu core's noise ("snow") screen on analog out instead of the Zaparoo UI.

Root cause: the release packaging treated the two MiSTer forks inconsistently.
`scripts/package-mister-release.sh` **hardcoded** the `Menu_MiSTer` tag, while
the release workflow **auto-resolved** `Main_MiSTer` to its latest release. The
host wrapper moved forward to the v2 native-video contract; the menu core stayed
frozen on the old tag. The old core can't consume the v2 DDR frames, so analog
output falls back to its default noise pattern. (Testers were unaffected because
they hand-deployed the current core.)

## Fix

- Resolve the menu core to its latest `Menu_MiSTer` release the same way the host
  wrapper is resolved, so the two forks can't drift apart again.
- Add an optional `menu_tag` workflow input (defaults to latest) and a matching
  `MENU_MISTER_TAG` env override for the packaging script, mirroring
  `MAIN_MISTER_TAG`.
- Bump to **1.2.1** (`CMakeLists.txt`, `rust/Cargo.toml`, `rust/Cargo.lock`).
- Drive the About page version from the CMake project version via
  `ZAPAROO_VERSION` instead of a hardcoded string, so it no longer drifts on a
  release bump (the v1.2.0 About page still read 1.1.0).
- Document the release flow in `docs/building.md` and `AGENTS.md`.

## Follow-up (separate repo)

After this release is cut, update the downloader DB in `Zaparoo_MiSTer`
(`db.json` archive url/hash/size and `summary_inline.files` hashes) and
regenerate its distributed zip(s).

## Verification

- `just build` / `just test` pass; the built binary reports version `1.2.1`.
- `shellcheck` and `actionlint` clean on the changed script and workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release packaging now supports an optional Menu_MiSTer tag selection, defaulting to the latest Menu_MiSTer release when not specified.

* **Bug Fixes**
  * Packaging now stops early if it can’t resolve the required Menu_MiSTer release tag, reducing inconsistent bundles.
  * The app’s displayed version now uses the build’s current version automatically.

* **Documentation**
  * Added a “Cutting a release” guide covering versioning, bundling, publishing, and verification steps.

* **Chores**
  * Updated the project version to **1.2.1**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->