### PR TITLE
chore(release): bump version to 1.2.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.22)
 
 project(
     zaparoo-frontend
-    VERSION 1.2.1
+    VERSION 1.2.2
     DESCRIPTION "Zaparoo Core frontend"
     HOMEPAGE_URL "https://zaparoo.org"
     LANGUAGES CXX

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "mock-core"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "futures-util",
  "serde",
@@ -1450,11 +1450,11 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zaparoo-build-info"
-version = "1.2.1"
+version = "1.2.2"
 
 [[package]]
 name = "zaparoo-core"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "dirs-next",
  "futures-util",
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "zaparoo-frontend-rs"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "base64",
  "cxx",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ members = ["build-info", "frontend", "mock-core", "zaparoo-core"]
 resolver = "2"
 
 [workspace.package]
-version      = "1.2.1"
+version      = "1.2.2"
 edition      = "2021"
 rust-version = "1.96"
 license      = "LicenseRef-PolyForm-Noncommercial-1.0.0"


### PR DESCRIPTION
- Bump `project(... VERSION ...)` in `CMakeLists.txt` and the workspace `version` in `rust/Cargo.toml` from 1.2.1 to 1.2.2.
- Regenerate `rust/Cargo.lock` so the four workspace crates (`mock-core`, `zaparoo-build-info`, `zaparoo-core`, `zaparoo-frontend-rs`) resolve to 1.2.2.
- Prepares the tree for the v1.2.2 tag; the About page derives its version from the CMake `VERSION`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the project version to **1.2.2** across build and workspace configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->