### PR TITLE
fix(input): debounce very-fast duplicate controller inputs

### DIFF
--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -2618,6 +2618,12 @@ MainLayout {
     readonly property int _repeatInitialMs: 350
     readonly property int _repeatTickMs: 90
     readonly property int _rapidNavigationQuietMs: 260
+    // Window for collapsing a second delivery of the same key into one
+    // press — hardware contact bounce or input-stack double send. Far
+    // below _repeatInitialMs and the repeat tick so it never touches
+    // hold-repeat, and below the floor for a deliberate human re-tap.
+    readonly property int _duplicateInputWindowMs: 40
+    property int _lastPressedKey: 0
     property string _heldAction: ""
     property int _heldKey: 0
     property bool rapidNavigationActive: false
@@ -2728,6 +2734,14 @@ MainLayout {
 
     function _isRepeatableAction(action: string): bool {
         return action === "up" || action === "down" || action === "left" || action === "right" || action === "page_prev" || action === "page_next";
+    }
+
+    // Drop a second delivery of the same key while the guard window is
+    // open — hardware contact bounce or input-stack double send. A
+    // different key, or the same key after the window closes, is not a
+    // duplicate. Pure so tst_navigation can assert it without a clock.
+    function _isDuplicateInput(key: int, lastKey: int, withinWindow: bool): bool {
+        return withinWindow && key === lastKey;
     }
 
     // State-machine half of handleKey: records the held key/action and
@@ -2906,6 +2920,14 @@ MainLayout {
         }
     }
 
+    // Open while a duplicate-input guard window is active; see the
+    // Keys.onPressed handler below.
+    Timer {
+        id: duplicateInputGuard
+        interval: root._duplicateInputWindowMs
+        repeat: false
+    }
+
     Timer {
         id: repeatInitial
         interval: root._repeatInitialMs
@@ -2948,9 +2970,19 @@ MainLayout {
         // that walk back through games → systems → hub → quit on
         // a single press. Our own controlled repeat (above) takes
         // over for dpad directions only.
+        //
+        // Then drop a second delivery of the same key inside the
+        // duplicate-input window: some controllers / input stacks
+        // double-send a single press, which would otherwise act
+        // twice. Returning before restart() keeps the window anchored
+        // to the first accepted press so a bounce can't extend it.
         Keys.onPressed: event => {
             if (event.isAutoRepeat)
                 return;
+            if (root._isDuplicateInput(event.key, root._lastPressedKey, duplicateInputGuard.running))
+                return;
+            root._lastPressedKey = event.key;
+            duplicateInputGuard.restart();
             root.handleKey(event.key);
         }
         Keys.onReleased: event => {

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -710,37 +710,37 @@ Euskara - devilschile2</source>
         <translation type="unfinished">إلغاء</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2993"/>
+        <location filename="../app/Main.qml" line="3025"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2995"/>
+        <location filename="../app/Main.qml" line="3027"/>
         <source>Loading games…</source>
         <translation>جارٍ تحميل الألعاب…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2997"/>
+        <location filename="../app/Main.qml" line="3029"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2999"/>
+        <location filename="../app/Main.qml" line="3031"/>
         <source>Loading favorites…</source>
         <translation>جارٍ تحميل المفضلة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3001"/>
+        <location filename="../app/Main.qml" line="3033"/>
         <source>Loading recently played…</source>
         <translation>جارٍ تحميل آخر ما تم لعبه…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3003"/>
+        <location filename="../app/Main.qml" line="3035"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3005"/>
+        <location filename="../app/Main.qml" line="3037"/>
         <source>Loading…</source>
         <translation>جارٍ التحميل…</translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -646,17 +646,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2993"/>
+        <location filename="../app/Main.qml" line="3025"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2999"/>
+        <location filename="../app/Main.qml" line="3031"/>
         <source>Loading favorites…</source>
         <translation>Favoriten werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2995"/>
+        <location filename="../app/Main.qml" line="3027"/>
         <source>Loading games…</source>
         <translation>Spiele werden geladen…</translation>
     </message>
@@ -725,22 +725,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Abbrechen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2997"/>
+        <location filename="../app/Main.qml" line="3029"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3001"/>
+        <location filename="../app/Main.qml" line="3033"/>
         <source>Loading recently played…</source>
         <translation>Zuletzt gespielte werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3003"/>
+        <location filename="../app/Main.qml" line="3035"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3005"/>
+        <location filename="../app/Main.qml" line="3037"/>
         <source>Loading…</source>
         <translation>Wird geladen…</translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -646,17 +646,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2993"/>
+        <location filename="../app/Main.qml" line="3025"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2999"/>
+        <location filename="../app/Main.qml" line="3031"/>
         <source>Loading favorites…</source>
         <translation>Φόρτωση αγαπημένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2995"/>
+        <location filename="../app/Main.qml" line="3027"/>
         <source>Loading games…</source>
         <translation>Φόρτωση παιχνιδιών…</translation>
     </message>
@@ -725,22 +725,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2997"/>
+        <location filename="../app/Main.qml" line="3029"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3001"/>
+        <location filename="../app/Main.qml" line="3033"/>
         <source>Loading recently played…</source>
         <translation>Φόρτωση πρόσφατα παιγμένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3003"/>
+        <location filename="../app/Main.qml" line="3035"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3005"/>
+        <location filename="../app/Main.qml" line="3037"/>
         <source>Loading…</source>
         <translation>Φόρτωση…</translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -634,17 +634,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2993"/>
+        <location filename="../app/Main.qml" line="3025"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2999"/>
+        <location filename="../app/Main.qml" line="3031"/>
         <source>Loading favorites…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2995"/>
+        <location filename="../app/Main.qml" line="3027"/>
         <source>Loading games…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -713,22 +713,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2997"/>
+        <location filename="../app/Main.qml" line="3029"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3001"/>
+        <location filename="../app/Main.qml" line="3033"/>
         <source>Loading recently played…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3003"/>
+        <location filename="../app/Main.qml" line="3035"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3005"/>
+        <location filename="../app/Main.qml" line="3037"/>
         <source>Loading…</source>
         <translation type="unfinished">Loading…</translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -646,17 +646,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2993"/>
+        <location filename="../app/Main.qml" line="3025"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2999"/>
+        <location filename="../app/Main.qml" line="3031"/>
         <source>Loading favorites…</source>
         <translation>Cargando favoritos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2995"/>
+        <location filename="../app/Main.qml" line="3027"/>
         <source>Loading games…</source>
         <translation>Cargando juegos…</translation>
     </message>
@@ -725,22 +725,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2997"/>
+        <location filename="../app/Main.qml" line="3029"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3001"/>
+        <location filename="../app/Main.qml" line="3033"/>
         <source>Loading recently played…</source>
         <translation>Cargando jugados recientemente…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3003"/>
+        <location filename="../app/Main.qml" line="3035"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3005"/>
+        <location filename="../app/Main.qml" line="3037"/>
         <source>Loading…</source>
         <translation>Cargando…</translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -654,17 +654,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2993"/>
+        <location filename="../app/Main.qml" line="3025"/>
         <source>Loading systems…</source>
         <translation type="unfinished">Sistemak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2999"/>
+        <location filename="../app/Main.qml" line="3031"/>
         <source>Loading favorites…</source>
         <translation type="unfinished">Gogokoak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2995"/>
+        <location filename="../app/Main.qml" line="3027"/>
         <source>Loading games…</source>
         <translation type="unfinished">Jokoak kargatzen</translation>
     </message>
@@ -733,22 +733,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Utzi</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2997"/>
+        <location filename="../app/Main.qml" line="3029"/>
         <source>Loading game…</source>
         <translation type="unfinished">Jokua kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3001"/>
+        <location filename="../app/Main.qml" line="3033"/>
         <source>Loading recently played…</source>
         <translation type="unfinished">Duela gutxi jokatutakoak kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3003"/>
+        <location filename="../app/Main.qml" line="3035"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3005"/>
+        <location filename="../app/Main.qml" line="3037"/>
         <source>Loading…</source>
         <translation type="unfinished">Kargatzen…</translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -710,37 +710,37 @@ Euskara - devilschile2</source>
         <translation type="unfinished">ביטול</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2993"/>
+        <location filename="../app/Main.qml" line="3025"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2995"/>
+        <location filename="../app/Main.qml" line="3027"/>
         <source>Loading games…</source>
         <translation>טוען משחקים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2997"/>
+        <location filename="../app/Main.qml" line="3029"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2999"/>
+        <location filename="../app/Main.qml" line="3031"/>
         <source>Loading favorites…</source>
         <translation>טוען מועדפים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3001"/>
+        <location filename="../app/Main.qml" line="3033"/>
         <source>Loading recently played…</source>
         <translation>טוען את הפריטים ששוחקו לאחרונה…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3003"/>
+        <location filename="../app/Main.qml" line="3035"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3005"/>
+        <location filename="../app/Main.qml" line="3037"/>
         <source>Loading…</source>
         <translation>טוען…</translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -710,37 +710,37 @@ Euskara - devilschile2</source>
         <translation type="unfinished">रद्द करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2993"/>
+        <location filename="../app/Main.qml" line="3025"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2995"/>
+        <location filename="../app/Main.qml" line="3027"/>
         <source>Loading games…</source>
         <translation>गेम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2997"/>
+        <location filename="../app/Main.qml" line="3029"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2999"/>
+        <location filename="../app/Main.qml" line="3031"/>
         <source>Loading favorites…</source>
         <translation>पसंदीदा लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3001"/>
+        <location filename="../app/Main.qml" line="3033"/>
         <source>Loading recently played…</source>
         <translation>हाल ही में खेले गए लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3003"/>
+        <location filename="../app/Main.qml" line="3035"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3005"/>
+        <location filename="../app/Main.qml" line="3037"/>
         <source>Loading…</source>
         <translation>लोड हो रहा है…</translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -646,17 +646,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2993"/>
+        <location filename="../app/Main.qml" line="3025"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2999"/>
+        <location filename="../app/Main.qml" line="3031"/>
         <source>Loading favorites…</source>
         <translation>Caricamento preferiti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2995"/>
+        <location filename="../app/Main.qml" line="3027"/>
         <source>Loading games…</source>
         <translation>Caricamento giochi…</translation>
     </message>
@@ -725,22 +725,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Annulla</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2997"/>
+        <location filename="../app/Main.qml" line="3029"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3001"/>
+        <location filename="../app/Main.qml" line="3033"/>
         <source>Loading recently played…</source>
         <translation>Caricamento recenti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3003"/>
+        <location filename="../app/Main.qml" line="3035"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3005"/>
+        <location filename="../app/Main.qml" line="3037"/>
         <source>Loading…</source>
         <translation>Caricamento…</translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -646,17 +646,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2993"/>
+        <location filename="../app/Main.qml" line="3025"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2999"/>
+        <location filename="../app/Main.qml" line="3031"/>
         <source>Loading favorites…</source>
         <translation>お気に入りを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2995"/>
+        <location filename="../app/Main.qml" line="3027"/>
         <source>Loading games…</source>
         <translation>ゲームを読み込み中…</translation>
     </message>
@@ -725,22 +725,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2997"/>
+        <location filename="../app/Main.qml" line="3029"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3001"/>
+        <location filename="../app/Main.qml" line="3033"/>
         <source>Loading recently played…</source>
         <translation>最近プレイしたゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3003"/>
+        <location filename="../app/Main.qml" line="3035"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3005"/>
+        <location filename="../app/Main.qml" line="3037"/>
         <source>Loading…</source>
         <translation>読み込み中…</translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -710,37 +710,37 @@ Euskara - devilschile2</source>
         <translation type="unfinished">취소</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2993"/>
+        <location filename="../app/Main.qml" line="3025"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2995"/>
+        <location filename="../app/Main.qml" line="3027"/>
         <source>Loading games…</source>
         <translation>게임 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2997"/>
+        <location filename="../app/Main.qml" line="3029"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2999"/>
+        <location filename="../app/Main.qml" line="3031"/>
         <source>Loading favorites…</source>
         <translation>즐겨찾기 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3001"/>
+        <location filename="../app/Main.qml" line="3033"/>
         <source>Loading recently played…</source>
         <translation>최근 플레이 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3003"/>
+        <location filename="../app/Main.qml" line="3035"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3005"/>
+        <location filename="../app/Main.qml" line="3037"/>
         <source>Loading…</source>
         <translation>불러오는 중…</translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -646,17 +646,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2993"/>
+        <location filename="../app/Main.qml" line="3025"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2999"/>
+        <location filename="../app/Main.qml" line="3031"/>
         <source>Loading favorites…</source>
         <translation>Favorieten laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2995"/>
+        <location filename="../app/Main.qml" line="3027"/>
         <source>Loading games…</source>
         <translation>Games laden…</translation>
     </message>
@@ -725,22 +725,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2997"/>
+        <location filename="../app/Main.qml" line="3029"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3001"/>
+        <location filename="../app/Main.qml" line="3033"/>
         <source>Loading recently played…</source>
         <translation>Recent gespeeld laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3003"/>
+        <location filename="../app/Main.qml" line="3035"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3005"/>
+        <location filename="../app/Main.qml" line="3037"/>
         <source>Loading…</source>
         <translation>Laden…</translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -646,17 +646,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2993"/>
+        <location filename="../app/Main.qml" line="3025"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2999"/>
+        <location filename="../app/Main.qml" line="3031"/>
         <source>Loading favorites…</source>
         <translation>Se încarcă favoritele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2995"/>
+        <location filename="../app/Main.qml" line="3027"/>
         <source>Loading games…</source>
         <translation>Se încarcă jocurile…</translation>
     </message>
@@ -725,22 +725,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Anulare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2997"/>
+        <location filename="../app/Main.qml" line="3029"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3001"/>
+        <location filename="../app/Main.qml" line="3033"/>
         <source>Loading recently played…</source>
         <translation>Se încarcă recent jucatele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3003"/>
+        <location filename="../app/Main.qml" line="3035"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3005"/>
+        <location filename="../app/Main.qml" line="3037"/>
         <source>Loading…</source>
         <translation>Se încarcă…</translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -646,17 +646,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2993"/>
+        <location filename="../app/Main.qml" line="3025"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2999"/>
+        <location filename="../app/Main.qml" line="3031"/>
         <source>Loading favorites…</source>
         <translation>Načítanie obľúbených…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2995"/>
+        <location filename="../app/Main.qml" line="3027"/>
         <source>Loading games…</source>
         <translation>Načítanie hier…</translation>
     </message>
@@ -725,22 +725,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Zrušiť</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2997"/>
+        <location filename="../app/Main.qml" line="3029"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3001"/>
+        <location filename="../app/Main.qml" line="3033"/>
         <source>Loading recently played…</source>
         <translation>Načítanie nedávno hraných…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3003"/>
+        <location filename="../app/Main.qml" line="3035"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3005"/>
+        <location filename="../app/Main.qml" line="3037"/>
         <source>Loading…</source>
         <translation>Načítanie…</translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -646,17 +646,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2993"/>
+        <location filename="../app/Main.qml" line="3025"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2999"/>
+        <location filename="../app/Main.qml" line="3031"/>
         <source>Loading favorites…</source>
         <translation>Завантаження вибраного…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2995"/>
+        <location filename="../app/Main.qml" line="3027"/>
         <source>Loading games…</source>
         <translation>Завантаження ігор…</translation>
     </message>
@@ -725,22 +725,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Скасувати</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2997"/>
+        <location filename="../app/Main.qml" line="3029"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3001"/>
+        <location filename="../app/Main.qml" line="3033"/>
         <source>Loading recently played…</source>
         <translation>Завантаження нещодавніх…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3003"/>
+        <location filename="../app/Main.qml" line="3035"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3005"/>
+        <location filename="../app/Main.qml" line="3037"/>
         <source>Loading…</source>
         <translation>Завантаження…</translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -710,37 +710,37 @@ Euskara - devilschile2</source>
         <translation type="unfinished">取消</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2993"/>
+        <location filename="../app/Main.qml" line="3025"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2995"/>
+        <location filename="../app/Main.qml" line="3027"/>
         <source>Loading games…</source>
         <translation>正在加载游戏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2997"/>
+        <location filename="../app/Main.qml" line="3029"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2999"/>
+        <location filename="../app/Main.qml" line="3031"/>
         <source>Loading favorites…</source>
         <translation>正在加载收藏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3001"/>
+        <location filename="../app/Main.qml" line="3033"/>
         <source>Loading recently played…</source>
         <translation>正在加载最近游玩…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3003"/>
+        <location filename="../app/Main.qml" line="3035"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3005"/>
+        <location filename="../app/Main.qml" line="3037"/>
         <source>Loading…</source>
         <translation>正在加载…</translation>
     </message>

--- a/tests/ui/tst_navigation.qml
+++ b/tests/ui/tst_navigation.qml
@@ -493,6 +493,24 @@ TestCase {
         compare(main.rapidNavigationActive, false);
     }
 
+    // Duplicate-input guard. The Keys.onPressed handler collapses a
+    // second delivery of the same key while the guard window is open
+    // (controller / input-stack double send). The decision is a pure
+    // helper so we can assert it without driving real key events or a
+    // clock — same key inside the window is a duplicate, a different
+    // key or the same key after the window are not.
+    function test_duplicate_input_drops_same_key_in_window(): void {
+        compare(main._isDuplicateInput(Qt.Key_Down, Qt.Key_Down, true), true, "same key inside the window is a duplicate");
+    }
+
+    function test_duplicate_input_passes_same_key_after_window(): void {
+        compare(main._isDuplicateInput(Qt.Key_Down, Qt.Key_Down, false), false, "same key after the window closes is a fresh press");
+    }
+
+    function test_duplicate_input_passes_different_key_in_window(): void {
+        compare(main._isDuplicateInput(Qt.Key_Up, Qt.Key_Down, true), false, "a different key inside the window is never a duplicate");
+    }
+
     // Context-menu builder. Drives the pure helper directly per the QML
     // test isolation rule — no real menu opening, no handleAction.
     // Compares only the entry id sequence; labels are qsTr() and asserted


### PR DESCRIPTION
- Drop a second delivery of the same key inside a short (40ms) window in `Main.qml`'s `Keys.onPressed` handler, so controllers and input stacks that double-send a single press no longer make the UI act twice.
- Place the guard ahead of `handleKey` so all real key input is covered, while the test harness (which calls `handleKey`/`handleAction` directly) and the hold-to-repeat machine (which re-dispatches through `handleAction`) are unaffected.
- Decide duplicates via a pure `_isDuplicateInput` helper; the window sits well below the repeat timings and the floor for a deliberate human re-tap, so distinct presses and fast taps still pass through.
- Add `tst_navigation.qml` coverage for the helper and regenerate the Qt Linguist catalogs for the shifted source locations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced accidental duplicate key actions by ignoring repeated key presses within a short window.
  * Improved loading-state behavior so key input is handled more reliably.

* **Tests**
  * Added UI coverage for duplicate-input handling, including repeated keys, delayed repeats, and different keys.

* **Chores**
  * Updated translation source references to match the latest UI line positions across multiple languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->