### PR TITLE
fix: paginate directory entries in media browse

### DIFF
--- a/rust/frontend/src/models/games.rs
+++ b/rust/frontend/src/models/games.rs
@@ -2916,11 +2916,53 @@ fn apply_status(mut model: Pin<&mut ffi::GamesModel>, status: ResourceStatus<Med
 // paths (`apply_favorite_tags`) keep the visible model in sync. Loading was set
 // true by the preceding Pending — clear it so a transient blip doesn't leave
 // the spinner stuck on after the refetch lands.
+fn result_total_dirs(result: &MediaBrowseResult) -> i32 {
+    let total_dirs = result.total_dirs.map_or_else(
+        || {
+            result
+                .entries
+                .iter()
+                .filter(|entry| entry.is_folder())
+                .count()
+        },
+        |total_dirs| usize::try_from(total_dirs).unwrap_or(usize::MAX),
+    );
+    i32::try_from(total_dirs).unwrap_or(i32::MAX)
+}
+
+fn seeded_refetch_has_seed_page_only(model_count: i32, seed_entry_count: usize) -> bool {
+    usize::try_from(model_count).is_ok_and(|count| count == seed_entry_count)
+}
+
+fn seeded_refetch_pagination_state(
+    model_count: i32,
+    seed_entry_count: usize,
+    current_next_cursor: Option<String>,
+    current_has_next_page: bool,
+    result_next_cursor: Option<String>,
+    result_has_next_page: bool,
+) -> (Option<String>, bool) {
+    if seeded_refetch_has_seed_page_only(model_count, seed_entry_count) {
+        (result_next_cursor, result_has_next_page)
+    } else {
+        (current_next_cursor, current_has_next_page)
+    }
+}
+
 fn apply_seeded_refetch(mut model: Pin<&mut ffi::GamesModel>, result: &MediaBrowseResult) {
-    let has_next_page = result.has_next_page();
+    let (next_cursor, has_next_page) = seeded_refetch_pagination_state(
+        model.count,
+        result.entries.len(),
+        model.next_cursor.clone(),
+        model.has_next_page,
+        result.next_cursor(),
+        result.has_next_page(),
+    );
     let total = i32::try_from(result.total_files).unwrap_or(i32::MAX);
-    let total_dirs = i32::try_from(result.total_dirs).unwrap_or(i32::MAX);
-    model.as_mut().rust_mut().next_cursor = result.next_cursor();
+    let total_dirs = result_total_dirs(result);
+    if model.next_cursor != next_cursor {
+        model.as_mut().rust_mut().next_cursor = next_cursor;
+    }
     if model.has_next_page != has_next_page {
         model.as_mut().set_has_next_page(has_next_page);
     }
@@ -2932,6 +2974,9 @@ fn apply_seeded_refetch(mut model: Pin<&mut ffi::GamesModel>, result: &MediaBrow
     }
     if model.loading {
         model.as_mut().set_loading(false);
+    }
+    if !model.error_message.is_empty() {
+        model.as_mut().set_error_message(QString::default());
     }
     finish_nav_timing(model.as_mut(), "already-seeded", 0);
 }
@@ -2945,7 +2990,7 @@ fn apply_initial_page(mut model: Pin<&mut ffi::GamesModel>, result: MediaBrowseR
     let has_next_page = result.has_next_page();
     let next_cursor = result.next_cursor();
     let total = i32::try_from(result.total_files).unwrap_or(i32::MAX);
-    let total_dirs = i32::try_from(result.total_dirs).unwrap_or(i32::MAX);
+    let total_dirs = result_total_dirs(&result);
     let platform = platform::current();
     let transform_started = Instant::now();
     let entries = transform_entries(result.entries, platform.as_ref());
@@ -3349,8 +3394,9 @@ mod tests {
         entry_system_id, is_media_capable_entry, is_strict_ancestor_path, jump_fetch_limit,
         media_capable_directory_browse_params, media_key_for, meta_params_for_entry,
         ordered_detail_image_keys, position_of_game_path, prefetch_around_plan,
-        prefetch_cursor_window_plan, project_status, run_text_for_entry,
-        singleton_directory_needs_launch_resolution, transform_entries, InitialAction, Projection,
+        prefetch_cursor_window_plan, project_status, result_total_dirs, run_text_for_entry,
+        seeded_refetch_pagination_state, singleton_directory_needs_launch_resolution,
+        transform_entries, InitialAction, Projection,
     };
     use super::{FETCH_MORE_RAPID_CHUNK_SIZE, JUMP_FETCH_CHUNK_SIZE};
     use crate::media_image_cache::{MediaImageCache, MediaKey};
@@ -3449,7 +3495,7 @@ mod tests {
             path: "/games/NES".into(),
             entries: vec![media("smb", "/games/NES/smb.nes", "NES")],
             total_files: 1,
-            total_dirs: 0,
+            total_dirs: Some(0),
             pagination: None,
         };
         match project_status(ResourceStatus::Ready(result)) {
@@ -3470,6 +3516,58 @@ mod tests {
             Projection::Errored { message } => assert_eq!(message, "rpc kaboom"),
             other => panic!("expected Errored, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn total_dirs_uses_present_zero_without_fallback() {
+        let result = MediaBrowseResult {
+            entries: vec![folder("Dir", "/games/Dir")],
+            total_dirs: Some(0),
+            ..MediaBrowseResult::default()
+        };
+        assert_eq!(result_total_dirs(&result), 0);
+    }
+
+    #[test]
+    fn total_dirs_falls_back_to_folder_count_when_missing() {
+        let result = MediaBrowseResult {
+            entries: vec![
+                folder("Dir", "/games/Dir"),
+                media("Game", "/games/game.rom", "NES"),
+                root("NES", "/games/NES", "NES"),
+            ],
+            total_dirs: None,
+            ..MediaBrowseResult::default()
+        };
+        assert_eq!(result_total_dirs(&result), 2);
+    }
+
+    #[test]
+    fn seeded_refetch_after_append_keeps_pagination_cursor() {
+        let (next_cursor, has_next_page) = seeded_refetch_pagination_state(
+            24,
+            12,
+            Some("page-3".into()),
+            true,
+            Some("page-2".into()),
+            true,
+        );
+        assert_eq!(next_cursor.as_deref(), Some("page-3"));
+        assert!(has_next_page);
+    }
+
+    #[test]
+    fn seeded_refetch_on_seed_page_refreshes_pagination_cursor() {
+        let (next_cursor, has_next_page) = seeded_refetch_pagination_state(
+            12,
+            12,
+            Some("stale".into()),
+            true,
+            Some("page-2".into()),
+            false,
+        );
+        assert_eq!(next_cursor.as_deref(), Some("page-2"));
+        assert!(!has_next_page);
     }
 
     #[test]
@@ -3950,7 +4048,7 @@ mod tests {
                 },
             ],
             total_files: 2,
-            total_dirs: 0,
+            total_dirs: Some(0),
             pagination: None,
         };
         assert_eq!(
@@ -3980,7 +4078,7 @@ mod tests {
                 ..BrowseEntry::default()
             }],
             total_files: 1,
-            total_dirs: 0,
+            total_dirs: Some(0),
             pagination: None,
         };
         assert!(singleton_directory_needs_launch_resolution(&parent));

--- a/rust/frontend/src/models/games.rs
+++ b/rust/frontend/src/models/games.rs
@@ -193,14 +193,14 @@ pub struct GamesModelRust {
     error_message: QString,
     has_next_page: bool,
     // Files-only count from Core (`BrowseFileCount`). Combined with
-    // `dir_count` to compute total entries for the page denominator —
-    // dirs are returned only on page 1 and always before files, so
-    // `dir_count + total_files` is exact, not an estimate.
+    // `total_dirs` to compute total entries for the page denominator.
+    // Directories always precede files, so `total_dirs + total_files`
+    // is exact, not an estimate.
     total_files: i32,
-    // Count of leading directory entries seen on page 1. Set once when
-    // page 1 lands and never touched on cursor follow-ups (Core never
-    // returns directories on follow-up pages).
-    dir_count: i32,
+    // Total directory count for the current scope (`BrowseDirCount`),
+    // carried forward by Core on every page. Directories always precede
+    // files, so `total_dirs + total_files` is the exact entry total.
+    total_dirs: i32,
     // API page size, bound to the QML grid's `pageSize` so the API page
     // matches the visual page exactly — no mid-page "Loading more…"
     // pause on the user's first scroll past row 0.
@@ -338,7 +338,7 @@ impl Default for GamesModelRust {
             error_message: QString::default(),
             has_next_page: false,
             total_files: 0,
-            dir_count: 0,
+            total_dirs: 0,
             page_size: DEFAULT_PAGE_SIZE,
             current_system_id: QString::default(),
             current_path: QString::default(),
@@ -410,7 +410,7 @@ pub mod ffi {
         #[qproperty(QString, error_message)]
         #[qproperty(bool, has_next_page)]
         #[qproperty(i32, total_files)]
-        #[qproperty(i32, dir_count)]
+        #[qproperty(i32, total_dirs)]
         #[qproperty(i32, page_size)]
         #[qproperty(QString, current_system_id)]
         #[qproperty(QString, current_path)]
@@ -1444,10 +1444,9 @@ impl ffi::GamesModel {
         // Total-files counter resets too — the previous path's
         // denominator would be misleading until the new fetch lands.
         self.as_mut().set_total_files(0);
-        // Same reasoning for dir_count: a stale value from the previous
-        // browse target would misclassify which leading entries are
-        // folders if the new fetch fails or stalls.
-        self.as_mut().set_dir_count(0);
+        // Total-dirs counter is the other denominator term; reset it for
+        // the same reason.
+        self.as_mut().set_total_dirs(0);
 
         if let Some(handle) = self.as_mut().rust_mut().watcher.take() {
             handle.abort();
@@ -2746,11 +2745,6 @@ fn display_name<'a>(raw: &'a str, platform: Option<&Platform>) -> std::borrow::C
     std::borrow::Cow::Borrowed(raw)
 }
 
-fn leading_dir_count(entries: &[BrowseEntry]) -> i32 {
-    let n = entries.iter().take_while(|e| e.is_folder()).count();
-    i32::try_from(n).unwrap_or(i32::MAX)
-}
-
 /// Drop any root-type entry whose path is a strict ancestor of another
 /// root entry's path. Defends against Core occasionally surfacing the
 /// shared parent dir (e.g. `/media/fat/games`) as a system root alongside
@@ -2914,47 +2908,52 @@ fn apply_status(mut model: Pin<&mut ffi::GamesModel>, status: ResourceStatus<Med
     }
 }
 
+// Already seeded: this Ready is a cache invalidation refetch on the same
+// browse target (e.g. `MediaTagsUpdateMutation`'s `MediaBrowseEndpoint`
+// invalidation after a favorite toggle, or a Loading→Ready cycle from a
+// connection blip / post-error retry). A full model reset would clobber any
+// pages the user paginated to and reset the grid to row 0; the local mutation
+// paths (`apply_favorite_tags`) keep the visible model in sync. Loading was set
+// true by the preceding Pending — clear it so a transient blip doesn't leave
+// the spinner stuck on after the refetch lands.
+fn apply_seeded_refetch(mut model: Pin<&mut ffi::GamesModel>, result: &MediaBrowseResult) {
+    let has_next_page = result.has_next_page();
+    let total = i32::try_from(result.total_files).unwrap_or(i32::MAX);
+    let total_dirs = i32::try_from(result.total_dirs).unwrap_or(i32::MAX);
+    model.as_mut().rust_mut().next_cursor = result.next_cursor();
+    if model.has_next_page != has_next_page {
+        model.as_mut().set_has_next_page(has_next_page);
+    }
+    if model.total_files != total {
+        model.as_mut().set_total_files(total);
+    }
+    if model.total_dirs != total_dirs {
+        model.as_mut().set_total_dirs(total_dirs);
+    }
+    if model.loading {
+        model.as_mut().set_loading(false);
+    }
+    finish_nav_timing(model.as_mut(), "already-seeded", 0);
+}
+
 fn apply_initial_page(mut model: Pin<&mut ffi::GamesModel>, result: MediaBrowseResult) {
     let apply_started = Instant::now();
-    // Already seeded: this Ready is a cache invalidation refetch on
-    // the same browse target (e.g. `MediaTagsUpdateMutation`'s
-    // `MediaBrowseEndpoint` invalidation after a favorite toggle, or
-    // a Loading→Ready cycle from a connection blip / post-error
-    // retry). The full reset below would clobber any pages the user
-    // paginated to and reset the grid to row 0; the local mutation
-    // paths (`apply_favorite_tags`) keep the visible model in sync.
-    // Loading was set true by the preceding Pending — clear it so a
-    // transient blip doesn't leave the spinner stuck on after the
-    // refetch lands.
     if model.is_seeded {
-        let has_next_page = result.has_next_page();
-        let next_cursor = result.next_cursor();
-        let total = i32::try_from(result.total_files).unwrap_or(i32::MAX);
-        model.as_mut().rust_mut().next_cursor = next_cursor;
-        if model.has_next_page != has_next_page {
-            model.as_mut().set_has_next_page(has_next_page);
-        }
-        if model.total_files != total {
-            model.as_mut().set_total_files(total);
-        }
-        if model.loading {
-            model.as_mut().set_loading(false);
-        }
-        finish_nav_timing(model.as_mut(), "already-seeded", 0);
+        apply_seeded_refetch(model, &result);
         return;
     }
     let has_next_page = result.has_next_page();
     let next_cursor = result.next_cursor();
     let total = i32::try_from(result.total_files).unwrap_or(i32::MAX);
+    let total_dirs = i32::try_from(result.total_dirs).unwrap_or(i32::MAX);
     let platform = platform::current();
     let transform_started = Instant::now();
     let entries = transform_entries(result.entries, platform.as_ref());
     let transform_ms = transform_started.elapsed().as_millis();
-    let dir_count = leading_dir_count(&entries);
     let count = i32::try_from(entries.len()).unwrap_or(i32::MAX);
     info!(
         count,
-        dir_count, total, has_next_page, "games: apply_initial_page"
+        total, total_dirs, has_next_page, "games: apply_initial_page"
     );
     let reset_started = Instant::now();
     let displays = compute_disambig_displays(&entries, model.show_original_filenames);
@@ -2976,8 +2975,8 @@ fn apply_initial_page(mut model: Pin<&mut ffi::GamesModel>, result: MediaBrowseR
     // when the flag flips false on the terminal chunk. A fresh
     // model reset has no pending-target watchdog to mislead, so
     // setting the flag early here is safe.
-    model.as_mut().set_dir_count(dir_count);
     model.as_mut().set_total_files(total);
+    model.as_mut().set_total_dirs(total_dirs);
     model.as_mut().set_has_next_page(has_next_page);
     model.as_mut().end_reset_model();
     model.as_mut().count_changed();
@@ -3265,8 +3264,9 @@ fn apply_append_page(
             // Remaining batches: post one frame apart on the Qt
             // thread, with the LAST one carrying the finaliser
             // (has_next_page, total_files, look-ahead gate release).
-            // dir_count intentionally not touched: Core only returns
-            // directory entries on page 1 (cursor == nil).
+            // total_dirs is not touched here: Core computes it once on
+            // page 1 and carries the same value forward, so it never
+            // changes across appended pages.
             //
             // No auto-prefetch here. apply_initial_page pre-warms
             // chunk 2 once; subsequent chunks are driven by the
@@ -3347,9 +3347,9 @@ mod tests {
         cover_key_for_with, cover_placeholder_for, decide_initial, dedup_roots_drop_ancestors,
         detail_image_keys_from_meta, detail_tags_from_tags, display_name, display_title_for_entry,
         entry_system_id, is_media_capable_entry, is_strict_ancestor_path, jump_fetch_limit,
-        leading_dir_count, media_capable_directory_browse_params, media_key_for,
-        meta_params_for_entry, ordered_detail_image_keys, position_of_game_path,
-        prefetch_around_plan, prefetch_cursor_window_plan, project_status, run_text_for_entry,
+        media_capable_directory_browse_params, media_key_for, meta_params_for_entry,
+        ordered_detail_image_keys, position_of_game_path, prefetch_around_plan,
+        prefetch_cursor_window_plan, project_status, run_text_for_entry,
         singleton_directory_needs_launch_resolution, transform_entries, InitialAction, Projection,
     };
     use super::{FETCH_MORE_RAPID_CHUNK_SIZE, JUMP_FETCH_CHUNK_SIZE};
@@ -3449,6 +3449,7 @@ mod tests {
             path: "/games/NES".into(),
             entries: vec![media("smb", "/games/NES/smb.nes", "NES")],
             total_files: 1,
+            total_dirs: 0,
             pagination: None,
         };
         match project_status(ResourceStatus::Ready(result)) {
@@ -3667,30 +3668,6 @@ mod tests {
         let off_mister = transform_entries(entries, Some(&Platform::Linux));
         assert_eq!(off_mister[0].name, "_Arcade");
         assert_eq!(off_mister[1].name, "_smb");
-    }
-
-    #[test]
-    fn leading_dir_count_counts_only_leading_folders() {
-        let entries = vec![
-            folder("a", "/a"),
-            folder("b", "/b"),
-            media("smb", "/smb", "NES"),
-            // A folder appearing after files would be a Core bug —
-            // the API contract is dirs-then-files. We don't count it.
-            folder("c", "/c"),
-        ];
-        assert_eq!(leading_dir_count(&entries), 2);
-    }
-
-    #[test]
-    fn leading_dir_count_zero_when_first_is_media() {
-        let entries = vec![media("smb", "/smb", "NES"), media("zelda", "/z", "NES")];
-        assert_eq!(leading_dir_count(&entries), 0);
-    }
-
-    #[test]
-    fn leading_dir_count_zero_on_empty() {
-        assert_eq!(leading_dir_count(&[]), 0);
     }
 
     #[test]
@@ -3973,6 +3950,7 @@ mod tests {
                 },
             ],
             total_files: 2,
+            total_dirs: 0,
             pagination: None,
         };
         assert_eq!(
@@ -4002,6 +3980,7 @@ mod tests {
                 ..BrowseEntry::default()
             }],
             total_files: 1,
+            total_dirs: 0,
             pagination: None,
         };
         assert!(singleton_directory_needs_launch_resolution(&parent));

--- a/rust/mock-core/src/fixtures.rs
+++ b/rust/mock-core/src/fixtures.rs
@@ -176,6 +176,8 @@ pub fn media_browse_response(params: &Value) -> Value {
         "path": path,
         "entries": entries,
         "totalFiles": total_files,
+        // Mock browse returns only media entries (no subdirectories).
+        "totalDirs": 0,
         "pagination": {
             "hasNextPage": false,
             "pageSize": 100,

--- a/rust/zaparoo-core/src/config.rs
+++ b/rust/zaparoo-core/src/config.rs
@@ -1209,13 +1209,31 @@ mod tests {
 
     // Single test because std::env is process-global; splitting into
     // separate #[test]s would race against each other. The env_guard() lock
-    // also serialises against the core_endpoint reader tests, which would
+    // also serializes against the core_endpoint reader tests, which would
     // otherwise observe this env var under threaded `cargo test`.
     #[test]
     fn env_var_overrides_endpoint_and_empty_string_is_ignored() {
         const KEY: &str = "ZAPAROO_CORE_ENDPOINT";
+
+        struct RestoreEnv {
+            key: &'static str,
+            prior: Option<String>,
+        }
+
+        impl Drop for RestoreEnv {
+            fn drop(&mut self) {
+                match &self.prior {
+                    Some(v) => std::env::set_var(self.key, v),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+
         let _env = env_guard();
-        let prior = std::env::var(KEY).ok();
+        let _restore = RestoreEnv {
+            key: KEY,
+            prior: std::env::var(KEY).ok(),
+        };
         let f = write_tmp("[core]\nendpoint = \"ws://example.com/api\"\n");
 
         std::env::set_var(KEY, "ws://localhost:27497/api/v0.1");
@@ -1247,10 +1265,5 @@ mod tests {
             load_config(bad.path()).core_endpoint,
             "ws://10.0.0.115:7497/api/v0.1"
         );
-
-        match prior {
-            Some(v) => std::env::set_var(KEY, v),
-            None => std::env::remove_var(KEY),
-        }
     }
 }

--- a/rust/zaparoo-core/src/config.rs
+++ b/rust/zaparoo-core/src/config.rs
@@ -653,6 +653,18 @@ mod tests {
         f
     }
 
+    // `load_config` consults the process-global ZAPAROO_CORE_ENDPOINT env var,
+    // so any test that sets it or asserts on `core_endpoint` must hold this
+    // lock to avoid cross-test pollution under threaded runners like plain
+    // `cargo test` (nextest isolates each test in its own process).
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn env_guard() -> std::sync::MutexGuard<'static, ()> {
+        ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
     #[test]
     fn defaults_match_production_values() {
         let cfg = Config::default();
@@ -762,6 +774,7 @@ mod tests {
 
     #[test]
     fn save_hidden_browse_prefs_preserves_other_config() {
+        let _env = env_guard();
         let f = write_tmp(
             "[core]\nendpoint = \"ws://example.com/api\"\n[settings]\nbutton_layout = \"b\"\n",
         );
@@ -787,6 +800,7 @@ mod tests {
 
     #[test]
     fn save_notice_ack_creates_section_and_preserves_others() {
+        let _env = env_guard();
         let f = write_tmp(
             "[core]\nendpoint = \"ws://example.com/api\"\n[settings]\nbutton_layout = \"b\"\n",
         );
@@ -884,6 +898,7 @@ mod tests {
 
     #[test]
     fn malformed_toml_returns_defaults() {
+        let _env = env_guard();
         let f = write_tmp("this is not = valid toml [[[");
         let cfg = load_config(f.path());
         assert_eq!(cfg.core_endpoint, Config::default().core_endpoint);
@@ -891,6 +906,7 @@ mod tests {
 
     #[test]
     fn partial_config_merges_with_defaults() {
+        let _env = env_guard();
         let f = write_tmp("[video]\nwidth = 1280\n");
         let cfg = load_config(f.path());
         assert_eq!(cfg.video_width, 1280);
@@ -900,6 +916,7 @@ mod tests {
 
     #[test]
     fn full_config_overrides_all_fields() {
+        let _env = env_guard();
         let toml = r#"
             [general]
             language = "it_IT"
@@ -1044,6 +1061,7 @@ mod tests {
 
     #[test]
     fn save_settings_mirror_preserves_other_sections() {
+        let _env = env_guard();
         let f = write_tmp(
             "[core]\nendpoint = \"ws://example.com/api\"\n[video]\nbackend = \"native-core-poc\"\nwidth = 1280\nheight = 720\n[settings]\nhidden_categories = [\"Arcade\"]\nhidden_system_ids = [\"NES\"]\n",
         );
@@ -1190,10 +1208,13 @@ mod tests {
     }
 
     // Single test because std::env is process-global; splitting into
-    // separate #[test]s would race when nextest runs them in parallel.
+    // separate #[test]s would race against each other. The env_guard() lock
+    // also serialises against the core_endpoint reader tests, which would
+    // otherwise observe this env var under threaded `cargo test`.
     #[test]
     fn env_var_overrides_endpoint_and_empty_string_is_ignored() {
         const KEY: &str = "ZAPAROO_CORE_ENDPOINT";
+        let _env = env_guard();
         let prior = std::env::var(KEY).ok();
         let f = write_tmp("[core]\nendpoint = \"ws://example.com/api\"\n");
 

--- a/rust/zaparoo-core/src/media_types.rs
+++ b/rust/zaparoo-core/src/media_types.rs
@@ -307,8 +307,7 @@ pub struct MediaBrowseResult {
     pub entries: Vec<BrowseEntry>,
     #[serde(default)]
     pub total_files: u32,
-    #[serde(default)]
-    pub total_dirs: u32,
+    pub total_dirs: Option<u32>,
     #[serde(default)]
     pub pagination: Option<Pagination>,
 }
@@ -1421,19 +1420,19 @@ mod tests {
         assert_eq!(result.entries[1].relative_path, "NES/smb.nes");
         assert_eq!(result.entries[1].description, "A platformer.");
         assert_eq!(result.total_files, 150);
-        assert_eq!(result.total_dirs, 7);
+        assert_eq!(result.total_dirs, Some(7));
         let pagination = result.pagination.expect("pagination present");
         assert!(pagination.has_next_page);
         assert_eq!(pagination.next_cursor.as_deref(), Some("x"));
     }
 
     #[test]
-    fn media_browse_result_total_dirs_defaults_to_zero_when_absent() {
-        // Legacy Core (pre-dir-pagination) omits totalDirs; it must default
-        // to 0 rather than failing to deserialize.
+    fn media_browse_result_total_dirs_preserves_absence() {
+        // Legacy Core (pre-dir-pagination) omits totalDirs; it must preserve
+        // absence rather than failing to deserialize or collapsing to zero.
         let json = r#"{"path":"/games","entries":[],"totalFiles":0}"#;
         let result: MediaBrowseResult = serde_json::from_str(json).expect("parse");
-        assert_eq!(result.total_dirs, 0);
+        assert_eq!(result.total_dirs, None);
     }
 
     #[test]

--- a/rust/zaparoo-core/src/media_types.rs
+++ b/rust/zaparoo-core/src/media_types.rs
@@ -308,6 +308,8 @@ pub struct MediaBrowseResult {
     #[serde(default)]
     pub total_files: u32,
     #[serde(default)]
+    pub total_dirs: u32,
+    #[serde(default)]
     pub pagination: Option<Pagination>,
 }
 
@@ -1407,6 +1409,7 @@ mod tests {
                 {"name":"SMB","path":"/games/NES/smb.nes","type":"media","systemId":"NES","zapScript":"@NES/smb","relativePath":"NES/smb.nes","description":"A platformer."}
             ],
             "totalFiles": 150,
+            "totalDirs": 7,
             "pagination": {"hasNextPage": true, "pageSize": 100, "nextCursor": "x"}
         }"#;
         let result: MediaBrowseResult = serde_json::from_str(json).expect("parse");
@@ -1418,9 +1421,19 @@ mod tests {
         assert_eq!(result.entries[1].relative_path, "NES/smb.nes");
         assert_eq!(result.entries[1].description, "A platformer.");
         assert_eq!(result.total_files, 150);
+        assert_eq!(result.total_dirs, 7);
         let pagination = result.pagination.expect("pagination present");
         assert!(pagination.has_next_page);
         assert_eq!(pagination.next_cursor.as_deref(), Some("x"));
+    }
+
+    #[test]
+    fn media_browse_result_total_dirs_defaults_to_zero_when_absent() {
+        // Legacy Core (pre-dir-pagination) omits totalDirs; it must default
+        // to 0 rather than failing to deserialize.
+        let json = r#"{"path":"/games","entries":[],"totalFiles":0}"#;
+        let result: MediaBrowseResult = serde_json::from_str(json).expect("parse");
+        assert_eq!(result.total_dirs, 0);
     }
 
     #[test]

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -47,7 +47,7 @@ MediaListScreen {
     mediaModel: Browse.GamesModel
     emptyText: qsTr("No games in this system")
     loadingText: qsTr("Loading games…")
-    totalItemsOverride: Browse.GamesModel.dir_count + Browse.GamesModel.total_files
+    totalItemsOverride: Browse.GamesModel.total_dirs + Browse.GamesModel.total_files
     targetVisibleRowCount: games._listPageSize
     detailShowDescription: false
     detailShowTitle: false
@@ -127,7 +127,7 @@ MediaListScreen {
         return idx >= 0 ? Browse.SystemsModel.system_name_at(idx) : sid;
     }
     topStripCurrentPageProvider: () => Math.floor(games.gamesGrid.currentIndex / games._browsePageSize)
-    topStripTotalPagesProvider: () => games._footerProfile && games._footerProfile.bottomStatusVisible ? 1 : Math.max(1, Math.ceil((Browse.GamesModel.dir_count + Browse.GamesModel.total_files) / games._browsePageSize))
+    topStripTotalPagesProvider: () => games._footerProfile && games._footerProfile.bottomStatusVisible ? 1 : Math.max(1, Math.ceil((Browse.GamesModel.total_dirs + Browse.GamesModel.total_files) / games._browsePageSize))
     topStripTotalTextProvider: () => games._listLayout || (games._footerProfile && games._footerProfile.bottomStatusVisible) ? "" : (Browse.GamesModel.total_files > 0 ? qsTr("%1 files").arg(Browse.GamesModel.total_files) : "")
     topStripRightTextProvider: () => {
         if (!games._listLayout)
@@ -136,13 +136,13 @@ MediaListScreen {
             return qsTr("Loading more…");
         if (games.gamesGrid.itemCount <= 0)
             return "";
-        const total = Math.max(1, Browse.GamesModel.dir_count + Browse.GamesModel.total_files);
+        const total = Math.max(1, Browse.GamesModel.total_dirs + Browse.GamesModel.total_files);
         return qsTr("%1 / %2").arg(games.gamesGrid.currentIndex + 1).arg(total);
     }
     gridBottomMargin: games._footerProfile ? games._footerProfile.gridBottomMargin : (Sizing.pctH(8) + Sizing.pctH(7))
     gridColumnsOverride: games._gridColumns
     gridRowsOverride: games._gridRows
-    gridTotalItemsOverride: Browse.GamesModel.dir_count + Browse.GamesModel.total_files
+    gridTotalItemsOverride: Browse.GamesModel.total_dirs + Browse.GamesModel.total_files
     gridHasMorePages: Browse.GamesModel.has_next_page
     gridLoadMoreAction: urgent => {
         // A letter jump bulk-loads to the target in one shot (overlay is up);
@@ -169,7 +169,7 @@ MediaListScreen {
     bottomStatusLeftMargin: games._footerProfile ? games._footerProfile.bottomStatusLeftMargin : 0
     bottomStatusRightMargin: games._footerProfile ? games._footerProfile.bottomStatusRightMargin : 0
     bottomStatusLeftText: games._footerProfile && games._footerProfile.bottomStatusVisible && Browse.GamesModel.total_files > 0 ? qsTr("%1 files").arg(Browse.GamesModel.total_files) : ""
-    bottomStatusRightText: games._footerProfile && games._footerProfile.bottomStatusVisible && Math.ceil((Browse.GamesModel.dir_count + Browse.GamesModel.total_files) / games._browsePageSize) > 1 ? qsTr("%1 / %2").arg(Math.floor(games.gamesGrid.currentIndex / games._browsePageSize) + 1).arg(Math.max(1, Math.ceil((Browse.GamesModel.dir_count + Browse.GamesModel.total_files) / games._browsePageSize))) : ""
+    bottomStatusRightText: games._footerProfile && games._footerProfile.bottomStatusVisible && Math.ceil((Browse.GamesModel.total_dirs + Browse.GamesModel.total_files) / games._browsePageSize) > 1 ? qsTr("%1 / %2").arg(Math.floor(games.gamesGrid.currentIndex / games._browsePageSize) + 1).arg(Math.max(1, Math.ceil((Browse.GamesModel.total_dirs + Browse.GamesModel.total_files) / games._browsePageSize))) : ""
     pageLoadingVisible: !games._listLayout && Browse.GamesModel.loading_more && games.gamesGrid.hasPendingTarget
     pageLoadingLeftMargin: games._footerProfile && games._footerProfile.bottomStatusVisible && games.bottomStatusLeftText !== "" ? Sizing.px(games.width / 3) : games.gamesGrid.leftInset
 
@@ -272,7 +272,7 @@ MediaListScreen {
         if (next < 0)
             next = count - 1;
         else if (next >= count) {
-            const knownTotal = Browse.GamesModel.dir_count + Browse.GamesModel.total_files;
+            const knownTotal = Browse.GamesModel.total_dirs + Browse.GamesModel.total_files;
             if (games._listHasMore(count, knownTotal)) {
                 Browse.GamesModel.fetch_more();
                 return;
@@ -306,7 +306,7 @@ MediaListScreen {
         if (!games._listLayout || Browse.GamesModel.loading_more)
             return;
         const count = games.gamesGrid.itemCount;
-        const knownTotal = Browse.GamesModel.dir_count + Browse.GamesModel.total_files;
+        const knownTotal = Browse.GamesModel.total_dirs + Browse.GamesModel.total_files;
         if (index >= count - games._listPageSize && games._listHasMore(count, knownTotal))
             Browse.GamesModel.fetch_more();
     }
@@ -329,13 +329,13 @@ MediaListScreen {
     }
 
     // Jump-to-letter. `itemOffset` is the cumulative count of all buckets before
-    // the chosen letter (from the letter-index facet); the leading directories
-    // come first in the grid, so the letter's first item sits at
-    // `dir_count + itemOffset`. Driving the grid's page-jump there loads the
+    // the chosen letter (from the letter-index facet); all directories come
+    // before files in the grid, so the letter's first item sits at
+    // `total_dirs + itemOffset`. Driving the grid's page-jump there loads the
     // intervening pages and lands on that absolute index, so the full list stays
     // navigable both ways and the page counter reflects the real position.
     function jumpToItem(itemOffset: int): void {
-        const absolute = Browse.GamesModel.dir_count + itemOffset;
+        const absolute = Browse.GamesModel.total_dirs + itemOffset;
         const landed = games.gamesGrid.jumpToIndex(absolute);
         // A deferred walk (target not yet loaded) returns false; show the
         // standard centered loading cue over the stale source page until the


### PR DESCRIPTION
## Problem

Browsing large all-directory folders (e.g. a MiSTer console folder where each game is its own zip — 2613 entries) froze on "Loading Games…" then "Reconnecting". Core returned every directory on page 1 and the app reset the whole model over all entries on the main thread (ZaparooProject/zaparoo-core#1022).

## Change

Consumes the Core directory-pagination change (ZaparooProject/zaparoo-core#1030):

- Add `total_dirs` to `MediaBrowseResult`, fed from Core's new `totalDirs` field. `#[serde(default)]` keeps it at 0 against older Core builds.
- `GamesModel` carries `total_dirs` as a qproperty. The scroll-range, page-count, and jump-to-letter math in `GamesScreen.qml` now uses `total_dirs + total_files`.
- Remove the now-dead `dir_count` scalar (leading loaded directories), which was only meaningful when Core returned all directories on page 1.
- `mock-core` browse fixture emits `totalDirs` for shape parity.

Directory pages now arrive incrementally like file pages, so the initial page is bounded to `page_size` entries and the main-thread reset shrinks accordingly.

## Also

Serialize the `config` tests that read the process-global `ZAPAROO_CORE_ENDPOINT` env var. They passed under nextest (per-process isolation) but raced under threaded `cargo test`; a shared lock around the env-mutating test and the endpoint-asserting tests fixes it.

Pairs with ZaparooProject/zaparoo-core#1030.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Directory/file totals in the Games browser pagination and navigation (including jump actions) are now computed reliably.
  * Paging indicators and status text now reflect the correct combined totals for directories and files.
  * Refreshes and cache invalidation now preserve pagination totals and cursor state more consistently.
  * Browsing gracefully handles cases where directory totals are missing from Core responses, preventing incorrect count displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->