### PR TITLE
fix(games): dispatch launch concurrently with press animation

### DIFF
--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -88,6 +88,11 @@ MediaListScreen {
             Browse.GamesModel.set_system(sid);
     }
     acceptAction: index => {
+        // Debounce the whole accept path: while a prior Accept's deferred
+        // leg is still pending, ignore repeats so neither the folder nor the
+        // launch branch re-fires the cue or reassigns the pending target.
+        if (pressCommit.running)
+            return;
         const entryType = Browse.GamesModel.entry_type_at(index);
         if ((entryType === "directory" || entryType === "root") && !Browse.GamesModel.is_media_capable_at(index)) {
             // Persist synchronously (MiSTer may be killed at any time), then
@@ -102,8 +107,6 @@ MediaListScreen {
         // Launch is dispatched immediately so the run command races the
         // push-in cue rather than waiting it out; the deferred leg only
         // settles the tile back to rest. State persistence is synchronous.
-        if (pressCommit.running)
-            return; // debounce a double Accept
         games._scheduleSelectedPersist(Browse.GamesModel.path_at(index));
         games.flushSelectedPersist();
         games.pulseActivate();

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -99,12 +99,15 @@ MediaListScreen {
             pressCommit.arm();
             return;
         }
-        // State persistence is synchronous; launch_at is deferred so the
-        // push-in cue plays on a fully static scene before Core takes the
-        // FPGA. Launch shares the same push-in as forward navigation.
+        // Launch is dispatched immediately so the run command races the
+        // push-in cue rather than waiting it out; the deferred leg only
+        // settles the tile back to rest. State persistence is synchronous.
+        if (pressCommit.running)
+            return; // debounce a double Accept
         games._scheduleSelectedPersist(Browse.GamesModel.path_at(index));
         games.flushSelectedPersist();
         games.pulseActivate();
+        Browse.GamesModel.launch_at(index);
         pressCommit._launchIndex = index;
         pressCommit.arm();
     }
@@ -215,9 +218,7 @@ MediaListScreen {
                 _folderPath = "";
                 games.requestNavigateIntoFolder(p);
             } else if (_launchIndex >= 0) {
-                const idx = _launchIndex;
                 _launchIndex = -1;
-                Browse.GamesModel.launch_at(idx);
                 // Settle the push-in back to rest. Invisible when the launch
                 // takes the FPGA or kills us; prevents a stuck pushed-in tile
                 // when the launcher stays on the page (e.g. an Audio track).

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -443,8 +443,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="171"/>
+        <location filename="../screens/GamesScreen.qml" line="134"/>
+        <location filename="../screens/GamesScreen.qml" line="174"/>
         <source>%1 files</source>
         <translation>%1 ملفات</translation>
     </message>
@@ -454,8 +454,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="140"/>
-        <location filename="../screens/GamesScreen.qml" line="172"/>
+        <location filename="../screens/GamesScreen.qml" line="143"/>
+        <location filename="../screens/GamesScreen.qml" line="175"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -470,7 +470,7 @@ Euskara - devilschile2</source>
         <translation>جارٍ تحميل الألعاب…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="136"/>
+        <location filename="../screens/GamesScreen.qml" line="139"/>
         <source>Loading more…</source>
         <translation>جارٍ تحميل المزيد…</translation>
     </message>

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -443,8 +443,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="134"/>
-        <location filename="../screens/GamesScreen.qml" line="174"/>
+        <location filename="../screens/GamesScreen.qml" line="137"/>
+        <location filename="../screens/GamesScreen.qml" line="177"/>
         <source>%1 files</source>
         <translation>%1 ملفات</translation>
     </message>
@@ -454,8 +454,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="143"/>
-        <location filename="../screens/GamesScreen.qml" line="175"/>
+        <location filename="../screens/GamesScreen.qml" line="146"/>
+        <location filename="../screens/GamesScreen.qml" line="178"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -470,7 +470,7 @@ Euskara - devilschile2</source>
         <translation>جارٍ تحميل الألعاب…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="139"/>
+        <location filename="../screens/GamesScreen.qml" line="142"/>
         <source>Loading more…</source>
         <translation>جارٍ تحميل المزيد…</translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -443,8 +443,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="171"/>
+        <location filename="../screens/GamesScreen.qml" line="134"/>
+        <location filename="../screens/GamesScreen.qml" line="174"/>
         <source>%1 files</source>
         <translation>%1 Dateien</translation>
     </message>
@@ -454,8 +454,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="140"/>
-        <location filename="../screens/GamesScreen.qml" line="172"/>
+        <location filename="../screens/GamesScreen.qml" line="143"/>
+        <location filename="../screens/GamesScreen.qml" line="175"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -465,7 +465,7 @@ Euskara - devilschile2</source>
         <translation>Spiele werden geladen…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="136"/>
+        <location filename="../screens/GamesScreen.qml" line="139"/>
         <source>Loading more…</source>
         <translation>Mehr laden…</translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -443,8 +443,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="134"/>
-        <location filename="../screens/GamesScreen.qml" line="174"/>
+        <location filename="../screens/GamesScreen.qml" line="137"/>
+        <location filename="../screens/GamesScreen.qml" line="177"/>
         <source>%1 files</source>
         <translation>%1 Dateien</translation>
     </message>
@@ -454,8 +454,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="143"/>
-        <location filename="../screens/GamesScreen.qml" line="175"/>
+        <location filename="../screens/GamesScreen.qml" line="146"/>
+        <location filename="../screens/GamesScreen.qml" line="178"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -465,7 +465,7 @@ Euskara - devilschile2</source>
         <translation>Spiele werden geladen…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="139"/>
+        <location filename="../screens/GamesScreen.qml" line="142"/>
         <source>Loading more…</source>
         <translation>Mehr laden…</translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -443,8 +443,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="171"/>
+        <location filename="../screens/GamesScreen.qml" line="134"/>
+        <location filename="../screens/GamesScreen.qml" line="174"/>
         <source>%1 files</source>
         <translation>%1 αρχεία</translation>
     </message>
@@ -454,8 +454,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="140"/>
-        <location filename="../screens/GamesScreen.qml" line="172"/>
+        <location filename="../screens/GamesScreen.qml" line="143"/>
+        <location filename="../screens/GamesScreen.qml" line="175"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -465,7 +465,7 @@ Euskara - devilschile2</source>
         <translation>Φόρτωση παιχνιδιών…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="136"/>
+        <location filename="../screens/GamesScreen.qml" line="139"/>
         <source>Loading more…</source>
         <translation>Φόρτωση περισσότερων…</translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -443,8 +443,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="134"/>
-        <location filename="../screens/GamesScreen.qml" line="174"/>
+        <location filename="../screens/GamesScreen.qml" line="137"/>
+        <location filename="../screens/GamesScreen.qml" line="177"/>
         <source>%1 files</source>
         <translation>%1 αρχεία</translation>
     </message>
@@ -454,8 +454,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="143"/>
-        <location filename="../screens/GamesScreen.qml" line="175"/>
+        <location filename="../screens/GamesScreen.qml" line="146"/>
+        <location filename="../screens/GamesScreen.qml" line="178"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -465,7 +465,7 @@ Euskara - devilschile2</source>
         <translation>Φόρτωση παιχνιδιών…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="139"/>
+        <location filename="../screens/GamesScreen.qml" line="142"/>
         <source>Loading more…</source>
         <translation>Φόρτωση περισσότερων…</translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -423,8 +423,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="171"/>
+        <location filename="../screens/GamesScreen.qml" line="134"/>
+        <location filename="../screens/GamesScreen.qml" line="174"/>
         <source>%1 files</source>
         <translation>%1 files</translation>
     </message>
@@ -434,8 +434,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="140"/>
-        <location filename="../screens/GamesScreen.qml" line="172"/>
+        <location filename="../screens/GamesScreen.qml" line="143"/>
+        <location filename="../screens/GamesScreen.qml" line="175"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -445,7 +445,7 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="136"/>
+        <location filename="../screens/GamesScreen.qml" line="139"/>
         <source>Loading more…</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -423,8 +423,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="134"/>
-        <location filename="../screens/GamesScreen.qml" line="174"/>
+        <location filename="../screens/GamesScreen.qml" line="137"/>
+        <location filename="../screens/GamesScreen.qml" line="177"/>
         <source>%1 files</source>
         <translation>%1 files</translation>
     </message>
@@ -434,8 +434,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="143"/>
-        <location filename="../screens/GamesScreen.qml" line="175"/>
+        <location filename="../screens/GamesScreen.qml" line="146"/>
+        <location filename="../screens/GamesScreen.qml" line="178"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -445,7 +445,7 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="139"/>
+        <location filename="../screens/GamesScreen.qml" line="142"/>
         <source>Loading more…</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -443,8 +443,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="171"/>
+        <location filename="../screens/GamesScreen.qml" line="134"/>
+        <location filename="../screens/GamesScreen.qml" line="174"/>
         <source>%1 files</source>
         <translation>%1 archivos</translation>
     </message>
@@ -454,8 +454,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="140"/>
-        <location filename="../screens/GamesScreen.qml" line="172"/>
+        <location filename="../screens/GamesScreen.qml" line="143"/>
+        <location filename="../screens/GamesScreen.qml" line="175"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -465,7 +465,7 @@ Euskara - devilschile2</source>
         <translation>Cargando juegos…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="136"/>
+        <location filename="../screens/GamesScreen.qml" line="139"/>
         <source>Loading more…</source>
         <translation>Cargando más…</translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -443,8 +443,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="134"/>
-        <location filename="../screens/GamesScreen.qml" line="174"/>
+        <location filename="../screens/GamesScreen.qml" line="137"/>
+        <location filename="../screens/GamesScreen.qml" line="177"/>
         <source>%1 files</source>
         <translation>%1 archivos</translation>
     </message>
@@ -454,8 +454,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="143"/>
-        <location filename="../screens/GamesScreen.qml" line="175"/>
+        <location filename="../screens/GamesScreen.qml" line="146"/>
+        <location filename="../screens/GamesScreen.qml" line="178"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -465,7 +465,7 @@ Euskara - devilschile2</source>
         <translation>Cargando juegos…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="139"/>
+        <location filename="../screens/GamesScreen.qml" line="142"/>
         <source>Loading more…</source>
         <translation>Cargando más…</translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -443,8 +443,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="134"/>
-        <location filename="../screens/GamesScreen.qml" line="174"/>
+        <location filename="../screens/GamesScreen.qml" line="137"/>
+        <location filename="../screens/GamesScreen.qml" line="177"/>
         <source>%1 files</source>
         <translation>%1 fitxategi</translation>
     </message>
@@ -454,8 +454,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Jokua kargatzen...</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="143"/>
-        <location filename="../screens/GamesScreen.qml" line="175"/>
+        <location filename="../screens/GamesScreen.qml" line="146"/>
+        <location filename="../screens/GamesScreen.qml" line="178"/>
         <source>%1 / %2</source>
         <translation type="unfinished">%1 / %2</translation>
     </message>
@@ -465,7 +465,7 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Jokuak kargatzen</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="139"/>
+        <location filename="../screens/GamesScreen.qml" line="142"/>
         <source>Loading more…</source>
         <translation type="unfinished">Gehiago kargatzen...</translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -443,8 +443,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="171"/>
+        <location filename="../screens/GamesScreen.qml" line="134"/>
+        <location filename="../screens/GamesScreen.qml" line="174"/>
         <source>%1 files</source>
         <translation>%1 fitxategi</translation>
     </message>
@@ -454,8 +454,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Jokua kargatzen...</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="140"/>
-        <location filename="../screens/GamesScreen.qml" line="172"/>
+        <location filename="../screens/GamesScreen.qml" line="143"/>
+        <location filename="../screens/GamesScreen.qml" line="175"/>
         <source>%1 / %2</source>
         <translation type="unfinished">%1 / %2</translation>
     </message>
@@ -465,7 +465,7 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Jokuak kargatzen</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="136"/>
+        <location filename="../screens/GamesScreen.qml" line="139"/>
         <source>Loading more…</source>
         <translation type="unfinished">Gehiago kargatzen...</translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -443,8 +443,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="134"/>
-        <location filename="../screens/GamesScreen.qml" line="174"/>
+        <location filename="../screens/GamesScreen.qml" line="137"/>
+        <location filename="../screens/GamesScreen.qml" line="177"/>
         <source>%1 files</source>
         <translation>%1 קבצים</translation>
     </message>
@@ -454,8 +454,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="143"/>
-        <location filename="../screens/GamesScreen.qml" line="175"/>
+        <location filename="../screens/GamesScreen.qml" line="146"/>
+        <location filename="../screens/GamesScreen.qml" line="178"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -470,7 +470,7 @@ Euskara - devilschile2</source>
         <translation>טוען משחקים…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="139"/>
+        <location filename="../screens/GamesScreen.qml" line="142"/>
         <source>Loading more…</source>
         <translation>טוען עוד…</translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -443,8 +443,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="171"/>
+        <location filename="../screens/GamesScreen.qml" line="134"/>
+        <location filename="../screens/GamesScreen.qml" line="174"/>
         <source>%1 files</source>
         <translation>%1 קבצים</translation>
     </message>
@@ -454,8 +454,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="140"/>
-        <location filename="../screens/GamesScreen.qml" line="172"/>
+        <location filename="../screens/GamesScreen.qml" line="143"/>
+        <location filename="../screens/GamesScreen.qml" line="175"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -470,7 +470,7 @@ Euskara - devilschile2</source>
         <translation>טוען משחקים…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="136"/>
+        <location filename="../screens/GamesScreen.qml" line="139"/>
         <source>Loading more…</source>
         <translation>טוען עוד…</translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -443,8 +443,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="134"/>
-        <location filename="../screens/GamesScreen.qml" line="174"/>
+        <location filename="../screens/GamesScreen.qml" line="137"/>
+        <location filename="../screens/GamesScreen.qml" line="177"/>
         <source>%1 files</source>
         <translation>%1 फ़ाइलें</translation>
     </message>
@@ -454,8 +454,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="143"/>
-        <location filename="../screens/GamesScreen.qml" line="175"/>
+        <location filename="../screens/GamesScreen.qml" line="146"/>
+        <location filename="../screens/GamesScreen.qml" line="178"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -470,7 +470,7 @@ Euskara - devilschile2</source>
         <translation>गेम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="139"/>
+        <location filename="../screens/GamesScreen.qml" line="142"/>
         <source>Loading more…</source>
         <translation>और लोड हो रहा है…</translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -443,8 +443,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="171"/>
+        <location filename="../screens/GamesScreen.qml" line="134"/>
+        <location filename="../screens/GamesScreen.qml" line="174"/>
         <source>%1 files</source>
         <translation>%1 फ़ाइलें</translation>
     </message>
@@ -454,8 +454,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="140"/>
-        <location filename="../screens/GamesScreen.qml" line="172"/>
+        <location filename="../screens/GamesScreen.qml" line="143"/>
+        <location filename="../screens/GamesScreen.qml" line="175"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -470,7 +470,7 @@ Euskara - devilschile2</source>
         <translation>गेम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="136"/>
+        <location filename="../screens/GamesScreen.qml" line="139"/>
         <source>Loading more…</source>
         <translation>और लोड हो रहा है…</translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -443,8 +443,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="134"/>
-        <location filename="../screens/GamesScreen.qml" line="174"/>
+        <location filename="../screens/GamesScreen.qml" line="137"/>
+        <location filename="../screens/GamesScreen.qml" line="177"/>
         <source>%1 files</source>
         <translation>%1 file</translation>
     </message>
@@ -454,8 +454,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="143"/>
-        <location filename="../screens/GamesScreen.qml" line="175"/>
+        <location filename="../screens/GamesScreen.qml" line="146"/>
+        <location filename="../screens/GamesScreen.qml" line="178"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -465,7 +465,7 @@ Euskara - devilschile2</source>
         <translation>Caricamento giochi…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="139"/>
+        <location filename="../screens/GamesScreen.qml" line="142"/>
         <source>Loading more…</source>
         <translation>Caricamento altro…</translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -443,8 +443,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="171"/>
+        <location filename="../screens/GamesScreen.qml" line="134"/>
+        <location filename="../screens/GamesScreen.qml" line="174"/>
         <source>%1 files</source>
         <translation>%1 file</translation>
     </message>
@@ -454,8 +454,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="140"/>
-        <location filename="../screens/GamesScreen.qml" line="172"/>
+        <location filename="../screens/GamesScreen.qml" line="143"/>
+        <location filename="../screens/GamesScreen.qml" line="175"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -465,7 +465,7 @@ Euskara - devilschile2</source>
         <translation>Caricamento giochi…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="136"/>
+        <location filename="../screens/GamesScreen.qml" line="139"/>
         <source>Loading more…</source>
         <translation>Caricamento altro…</translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -443,8 +443,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="171"/>
+        <location filename="../screens/GamesScreen.qml" line="134"/>
+        <location filename="../screens/GamesScreen.qml" line="174"/>
         <source>%1 files</source>
         <translation>%1 ファイル</translation>
     </message>
@@ -454,8 +454,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="140"/>
-        <location filename="../screens/GamesScreen.qml" line="172"/>
+        <location filename="../screens/GamesScreen.qml" line="143"/>
+        <location filename="../screens/GamesScreen.qml" line="175"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -465,7 +465,7 @@ Euskara - devilschile2</source>
         <translation>ゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="136"/>
+        <location filename="../screens/GamesScreen.qml" line="139"/>
         <source>Loading more…</source>
         <translation>さらに読み込み中…</translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -443,8 +443,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="134"/>
-        <location filename="../screens/GamesScreen.qml" line="174"/>
+        <location filename="../screens/GamesScreen.qml" line="137"/>
+        <location filename="../screens/GamesScreen.qml" line="177"/>
         <source>%1 files</source>
         <translation>%1 ファイル</translation>
     </message>
@@ -454,8 +454,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="143"/>
-        <location filename="../screens/GamesScreen.qml" line="175"/>
+        <location filename="../screens/GamesScreen.qml" line="146"/>
+        <location filename="../screens/GamesScreen.qml" line="178"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -465,7 +465,7 @@ Euskara - devilschile2</source>
         <translation>ゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="139"/>
+        <location filename="../screens/GamesScreen.qml" line="142"/>
         <source>Loading more…</source>
         <translation>さらに読み込み中…</translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -443,8 +443,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="171"/>
+        <location filename="../screens/GamesScreen.qml" line="134"/>
+        <location filename="../screens/GamesScreen.qml" line="174"/>
         <source>%1 files</source>
         <translation>파일 %1개</translation>
     </message>
@@ -454,8 +454,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="140"/>
-        <location filename="../screens/GamesScreen.qml" line="172"/>
+        <location filename="../screens/GamesScreen.qml" line="143"/>
+        <location filename="../screens/GamesScreen.qml" line="175"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -470,7 +470,7 @@ Euskara - devilschile2</source>
         <translation>게임 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="136"/>
+        <location filename="../screens/GamesScreen.qml" line="139"/>
         <source>Loading more…</source>
         <translation>더 불러오는 중…</translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -443,8 +443,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="134"/>
-        <location filename="../screens/GamesScreen.qml" line="174"/>
+        <location filename="../screens/GamesScreen.qml" line="137"/>
+        <location filename="../screens/GamesScreen.qml" line="177"/>
         <source>%1 files</source>
         <translation>파일 %1개</translation>
     </message>
@@ -454,8 +454,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="143"/>
-        <location filename="../screens/GamesScreen.qml" line="175"/>
+        <location filename="../screens/GamesScreen.qml" line="146"/>
+        <location filename="../screens/GamesScreen.qml" line="178"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -470,7 +470,7 @@ Euskara - devilschile2</source>
         <translation>게임 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="139"/>
+        <location filename="../screens/GamesScreen.qml" line="142"/>
         <source>Loading more…</source>
         <translation>더 불러오는 중…</translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -443,8 +443,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="171"/>
+        <location filename="../screens/GamesScreen.qml" line="134"/>
+        <location filename="../screens/GamesScreen.qml" line="174"/>
         <source>%1 files</source>
         <translation>%1 bestanden</translation>
     </message>
@@ -454,8 +454,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="140"/>
-        <location filename="../screens/GamesScreen.qml" line="172"/>
+        <location filename="../screens/GamesScreen.qml" line="143"/>
+        <location filename="../screens/GamesScreen.qml" line="175"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -465,7 +465,7 @@ Euskara - devilschile2</source>
         <translation>Games laden…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="136"/>
+        <location filename="../screens/GamesScreen.qml" line="139"/>
         <source>Loading more…</source>
         <translation>Meer laden…</translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -443,8 +443,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="134"/>
-        <location filename="../screens/GamesScreen.qml" line="174"/>
+        <location filename="../screens/GamesScreen.qml" line="137"/>
+        <location filename="../screens/GamesScreen.qml" line="177"/>
         <source>%1 files</source>
         <translation>%1 bestanden</translation>
     </message>
@@ -454,8 +454,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="143"/>
-        <location filename="../screens/GamesScreen.qml" line="175"/>
+        <location filename="../screens/GamesScreen.qml" line="146"/>
+        <location filename="../screens/GamesScreen.qml" line="178"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -465,7 +465,7 @@ Euskara - devilschile2</source>
         <translation>Games laden…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="139"/>
+        <location filename="../screens/GamesScreen.qml" line="142"/>
         <source>Loading more…</source>
         <translation>Meer laden…</translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -443,8 +443,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="171"/>
+        <location filename="../screens/GamesScreen.qml" line="134"/>
+        <location filename="../screens/GamesScreen.qml" line="174"/>
         <source>%1 files</source>
         <translation>%1 fișiere</translation>
     </message>
@@ -454,8 +454,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="140"/>
-        <location filename="../screens/GamesScreen.qml" line="172"/>
+        <location filename="../screens/GamesScreen.qml" line="143"/>
+        <location filename="../screens/GamesScreen.qml" line="175"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -465,7 +465,7 @@ Euskara - devilschile2</source>
         <translation>Se încarcă jocurile…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="136"/>
+        <location filename="../screens/GamesScreen.qml" line="139"/>
         <source>Loading more…</source>
         <translation>Se încarcă mai multe…</translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -443,8 +443,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="134"/>
-        <location filename="../screens/GamesScreen.qml" line="174"/>
+        <location filename="../screens/GamesScreen.qml" line="137"/>
+        <location filename="../screens/GamesScreen.qml" line="177"/>
         <source>%1 files</source>
         <translation>%1 fișiere</translation>
     </message>
@@ -454,8 +454,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="143"/>
-        <location filename="../screens/GamesScreen.qml" line="175"/>
+        <location filename="../screens/GamesScreen.qml" line="146"/>
+        <location filename="../screens/GamesScreen.qml" line="178"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -465,7 +465,7 @@ Euskara - devilschile2</source>
         <translation>Se încarcă jocurile…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="139"/>
+        <location filename="../screens/GamesScreen.qml" line="142"/>
         <source>Loading more…</source>
         <translation>Se încarcă mai multe…</translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -443,8 +443,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="134"/>
-        <location filename="../screens/GamesScreen.qml" line="174"/>
+        <location filename="../screens/GamesScreen.qml" line="137"/>
+        <location filename="../screens/GamesScreen.qml" line="177"/>
         <source>%1 files</source>
         <translation>%1 súborov</translation>
     </message>
@@ -454,8 +454,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="143"/>
-        <location filename="../screens/GamesScreen.qml" line="175"/>
+        <location filename="../screens/GamesScreen.qml" line="146"/>
+        <location filename="../screens/GamesScreen.qml" line="178"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -465,7 +465,7 @@ Euskara - devilschile2</source>
         <translation>Načítanie hier…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="139"/>
+        <location filename="../screens/GamesScreen.qml" line="142"/>
         <source>Loading more…</source>
         <translation>Načítava sa viac…</translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -443,8 +443,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="171"/>
+        <location filename="../screens/GamesScreen.qml" line="134"/>
+        <location filename="../screens/GamesScreen.qml" line="174"/>
         <source>%1 files</source>
         <translation>%1 súborov</translation>
     </message>
@@ -454,8 +454,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="140"/>
-        <location filename="../screens/GamesScreen.qml" line="172"/>
+        <location filename="../screens/GamesScreen.qml" line="143"/>
+        <location filename="../screens/GamesScreen.qml" line="175"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -465,7 +465,7 @@ Euskara - devilschile2</source>
         <translation>Načítanie hier…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="136"/>
+        <location filename="../screens/GamesScreen.qml" line="139"/>
         <source>Loading more…</source>
         <translation>Načítava sa viac…</translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -443,8 +443,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="134"/>
-        <location filename="../screens/GamesScreen.qml" line="174"/>
+        <location filename="../screens/GamesScreen.qml" line="137"/>
+        <location filename="../screens/GamesScreen.qml" line="177"/>
         <source>%1 files</source>
         <translation>%1 файлів</translation>
     </message>
@@ -454,8 +454,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="143"/>
-        <location filename="../screens/GamesScreen.qml" line="175"/>
+        <location filename="../screens/GamesScreen.qml" line="146"/>
+        <location filename="../screens/GamesScreen.qml" line="178"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -465,7 +465,7 @@ Euskara - devilschile2</source>
         <translation>Завантаження ігор…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="139"/>
+        <location filename="../screens/GamesScreen.qml" line="142"/>
         <source>Loading more…</source>
         <translation>Завантаження ще…</translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -443,8 +443,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="171"/>
+        <location filename="../screens/GamesScreen.qml" line="134"/>
+        <location filename="../screens/GamesScreen.qml" line="174"/>
         <source>%1 files</source>
         <translation>%1 файлів</translation>
     </message>
@@ -454,8 +454,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="140"/>
-        <location filename="../screens/GamesScreen.qml" line="172"/>
+        <location filename="../screens/GamesScreen.qml" line="143"/>
+        <location filename="../screens/GamesScreen.qml" line="175"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -465,7 +465,7 @@ Euskara - devilschile2</source>
         <translation>Завантаження ігор…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="136"/>
+        <location filename="../screens/GamesScreen.qml" line="139"/>
         <source>Loading more…</source>
         <translation>Завантаження ще…</translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -443,8 +443,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="134"/>
-        <location filename="../screens/GamesScreen.qml" line="174"/>
+        <location filename="../screens/GamesScreen.qml" line="137"/>
+        <location filename="../screens/GamesScreen.qml" line="177"/>
         <source>%1 files</source>
         <translation>%1 个文件</translation>
     </message>
@@ -454,8 +454,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="143"/>
-        <location filename="../screens/GamesScreen.qml" line="175"/>
+        <location filename="../screens/GamesScreen.qml" line="146"/>
+        <location filename="../screens/GamesScreen.qml" line="178"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -470,7 +470,7 @@ Euskara - devilschile2</source>
         <translation>正在加载游戏…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="139"/>
+        <location filename="../screens/GamesScreen.qml" line="142"/>
         <source>Loading more…</source>
         <translation>正在加载更多…</translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -443,8 +443,8 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="131"/>
-        <location filename="../screens/GamesScreen.qml" line="171"/>
+        <location filename="../screens/GamesScreen.qml" line="134"/>
+        <location filename="../screens/GamesScreen.qml" line="174"/>
         <source>%1 files</source>
         <translation>%1 个文件</translation>
     </message>
@@ -454,8 +454,8 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="140"/>
-        <location filename="../screens/GamesScreen.qml" line="172"/>
+        <location filename="../screens/GamesScreen.qml" line="143"/>
+        <location filename="../screens/GamesScreen.qml" line="175"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -470,7 +470,7 @@ Euskara - devilschile2</source>
         <translation>正在加载游戏…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="136"/>
+        <location filename="../screens/GamesScreen.qml" line="139"/>
         <source>Loading more…</source>
         <translation>正在加载更多…</translation>
     </message>


### PR DESCRIPTION
- Game launch now fires `launch_at` immediately when Accept is pressed, concurrent with the tile push-in animation, instead of holding the run command behind an 80 ms timer (`Motion.pressMs`). This removes the fixed delay that made launching feel sluggish.
- The deferred leg now only settles the tile back to rest after the push-in; a running-timer guard preserves the double-Accept debounce so a game still launches only once.
- Folder navigation and the Hub resume path are unchanged (still deferred so they land on a static scene before a model reload).
- Regenerated the Qt translation catalogs for the shifted source line numbers; no string content changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the launch flow for game/library entries so selections open more reliably, with reduced risk of accidental duplicate launches.
  * Tightened the handling of activation so the selection and activation feedback remain consistent during navigation.

* **Chores**
  * Updated translation metadata source references for the Games screen across multiple languages to reflect the latest screen layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->