### PR TITLE
fix(hub): preserve category focus when backing out from a category

### DIFF
--- a/src/ui/screens/HubScreen.qml
+++ b/src/ui/screens/HubScreen.qml
@@ -329,7 +329,13 @@ Item {
             hub.currentRow = 0;
             hub.currentIndex = chosenCategoryIndex;
         } else if (hub.resumeActionVisible) {
-            hub.focusResumeIfVisible();
+            // Non-persisting seat: this is a programmatic restore, so it must
+            // not commit like focusResumeIfVisible() would. Committing here
+            // clobbers a saved category-row intent whenever the catalog is
+            // momentarily empty (cold-boot restore, in-session catalog
+            // refresh), stranding the user on Resume when they back out.
+            hub.currentRow = 1;
+            hub.currentIndex = hub._actionIndexForId("resume");
         } else if (Browse.CategoriesModel.count === 0) {
             hub.currentRow = 1;
             hub.currentIndex = hub._actionIndexForId(hub._emptyCatalogFallbackAction);

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -532,7 +532,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">الإعدادات</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="790"/>
+        <location filename="../screens/HubScreen.qml" line="796"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>لا توجد أنظمة متاحة. شغّل تحديث قاعدة بيانات الوسائط من الإعدادات.</translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -532,7 +532,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Einstellungen</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="790"/>
+        <location filename="../screens/HubScreen.qml" line="796"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Keine Systeme verfügbar. Bitte Mediendatenbank unter Einstellungen aktualisieren.</translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -532,7 +532,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Ρυθμίσεις</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="790"/>
+        <location filename="../screens/HubScreen.qml" line="796"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Δεν υπάρχουν διαθέσιμα συστήματα. Εκτελέστε Ενημέρωση βάσης δεδομένων από τις Ρυθμίσεις.</translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -520,7 +520,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Settings</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="790"/>
+        <location filename="../screens/HubScreen.qml" line="796"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -532,7 +532,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Ajustes</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="790"/>
+        <location filename="../screens/HubScreen.qml" line="796"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>No hay sistemas disponibles. Ejecuta Actualizar la base de datos de medios desde Ajustes.</translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -540,7 +540,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Ezarpenak</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="790"/>
+        <location filename="../screens/HubScreen.qml" line="796"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation type="unfinished">Ez dago sistemarik eskuragarri. Exekutatu Eguneratu baliabide datubasea Aukeretatik</translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -532,7 +532,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">הגדרות</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="790"/>
+        <location filename="../screens/HubScreen.qml" line="796"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>אין מערכות זמינות. הפעילו &quot;עדכון מסד נתוני מדיה&quot; מההגדרות.</translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -532,7 +532,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">सेटिंग्स</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="790"/>
+        <location filename="../screens/HubScreen.qml" line="796"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>कोई सिस्टम उपलब्ध नहीं है। सेटिंग्स से मीडिया डेटाबेस अपडेट चलाएँ।</translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -532,7 +532,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Impostazioni</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="790"/>
+        <location filename="../screens/HubScreen.qml" line="796"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Nessun sistema disponibile. Esegui Aggiorna database multimediale dalle Impostazioni.</translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -532,7 +532,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">設定</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="790"/>
+        <location filename="../screens/HubScreen.qml" line="796"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>利用可能なシステムがありません。設定からメディアデータベースの更新を実行してください。</translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -532,7 +532,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">설정</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="790"/>
+        <location filename="../screens/HubScreen.qml" line="796"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>사용 가능한 시스템이 없습니다. 설정에서 미디어 데이터베이스 업데이트를 실행하세요.</translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -532,7 +532,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Instellingen</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="790"/>
+        <location filename="../screens/HubScreen.qml" line="796"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Geen systemen beschikbaar. Voer Database bijwerken uit via Instellingen.</translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -532,7 +532,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Setări</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="790"/>
+        <location filename="../screens/HubScreen.qml" line="796"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Niciun sistem disponibil. Rulați Actualizare bază de date din Setări.</translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -532,7 +532,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Nastavenia</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="790"/>
+        <location filename="../screens/HubScreen.qml" line="796"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Žiadne systémy nie sú dostupné. Spustite Aktualizovať databázu médií v Nastaveniach.</translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -532,7 +532,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">Налаштування</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="790"/>
+        <location filename="../screens/HubScreen.qml" line="796"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Немає доступних систем. Запустіть Оновлення бази даних з Налаштувань.</translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -532,7 +532,7 @@ Euskara - devilschile2</source>
         <translation type="vanished">设置</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="790"/>
+        <location filename="../screens/HubScreen.qml" line="796"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>没有可用系统。请在“设置”中运行“更新媒体数据库”。</translation>
     </message>

--- a/tests/ui/tst_persistence.qml
+++ b/tests/ui/tst_persistence.qml
@@ -193,4 +193,18 @@ TestCase {
         const sels = Browse.GamesState.selected_at_level;
         compare(sels[sels.length - 1], "persistence-probe-path", "Enter on an empty games grid must not overwrite GamesState selection");
     }
+
+    // Restoring Hub focus before the catalog arrives (count == 0 in this
+    // harness) must not overwrite the saved category-row intent with the
+    // Resume action. Otherwise a process restart into a category — or an
+    // in-session catalog refresh — strands the user on Resume when they
+    // back out to the Hub.
+    function test_restore_with_empty_catalog_preserves_saved_category_row(): void {
+        Browse.HubState.category = "Console";
+        Browse.HubState.selected_row = 0;
+        Browse.HubState.selected_action = "";
+        main.hubScreen.restoreFromCategoriesReset(false);
+        compare(Browse.HubState.selected_row, 0, "An empty-catalog restore must not overwrite the saved category row with the Resume action");
+        compare(Browse.HubState.selected_action, "", "An empty-catalog restore must not persist a Resume fallback action");
+    }
 }


### PR DESCRIPTION
- Fixed the Hub restoring focus to Resume instead of the last category tile when backing out of a category. `restoreFromCategoriesReset`'s Resume fallback called the committing `focusResumeIfVisible`, which persisted `selected_row`/`selected_action` and clobbered the saved category-row intent whenever the catalog was momentarily empty (process restart into a category, in-session catalog refresh).
- Seated the Resume fallback focus directly without persisting, matching every other branch in that programmatic restore function; `focusResumeIfVisible` remains the committing helper for the genuine cold-boot default.
- Added a persistence regression test asserting an empty-catalog restore does not overwrite the saved category row/action, and regenerated the Qt Linguist location line numbers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restore behavior on the Hub screen so saved category-row selections are preserved when no catalog entries are available.
  * Prevented the Resume action from being selected automatically during this fallback path.

* **Tests**
  * Added a regression test covering restore behavior with an empty catalog to ensure the saved selection stays intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->