### PR TITLE
fix(qml): stop help bar verticalCenter warning spam

### DIFF
--- a/src/ui/app/MainLayout.qml
+++ b/src/ui/app/MainLayout.qml
@@ -1479,7 +1479,7 @@ ApplicationWindow {
                                 model: helpEntry.buttonList
                                 delegate: Image {
                                     required property string modelData
-                                    anchors.verticalCenter: parent.verticalCenter
+                                    anchors.verticalCenter: helpEntry.verticalCenter
                                     height: Sizing.pctH(4)
                                     width: height
                                     fillMode: Image.PreserveAspectFit


### PR DESCRIPTION
## Summary

Fix help-bar icon anchoring so QML no longer reads `parent.verticalCenter` from repeater image delegates during delegate churn. This stops repeated `Cannot read property 'verticalCenter' of null` warnings from filling frontend logs.

## Motivation

Reported from support log: https://logs.zaparoo.org/12niu8yH.log

## Test plan

- `just lint` (passes; existing QML compiler warnings still emitted from tests/ui/tst_navigation.qml)
- `just test-qml`

## Checklist

- [ ] `just lint` is green (zero warnings)
- [ ] `just test` passes
- [ ] If this touches QML, the FPS counter stays green (≥ 55) at 720p+ and ≥ 30 at 240p
- [x] If this could affect the MiSTer build, I considered ARM32 implications (see `docs/architecture.md`)
- [x] If this adds user-visible strings, they are wrapped in `qsTr()` (QML) or `tr()` (C++)
- [ ] I have signed the [CLA](../.github/CLA.md) (first-time contributors only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved icon alignment in the instructions/help bar so the button icon is centered more consistently within each entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->